### PR TITLE
Bump S.R.Metadata to v1.4

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
@@ -227,7 +227,7 @@
       <Version>4.0.1</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Reflection.Metadata">
-      <Version>1.3.0</Version>
+      <Version>1.4.0</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Reflection">
       <Version>4.1.0</Version>

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -11,7 +11,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <NoWarn>1591</NoWarn>
     <CLSCompliant>false</CLSCompliant>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
     <DefineConstants>$(DefineConstants)</DefineConstants>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
   </PropertyGroup>


### PR DESCRIPTION
Follow up to #8850, make the master/vnext version 1.4. Roslyn future should upgrade to 1.4 once packages are published.

@tmat