### PR TITLE
Fix ValueTask<T>.ToString behavior with null results

### DIFF
--- a/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
@@ -174,10 +174,18 @@ namespace System.Threading.Tasks
         /// <summary>Gets a string-representation of this <see cref="ValueTask{TResult}"/>.</summary>
         public override string ToString()
         {
-            return
-                _task == null ? _result.ToString() :
-                _task.Status == TaskStatus.RanToCompletion ? _task.Result.ToString() :
-                _task.Status.ToString();
+            if (_task != null)
+            {
+                return _task.Status == TaskStatus.RanToCompletion && _task.Result != null ?
+                    _task.Result.ToString() :
+                    string.Empty;
+            }
+            else
+            {
+                return _result != null ?
+                    _result.ToString() :
+                    string.Empty;
+            }
         }
     }
 }

--- a/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
@@ -353,17 +353,25 @@ namespace System.Threading.Tasks.Channels.Tests
         public void ToString_Success()
         {
             Assert.Equal("Hello", new ValueTask<string>("Hello").ToString());
-            Assert.Equal(string.Empty, new ValueTask<string>(string.Empty).ToString());
-            Assert.Equal("42", new ValueTask<int>(42).ToString());
-
             Assert.Equal("Hello", new ValueTask<string>(Task.FromResult("Hello")).ToString());
-            Assert.Equal(string.Empty, new ValueTask<string>(Task.FromResult(string.Empty)).ToString());
+
+            Assert.Equal("42", new ValueTask<int>(42).ToString());
             Assert.Equal("42", new ValueTask<int>(Task.FromResult(42)).ToString());
 
-            Assert.Equal("Faulted", new ValueTask<string>(Task.FromException<string>(new InvalidOperationException())).ToString());
-            Assert.Equal("Faulted", new ValueTask<string>(Task.FromException<string>(new OperationCanceledException())).ToString());
+            Assert.Same(string.Empty, new ValueTask<string>(string.Empty).ToString());
+            Assert.Same(string.Empty, new ValueTask<string>(Task.FromResult(string.Empty)).ToString());
 
-            Assert.Equal("Canceled", new ValueTask<string>(Task.FromCanceled<string>(new CancellationToken(true))).ToString());
+            Assert.Same(string.Empty, new ValueTask<string>(Task.FromException<string>(new InvalidOperationException())).ToString());
+            Assert.Same(string.Empty, new ValueTask<string>(Task.FromException<string>(new OperationCanceledException())).ToString());
+
+            Assert.Same(string.Empty, new ValueTask<string>(Task.FromCanceled<string>(new CancellationToken(true))).ToString());
+
+            Assert.Equal("0", default(ValueTask<int>).ToString());
+            Assert.Same(string.Empty, default(ValueTask<string>).ToString());
+            Assert.Same(string.Empty, new ValueTask<string>((string)null).ToString());
+            Assert.Same(string.Empty, new ValueTask<string>(Task.FromResult<string>(null)).ToString());
+
+            Assert.Same(string.Empty, new ValueTask<DateTime>(new TaskCompletionSource<DateTime>().Task).ToString());
         }
 
         private sealed class TrackingSynchronizationContext : SynchronizationContext


### PR DESCRIPTION
ValueTask<T>'s ToString implementation doesn't special-case null results today, under the argument that it's just a wrapper for a T, and so if you do "new ValueTask<string>((string)null).ToString()", that should behave similarly to "((string)null).ToString()).  But, of course, that means NullReferenceExceptions can emerge from calling ToString on a value type, and that code like "default(ValueTask<SomeRefType>).ToString() will null ref, which is likely unexpected.

This commit changes the behavior of ToString to be less complicated and to handle nulls: if the ```ValueTask<T>``` has a non-null result (either from the ```Task<T>``` or the ```T```), the result's ToString is returned, otherwise string.Empty is returned.

cc: @ellismg, @bartonjs, @ljw1004, @terrajobst, @KrzysztofCwalina 