### PR TITLE
Improve the CoreFX test runner

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -55,6 +55,18 @@ usage()
     exit 1
 }
 
+# Handle Ctrl-C.
+function handle_ctrl_c {
+  local errorSource='handle_ctrl_c'
+
+  echo ""
+  echo "Cancelling test execution."
+  exit $TestsFailed
+}
+
+# Register the Ctrl-C handler
+trap handle_ctrl_c INT
+
 ProjectRoot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Location parameters
 # OS/ConfigurationGroup defaults


### PR DESCRIPTION
Handle a ctrl-c interrupt on test runner
If a ctrl-c interrupt occurs, the test runner will stop and
return the total number of failed.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Fix #8908 
