### PR TITLE
ValueTuple: adding Deconstruct and other tuple interop methods for System.Tuple

### DIFF
--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Runtime\CompilerServices\TupleElementNamesAttribute.cs" />
+    <Compile Include="System\ValueTuple\TupleExtensions.cs" />
     <Compile Include="System\ValueTuple\ValueTuple.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
@@ -13,7 +13,7 @@ namespace System
     {
         #region Deconstruct
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 1 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 1 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1>(
@@ -24,7 +24,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 2 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 2 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2>(
@@ -36,7 +36,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 3 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 3 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3>(
@@ -49,7 +49,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 4 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 4 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4>(
@@ -63,7 +63,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 5 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 5 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5>(
@@ -78,7 +78,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 6 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 6 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6>(
@@ -94,7 +94,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 7 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 7 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(
@@ -111,7 +111,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 8 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 8 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(
@@ -129,7 +129,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 9 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 9 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
@@ -148,7 +148,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 10 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 10 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
@@ -168,7 +168,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 11 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 11 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
@@ -189,7 +189,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 12 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 12 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
@@ -211,7 +211,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 13 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 13 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
@@ -234,7 +234,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 14 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 14 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
@@ -258,7 +258,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 15 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 15 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
@@ -283,7 +283,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 16 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 16 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
@@ -309,7 +309,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 17 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 17 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
@@ -336,7 +336,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 18 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 18 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
@@ -364,7 +364,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 19 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 19 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
@@ -393,7 +393,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 20 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 20 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
@@ -423,7 +423,7 @@ namespace System
         }
 
         /// <summary>
-        /// Deconstruct a propertly nested <see cref="Tuple"/> with 21 elements.
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 21 elements.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(

--- a/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+
 namespace System
 {
     /// <summary>
@@ -13,6 +15,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 1 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1>(
             this Tuple<T1> value,
             out T1 item1)
@@ -23,6 +26,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 2 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2>(
             this Tuple<T1, T2> value,
             out T1 item1, out T2 item2)
@@ -34,6 +38,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 3 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3>(
             this Tuple<T1, T2, T3> value,
             out T1 item1, out T2 item2, out T3 item3)
@@ -46,6 +51,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 4 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4>(
             this Tuple<T1, T2, T3, T4> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4)
@@ -59,6 +65,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 5 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5>(
             this Tuple<T1, T2, T3, T4, T5> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5)
@@ -73,6 +80,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 6 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6>(
             this Tuple<T1, T2, T3, T4, T5, T6> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6)
@@ -88,6 +96,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 7 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7)
@@ -104,6 +113,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 8 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8)
@@ -121,6 +131,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 9 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9)
@@ -139,6 +150,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 10 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10)
@@ -158,6 +170,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 11 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11)
@@ -178,6 +191,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 12 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12)
@@ -199,6 +213,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 13 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13)
@@ -221,6 +236,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 14 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14)
@@ -244,6 +260,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 15 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15)
@@ -268,6 +285,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 16 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16)
@@ -293,6 +311,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 17 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17)
@@ -319,6 +338,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 18 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18)
@@ -346,6 +366,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 19 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19)
@@ -374,6 +395,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 20 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20)
@@ -403,6 +425,7 @@ namespace System
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 21 elements.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20, out T21 item21)
@@ -664,12 +687,12 @@ namespace System
         }
         #endregion
 
-        #region ToRefTuple
+        #region ToTuple
         /// <summary>
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 1 element.
         /// </summary>
         public static Tuple<T1>
