### PR TITLE
Switch test-runtime to NETStandard.Library

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -82,7 +82,7 @@
     <ValidatePackageVersions>true</ValidatePackageVersions>
     <ProhibitFloatingDependencies>true</ProhibitFloatingDependencies>
     <CoreFxExpectedPrerelease>rc4-24131-00</CoreFxExpectedPrerelease>
-    <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore.*)|(Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative))|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)(?&lt;!System\.Data\.SqlClient)(?&lt;!System\.IO\.Compression)$</CoreFxVersionsIdentityRegex>
+    <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore\.Targets)|(Microsoft\.NETCore\.Platforms)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)(?&lt;!System\.Data\.SqlClient)(?&lt;!System\.IO\.Compression)$</CoreFxVersionsIdentityRegex>
   </PropertyGroup>
   
   <Import Project="$(MSBuildThisFileDirectory)pkg/ExternalPackages/versions.props" Condition="Exists('$(MSBuildThisFileDirectory)pkg/ExternalPackages/versions.props')" />
@@ -90,6 +90,14 @@
   <ItemGroup>
     <ValidationPattern Include="CoreFxVersions">
       <IdentityRegex>$(CoreFxVersionsIdentityRegex)</IdentityRegex>
+      <ExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExpectedPrerelease>
+    </ValidationPattern>
+    <ValidationPattern Include="CoreClrVersions">
+      <IdentityRegex>^(?i)Microsoft\.NETCore\.Runtime.*$</IdentityRegex>
+      <ExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExpectedPrerelease>
+    </ValidationPattern>
+    <ValidationPattern Include="CoreLibTargetingPackVersions">
+      <IdentityRegex>^(?i)Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative)$</IdentityRegex>
       <ExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExpectedPrerelease>
     </ValidationPattern>
     <ValidationPattern Include="ExternalVersions">

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -2,9 +2,12 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
     "Microsoft.NETCore.TestHost": "1.0.0-rc4-24131-00",
-    "Microsoft.NETCore.Console": "1.0.0-rc4-24131-00",
+    "Microsoft.NETCore.Runtime": "1.0.2-rc4-24131-00",
+    "NETStandard.Library": "1.6.0-rc4-24131-00",
+    "System.Diagnostics.Contracts": "4.0.1-rc4-24131-00",
     "System.IO.Compression": "4.1.0-rc4-24131-00",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc4-24131-00",
+    "System.Linq.Parallel": "4.0.1-rc4-24131-00",
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.3",

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -2,6 +2,8 @@
   "dependencies": {
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0035",
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
+    "System.Collections.NonGeneric": "4.0.1-rc4-24131-00",
+    "System.Collections.Specialized": "4.0.1-rc4-24131-00",
     "System.ComponentModel.Primitives": "4.1.0-rc4-24131-00",
     "System.Globalization": "4.0.11-rc4-24131-00",
     "System.Linq.Expressions": "4.1.0-rc4-24131-00",

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -2,7 +2,10 @@
   "dependencies": {
     "Microsoft.CSharp": "4.0.1-rc4-24131-00",
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
+    "runtime.native.System.Data.SqlClient.sni": "4.0.0-rc3-24131-00",
     "System.Data.Common": "4.1.0-rc4-24131-00",
+    "System.Data.SqlClient": "4.1.0-rc4-24131-00",
+    "System.Text.Encoding.CodePages": "4.0.1-rc4-24131-00",
     "System.Text.RegularExpressions": "4.1.0-rc4-24131-00",
     "System.Collections": "4.0.11-rc4-24131-00",
     "System.Collections.Concurrent": "4.0.12-rc4-24131-00",

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
+    "System.Diagnostics.FileVersionInfo": "4.0.0-rc4-24131-00",
     "System.Globalization": "4.0.11-rc4-24131-00",
     "System.IO.FileSystem": "4.0.1-rc4-24131-00",
     "System.Linq.Expressions": "4.1.0-rc4-24131-00",

--- a/src/System.Reflection.Metadata/tests/project.json
+++ b/src/System.Reflection.Metadata/tests/project.json
@@ -8,6 +8,7 @@
     "System.IO": "4.1.0-rc4-24131-00",
     "System.IO.FileSystem": "4.0.1-rc4-24131-00",
     "System.IO.FileSystem.Primitives": "4.0.1-rc4-24131-00",
+    "System.IO.MemoryMappedFiles": "4.0.0-rc4-24131-00",
     "System.Linq": "4.1.0-rc4-24131-00",
     "System.Linq.Expressions": "4.1.0-rc4-24131-00",
     "System.ObjectModel": "4.0.12-rc4-24131-00",

--- a/src/System.Threading.Tasks.Dataflow/tests/project.json
+++ b/src/System.Threading.Tasks.Dataflow/tests/project.json
@@ -5,6 +5,7 @@
     "System.Diagnostics.Contracts": "4.0.1-rc4-24131-00",
     "System.Diagnostics.Debug": "4.0.11-rc4-24131-00",
     "System.Diagnostics.Tracing": "4.1.0-rc4-24131-00",
+    "System.Dynamic.Runtime": "4.0.11-rc4-24131-00",
     "System.Linq": "4.1.0-rc4-24131-00",
     "System.Linq.Expressions": "4.1.0-rc4-24131-00",
     "System.ObjectModel": "4.0.12-rc4-24131-00",


### PR DESCRIPTION
Microsoft.NETCore.Console soon won't be built with the same versioning
as the rest of CoreFx: https://github.com/dotnet/core-setup/pull/14

We don't want to have to "know" which version of this package is
consistent with the CoreFx version we're picking up.

In addition to this Microsoft.NETCore.Console was too large: we really
only need the test-runtime to bring in a closure of dependencies for the
test runner and libraries.

In addition to this I've split up the validation rules for packages that
will soon start coming from other repos.

/cc @weshaggard @joperezr @karajas @dagood 