### PR TITLE
Move HTTP request content disposal responsibility to handlers

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -552,7 +552,15 @@ namespace System.Net.Http
 
             s_diagnosticListener.LogHttpResponse(tcs.Task, loggingRequestId);
 
-            return tcs.Task;
+            return request.Content == null ?
+                tcs.Task :
+                DisposeContentWhenCompleted(request.Content, tcs.Task);
+        }
+
+        private static async Task<HttpResponseMessage> DisposeContentWhenCompleted(HttpContent content, Task<HttpResponseMessage> task)
+        {
+            try { return await task.ConfigureAwait(false); }
+            finally { content.Dispose(); }
         }
 
         private static bool IsChunkedModeForSend(HttpRequestMessage requestMessage)

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -653,7 +653,6 @@ namespace System.Net.Http
                 try
                 {
                     easy.InitializeCurl();
-                    easy._requestContentStream?.Run();
 
                     easy._associatedMultiAgent = this;
                     easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_PRIVATE, gcHandlePtr);
@@ -1206,9 +1205,6 @@ namespace System.Net.Http
                         {
                             // Dump any state associated with the old stream's position
                             easy._sendTransferState?.SetTaskOffsetCount(null, 0, 0);
-
-                            // Restart the transfer
-                            easy._requestContentStream.Run();
 
                             CurlHandler.EventSourceTrace("Seek successful", easy: easy);
                             return Interop.Http.CurlSeekResult.CURL_SEEKFUNC_OK;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -556,7 +556,21 @@ namespace System.Net.Http.Functional.Tests
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
-                return _func(request, cancellationToken);
+                try
+                {
+                    return DisposeWhenCompleted(_func(request, cancellationToken), request);
+                }
+                catch
+                {
+                    request.Content?.Dispose();
+                    throw;
+                }
+            }
+
+            private static async Task<T> DisposeWhenCompleted<T>(Task<T> t, HttpRequestMessage request)
+            {
+                try { return await t; }
+                finally { request.Content?.Dispose(); }
             }
         }
 


### PR DESCRIPTION
Alternate to https://github.com/dotnet/corefx/pull/8884.

Same core problem, but rather than addressing it by making CurlHandler artificially delay the SendAsync task's completion until all request data has been sent, it allows for that case and instead moves the responsibility for disposing of the request content from HttpClient to the handler.

The first commit here is the same as in the other PR and simply adds a bunch of tracing (a small amount of that made it into the second PR as well).

cc: @davidsh, @ericeil, @mconnew, @KKhurin, @bartonjs
Partially addresses dotnet/wcf#1211.