### PR TITLE
Resize grouping elements when necessary within ToArray/List.

### DIFF
--- a/src/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/System.Linq/src/System/Linq/Grouping.cs
@@ -85,6 +85,14 @@ namespace System.Linq
             _count++;
         }
 
+        internal void Trim()
+        {
+            if (_elements.Length != _count)
+            {
+                Array.Resize(ref _elements, _count);
+            }
+        }
+
         public IEnumerator<TElement> GetEnumerator()
         {
             for (int i = 0; i < _count; i++)

--- a/src/System.Linq/src/System/Linq/Lookup.cs
+++ b/src/System.Linq/src/System/Linq/Lookup.cs
@@ -189,6 +189,7 @@ namespace System.Linq
                 do
                 {
                     g = g._next;
+                    g.Trim();
                     array[index] = resultSelector(g._key, g._elements);
                     ++index;
                 }
@@ -224,6 +225,7 @@ namespace System.Linq
                 do
                 {
                     g = g._next;
+                    g.Trim();
                     list.Add(resultSelector(g._key, g._elements));
                 }
                 while (g != _lastGrouping);
@@ -245,11 +247,7 @@ namespace System.Linq
                 do
                 {
                     g = g._next;
-                    if (g._count != g._elements.Length)
-                    {
-                        Array.Resize(ref g._elements, g._count);
-                    }
-
+                    g.Trim();
                     yield return resultSelector(g._key, g._elements);
                 }
                 while (g != _lastGrouping);


### PR DESCRIPTION
Groupings are created with extraneous empty elements and resized on-the-fly as needed. The optimised `ToArray` and `ToList` methods weren’t doing that. Fix this.

Fixes #8848