### PR TITLE
Remove string constants partial duplication

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography.X509Certificates
     public sealed class X509Store : IDisposable
     {
         public X509Store()
-            : this("MY", StoreLocation.CurrentUser)
+            : this(StoreName.My, StoreLocation.CurrentUser)
         {
         }
 


### PR DESCRIPTION
Use "name enum" version of the constructor instead of "name string" version. This resolves https://github.com/dotnet/corefx/issues/8845