### PR TITLE
Dispose of request HttpContent after buffering response

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -347,19 +347,8 @@ namespace System.Net.Http
             HttpResponseMessage response = null;
             try
             {
-                try
-                {
-                    // Wait for the send request to complete, getting back the response.
-                    response = await sendTask.ConfigureAwait(false);
-                }
-                finally
-                {
-                    // When a request completes, dispose the request content so the user doesn't have to. This also
-                    // ensures that a HttpContent object is only sent once using HttpClient (similar to HttpRequestMessages
-                    // that can also be sent only once).
-                    request.Content?.Dispose();
-                }
-
+                // Wait for the send request to complete, getting back the response.
+                response = await sendTask.ConfigureAwait(false);
                 if (response == null)
                 {
                     throw new InvalidOperationException(SR.net_http_handler_noresponse);
@@ -394,7 +383,17 @@ namespace System.Net.Http
             }
             finally
             {
-                linkedCts.Dispose();
+                try
+                {
+                    // When a request completes, dispose the request content so the user doesn't have to. This also
+                    // helps ensure that a HttpContent object is only sent once using HttpClient (similar to HttpRequestMessages
+                    // that can also be sent only once).
+                    request.Content?.Dispose();
+                }
+                finally
+                {
+                    linkedCts.Dispose();
+                }
             }
         }
 


### PR DESCRIPTION
Related to:
https://github.com/dotnet/corefx/pull/8884
and
https://github.com/dotnet/corefx/pull/8894

Both of those PRs attempt to fix the issue described in https://github.com/dotnet/corefx/pull/8884.  The first does it by delaying the completion of the HttpClientHandler's SendAsync task until all request data has been sent.  The second does it by moving the responsibility for Dispose into the HttpClientHandler, which can then do it when it knows it's done with the request content.

Both of those changes carry some risk.  In contrast, this PR is a very low-risk change, which just moves the request content Dispose done by HttpClient to be a bit later, though it's only a partial mitigation rather than an actual fix.  For several of the methods on HttpClient, e.g. GetAsync, PostAsync, etc., the default mode is to buffer all of the response data (HttpCompletionOption.ResponseContentRead), and in the rare situations where a server does start sending a response body before it's received all of the request body, it will still likely not send all of the response body until it's received all of the request body.  As such, if we delay the disposal of the request content until after we've finished buffering the response, the chances of hitting an issue here are further reduced. (This doesn't solve the issue for WCF; WCF would still need to take a separate fix to workaround the issue, but it would hopefully mitigate an already rare case to the point where it's unlikely to be impactful.)

cc: @davidsh, @cipop, @ericeil, @mconnew, @KKhurin 