### PR TITLE
Add a few more parameter names to System.Linq.Expressions exceptions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -1029,7 +1029,7 @@ namespace System.Linq.Expressions
                 case ExpressionType.MultiplyAssignChecked:
                     return MultiplyAssignChecked(left, right, method, conversion);
                 default:
-                    throw Error.UnhandledBinary(binaryType);
+                    throw Error.UnhandledBinary(binaryType, nameof(binaryType));
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -345,7 +345,7 @@ namespace System.Linq.Expressions.Compiler
                     }
                     break;
                 default:
-                    throw Error.UnhandledBinary(op);
+                    throw Error.UnhandledBinary(op, nameof(op));
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -522,7 +522,7 @@ namespace System.Linq.Expressions
         /// </summary>
         internal static Exception LambdaTypeMustBeDerivedFromSystemDelegate(string paramName)
         {
-            return new ArgumentException(Strings.LambdaTypeMustBeDerivedFromSystemDelegate);
+            return new ArgumentException(Strings.LambdaTypeMustBeDerivedFromSystemDelegate, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Member '{0}' not field or property"

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -520,7 +520,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Lambda type parameter must be derived from System.MulticastDelegate"
         /// </summary>
-        internal static Exception LambdaTypeMustBeDerivedFromSystemDelegate()
+        internal static Exception LambdaTypeMustBeDerivedFromSystemDelegate(string paramName)
         {
             return new ArgumentException(Strings.LambdaTypeMustBeDerivedFromSystemDelegate);
         }
@@ -576,9 +576,9 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "'{0}' is not a member of type '{1}'"
         /// </summary>
-        internal static Exception NotAMemberOfType(object p0, object p1)
+        internal static Exception NotAMemberOfType(object p0, object p1, string paramName)
         {
-            return new ArgumentException(Strings.NotAMemberOfType(p0, p1));
+            return new ArgumentException(Strings.NotAMemberOfType(p0, p1), paramName);
         }
         /// <summary>
         /// PlatformNotSupportedException with message like "The instruction '{0}' is not supported for type '{1}'"
@@ -604,16 +604,16 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Property '{0}' is not defined for type '{1}'"
         /// </summary>
-        internal static Exception PropertyNotDefinedForType(object p0, object p1)
+        internal static Exception PropertyNotDefinedForType(object p0, object p1, string paramName)
         {
-            return new ArgumentException(Strings.PropertyNotDefinedForType(p0, p1));
+            return new ArgumentException(Strings.PropertyNotDefinedForType(p0, p1), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Instance property '{0}' is not defined for type '{1}'"
         /// </summary>
-        internal static Exception InstancePropertyNotDefinedForType(object p0, object p1)
+        internal static Exception InstancePropertyNotDefinedForType(object p0, object p1, string paramName)
         {
-            return new ArgumentException(Strings.InstancePropertyNotDefinedForType(p0, p1));
+            return new ArgumentException(Strings.InstancePropertyNotDefinedForType(p0, p1), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Instance property '{0}' that takes no argument is not defined for type '{1}'"
@@ -697,9 +697,9 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Unhandled binary: {0}"
         /// </summary>
-        internal static Exception UnhandledBinary(object p0)
+        internal static Exception UnhandledBinary(object p0, string paramName)
         {
-            return new ArgumentException(Strings.UnhandledBinary(p0));
+            return new ArgumentException(Strings.UnhandledBinary(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Unhandled binding "

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -351,7 +351,7 @@ namespace System.Linq.Expressions
         public static Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, bool tailCall, IEnumerable<ParameterExpression> parameters)
         {
             var parameterList = parameters.ToReadOnly();
-            ValidateLambdaArgs(typeof(TDelegate), ref body, parameterList);
+            ValidateLambdaArgs(typeof(TDelegate), ref body, parameterList, nameof(TDelegate));
             return new Expression<TDelegate>(body, name, tailCall, parameterList);
         }
 
@@ -512,7 +512,7 @@ namespace System.Linq.Expressions
         public static LambdaExpression Lambda(Type delegateType, Expression body, string name, IEnumerable<ParameterExpression> parameters)
         {
             var paramList = parameters.ToReadOnly();
-            ValidateLambdaArgs(delegateType, ref body, paramList);
+            ValidateLambdaArgs(delegateType, ref body, paramList, nameof(delegateType));
 
             return CreateLambda(delegateType, body, name, false, paramList);
         }
@@ -529,19 +529,19 @@ namespace System.Linq.Expressions
         public static LambdaExpression Lambda(Type delegateType, Expression body, string name, bool tailCall, IEnumerable<ParameterExpression> parameters)
         {
             var paramList = parameters.ToReadOnly();
-            ValidateLambdaArgs(delegateType, ref body, paramList);
+            ValidateLambdaArgs(delegateType, ref body, paramList, nameof(delegateType));
 
             return CreateLambda(delegateType, body, name, tailCall, paramList);
         }
 
-        private static void ValidateLambdaArgs(Type delegateType, ref Expression body, ReadOnlyCollection<ParameterExpression> parameters)
+        private static void ValidateLambdaArgs(Type delegateType, ref Expression body, ReadOnlyCollection<ParameterExpression> parameters, string paramName)
         {
             ContractUtils.RequiresNotNull(delegateType, nameof(delegateType));
             RequiresCanRead(body, nameof(body));
 
             if (!typeof(MulticastDelegate).IsAssignableFrom(delegateType) || delegateType == typeof(MulticastDelegate))
             {
-                throw Error.LambdaTypeMustBeDerivedFromSystemDelegate();
+                throw Error.LambdaTypeMustBeDerivedFromSystemDelegate(paramName);
             }
 
             MethodInfo mi;
@@ -585,7 +585,7 @@ namespace System.Linq.Expressions
                     }
                     if (!set.Add(pex))
                     {
-                        throw Error.DuplicateVariable(pex, $"parameters[{i}]");
+                        throw Error.DuplicateVariable(pex, $"{nameof(parameters)}[{i}]");
                     }
                 }
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -241,7 +241,7 @@ namespace System.Linq.Expressions
             }
             if (pi == null)
             {
-                throw Error.InstancePropertyNotDefinedForType(propertyName, expression.Type);
+                throw Error.InstancePropertyNotDefinedForType(propertyName, expression.Type, nameof(propertyName));
             }
             return Property(expression, pi);
         }
@@ -265,7 +265,7 @@ namespace System.Linq.Expressions
             }
             if (pi == null)
             {
-                throw Error.PropertyNotDefinedForType(propertyName, type);
+                throw Error.PropertyNotDefinedForType(propertyName, type, nameof(propertyName));
             }
             return Property(expression, pi);
         }
@@ -311,7 +311,7 @@ namespace System.Linq.Expressions
                 RequiresCanRead(expression, nameof(expression));
                 if (!TypeUtils.IsValidInstanceType(property, expression.Type))
                 {
-                    throw Error.PropertyNotDefinedForType(property, expression.Type);
+                    throw Error.PropertyNotDefinedForType(property, expression.Type, nameof(property));
                 }
             }
 
@@ -393,7 +393,7 @@ namespace System.Linq.Expressions
             if (fi != null)
                 return Field(expression, fi);
 
-            throw Error.NotAMemberOfType(propertyOrFieldName, expression.Type);
+            throw Error.NotAMemberOfType(propertyOrFieldName, expression.Type, nameof(propertyOrFieldName));
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions
                 ContractUtils.RequiresNotNull(b, nameof(bindings));
                 if (!b.Member.DeclaringType.IsAssignableFrom(type))
                 {
-                    throw Error.NotAMemberOfType(b.Member.Name, type);
+                    throw Error.NotAMemberOfType(b.Member.Name, type, $"{nameof(bindings)}[{i}]");
                 }
             }
         }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/GeneralBinaryTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/GeneralBinaryTests.cs