-            ToRefTuple<T1>(
+            ToTuple<T1>(
                 this ValueTuple<T1> value)
         {
             return Tuple.Create(value.Item1);
@@ -679,7 +702,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 2 elements.
         /// </summary>
         public static Tuple<T1, T2>
-            ToRefTuple<T1, T2>(
+            ToTuple<T1, T2>(
                 this ValueTuple<T1, T2> value)
         {
             return Tuple.Create(value.Item1, value.Item2);
@@ -689,7 +712,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 3 elements.
         /// </summary>
         public static Tuple<T1, T2, T3>
-            ToRefTuple<T1, T2, T3>(
+            ToTuple<T1, T2, T3>(
                 this ValueTuple<T1, T2, T3> value)
         {
             return Tuple.Create(value.Item1, value.Item2, value.Item3);
@@ -699,7 +722,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 4 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4>
-            ToRefTuple<T1, T2, T3, T4>(
+            ToTuple<T1, T2, T3, T4>(
                 this ValueTuple<T1, T2, T3, T4> value)
         {
             return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4);
@@ -709,7 +732,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 5 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5>
-            ToRefTuple<T1, T2, T3, T4, T5>(
+            ToTuple<T1, T2, T3, T4, T5>(
                 this ValueTuple<T1, T2, T3, T4, T5> value)
         {
             return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5);
@@ -719,7 +742,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 6 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6>
-            ToRefTuple<T1, T2, T3, T4, T5, T6>(
+            ToTuple<T1, T2, T3, T4, T5, T6>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6> value)
         {
             return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6);
@@ -729,7 +752,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 7 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7> value)
         {
             return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7);
@@ -739,7 +762,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 8 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -750,7 +773,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 9 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -761,7 +784,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 10 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -772,7 +795,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 11 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -783,7 +806,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 12 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -794,7 +817,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 13 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -805,7 +828,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 14 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -816,7 +839,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 15 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15>>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -828,7 +851,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 16 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16>>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -840,7 +863,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 17 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17>>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -852,7 +875,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 18 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18>>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -864,7 +887,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 19 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19>>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -876,7 +899,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 20 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20>>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
@@ -888,7 +911,7 @@ namespace System
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 21 elements.
         /// </summary>
         public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>>
-            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
                 this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20, T21>>> value)
         {
             return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,

--- a/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
@@ -9,6 +9,7 @@ namespace System
     /// </summary>
     public static class TupleExtensions
     {
+        #region Deconstruct
         /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 1 elements.
         /// </summary>
@@ -428,6 +429,227 @@ namespace System
             item20 = value.Rest.Rest.Item6;
             item21 = value.Rest.Rest.Item7;
         }
+        #endregion
+
+        #region ToValueTuple
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 1 element.
+        /// </summary>
+        public static ValueTuple<T1>
+            ToValueTuple<T1>(
+                this Tuple<T1> value)
+        {
+            return ValueTuple.Create(value.Item1);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 2 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2>
+            ToValueTuple<T1, T2>(
+                this Tuple<T1, T2> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 3 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3>
+            ToValueTuple<T1, T2, T3>(
+                this Tuple<T1, T2, T3> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 4 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4>
+            ToValueTuple<T1, T2, T3, T4>(
+                this Tuple<T1, T2, T3, T4> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 5 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5>
+            ToValueTuple<T1, T2, T3, T4, T5>(
+                this Tuple<T1, T2, T3, T4, T5> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 6 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6>
+            ToValueTuple<T1, T2, T3, T4, T5, T6>(
+                this Tuple<T1, T2, T3, T4, T5, T6> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 7 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 8 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 9 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 10 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 11 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 12 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 13 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 14 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 15 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 16 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 17 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 18 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 19 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 20 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6)));
+        }
 
         /// <summary>
         /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 21 elements.
@@ -440,6 +662,7 @@ namespace System
                         CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
                             ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6, value.Rest.Rest.Item7)));
         }
+        #endregion
 
         /// <summary>
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 21 elements.

--- a/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
@@ -664,6 +664,226 @@ namespace System
         }
         #endregion
 
+        #region ToRefTuple
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 1 element.
+        /// </summary>
+        public static Tuple<T1>
+            ToRefTuple<T1>(
+                this ValueTuple<T1> value)
+        {
+            return Tuple.Create(value.Item1);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 2 elements.
+        /// </summary>
+        public static Tuple<T1, T2>
+            ToRefTuple<T1, T2>(
+                this ValueTuple<T1, T2> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 3 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3>
+            ToRefTuple<T1, T2, T3>(
+                this ValueTuple<T1, T2, T3> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 4 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4>
+            ToRefTuple<T1, T2, T3, T4>(
+                this ValueTuple<T1, T2, T3, T4> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 5 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5>
+            ToRefTuple<T1, T2, T3, T4, T5>(
+                this ValueTuple<T1, T2, T3, T4, T5> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 6 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6>
+            ToRefTuple<T1, T2, T3, T4, T5, T6>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 7 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 8 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 9 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 10 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 11 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 12 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 13 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 14 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 15 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 16 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 17 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 18 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 19 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 20 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6)));
+        }
+
         /// <summary>
         /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 21 elements.
         /// </summary>
@@ -675,6 +895,7 @@ namespace System
                         CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
                             Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6, value.Rest.Rest.Item7)));
         }
+        #endregion
 
         private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct =>
             new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);

