### PR TITLE
Make Platforms/Targets pkgs work w/packages.config

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
+++ b/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
@@ -4,10 +4,15 @@
   
   <PropertyGroup>
     <Version>1.0.1</Version>
+    <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
   
   <ItemGroup>
     <File Include="runtime.json" />
+    <!-- make this package installable and noop in a packages.config-based project -->
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>lib/netstandard1.0</TargetPath>
+    </File>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -6,11 +6,17 @@
     <Version>1.0.1</Version>
     <IsLineupPackage>true</IsLineupPackage>
     <RuntimeFileSource>runtime.json</RuntimeFileSource>
+    <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
   
   <Import Project="..\NETStandard.Library\NETStandard.Library.packages.targets" />
   
   <ItemGroup>
+    <!-- make this package installable and noop in a packages.config-based project -->
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>lib/netstandard1.0</TargetPath>
+    </File>
+
     <Package Include="System.Private.Uri" />
     <NativePackage Include="runtime.native.System.IO.Compression" />
     <NativePackage Include="runtime.native.System" />


### PR DESCRIPTION
Microsoft.NETCore.Platforms and Microsoft.NETCore.Targets both contain
no dependencies or convention-based assets.  They only contain
runtime.json's.  This is understood by NuGet3+project.json but not
packages.config (NuGet 3 or 2).

To permit these packages to install add a placeholder.

Fixes https://github.com/dotnet/corefx/issues/8822