### PR TITLE
Avoid using tmp subdirectories in Pipes and MMF on Unix

### DIFF
--- a/src/Common/src/System/IO/PersistedFiles.Unix.cs
+++ b/src/Common/src/System/IO/PersistedFiles.Unix.cs
@@ -9,25 +9,7 @@ namespace System.IO
 {
     internal static partial class PersistedFiles
     {
-        private static string s_tempProductDirectory;
         private static string s_userProductDirectory;
-
-        /// <summary>
-        /// Get the location of where to store temporary files for a particular aspect of the framework,
-        /// such as "maps".
-        /// </summary>
-        /// <param name="featureName">The directory name for the feature</param>
-        /// <returns>A path within the temp directory for storing temporary files related to the feature.</returns>
-        internal static string GetTempFeatureDirectory(string featureName)
-        {
-            string path = s_tempProductDirectory;
-            if (path == null)
-            {
-                s_tempProductDirectory = path = Path.Combine(Path.GetTempPath(), TopLevelHiddenDirectory, SecondLevelDirectory);
-            }
-
-            return Path.Combine(path, featureName);
-        }
 
         /// <summary>
         /// Get the location of where to persist information for a particular aspect of the framework,

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -189,20 +189,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ShmOpen.cs">
       <Link>Common\Interop\Unix\Interop.ShmOpen.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEUid.cs">
-      <Link>Common\Interop\Unix\Interop.GetEUid.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPwUid.cs">
-      <Link>Common\Interop\Unix\Interop.GetPwUid.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Unlink.cs">
       <Link>Common\Interop\Unix\Interop.Unlink.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Names.Unix.cs">
-      <Link>Common\System\IO\PersistedFiles.Names.Unix.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Unix.cs">
-      <Link>Common\System\IO\PersistedFiles.Unix.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
@@ -209,13 +209,11 @@ namespace System.IO.MemoryMappedFiles
             }
         }
 