--- a/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
@@ -10,6 +10,396 @@ namespace System
     public static class TupleExtensions
     {
         /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 1 elements.
+        /// </summary>
+        public static void Deconstruct<T1>(
+            this Tuple<T1> value,
+            out T1 item1)
+        {
+            item1 = value.Item1;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 2 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2>(
+            this Tuple<T1, T2> value,
+            out T1 item1, out T2 item2)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 3 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3>(
+            this Tuple<T1, T2, T3> value,
+            out T1 item1, out T2 item2, out T3 item3)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 4 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4>(
+            this Tuple<T1, T2, T3, T4> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 5 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5>(
+            this Tuple<T1, T2, T3, T4, T5> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 6 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6>(
+            this Tuple<T1, T2, T3, T4, T5, T6> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 7 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 8 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 9 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 10 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 11 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 12 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 13 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 14 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 15 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 16 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 17 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 18 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 19 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+            item19 = value.Rest.Rest.Item5;
+        }
+
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 20 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+            item19 = value.Rest.Rest.Item5;
+            item20 = value.Rest.Rest.Item6;
+        }
+
+        /// <summary>
         /// Deconstruct a propertly nested <see cref="Tuple"/> with 21 elements.
         /// </summary>
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(

--- a/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="Tuple"/> instances to interop with C# tuples features (deconstruction syntax, converting from and to <see cref="ValueTuple"/>).
+    /// </summary>
+    public static class TupleExtensions
+    {
+        /// <summary>
+        /// Deconstruct a propertly nested <see cref="Tuple"/> with 21 elements.
+        /// </summary>
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20, out T21 item21)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+            item19 = value.Rest.Rest.Item5;
+            item20 = value.Rest.Rest.Item6;
+            item21 = value.Rest.Rest.Item7;
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 21 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20, T21>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6, value.Rest.Rest.Item7)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 21 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>>
+            ToRefTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20, T21>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6, value.Rest.Rest.Item7)));
+        }
+
+        private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
+
+        private static Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLongRef<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) =>
+            new Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
+    }
+}

--- a/src/System.ValueTuple/tests/System.ValueTuple.Tests.csproj
+++ b/src/System.ValueTuple/tests/System.ValueTuple.Tests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TupleElementNamesAttribute\UnitTests.cs" />
+    <Compile Include="ValueTuple\ExtensionsTests.cs" />
     <Compile Include="ValueTuple\UnitTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
+++ b/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
@@ -9,6 +9,7 @@ using static ValueTupleTests;
 
 public class ExtensionsTests
 {
+    #region Deconstruct
     [Fact]
     public void Deconstruct1()
     {
@@ -218,6 +219,8 @@ public class ExtensionsTests
         tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11, out h.x12, out h.x13, out h.x14, out h.x15, out h.x16, out h.x17, out h.x18, out h.x19, out h.x20, out h.x21);
         Assert.Equal("1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21", h.ToString());
     }
