### PR TITLE
Port rtm netstandard.library 1.6

### DIFF
--- a/pkg/NETStandard.Library/NETStandard.Library.packages.targets
+++ b/pkg/NETStandard.Library/NETStandard.Library.packages.targets
@@ -17,6 +17,7 @@
     <Package Include="System.IO.FileSystem" />
     <Package Include="System.IO.FileSystem.Primitives" />
     <Package Include="System.Linq" />
+    <Package Include="System.Linq.Expressions" />
     <Package Include="System.Net.Http" />
     <Package Include="System.Net.Primitives" />
     <Package Include="System.Net.Sockets" />

--- a/pkg/NETStandard.Library/NETStandard.Library.pkgproj
+++ b/pkg/NETStandard.Library/NETStandard.Library.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <SplitDependenciesBySupport>true</SplitDependenciesBySupport>
   </PropertyGroup>
 


### PR DESCRIPTION
We now have API included in NETStandard.Library that has netstandard1.6
specific surface area so we should bump the version of the package to
1.6:

System.AppContext
System.Security.Cryptography.Algorithms
Also fixing #8315. /cc @weshaggard @KrzysztofCwalina