### PR TITLE
Cleanup Stack tests, add tests for Contains

### DIFF
--- a/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
+++ b/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
@@ -17,7 +17,7 @@ namespace System.Collections.Tests
     /// </summary>
     public abstract class IGenericSharedAPI_Tests<T> : IEnumerable_Generic_Tests<T>
     {
-        #region IGenericSharedAPI<T> Helper methods
+        // IGenericSharedAPI<T> Helper methods
 
         protected virtual bool DuplicateValuesAllowed { get { return true; } }
         protected virtual bool DefaultValueWhenNotAllowed_Throws { get { return true; } }
@@ -48,9 +48,7 @@ namespace System.Collections.Tests
         protected abstract void CopyTo(IEnumerable<T> enumerable, T[] array, int index);
         protected abstract bool Remove(IEnumerable<T> enumerable);
 
-        #endregion
-
-        #region IEnumerable<T> helper methods
+        // IEnumerable<T> helper methods
 
         protected override IEnumerable<T> GenericIEnumerableFactory(int count)
         {
@@ -89,9 +87,8 @@ namespace System.Collections.Tests
                 };
             }
         }
-        #endregion
 
-        #region Count
+        // Count
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -101,9 +98,7 @@ namespace System.Collections.Tests
             Assert.Equal(count, Count(collection));
         }
 
-        #endregion
-
-        #region Add
+        // Add
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -234,9 +229,7 @@ namespace System.Collections.Tests
             }
         }
 
-        #endregion
-
-        #region Clear
+        // Clear
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -255,9 +248,7 @@ namespace System.Collections.Tests
             }
         }
 
-        #endregion
-
-        #region Contains
+        // Contains
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -339,9 +330,7 @@ namespace System.Collections.Tests
             }
         }
 
-        #endregion
-
-        #region CopyTo
+        // CopyTo
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -413,7 +402,5 @@ namespace System.Collections.Tests
             CopyTo(collection, array, 0);
             Assert.True(Enumerable.SequenceEqual(collection, array.Take(count)));
         }
-
-        #endregion
     }
 }

--- a/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
+++ b/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
@@ -280,28 +280,6 @@ namespace System.Collections.Tests
             // Collection should contain whatever items are added back to it
             Assert.All(array, item => Assert.True(Contains(collection, item)));
         }
-        
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IGenericSharedAPI_Contains_BasicFunctionality(int count)
-        {
-            IEnumerable<T> collection = GenericIEnumerableFactory(count);
-            T[] array = collection.ToArray();
-            
-            // Collection should contain all items that result from enumeration
-            Assert.All(array, item => Assert.True(Contains(collection, item)));
-            
-            Clear(collection);
-            
-            // Collection should not contain any items after being cleared
-            Assert.All(array, item => Assert.False(Contains(collection, item)));
-            
-            foreach (T item in array)
-                Add(collection, item);
-            
-            // Collection should contain whatever items are added back to it
-            Assert.All(array, item => Assert.True(Contains(collection, item)));
-        }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]

--- a/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
+++ b/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
@@ -17,7 +17,7 @@ namespace System.Collections.Tests
     /// </summary>
     public abstract class IGenericSharedAPI_Tests<T> : IEnumerable_Generic_Tests<T>
     {
-        // IGenericSharedAPI<T> Helper methods
+        #region IGenericSharedAPI<T> Helper methods
 
         protected virtual bool DuplicateValuesAllowed { get { return true; } }
         protected virtual bool DefaultValueWhenNotAllowed_Throws { get { return true; } }
@@ -48,7 +48,9 @@ namespace System.Collections.Tests
         protected abstract void CopyTo(IEnumerable<T> enumerable, T[] array, int index);
         protected abstract bool Remove(IEnumerable<T> enumerable);
 
-        // IEnumerable<T> helper methods
+        #endregion
+
+        #region IEnumerable<T> helper methods
 
         protected override IEnumerable<T> GenericIEnumerableFactory(int count)
         {
@@ -87,8 +89,9 @@ namespace System.Collections.Tests
                 };
             }
         }
