### PR TITLE
Remove redundant code from Stack<T>.Contains

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -100,12 +100,7 @@ namespace System.Collections.Generic
             EqualityComparer<T> c = EqualityComparer<T>.Default;
             while (count-- > 0)
             {
-                if (((Object)item) == null)
-                {
-                    if (((Object)_array[count]) == null)
-                        return true;
-                }
-                else if (_array[count] != null && c.Equals(_array[count], item))
+                if (c.Equals(_array[count], item))
                 {
                     return true;
                 }


### PR DESCRIPTION
Was browsing through the source for `Stack` when I noticed this; we don't need to specialize explicitly for null, as `EqualityComparer<T>.Default` handles this for us. Same change as was made for `Queue` in #5276.

cc @ianhays @stephentoub 