### PR TITLE
Fix dangling Stream in ReadLinesIterator

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/ReadLinesIterator.cs
+++ b/src/System.IO.FileSystem/src/System/IO/ReadLinesIterator.cs
@@ -97,9 +97,7 @@ namespace System.IO
 
         private static ReadLinesIterator CreateIterator(string path, Encoding encoding, StreamReader reader)
         {
-            Stream stream = FileStream.InternalOpen(path, useAsync: false);
-
-            return new ReadLinesIterator(path, encoding, reader ?? new StreamReader(stream, encoding));
+            return new ReadLinesIterator(path, encoding, reader ?? new StreamReader(FileStream.InternalOpen(path, useAsync: false), encoding));
         }
     }
 }


### PR DESCRIPTION
We only need to construct a new one if we actually need it. This
will avoid keeping the file locked after the iterator is disposed.

#8773 
@ianhays, @pdelvo, @ericstj 