@@ -44,9 +44,9 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(NonBinaryTypesIncludingInvalidData))]
         public void MakeBinaryInvalidType(ExpressionType type)
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0), false, null));
-            Assert.Throws<ArgumentException>(null, () => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0), false, null, null));
+            Assert.Throws<ArgumentException>("binaryType", () => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("binaryType", () => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0), false, null));
+            Assert.Throws<ArgumentException>("binaryType", () => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0), false, null, null));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -149,27 +149,27 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void LambdaTypeMustBeDelegate()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<object>(Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<int>(Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<object>(Expression.Constant(0), true));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<object>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<object>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(object), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(int), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(object), Expression.Constant(0), true));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(object), Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(object), Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>("TDelegate", () => Expression.Lambda<object>(Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("TDelegate", () => Expression.Lambda<int>(Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("TDelegate", () => Expression.Lambda<object>(Expression.Constant(0), true));
+            Assert.Throws<ArgumentException>("TDelegate", () => Expression.Lambda<object>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>("TDelegate", () => Expression.Lambda<object>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(object), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(int), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(object), Expression.Constant(0), true));
+            Assert.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(object), Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(object), Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
 
             // Note, be derived from MulticastDelegate, not merely actually MulticastDelegate or Delegate.
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<Delegate>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<Delegate>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(Delegate), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(Delegate), Expression.Constant(0), true));
+            Assert.Throws<ArgumentException>("TDelegate", () => Expression.Lambda<Delegate>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>("TDelegate", () => Expression.Lambda<Delegate>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(Delegate), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(Delegate), Expression.Constant(0), true));
 
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<MulticastDelegate>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<MulticastDelegate>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(MulticastDelegate), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(MulticastDelegate), Expression.Constant(0), true));
+            Assert.Throws<ArgumentException>("TDelegate", () => Expression.Lambda<MulticastDelegate>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>("TDelegate", () => Expression.Lambda<MulticastDelegate>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(MulticastDelegate), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(MulticastDelegate), Expression.Constant(0), true));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -103,7 +103,7 @@ namespace System.Linq.Expressions.Tests
                 typeof(PropertyAndFields).GetProperty(nameof(PropertyAndFields.StringProperty)),
                 Expression.Constant("value")
                 );
-            Assert.Throws<ArgumentException>(null, () => Expression.MemberInit(newExp, bind));
+            Assert.Throws<ArgumentException>("bindings[0]", () => Expression.MemberInit(newExp, bind));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]


### PR DESCRIPTION
I missed a few of these: existing tests cover the changes, but had to change param names in the tests.
/cc @JonHanna @VSadov