+    #endregion
+
 
     [Fact]
     public void ConvertToRef21()
@@ -229,6 +232,18 @@ public class ExtensionsTests
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)", refTuple.ToString());
     }
 
+    #region ToValue
+
+    [Fact]
+    public void ConvertToValue20()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1, -1, -1, -1, -1)));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16, 17, 18, 19, 20)));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)", valueTuple.ToString());
+    }
+
     [Fact]
     public void ConvertToValue21()
     {
@@ -238,6 +253,7 @@ public class ExtensionsTests
         valueTuple = refTuple.ToValueTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)", valueTuple.ToString());
     }
+    #endregion
 
     // Holds 21 int values
     private struct IntHolder

--- a/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
+++ b/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
@@ -221,14 +221,14 @@ public class ExtensionsTests
     }
     #endregion
 
-    #region ToRefTuple
+    #region ToTuple
     [Fact]
     public void ConvertToRef1()
     {
         var refTuple = Tuple.Create(-1);
         var valueTuple = ValueTuple.Create(1);
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1)", refTuple.ToString());
     }
 
@@ -238,7 +238,7 @@ public class ExtensionsTests
         var refTuple = Tuple.Create(-1, -1);
         var valueTuple = ValueTuple.Create(1, 2);
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2)", refTuple.ToString());
     }
 
@@ -248,7 +248,7 @@ public class ExtensionsTests
         var refTuple = Tuple.Create(-1, -1, -1);
         var valueTuple = ValueTuple.Create(1, 2, 3);
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3)", refTuple.ToString());
     }
 
@@ -258,7 +258,7 @@ public class ExtensionsTests
         var refTuple = Tuple.Create(-1, -1, -1, -1);
         var valueTuple = ValueTuple.Create(1, 2, 3, 4);
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4)", refTuple.ToString());
     }
 
@@ -268,7 +268,7 @@ public class ExtensionsTests
         var refTuple = Tuple.Create(-1, -1, -1, -1, -1);
         var valueTuple = ValueTuple.Create(1, 2, 3, 4, 5);
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5)", refTuple.ToString());
     }
 
@@ -278,7 +278,7 @@ public class ExtensionsTests
         var refTuple = Tuple.Create(-1, -1, -1, -1, -1, -1);
         var valueTuple = ValueTuple.Create(1, 2, 3, 4, 5, 6);
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6)", refTuple.ToString());
     }
 
@@ -288,7 +288,7 @@ public class ExtensionsTests
         var refTuple = Tuple.Create(-1, -1, -1, -1, -1, -1, -1);
         var valueTuple = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7);
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7)", refTuple.ToString());
     }
 
@@ -298,7 +298,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8)", refTuple.ToString());
     }
 
@@ -308,7 +308,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9)", refTuple.ToString());
     }
 
@@ -318,7 +318,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)", refTuple.ToString());
     }
 
@@ -328,7 +328,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)", refTuple.ToString());
     }
 
@@ -338,7 +338,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)", refTuple.ToString());
     }
 
@@ -348,7 +348,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1, -1));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)", refTuple.ToString());
     }
 
@@ -358,7 +358,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1, -1, -1));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13, 14));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)", refTuple.ToString());
     }
 
@@ -368,7 +368,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1)));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15)));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)", refTuple.ToString());
     }
 
@@ -378,7 +378,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1)));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16)));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)", refTuple.ToString());
     }
 
@@ -388,7 +388,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1)));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16, 17)));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)", refTuple.ToString());
     }
 
@@ -398,7 +398,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1)));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16, 17, 18)));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18)", refTuple.ToString());
     }
 
@@ -408,7 +408,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1)));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16, 17, 18, 19)));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)", refTuple.ToString());
     }
 
@@ -418,7 +418,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1, -1)));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16, 17, 18, 19, 20)));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)", refTuple.ToString());
     }
 