+        #endregion
 
-        // Count
+        #region Count
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -98,7 +101,9 @@ namespace System.Collections.Tests
             Assert.Equal(count, Count(collection));
         }
 
-        // Add
+        #endregion
+
+        #region Add
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -229,7 +234,9 @@ namespace System.Collections.Tests
             }
         }
 
-        // Clear
+        #endregion
+
+        #region Clear
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -247,8 +254,32 @@ namespace System.Collections.Tests
                 Assert.Equal(0, Count(collection));
             }
         }
+        
+        #endregion
 
-        // Contains
+        #region Contains
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void IGenericSharedAPI_Contains_BasicFunctionality(int count)
+        {
+            IEnumerable<T> collection = GenericIEnumerableFactory(count);
+            T[] array = collection.ToArray();
+            
+            // Collection should contain all items that result from enumeration
+            Assert.All(array, item => Assert.True(Contains(collection, item)));
+            
+            Clear(collection);
+            
+            // Collection should not contain any items after being cleared
+            Assert.All(array, item => Assert.False(Contains(collection, item)));
+            
+            foreach (T item in array)
+                Add(collection, item);
+            
+            // Collection should contain whatever items are added back to it
+            Assert.All(array, item => Assert.True(Contains(collection, item)));
+        }
         
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -352,7 +383,9 @@ namespace System.Collections.Tests
             }
         }
 
-        // CopyTo
+        #endregion
+
+        #region CopyTo
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -424,5 +457,7 @@ namespace System.Collections.Tests
             CopyTo(collection, array, 0);
             Assert.True(Enumerable.SequenceEqual(collection, array.Take(count)));
         }
+
+        #endregion
     }
 }

--- a/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
+++ b/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
@@ -249,6 +249,28 @@ namespace System.Collections.Tests
         }
 
         // Contains
+        
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void IGenericSharedAPI_Contains_BasicFunctionality(int count)
+        {
+            IEnumerable<T> collection = GenericIEnumerableFactory(count);
+            T[] array = collection.ToArray();
+            
+            // Collection should contain all items that result from enumeration
+            Assert.All(array, item => Assert.True(Contains(collection, item)));
+            
+            Clear(collection);
+            
+            // Collection should not contain any items after being cleared
+            Assert.All(array, item => Assert.False(Contains(collection, item)));
+            
+            foreach (T item in array)
+                Add(collection, item);
+            
+            // Collection should contain whatever items are added back to it
+            Assert.All(array, item => Assert.True(Contains(collection, item)));
+        }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]

--- a/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
+++ b/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
@@ -445,7 +445,7 @@ namespace System.Collections.Tests
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
             T[] array = new T[count];
             CopyTo(collection, array, 0);
-            Assert.True(Enumerable.SequenceEqual(collection, array));
+            Assert.Equal(collection, array);
         }
 
         [Theory]
@@ -455,7 +455,7 @@ namespace System.Collections.Tests
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
             T[] array = new T[count * 3 / 2];
             CopyTo(collection, array, 0);
-            Assert.True(Enumerable.SequenceEqual(collection, array.Take(count)));
+            Assert.Equal(collection, array.Take(count));
         }
 
         #endregion

--- a/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
@@ -53,8 +53,8 @@ namespace System.Collections.Tests
         protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
 
         #endregion
-        
-        // Constructor
+
+        #region Constructor
         
         [Fact]
         public void Stack_Generic_Constructor_InitialValues()
@@ -64,8 +64,10 @@ namespace System.Collections.Tests
             Assert.Equal(0, stack.ToArray().Length);
             Assert.NotNull(((ICollection)stack).SyncRoot);
         }
-        
-        // IEnumerable constructor
+
+        #endregion
+
+        #region Constructor_IEnumerable
 
         [Theory]
         [MemberData(nameof(EnumerableTestData))]
