### PR TITLE
[RTMPort] Update System.Security.Cryptography.OpenSsl contract

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -12,9 +12,9 @@
     <AssemblyName>System.Net.Http</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <WindowsRID>win</WindowsRID>
-    <PackageTargetFramework Condition="'$(TargetsUnix)' == 'true'">netstandard1.4</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(TargetsUnix)' == 'true'">netstandard1.6</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
-    <NuGetTargetMoniker Condition="'$(TargetsUnix)' == 'true'">.NETStandard,Version=v1.4</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetsUnix)' == 'true'">.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' and '$(ProjectJson)' == '' ">
     <ProjectJson>unix/project.json</ProjectJson>

--- a/src/System.Net.Http/src/unix/project.json
+++ b/src/System.Net.Http/src/unix/project.json
@@ -3,7 +3,7 @@
     "System.Diagnostics.DiagnosticSource": "4.0.0-rc3-24117-00"
   },
   "frameworks": {
-    "netstandard1.4": {
+    "netstandard1.6": {
       "imports": [
         "dotnet5.5"
       ],

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -13,9 +13,9 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
-    <PackageTargetFramework Condition="'$(TargetsUnix)' == 'true'">netstandard1.4</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(TargetsUnix)' == 'true'">netstandard1.6</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
-    <NuGetTargetMoniker Condition="'$(TargetsUnix)' == 'true'">.NETStandard,Version=v1.4</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetsUnix)' == 'true'">.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' and '$(ProjectJson)' == '' ">
     <ProjectJson>win/project.json</ProjectJson>

--- a/src/System.Net.Security/src/unix/project.json
+++ b/src/System.Net.Security/src/unix/project.json
@@ -23,7 +23,7 @@
     "System.Threading.ThreadPool": "4.0.10-rc3-24117-00"
   },
   "frameworks": {
-    "netstandard1.4": {
+    "netstandard1.6": {
       "imports": [
         "dotnet5.5"
       ]

--- a/src/System.Security.Cryptography.OpenSsl/pkg/System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/System.Security.Cryptography.OpenSsl/pkg/System.Security.Cryptography.OpenSsl.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.OpenSsl.csproj">
-      <SupportedFramework>netcoreapp1.0;net461;netcore50</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.0</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.OpenSsl.builds" />
 

--- a/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.cs
+++ b/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.cs
@@ -12,13 +12,18 @@ namespace System.Security.Cryptography
         public ECDsaOpenSsl() { }
         public ECDsaOpenSsl(int keySize) { }
         public ECDsaOpenSsl(System.IntPtr handle) { }
+        public ECDsaOpenSsl(System.Security.Cryptography.ECCurve curve) { }
         public ECDsaOpenSsl(System.Security.Cryptography.SafeEvpPKeyHandle pkeyHandle) { }
-        public override int KeySize { set { } }
+        public override int KeySize { get { return default(int); } set { } }
         public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
         protected override void Dispose(bool disposing) { }
         public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle() { return default(System.Security.Cryptography.SafeEvpPKeyHandle); }
+        public override System.Security.Cryptography.ECParameters ExportExplicitParameters(bool includePrivateParameters) { return default(System.Security.Cryptography.ECParameters); }
+        public override System.Security.Cryptography.ECParameters ExportParameters(bool includePrivateParameters) { return default(System.Security.Cryptography.ECParameters); }
+        public override void GenerateKey(System.Security.Cryptography.ECCurve curve) { }
         protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
         protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
+        public override void ImportParameters(System.Security.Cryptography.ECParameters parameters) { }
         public override byte[] SignHash(byte[] hash) { return default(byte[]); }
         public override bool VerifyHash(byte[] hash, byte[] signature) { return default(bool); }
     }

--- a/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.csproj
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.4</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.6</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.OpenSsl.cs" />

--- a/src/System.Security.Cryptography.OpenSsl/ref/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/ref/project.json
@@ -7,7 +7,7 @@
     "System.Security.Cryptography.Primitives": "4.0.0-rc3-24117-00"
   },
   "frameworks": {
-    "netstandard1.4": {
+    "netstandard1.6": {
       "imports": [
         "dotnet5.5"
       ]

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -16,8 +16,6 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
     <GeneratePlatformNotSupportedAssembly>true</GeneratePlatformNotSupportedAssembly>
-    <PackageTargetFramework>netstandard1.4</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
     <!-- Clear PackageTargetRuntime on Windows to package the PlatformNotSupported assembly 
          without a RID so that it applies in desktop packages.config projects as well -->
     <PackageTargetRuntime></PackageTargetRuntime>

--- a/src/System.Security.Cryptography.OpenSsl/src/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/src/project.json
@@ -18,11 +18,6 @@
       "imports": [
         "dotnet5.5"
       ]
-    },
-    "netstandard1.4": {
-      "imports": [
-        "dotnet5.5"
-      ]
     }
   }
 }

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>System.Security.Cryptography.OpenSsl.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.OpenSsl.Tests</RootNamespace>
     <NuGetTargetMoniker>.NETCoreApp,Version=v1.0</NuGetTargetMoniker>
-    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -14,9 +14,9 @@
     <AssemblyVersion Condition="'$(TargetGroup)'=='net46'">4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.4</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.6</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46' OR '$(TargetGroup)'=='net461'">true</IsPartialFacadeAssembly>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.4</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetGroup)' == 'netcore50' and '$(ProjectJson)' == '' ">
     <ProjectJson>netcore50/project.json</ProjectJson>

--- a/src/System.Security.Cryptography.X509Certificates/src/unix/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/unix/project.json
@@ -20,7 +20,7 @@
     "System.Threading": "4.0.10"
   },
   "frameworks": {
-    "netstandard1.4": {
+    "netstandard1.6": {
       "imports": [
         "dotnet5.5"
       ]

--- a/src/System.Security.Cryptography.X509Certificates/src/win/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/win/project.json
@@ -21,7 +21,7 @@
     "System.Threading": "4.0.10"
   },
   "frameworks": {
-    "netstandard1.4": {
+    "netstandard1.6": {
       "imports": [
         "dotnet5.5"
       ],

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -72,6 +72,15 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Target Name="ChangeTestTargetFramework" BeforeTargets="BeforeBuild" >
+    <ItemGroup>
+      <TestTargetFramework Remove="@(TestTargetFramework)" />
+      <TestTargetFramework Include=".NETCoreApp,Version=v1.0">
+        <!-- Folder should be netcoreapp10, but dnxcore50 hardcoded in runtest.sh -->
+        <Folder>dnxcore50</Folder>
+      </TestTargetFramework>
+    </ItemGroup>
+  </Target>
   <ItemGroup>
     <SupplementalTestData Include="$(PackagesDir)System.Security.Cryptography.X509Certificates.TestData\1.0.2-prerelease\content\**\*.*" />
   </ItemGroup>

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.json
@@ -22,9 +22,9 @@
     }
   },
   "frameworks": {
-    "dnxcore50": {
+    "netcoreapp1.0": {
       "imports": [
-        "netstandard1.6",
+        "dnxcore50",
         "portable-net45+win8"
       ]
     }


### PR DESCRIPTION
This is the release/1.0.0 port of #8732.

This change regenerates the System.Security.Cryptography.OpenSsl contract, which requires moving it to a netstandard1.6 target.

It also includes all of the downlevel consequences of that change (changing the target framework of some implementation libraries, making the S.S.C.OpenSsl test library run with the netstandardapp1.0 moniker, and clearing the "test project does not successfully build using the contract" flag from the test project).