### PR TITLE
Add back System.Runtime forwards for GCHandle

### DIFF
--- a/src/System.Runtime/src/System.Runtime.Forwards.cs
+++ b/src/System.Runtime/src/System.Runtime.Forwards.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements. 
+// The .NET Foundation licenses this file to you under the MIT license. 
+// See the LICENSE file in the project root for more information. 
+
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandle))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandleType))]

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -16,6 +16,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System.Runtime.Forwards.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net462'">
     <Compile Include="System\Action.cs" />
     <Compile Include="System\Function.cs" />


### PR DESCRIPTION
Adding these forwards back to make upgrades from rc2 easier.