@@ -428,7 +428,7 @@ public class ExtensionsTests
         var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1, -1, -1)));
         var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16, 17, 18, 19, 20, 21)));
 
-        refTuple = valueTuple.ToRefTuple();
+        refTuple = valueTuple.ToTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)", refTuple.ToString());
     }
     #endregion

--- a/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
+++ b/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
@@ -221,6 +221,206 @@ public class ExtensionsTests
     }
     #endregion
 
+    #region ToRefTuple
+    [Fact]
+    public void ConvertToRef1()
+    {
+        var refTuple = Tuple.Create(-1);
+        var valueTuple = ValueTuple.Create(1);
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef2()
+    {
+        var refTuple = Tuple.Create(-1, -1);
+        var valueTuple = ValueTuple.Create(1, 2);
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef3()
+    {
+        var refTuple = Tuple.Create(-1, -1, -1);
+        var valueTuple = ValueTuple.Create(1, 2, 3);
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef4()
+    {
+        var refTuple = Tuple.Create(-1, -1, -1, -1);
+        var valueTuple = ValueTuple.Create(1, 2, 3, 4);
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef5()
+    {
+        var refTuple = Tuple.Create(-1, -1, -1, -1, -1);
+        var valueTuple = ValueTuple.Create(1, 2, 3, 4, 5);
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef6()
+    {
+        var refTuple = Tuple.Create(-1, -1, -1, -1, -1, -1);
+        var valueTuple = ValueTuple.Create(1, 2, 3, 4, 5, 6);
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef7()
+    {
+        var refTuple = Tuple.Create(-1, -1, -1, -1, -1, -1, -1);
+        var valueTuple = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7);
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef8()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef9()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef10()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef11()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef12()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef13()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1, -1));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef14()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1, -1, -1));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13, 14));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef15()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1)));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15)));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef16()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1)));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16)));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef17()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1)));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16, 17)));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef18()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1)));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16, 17, 18)));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef19()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1)));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16, 17, 18, 19)));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef20()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1, -1)));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16, 17, 18, 19, 20)));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)", refTuple.ToString());
+    }
 
     [Fact]
     public void ConvertToRef21()
@@ -231,9 +431,9 @@ public class ExtensionsTests
         refTuple = valueTuple.ToRefTuple();
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)", refTuple.ToString());
     }
+    #endregion
 
     #region ToValue
-
     [Fact]
     public void ConvertToValue1()
     {

--- a/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
+++ b/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
@@ -10,6 +10,206 @@ using static ValueTupleTests;
 public class ExtensionsTests
 {
     [Fact]
+    public void Deconstruct1()
+    {
+        var tuple = Tuple.Create(1);
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1);
+        Assert.Equal("1", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct2()
+    {
+        var tuple = Tuple.Create(1, 2);
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2);
+        Assert.Equal("1 2", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct3()
+    {
+        var tuple = Tuple.Create(1, 2, 3);
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3);
+        Assert.Equal("1 2 3", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct4()
+    {
+        var tuple = Tuple.Create(1, 2, 3, 4);
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4);
+        Assert.Equal("1 2 3 4", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct5()
+    {
+        var tuple = Tuple.Create(1, 2, 3, 4, 5);
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5);
+        Assert.Equal("1 2 3 4 5", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct6()
+    {
+        var tuple = Tuple.Create(1, 2, 3, 4, 5, 6);
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6);
+        Assert.Equal("1 2 3 4 5 6", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct7()
+    {
+        var tuple = Tuple.Create(1, 2, 3, 4, 5, 6, 7);
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7);
+        Assert.Equal("1 2 3 4 5 6 7", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct8()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8);
+        Assert.Equal("1 2 3 4 5 6 7 8", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct9()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9);
+        Assert.Equal("1 2 3 4 5 6 7 8 9", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct10()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9, 10));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct11()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9, 10, 11));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10 11", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct12()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9, 10, 11, 12));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11, out h.x12);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10 11 12", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct13()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9, 10, 11, 12, 13));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11, out h.x12, out h.x13);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10 11 12 13", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct14()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9, 10, 11, 12, 13, 14));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11, out h.x12, out h.x13, out h.x14);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10 11 12 13 14", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct15()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15)));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11, out h.x12, out h.x13, out h.x14, out h.x15);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10 11 12 13 14 15", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct16()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16)));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11, out h.x12, out h.x13, out h.x14, out h.x15, out h.x16);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct17()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16, 17)));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11, out h.x12, out h.x13, out h.x14, out h.x15, out h.x16, out h.x17);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct18()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16, 17, 18)));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11, out h.x12, out h.x13, out h.x14, out h.x15, out h.x16, out h.x17, out h.x18);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct19()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16, 17, 18, 19)));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11, out h.x12, out h.x13, out h.x14, out h.x15, out h.x16, out h.x17, out h.x18, out h.x19);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19", h.ToString());
+    }
+
+    [Fact]
+    public void Deconstruct20()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16, 17, 18, 19, 20)));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11, out h.x12, out h.x13, out h.x14, out h.x15, out h.x16, out h.x17, out h.x18, out h.x19, out h.x20);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20", h.ToString());
+    }
+
+    [Fact]
     public void Deconstruct21()
     {
         var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16, 17, 18, 19, 20, 21)));

