### PR TITLE
Delay HttpResponseMessage publishing in CurlHandler until all request data sent

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -101,6 +101,7 @@ namespace System.Net.Http
         private const int MaxRequestBufferSize = 16384; // Default used by libcurl
         private const string NoTransferEncoding = HttpKnownHeaderNames.TransferEncoding + ":";
         private const string NoContentType = HttpKnownHeaderNames.ContentType + ":";
+        private const string NoExpect = HttpKnownHeaderNames.Expect + ":";
         private const int CurlAge = 5;
         private const int MinCurlAge = 3;
 


### PR DESCRIPTION
libcurl uses a callback model, where it asks for request data when it wants to send it and passes back response information as it's received.  It doesn't enforce any significant constraints on top of this, such that if a server sends response headers and even body before all of the request information has been received, libcurl will dutifully pass that data back to the application as it's received.  CurlHandler responses to receiving response body data by completing the SendAsync with the HttpResponseMessage, which means it can complete this task after receiving all response headers but in some cases before all of the request data has been sent.  This can actually be beneficial for some scenarios, however with the current HttpClient implementation, it can cause a problem: the request message is Dispose'd of as soon as the SendAsync Task completes, which means HttpClient might dispose of the request message while we're still trying to send data from it.

There are two high-level solutions here:
1. Stop always disposing of the request message when SendAsync completes, leaving such disposal up to the consumer (or moving the responsibility to the handler), and state that it's allowed for a handler to complete the SendAsync task when all response headers have been received even if all request data has not yet been sent.
2. Force CurlHandler to not complete the SendAsync task until all request data has been sent, even if the response headers were completed before then.

While in the future I would like to see us go with (1), as it opens up additional scenarios and simplifies this implementation, a decision was made to go with (2) for now.  This PR implements that.  There are two commits:
- The first commit adds a bunch of additional tracing.  This was beneficial in tracking down the cause of the original problem as seen in some WCF workloads, and it's useful to check it in to help with future investigations.
- The second commit adds the completion delay to SendAsync.  This is done primarily in the routine that's used to complete the SendAsync task and publish the response message: it now keeps track of whether it was previously invoked, and if it wasn't, it proceeds to do the publishing... but if a copy operation is still in progress, rather than doing the publishing directly, it hooks up a continuation to the copy task so that the publishing will be done when the copy completes.  It also disables the "Expect: 100-continue" header that libcurl uses with posts by default, as otherwise libcurl may decide in certain situations not to send the payload, and if we've already kicked off the copy operation, we could end up hanging until the operation times out (such hanging is the biggest risk with this change).

I also added several additional tests.

cc: @davidsh, @ericeil, @mconnew, @KKhurin, @bartonjs
Fixes https://github.com/dotnet/wcf/issues/1211