### PR TITLE
Fix for Interop.mincore.IdnToAscii/IdnToUnicode fails on UWP issue

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.Idna.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Idna.cs
@@ -14,23 +14,21 @@ internal partial class Interop
         //
 
         [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static unsafe extern int IdnToAscii(
+        internal static extern int IdnToAscii(
                                         uint dwFlags,
-                                        char* lpUnicodeCharStr,
+                                        IntPtr lpUnicodeCharStr,
                                         int cchUnicodeChar,
                                         [System.Runtime.InteropServices.OutAttribute()]
-
-                                        char* lpASCIICharStr,
+                                        IntPtr lpASCIICharStr,
                                         int cchASCIIChar);
 
         [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static unsafe extern int IdnToUnicode(
+        internal static extern int IdnToUnicode(
                                         uint dwFlags,
-                                        char* lpASCIICharStr,
+                                        IntPtr lpASCIICharStr,
                                         int cchASCIIChar,
                                         [System.Runtime.InteropServices.OutAttribute()]
-
-                                        char* lpUnicodeCharStr,
+                                        IntPtr lpUnicodeCharStr,
                                         int cchUnicodeChar);
 
         internal const int IDN_ALLOW_UNASSIGNED = 0x1;

--- a/src/Common/src/System/Globalization/IdnMapping.Windows.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Windows.cs
@@ -14,7 +14,7 @@ namespace System.Globalization
             uint flags = Flags;
 
             // Determine the required length
-            int length = Interop.mincore.IdnToAscii(flags, unicode, count, null, 0);
+            int length = Interop.mincore.IdnToAscii(flags, new IntPtr(unicode), count, IntPtr.Zero, 0);
             if (length == 0)
             {
                 ThrowForZeroLength(nameof(unicode), SR.Argument_IdnIllegalName, SR.Argument_InvalidCharSequenceNoIndex);
@@ -39,7 +39,7 @@ namespace System.Globalization
 
         private unsafe string GetAsciiCore(char* unicode, int count, uint flags, char* output, int outputLength)
         {
-            int length = Interop.mincore.IdnToAscii(flags, unicode, count, output, outputLength);
+            int length = Interop.mincore.IdnToAscii(flags, new IntPtr(unicode), count, new IntPtr(output), outputLength);
             if (length == 0)
             {
                 ThrowForZeroLength(nameof(unicode), SR.Argument_IdnIllegalName, SR.Argument_InvalidCharSequenceNoIndex);
@@ -53,7 +53,7 @@ namespace System.Globalization
             uint flags = Flags;
 
             // Determine the required length
-            int length = Interop.mincore.IdnToUnicode(flags, ascii, count, null, 0);
+            int length = Interop.mincore.IdnToUnicode(flags, new IntPtr(ascii), count, IntPtr.Zero, 0);
             if (length == 0)
             {
                 ThrowForZeroLength(nameof(ascii), SR.Argument_IdnIllegalName, SR.Argument_IdnBadPunycode);
@@ -78,7 +78,7 @@ namespace System.Globalization
 
         private unsafe string GetUnicodeCore(char* ascii, int count, uint flags, char* output, int outputLength)
         {
-            int length = Interop.mincore.IdnToUnicode(flags, ascii, count, output, outputLength);
+            int length = Interop.mincore.IdnToUnicode(flags, new IntPtr(ascii), count, new IntPtr(output), outputLength);
             if (length == 0)
             {
                 ThrowForZeroLength(nameof(ascii), SR.Argument_IdnIllegalName, SR.Argument_IdnBadPunycode);


### PR DESCRIPTION
The pinvoke definition in Interop.Idna.cs isn't compatible with UWP
apps. This change will make sure these pinvoke definition works fine
with Visual Studio 2015 Update 2.

also Update the other char * to IntPtr for consistency--- 
Suggested by Stephentoub in code review comment