### PR TITLE
Check for NULL before deciding on returning default value

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionOptions.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionOptions.cs
@@ -223,7 +223,7 @@ namespace System.Data.Common
         public string ConvertValueToString(string keyName, string defaultValue)
         {
             string value;
-            return _parsetable.TryGetValue(keyName, out value) ? value : defaultValue;
+            return _parsetable.TryGetValue(keyName, out value) && value != null ? value : defaultValue;
         }
 
         static private bool CompareInsensitiveInvariant(string strvalue, string strconst)


### PR DESCRIPTION
The repro code is below 
SqlConnectionStringBuilder bldr = new SqlConnectionStringBuilder(); bldr.Password = string.Empty; SqlConnection conn = new SqlConnection(bldr.ConnectionString); 

The above code throws a NullReferenceException when an empty password is set.
The Connection string should allow an empty password