### PR TITLE
Check for NULL before deciding on returning default value

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionOptions.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionOptions.cs
@@ -223,7 +223,7 @@ namespace System.Data.Common
         public string ConvertValueToString(string keyName, string defaultValue)
         {
             string value;
-            return _parsetable.TryGetValue(keyName, out value) ? value : defaultValue;
+            return _parsetable.TryGetValue(keyName, out value) && value != null ? value : defaultValue;
         }
 
         static private bool CompareInsensitiveInvariant(string strvalue, string strconst)


### PR DESCRIPTION
The connection string parsing adds nulls in the parse table for empty string values.
This should be checked while returning the default value.

The functionality regressed when HashTables were replaced by Dictionary