### PR TITLE
Remove "Result" property of ValueTask<T>

### DIFF
--- a/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
@@ -153,9 +153,6 @@ namespace System.Threading.Tasks
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> represents a canceled operation.</summary>
         public bool IsCanceled { get { return _task != null && _task.IsCanceled; } }
 
-        /// <summary>Gets the result.</summary>
-        public TResult Result { get { return _task == null ? _result : _task.GetAwaiter().GetResult(); } }
-
         /// <summary>Gets an awaiter for this value.</summary>
         public ValueTaskAwaiter<TResult> GetAwaiter()
         {

--- a/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
@@ -16,13 +16,13 @@ namespace System.Threading.Tasks.Channels.Tests
             Assert.True(default(ValueTask<int>).IsCompletedSuccessfully);
             Assert.False(default(ValueTask<int>).IsFaulted);
             Assert.False(default(ValueTask<int>).IsCanceled);
-            Assert.Equal(0, default(ValueTask<int>).Result);
+            Assert.Equal(0, default(ValueTask<int>).GetAwaiter().GetResult());
 
             Assert.True(default(ValueTask<string>).IsCompleted);
             Assert.True(default(ValueTask<string>).IsCompletedSuccessfully);
             Assert.False(default(ValueTask<string>).IsFaulted);
             Assert.False(default(ValueTask<string>).IsCanceled);
-            Assert.Equal(null, default(ValueTask<string>).Result);
+            Assert.Equal(null, default(ValueTask<string>).GetAwaiter().GetResult());
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace System.Threading.Tasks.Channels.Tests
             Assert.True(t.IsCompletedSuccessfully);
             Assert.False(t.IsFaulted);
             Assert.False(t.IsCanceled);
-            Assert.Equal(42, t.Result);
+            Assert.Equal(42, t.GetAwaiter().GetResult());
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace System.Threading.Tasks.Channels.Tests
             Assert.True(t.IsCompletedSuccessfully);
             Assert.False(t.IsFaulted);
             Assert.False(t.IsCanceled);
-            Assert.Equal(42, t.Result);
+            Assert.Equal(42, t.GetAwaiter().GetResult());
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace System.Threading.Tasks.Channels.Tests
 
             tcs.SetResult(42);
 
-            Assert.Equal(42, t.Result);
+            Assert.Equal(42, t.GetAwaiter().GetResult());
             Assert.True(t.IsCompleted);
             Assert.True(t.IsCompletedSuccessfully);
             Assert.False(t.IsFaulted);
@@ -79,7 +79,7 @@ namespace System.Threading.Tasks.Channels.Tests
         {
             ValueTask<int> t = 42;
 
-            Assert.Equal(42, t.Result);
+            Assert.Equal(42, t.GetAwaiter().GetResult());
 
             Assert.True(t.IsCompleted);
             Assert.True(t.IsCompletedSuccessfully);
@@ -92,7 +92,7 @@ namespace System.Threading.Tasks.Channels.Tests
         {
             ValueTask<int> t = Task.FromResult(42);
 
-            Assert.Equal(42, t.Result);
+            Assert.Equal(42, t.GetAwaiter().GetResult());
 
             Assert.True(t.IsCompleted);
             Assert.True(t.IsCompletedSuccessfully);
@@ -105,7 +105,7 @@ namespace System.Threading.Tasks.Channels.Tests
         {
             ValueTask<int> t = Task.FromException<int>(new FormatException());
 
-            Assert.Throws<FormatException>(() => t.Result);
+            Assert.Throws<FormatException>(() => t.GetAwaiter().GetResult());
 
             Assert.True(t.IsCompleted);
             Assert.False(t.IsCompletedSuccessfully);
@@ -118,7 +118,7 @@ namespace System.Threading.Tasks.Channels.Tests
         {
             ValueTask<int> t = Task.FromCanceled<int>(new CancellationToken(true));
 
-            Assert.Throws<TaskCanceledException>(() => t.Result);
+            Assert.Throws<TaskCanceledException>(() => t.GetAwaiter().GetResult());
 
             Assert.True(t.IsCompleted);
             Assert.False(t.IsCompletedSuccessfully);
@@ -264,7 +264,7 @@ namespace System.Threading.Tasks.Channels.Tests
         public void GetHashCode_ContainsResult()
         {
             ValueTask<int> t = 42;
-            Assert.Equal(t.Result.GetHashCode(), t.GetHashCode());
+            Assert.Equal(t.GetAwaiter().GetResult().GetHashCode(), t.GetHashCode());
         }
 
         [Fact]


### PR DESCRIPTION
I think we should remove the "Result" property

* I think it's bad to have implicit blocking. If you invoke an async method in a UI app, and try to fetch the .Result of the returned task/valuetask, you’ll get a deadlock.

* ValueTask.Result has different exception behavior from Task.Result: the latter wraps them up in an AggregateException but the former doesn’t.

* There is a niche scenario where .Result is what you want: namely, when you’ve got a synchronous existing codebase and you need to add async into a small corner of it. But I think it’s fine for folks to write “.GetAwaiter().GetResult()” in this case. The extra wordiness of this workaround is commensurate with how carefully you should use it.

* It was a shame to have .Wait() and .Result on the return type of async methods in the first place. We discussed having an ITask<T> instead, a pure promise-like thing which has the advantage of lacking them, but the disadvantage of dealing with an entirely new type was too much.