@@ -81,8 +83,10 @@ namespace System.Collections.Tests
         {
             Assert.Throws<ArgumentNullException>("collection", () => new Stack<T>(null));
         }
-        
-        // Capacity-based constructor
+
+        #endregion
+
+        #region Constructor_Capacity
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -98,8 +102,10 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Stack<T>(-1));
             Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Stack<T>(int.MinValue));
         }
-        
-        // Pop
+
+        #endregion
+
+        #region Pop
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -117,7 +123,9 @@ namespace System.Collections.Tests
             Assert.Throws<InvalidOperationException>(() => new Stack<T>().Pop());
         }
 
-        // ToArray
+        #endregion
+
+        #region ToArray
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -127,7 +135,9 @@ namespace System.Collections.Tests
             Assert.Equal(stack.ToArray(), stack.ToArray());
         }
 
-        // Peek
+        #endregion
+
+        #region Peek
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -148,7 +158,9 @@ namespace System.Collections.Tests
             Assert.Throws<InvalidOperationException>(() => new Stack<T>().Peek());
         }
 
-        // TrimExcess
+        #endregion
+
+        #region TrimExcess
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -224,5 +236,7 @@ namespace System.Collections.Tests
                 Assert.Equal(count, stack.Count);
             }
         }
+
+        #endregion
     }
 }

--- a/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
@@ -132,7 +132,7 @@ namespace System.Collections.Tests
         public void Stack_Generic_ToArray(int count)
         {
             Stack<T> stack = GenericStackFactory(count);
-            Assert.Equal(stack.ToArray(), stack.ToArray());
+            Assert.Equal(Enumerable.ToArray(stack), stack.ToArray());
         }
 
         #endregion

--- a/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
@@ -54,7 +54,16 @@ namespace System.Collections.Tests
 
         #endregion
         
-        // Constructor (TODO)
+        // Constructor
+        
+        [Fact]
+        public void Stack_Generic_Constructor_InitialValues()
+        {
+            var stack = new Stack<T>();
+            Assert.Equal(0, stack.Count);
+            Assert.Equal(0, stack.ToArray().Length);
+            Assert.NotNull(((ICollection)stack).SyncRoot);
+        }
         
         // IEnumerable constructor
 

--- a/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
@@ -53,12 +53,10 @@ namespace System.Collections.Tests
         protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
 
         #endregion
-
-        #region Constructor
-
-        #endregion
-
-        #region Constructor_IEnumerable
+        
+        // Constructor (TODO)
+        
+        // IEnumerable constructor
 
         [Theory]
         [MemberData(nameof(EnumerableTestData))]
@@ -74,10 +72,8 @@ namespace System.Collections.Tests
         {
             Assert.Throws<ArgumentNullException>("collection", () => new Stack<T>(null));
         }
-
-        #endregion
-
-        #region Constructor_Capacity
+        
+        // Capacity-based constructor
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -93,10 +89,8 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Stack<T>(-1));
             Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Stack<T>(int.MinValue));
         }
-
-        #endregion
-
-        #region Pop
+        
+        // Pop
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -114,21 +108,17 @@ namespace System.Collections.Tests
             Assert.Throws<InvalidOperationException>(() => new Stack<T>().Pop());
         }
 
-        #endregion
-
-        #region ToArray
+        // ToArray
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void Stack_Generic_ToArray(int count)
         {
             Stack<T> stack = GenericStackFactory(count);
-            Assert.True(stack.ToArray().SequenceEqual(stack.ToArray<T>()));
+            Assert.Equal(stack.ToArray(), stack.ToArray());
         }
 
-        #endregion
-
-        #region Peek
+        // Peek
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -149,9 +139,7 @@ namespace System.Collections.Tests
             Assert.Throws<InvalidOperationException>(() => new Stack<T>().Peek());
         }
 
