### PR TITLE
[Port to RTM]Run innerloop tests against release package versions.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -611,7 +611,7 @@ def supportedFullCyclePlatforms = ['Windows_NT', 'Ubuntu14.04', 'OSX']
                     else {
                         // Use Server GC for Ubuntu/OSX Debug PR build & test
                         def useServerGC = (configurationGroup == 'Release' && isPR) ? 'useServerGC' : ''
-                        shell("HOME=\$WORKSPACE/tempHome ./build.sh ${useServerGC} ${configurationGroup.toLowerCase()} /p:ConfigurationGroup=${configurationGroup} /p:TestWithLocalLibraries=true /p:WithoutCategories=IgnoreForCI")
+                        shell("HOME=\$WORKSPACE/tempHome ./build.sh ${useServerGC} ${configurationGroup.toLowerCase()} /p:ConfigurationGroup=${configurationGroup} /p:WithoutCategories=IgnoreForCI")
                         // Tar up the appropriate bits.  On OSX the tarring is a different syntax for exclusion.
                         if (os == 'OSX') {
                             shell("tar -czf bin/build.tar.gz --exclude *.Tests bin/*.${configurationGroup} bin/ref bin/packages")


### PR DESCRIPTION
cc @ellismg @joshfree 

We are using TestWithLocalLibraries in innerloop runs to ensure we didn't break build for shim change,  without updating package versions. But since this is release branch, and no active dev work is happening, making innerloop to test against the package version that we will ship out of this branch. Note, the outerloop still tests against local libraries, hence by removing this, we are not creating a test gap.

This is in preparation to enabling automatic package version update from internal release TFS build to open release branch.