### PR TITLE
Improve tracing in CurlHandler

### DIFF
--- a/src/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs
+++ b/src/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace System.Diagnostics.Tracing
 {
@@ -91,13 +92,16 @@ namespace System.Diagnostics.Tracing
             finally { _eventWritten = null; }
         }
 
+        public async Task RunWithCallbackAsync(Action<EventWrittenEventArgs> handler, Func<Task> body)
+        {
+            _eventWritten = handler;
+            try { await body().ConfigureAwait(false); }
+            finally { _eventWritten = null; }
+        }
+
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            Action<EventWrittenEventArgs> callback = _eventWritten;
-            if (callback != null)
-            {
-                callback(eventData);
-            }
+            _eventWritten?.Invoke(eventData);
         }
     }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -58,7 +58,7 @@ namespace System.Net.Http
 
                 if (requestMessage.Content != null)
                 {
-                    _requestContentStream = new HttpContentAsyncStream(requestMessage.Content);
+                    _requestContentStream = new HttpContentAsyncStream(this);
                 }
 
                 _responseMessage = new CurlResponseMessage(this);
@@ -102,6 +102,8 @@ namespace System.Net.Http
                 // If the response message hasn't been published yet, do any final processing of it before it is.
                 if (!Task.IsCompleted)
                 {
+                    EventSourceTrace("Publishing response message");
+
                     // On Windows, if the response was automatically decompressed, Content-Encoding and Content-Length
                     // headers are removed from the response. Do the same thing here.
                     DecompressionMethods dm = _handler.AutomaticDecompression;
@@ -150,6 +152,7 @@ namespace System.Net.Http
             public void FailRequest(Exception error)
             {
                 Debug.Assert(error != null, "Expected non-null exception");
+                EventSourceTrace("Failing request: {0}", error);
 
                 var oce = error as OperationCanceledException;
                 if (oce != null)

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -72,7 +72,7 @@ namespace System.Net.Http
                         // with relation to handling of certificates.  But if that's not the case, failing to 
                         // register the callback will result in those options not being factored in, which is
                         // a significant enough error that we need to fail.
-                        EventSourceTrace("CURLOPT_SSL_CTX_FUNCTION not supported: {0}", answer);
+                        EventSourceTrace("CURLOPT_SSL_CTX_FUNCTION not supported: {0}", answer, easy: easy);
                         if (certProvider != null ||
                             easy._handler.ServerCertificateValidationCallback != null ||
                             easy._handler.CheckCertificateRevocationList)
@@ -165,7 +165,7 @@ namespace System.Net.Http
 
                         // Register the callback.
                         Interop.Ssl.SslCtxSetClientCertCallback(sslCtx, provider._callback);
-                        EventSourceTrace("Registered client certificate callback.");
+                        EventSourceTrace("Registered client certificate callback.", easy: easy);
                     }
                     catch (Exception e)
                     {
@@ -207,7 +207,7 @@ namespace System.Net.Http
                     IntPtr leafCertPtr = Interop.Crypto.X509StoreCtxGetTargetCert(storeCtx);
                     if (IntPtr.Zero == leafCertPtr)
                     {
-                        EventSourceTrace("Invalid certificate pointer");
+                        EventSourceTrace("Invalid certificate pointer", easy: easy);
                         return 0;
                     }
 
@@ -288,7 +288,7 @@ namespace System.Net.Http
                                 }
                                 catch (Exception exc)
                                 {
-                                    EventSourceTrace("Server validation callback threw exception: {0}", exc);
+                                    EventSourceTrace("Server validation callback threw exception: {0}", exc, easy: easy);
                                     easy.FailRequest(exc);
                                     success = false;
                                 }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -455,7 +455,6 @@ namespace System.Net.Http
                 return Task.FromCanceled<HttpResponseMessage>(cancellationToken);
             }
 
-            EventSourceTrace("{0}", request);
             Guid loggingRequestId = s_diagnosticListener.LogHttpRequest(request);
 
             // Create the easy request.  This associates the easy request with this handler and configures
@@ -463,6 +462,7 @@ namespace System.Net.Http
             var easy = new EasyRequest(this, request, cancellationToken);
             try
             {
+                EventSourceTrace("{0}", request, easy: easy, agent: _agent);
                 _agent.Queue(new MultiAgent.IncomingRequest { Easy = easy, Type = MultiAgent.IncomingRequestType.New });
             }
             catch (Exception exc)
@@ -562,7 +562,8 @@ namespace System.Net.Http
             {
                 EventSourceTrace(
                     "Malformed cookie parsing failed: {0}, server: {1}, cookie: {2}", 
-                    e.Message, state._requestMessage.RequestUri, cookieHeader);
+                    e.Message, state._requestMessage.RequestUri, cookieHeader,
+                    easy: state);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -33,6 +33,9 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
       <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+      <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\IO\DelegateStream.cs">
       <Link>Common\System\IO\DelegateStream.cs</Link>
     </Compile>


### PR DESCRIPTION
While debugging some HttpClient issues, I needed more tracing in CurlHandler.  It's useful to check this in to help with future investigations.

This is the same changes as from:
https://github.com/dotnet/corefx/pull/8894
https://github.com/dotnet/corefx/pull/8884
as I'd like to get these tracing changes merged without first resolving what to do with those changes.

cc: @bartonjs, @ericeil (you guys already reviewed these changes as part of that other commit)