### PR TITLE
Execute Windows Nano tests in parallel.

### DIFF
--- a/run-test.cmd
+++ b/run-test.cmd
@@ -9,9 +9,11 @@ pushd %1
 FOR /D %%F IN (*.Tests) DO (
 	IF EXIST %%F\netstandard\dnxcore50 (
 		pushd %%F\netstandard\dnxcore50
-		CALL RunTests.cmd %2
+		START /b cmd /c RunTests.cmd %2
 		popd
 	)
 )
 
 popd
+
+exit


### PR DESCRIPTION
cc @ellismg 

Currently Windows Nano test job alone takes an hour to run, with the build job around 3 hrs. This should provide some improvement.