### PR TITLE
Check if process has started, before checking for exit.

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -365,11 +365,12 @@ namespace System.Diagnostics.Tests
             p.StartInfo.LoadUserProfile = true;
             p.StartInfo.UserName = username;
             p.StartInfo.PasswordInClearText = password;
+            bool hasStarted = false;
 
             SafeProcessHandle handle = null;
             try
             {
-                p.Start();
+                hasStarted = p.Start();
                 if (Interop.OpenProcessToken(p.SafeHandle, 0x8u, out handle))
                 {
                     SecurityIdentifier sid;
@@ -389,14 +390,18 @@ namespace System.Diagnostics.Tests
             }
             finally
             {
+                Interop.NetUserDel(null, username);
+
                 if (handle != null)
                     handle.Dispose();
 
-                if (!p.HasExited)
-                    p.Kill();
+                if (hasStarted)
+                {
+                    if (!p.HasExited)
+                        p.Kill();
 
-                Interop.NetUserDel(null, username);
-                Assert.True(p.WaitForExit(WaitInMS));
+                    Assert.True(p.WaitForExit(WaitInMS));
+                }
             }
         }
 

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -360,17 +360,20 @@ namespace System.Diagnostics.Tests
                 return; // test is irrelevant if we can't add a user
             }
 
-            Process p = CreateProcessLong();
-
-            p.StartInfo.LoadUserProfile = true;
-            p.StartInfo.UserName = username;
-            p.StartInfo.PasswordInClearText = password;
             bool hasStarted = false;
-
             SafeProcessHandle handle = null;
+            Process p = null;
+
             try
             {
+                p = CreateProcessLong();
+
+                p.StartInfo.LoadUserProfile = true;
+                p.StartInfo.UserName = username;
+                p.StartInfo.PasswordInClearText = password;
+
                 hasStarted = p.Start();
+
                 if (Interop.OpenProcessToken(p.SafeHandle, 0x8u, out handle))
                 {
                     SecurityIdentifier sid;
@@ -390,7 +393,7 @@ namespace System.Diagnostics.Tests
             }
             finally
             {
-                Interop.NetUserDel(null, username);
+                Assert.Equal((uint)0, Interop.NetUserDel(null, username));
 
                 if (handle != null)
                     handle.Dispose();


### PR DESCRIPTION
This is for issue #4466 

Debugging on my local computer, I always get a Error_access_denied errorcode from p.Start(), even when run with admin account, and using an admin logon credentials. Not sure if the same is happening in CI, will verify with this fix. Also, keeping the issue open to dig into why we are getting Access denied error from the windows native API call.

cc @stephentoub