### PR TITLE
Enable all tests for System.Numerics.Vectors

### DIFF
--- a/src/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
@@ -257,7 +257,6 @@ namespace System.Numerics.Tests
 
         // Various rotation decompose test.
         [Fact]
-        [ActiveIssue(4833, PlatformID.OSX)]
         public void Matrix4x4DecomposeTest01()
         {
             DecomposeTest(10.0f, 20.0f, 30.0f, new Vector3(10, 20, 30), new Vector3(2, 3, 4));
@@ -543,7 +542,6 @@ namespace System.Numerics.Tests
 
         // Covers more numeric rigions
         [Fact]
-        [ActiveIssue(4882, PlatformID.OSX)]
         public void Matrix4x4CreateFromYawPitchRollTest2()
         {
             const float step = 35.0f;

--- a/src/System.Numerics.Vectors/tests/Vector2Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector2Tests.cs
@@ -1054,7 +1054,6 @@ namespace System.Numerics.Tests
 
         // A test for Reflect (Vector2f, Vector2f)
         [Fact]
-        [ActiveIssue(1011)]
         public void Vector2ReflectTest()
         {
             Vector2 a = Vector2.Normalize(new Vector2(1.0f, 1.0f));
@@ -1081,7 +1080,6 @@ namespace System.Numerics.Tests
         // A test for Reflect (Vector2f, Vector2f)
         // Reflection when normal and source are the same
         [Fact]
-        [ActiveIssue(1011)]
         public void Vector2ReflectTest1()
         {
             Vector2 n = new Vector2(0.45f, 1.28f);


### PR DESCRIPTION
#1011 has been fixed for a while, but the tests were never re-enabled. #4833 and #4882 have been active for a long time, but may no longer be relevant.

Let's re-enable these and see if we get repros for anything.

@LLITCHEV 