-        private static string s_tempMapsDirectory;
-
         private static FileStream CreateSharedBackingObjectUsingFile(Interop.Sys.MemoryMappedProtections protections, long capacity)
         {
-            string tempMapsDirectory = s_tempMapsDirectory ?? (s_tempMapsDirectory = PersistedFiles.GetTempFeatureDirectory("maps"));
-            Directory.CreateDirectory(tempMapsDirectory);
-            string path = Path.Combine(tempMapsDirectory, Guid.NewGuid().ToString("N"));
+            // We create a temporary backing file in TMPDIR.  We don't bother putting it into subdirectories as the file exists
+            // extremely briefly: it's opened/created and then immediately unlinked.
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
 
             FileAccess access =
                 (protections & (Interop.Sys.MemoryMappedProtections.PROT_READ | Interop.Sys.MemoryMappedProtections.PROT_WRITE)) != 0 ? FileAccess.ReadWrite :

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -227,9 +227,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.Pipe.cs">
       <Link>Common\Interop\Unix\Interop.Stat.Pipe.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Names.Unix.cs">
-      <Link>Common\System\IO\PersistedFiles.Names.Unix.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Threading\Tasks\ForceAsyncAwaiter.cs">
       <Link>Common\System\Threading\Tasks\ForceAsyncAwaiter.cs</Link>
     </Compile>

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -21,6 +21,12 @@ namespace System.IO.Pipes
         // Windows, but can't assume a valid handle on Unix.
         internal const bool CheckOperationsRequiresSetHandle = false;
 
+        /// <summary>Characters that can't be used in a pipe's name.</summary>
+        private readonly static char[] s_invalidFileNameChars = Path.GetInvalidFileNameChars();
+
+        /// <summary>Prefix to prepend to all pipe names.</summary>
+        private readonly static string s_pipePrefix = Path.Combine(Path.GetTempPath(), "CoreFxPipe_");
+
         internal static string GetPipePath(string serverName, string pipeName)
         {
             if (serverName != "." && serverName != Interop.Sys.GetHostName())
@@ -35,7 +41,7 @@ namespace System.IO.Pipes
                 throw new ArgumentOutOfRangeException(nameof(pipeName), SR.ArgumentOutOfRange_AnonymousReserved);
             }
 
-            if (pipeName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            if (pipeName.IndexOfAny(s_invalidFileNameChars) >= 0)
             {
                 // Since pipes are stored as files in the file system, we don't support
                 // pipe names that are actually paths or that otherwise have invalid
@@ -43,8 +49,11 @@ namespace System.IO.Pipes
                 throw new PlatformNotSupportedException(SR.PlatformNotSupproted_InvalidNameChars);
             }
 
-            // Return the pipe path
-            return Path.Combine(EnsurePipeDirectoryPath(), pipeName);
+            // Return the pipe path.  The pipe is created directly under %TMPDIR%.  We don't bother
+            // putting it into subdirectories, as the pipe will only exist on disk for the
+            // duration between when the server starts listening and the client connects, after
+            // which the pipe will be deleted.
+            return s_pipePrefix + pipeName;
         }
 
         /// <summary>Throws an exception if the supplied handle does not represent a valid pipe.</summary>
@@ -322,8 +331,6 @@ namespace System.IO.Pipes
         // ---- PAL layer ends here ----
         // -----------------------------
 
-        private static string s_pipeDirectoryPath;
-
         /// <summary>
         /// We want to ensure that only one asynchronous operation is actually in flight
         /// at a time. The base Stream class ensures this by serializing execution via a 
@@ -335,59 +342,6 @@ namespace System.IO.Pipes
         private SemaphoreSlim EnsureAsyncActiveSemaphoreInitialized()
         {
             return LazyInitializer.EnsureInitialized(ref _asyncActiveSemaphore, () => new SemaphoreSlim(1, 1));
-        }
-
-        private static string EnsurePipeDirectoryPath()
-        {
-            const string PipesFeatureName = "pipe";
-
-            // Ideally this would simply use PersistedFiles.GetTempFeatureDirectory(PipesFeatureName) and then
-            // Directory.CreateDirectory to ensure it exists.  But this assembly doesn't reference System.IO.FileSystem.
-            // As such, we'd be calling GetTempFeatureDirectory, only to then need to parse it in order
-            // to create each of the individual directories as part of the path.  We instead access the named portions 
-            // of the path directly and do the building of the path and directory structure manually.
-
-            // First ensure we know what the full path should be, e.g. /tmp/.dotnet/corefx/pipe/
-            string fullPath = s_pipeDirectoryPath;
-            string tempPath = null;
-            if (fullPath == null)
-            {
-                tempPath = Path.GetTempPath();
-                fullPath = Path.Combine(tempPath, PersistedFiles.TopLevelHiddenDirectory, PersistedFiles.SecondLevelDirectory, PipesFeatureName);
-                s_pipeDirectoryPath = fullPath;
-            }
-
-            // Then create the directory if it doesn't already exist.  If we get any error back from stat,
-            // just proceed to build up the directory, failing in the CreateDirectory calls if there's some
-            // problem.  Similarly, it's possible stat succeeds but the path is a file rather than directory; we'll
-            // call that success for now and let this fail later when the code tries to create a file in this "directory"
-            // (we don't want to overwrite/delete whatever that unknown file may be, and this is similar to other cases
-            // we can't control where the file system is manipulated concurrently with and separately from this code).
-            Interop.Sys.FileStatus ignored;
-            bool pathExists = Interop.Sys.Stat(fullPath, out ignored) == 0;
-            if (!pathExists)
-            {
-                // We need to build up the directory manually.  Ensure we have the temp directory in which
-                // we'll create the structure, e.g. /tmp/
-                if (tempPath == null)
-                {
-                    tempPath = Path.GetTempPath();
-                }
-                Debug.Assert(Interop.Sys.Stat(tempPath, out ignored) == 0, "Path.GetTempPath() directory could not be accessed");
-
-                // Create /tmp/.dotnet/ if it doesn't exist.
-                string partialPath = Path.Combine(tempPath, PersistedFiles.TopLevelHiddenDirectory);
-                CreateDirectory(partialPath);
-
-                // Create /tmp/.dotnet/corefx/ if it doesn't exist
-                partialPath = Path.Combine(partialPath, PersistedFiles.SecondLevelDirectory);
-                CreateDirectory(partialPath);
-
-                // Create /tmp/.dotnet/corefx/pipe/ if it doesn't exist
-                CreateDirectory(fullPath);
-            }
-
-            return fullPath;
         }
 
         private static void CreateDirectory(string directoryPath)


### PR DESCRIPTION
When we originally implemented the System.IO.Pipes and System.IO.MemoryMappedFiles libraries on Unix, they would end up persisting temporary files for potentially long durations, and in a manner that would make it likely for these files to persist even after a clean process shutdown.  As a result, we put these temporary files in subdirectories of TMPDIR, e.g. /tmp/.dotnet/corefx/maps/.

Since then, we've changed these implementations such that the files are much less persistent.  Files created by the MMF library exist only for a moment, created and then immediately unlinked.  And files created by the pipes library typically also exist for a very short period of time, between the time when the server starts listening and the client connects, after which the file is deleted.  This makes the subdirectories much less useful.

Further, the subdirectories cause permissions problems.  When mkdir is used to create a directory, the process' umask is automatically applied, such that even if we ask for 777 permissions, we're likely to actually create the directory as 775 (if we're a normal user) or as 755 (if we're root).  In either case, this causes problems when one user creates the temporary directory that another user then tries to open and write into.  There are workarounds for this, such as creating a temporary directory with mkdir, chmod'ing it to get the actual desired permissions, and then renaming that to the actual target directory desired, but that's complicated and leads to more potential points of unnecessary failure.

As a result of all of this, we can simply do away with these subdirectories, simplifying the code and leading to fewer issues in production.

cc: @ellismg, @bartonjs
Fixes https://github.com/dotnet/corefx/issues/8761