--- a/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
+++ b/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using Xunit;
+using static ValueTupleTests;
+
+public class ExtensionsTests
+{
+    [Fact]
+    public void Deconstruct21()
+    {
+        var tuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16, 17, 18, 19, 20, 21)));
+        var h = new IntHolder();
+
+        tuple.Deconstruct(out h.x1, out h.x2, out h.x3, out h.x4, out h.x5, out h.x6, out h.x7, out h.x8, out h.x9, out h.x10, out h.x11, out h.x12, out h.x13, out h.x14, out h.x15, out h.x16, out h.x17, out h.x18, out h.x19, out h.x20, out h.x21);
+        Assert.Equal("1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21", h.ToString());
+    }
+
+    [Fact]
+    public void ConvertToRef21()
+    {
+        var refTuple = CreateLongRef(-1, -1, -1, -1, -1, -1, -1, CreateLongRef(-1, -1, -1, -1, -1, -1, -1, Tuple.Create(-1, -1, -1, -1, -1, -1, -1)));
+        var valueTuple = CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16, 17, 18, 19, 20, 21)));
+
+        refTuple = valueTuple.ToRefTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)", refTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue21()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1, -1, -1, -1, -1, -1)));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16, 17, 18, 19, 20, 21)));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)", valueTuple.ToString());
+    }
+
+    // Holds 21 int values
+    private struct IntHolder
+    {
+        public int x1;
+        public int x2;
+        public int x3;
+        public int x4;
+        public int x5;
+        public int x6;
+        public int x7;
+        public int x8;
+        public int x9;
+        public int x10;
+        public int x11;
+        public int x12;
+        public int x13;
+        public int x14;
+        public int x15;
+        public int x16;
+        public int x17;
+        public int x18;
+        public int x19;
+        public int x20;
+        public int x21;
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            if (x1 > 0) { builder.Append($"{x1}"); }
+            if (x2 > 0) { builder.Append($" {x2}"); }
+            if (x3 > 0) { builder.Append($" {x3}"); }
+            if (x4 > 0) { builder.Append($" {x4}"); }
+            if (x5 > 0) { builder.Append($" {x5}"); }
+            if (x6 > 0) { builder.Append($" {x6}"); }
+            if (x7 > 0) { builder.Append($" {x7}"); }
+            if (x8 > 0) { builder.Append($" {x8}"); }
+            if (x9 > 0) { builder.Append($" {x9}"); }
+            if (x10 > 0) { builder.Append($" {x10}"); }
+            if (x11 > 0) { builder.Append($" {x11}"); }
+            if (x12 > 0) { builder.Append($" {x12}"); }
+            if (x13 > 0) { builder.Append($" {x13}"); }
+            if (x14 > 0) { builder.Append($" {x14}"); }
+            if (x15 > 0) { builder.Append($" {x15}"); }
+            if (x16 > 0) { builder.Append($" {x16}"); }
+            if (x17 > 0) { builder.Append($" {x17}"); }
+            if (x18 > 0) { builder.Append($" {x18}"); }
+            if (x19 > 0) { builder.Append($" {x19}"); }
+            if (x20 > 0) { builder.Append($" {x20}"); }
+            if (x21 > 0) { builder.Append($" {x21}"); }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
+++ b/src/System.ValueTuple/tests/ValueTuple/ExtensionsTests.cs
@@ -235,6 +235,196 @@ public class ExtensionsTests
     #region ToValue
 
     [Fact]
+    public void ConvertToValue1()
+    {
+        var valueTuple = ValueTuple.Create(-1);
+        var refTuple = Tuple.Create(1);
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue2()
+    {
+        var valueTuple = ValueTuple.Create(-1, -1);
+        var refTuple = Tuple.Create(1, 2);
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue3()
+    {
+        var valueTuple = ValueTuple.Create(-1, -1, -1);
+        var refTuple = Tuple.Create(1, 2, 3);
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue4()
+    {
+        var valueTuple = ValueTuple.Create(-1, -1, -1, -1);
+        var refTuple = Tuple.Create(1, 2, 3, 4);
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue5()
+    {
+        var valueTuple = ValueTuple.Create(-1, -1, -1, -1, -1);
+        var refTuple = Tuple.Create(1, 2, 3, 4, 5);
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue6()
+    {
+        var valueTuple = ValueTuple.Create(-1, -1, -1, -1, -1, -1);
+        var refTuple = Tuple.Create(1, 2, 3, 4, 5, 6);
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue7()
+    {
+        var valueTuple = ValueTuple.Create(-1, -1, -1, -1, -1, -1, -1);
+        var refTuple = Tuple.Create(1, 2, 3, 4, 5, 6, 7);
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue8()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue9()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue10()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1, -1));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9, 10));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue11()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1, -1, -1));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9, 10, 11));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue12()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1, -1, -1, -1));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9, 10, 11, 12));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue13()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1, -1, -1, -1, -1));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9, 10, 11, 12, 13));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue14()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1, -1, -1, -1, -1, -1));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, Tuple.Create(8, 9, 10, 11, 12, 13, 14));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue15()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1)));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15)));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue16()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1)));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16)));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue17()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1, -1)));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16, 17)));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue18()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1, -1, -1)));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16, 17, 18)));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18)", valueTuple.ToString());
+    }
+
+    [Fact]
+    public void ConvertToValue19()
+    {
+        var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1, -1, -1, -1)));
+        var refTuple = CreateLongRef(1, 2, 3, 4, 5, 6, 7, CreateLongRef(8, 9, 10, 11, 12, 13, 14, Tuple.Create(15, 16, 17, 18, 19)));
+
+        valueTuple = refTuple.ToValueTuple();
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)", valueTuple.ToString());
+    }
+
+    [Fact]
     public void ConvertToValue20()
     {
         var valueTuple = CreateLong(-1, -1, -1, -1, -1, -1, -1, CreateLong(-1, -1, -1, -1, -1, -1, -1, ValueTuple.Create(-1, -1, -1, -1, -1, -1)));


### PR DESCRIPTION
This PR is meant for early feedback.
It only includes extension methods for ref tuples (`System.Tuple`) of length 21. The three extension methods are Deconstruct, ToRefTuple and ToValueTuple.
I will add the deconstruct and helper methods for tuples from 1 to 20 before asking to merge.

@stephentoub @KevinRansom @VSadov for feedback.