-        #endregion
-
-        #region TrimExcess
+        // TrimExcess
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
@@ -165,12 +153,12 @@ namespace System.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void Stack_Generic_TrimExcess_Repeatedly(int count)
         {
-            Stack<T> stack = GenericStackFactory(count);;
+            Stack<T> stack = GenericStackFactory(count);
             List<T> expected = stack.ToList();
             stack.TrimExcess();
             stack.TrimExcess();
             stack.TrimExcess();
-            Assert.True(stack.SequenceEqual(expected));
+            Assert.Equal(expected, stack);
         }
 
         [Theory]
@@ -179,7 +167,7 @@ namespace System.Collections.Tests
         {
             if (count > 0)
             {
-                Stack<T> stack = GenericStackFactory(count);;
+                Stack<T> stack = GenericStackFactory(count);
                 List<T> expected = stack.ToList();
                 T elementToRemove = stack.ElementAt(0);
 
@@ -188,7 +176,7 @@ namespace System.Collections.Tests
                 expected.RemoveAt(0);
                 stack.TrimExcess();
 
-                Assert.True(stack.SequenceEqual(expected));
+                Assert.Equal(expected, stack);
             }
         }
 
@@ -198,7 +186,7 @@ namespace System.Collections.Tests
         {
             if (count > 0)
             {
-                Stack<T> stack = GenericStackFactory(count);;
+                Stack<T> stack = GenericStackFactory(count);
                 stack.TrimExcess();
                 stack.Clear();
                 stack.TrimExcess();
@@ -216,7 +204,7 @@ namespace System.Collections.Tests
         {
             if (count > 0)
             {
-                Stack<T> stack = GenericStackFactory(count);;
+                Stack<T> stack = GenericStackFactory(count);
                 stack.TrimExcess();
                 stack.Clear();
                 stack.TrimExcess();
@@ -227,7 +215,28 @@ namespace System.Collections.Tests
                 Assert.Equal(count, stack.Count);
             }
         }
-
-        #endregion
+        
+        // Contains
+        
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void Stack_Generic_Contains_BasicFunctionality(int count)
+        {
+            Stack<T> stack = GenericStackFactory(count);
+            List<T> list = stack.ToList();
+            
+            // Stack should contain all items that result from enumeration
+            Assert.All(list, item => Assert.True(stack.Contains(item)));
+            
+            stack.Clear();
+            
+            // Stack should not contain any items after being cleared
+            Assert.All(list, item => Assert.False(stack.Contains(item)));
+            
+            foreach (T item in list) stack.Push(item);
+            
+            // Stack should contain whatever items are pushed to it
+            Assert.All(list, item => Assert.True(stack.Contains(item)));
+        }
     }
 }

--- a/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
@@ -224,28 +224,5 @@ namespace System.Collections.Tests
                 Assert.Equal(count, stack.Count);
             }
         }
-        
-        // Contains
-        
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void Stack_Generic_Contains_BasicFunctionality(int count)
-        {
-            Stack<T> stack = GenericStackFactory(count);
-            List<T> list = stack.ToList();
-            
-            // Stack should contain all items that result from enumeration
-            Assert.All(list, item => Assert.True(stack.Contains(item)));
-            
-            stack.Clear();
-            
-            // Stack should not contain any items after being cleared
-            Assert.All(list, item => Assert.False(stack.Contains(item)));
-            
-            foreach (T item in list) stack.Push(item);
-            
-            // Stack should contain whatever items are pushed to it
-            Assert.All(list, item => Assert.True(stack.Contains(item)));
-        }
     }
 }


### PR DESCRIPTION
Adds tests for the changes made in #8833 (I thought I'd make a separate PR), as well as a few more changes:

- Remove excessive `#region` usage
- Replace some `Assert.True(x.SequenceEqual(y))` usage with `Assert.Equal(x, y)` (xUnit supports collections)

cc @ianhays @stephentoub 