### PR TITLE
Fixed executing msbuild on solutions

### DIFF
--- a/src/Microsoft.VisualBasic/Microsoft.VisualBasic.sln
+++ b/src/Microsoft.VisualBasic/Microsoft.VisualBasic.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Microsoft.VisualBasic", "src\Microsoft.VisualBasic.vbproj", "{FE25D593-8029-4726-ABC2-944522B5BE04}"
 EndProject
-Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Microsoft.VisualBasic.Tests", "src\Microsoft.VisualBasic.Tests.csproj", "{82B54697-0251-47A1-8546-FC507D0F3B08}"
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Microsoft.VisualBasic.Tests", "tests\Microsoft.VisualBasic.Tests.csproj", "{82B54697-0251-47A1-8546-FC507D0F3B08}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Microsoft.Win32.Registry.AccessControl/Microsoft.Win32.Registry.AccessControl.sln
+++ b/src/Microsoft.Win32.Registry.AccessControl/Microsoft.Win32.Registry.AccessControl.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Win32.Registry.AccessControl", "src\Microsoft.Win32.Registry.AccessControl.csproj", "{63B68403-290D-4034-AD85-F1E37F995432}"
 EndProject
@@ -17,39 +17,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Win32.Registry.Ac
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		net46_Debug|Any CPU = net46_Debug|Any CPU
-		net46_Release|Any CPU = net46_Release|Any CPU
 		Windows_Debug|Any CPU = Windows_Debug|Any CPU
 		Windows_Release|Any CPU = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{63B68403-290D-4034-AD85-F1E37F995432}.Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
-		{63B68403-290D-4034-AD85-F1E37F995432}.Debug|Any CPU.Build.0 = net46_Debug|Any CPU
-		{63B68403-290D-4034-AD85-F1E37F995432}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
-		{63B68403-290D-4034-AD85-F1E37F995432}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
-		{63B68403-290D-4034-AD85-F1E37F995432}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
-		{63B68403-290D-4034-AD85-F1E37F995432}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
 		{63B68403-290D-4034-AD85-F1E37F995432}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{63B68403-290D-4034-AD85-F1E37F995432}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{63B68403-290D-4034-AD85-F1E37F995432}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{63B68403-290D-4034-AD85-F1E37F995432}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
-		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.net46_Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.net46_Release|Any CPU.Build.0 = Debug|Any CPU
 		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.Windows_Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.Windows_Release|Any CPU.Build.0 = Debug|Any CPU
-		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{82B54697-0251-47A1-8546-FC507D0F3B08}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{82B54697-0251-47A1-8546-FC507D0F3B08}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{82B54697-0251-47A1-8546-FC507D0F3B08}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
-		{82B54697-0251-47A1-8546-FC507D0F3B08}.net46_Release|Any CPU.Build.0 = Release|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/System.IO.Compression/System.IO.Compression.sln
+++ b/src/System.IO.Compression/System.IO.Compression.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Compression", "src\System.IO.Compression.csproj", "{5471BFE8-8071-466F-838E-5ADAA779E742}"
 EndProject
@@ -17,60 +17,32 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Compression.Tests
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Unix_Debug|Any CPU = Unix_Debug|Any CPU
 		Unix_Release|Any CPU = Unix_Release|Any CPU
-		net46_Debug|Any CPU = net46_Debug|Any CPU
-		net46_Release|Any CPU = net46_Release|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Windows_Debug|Any CPU = Windows_Debug|Any CPU
 		Windows_Release|Any CPU = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{5471BFE8-8071-466F-838E-5ADAA779E742}.Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
-		{5471BFE8-8071-466F-838E-5ADAA779E742}.Debug|Any CPU.Build.0 = net46_Debug|Any CPU
 		{5471BFE8-8071-466F-838E-5ADAA779E742}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
 		{5471BFE8-8071-466F-838E-5ADAA779E742}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
 		{5471BFE8-8071-466F-838E-5ADAA779E742}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
 		{5471BFE8-8071-466F-838E-5ADAA779E742}.Unix_Release|Any CPU.Build.0 = Unix_Release|Any CPU
-		{5471BFE8-8071-466F-838E-5ADAA779E742}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
-		{5471BFE8-8071-466F-838E-5ADAA779E742}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
-		{5471BFE8-8071-466F-838E-5ADAA779E742}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
-		{5471BFE8-8071-466F-838E-5ADAA779E742}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
-		{5471BFE8-8071-466F-838E-5ADAA779E742}.Release|Any CPU.ActiveCfg = net46_Release|Any CPU
-		{5471BFE8-8071-466F-838E-5ADAA779E742}.Release|Any CPU.Build.0 = net46_Release|Any CPU
 		{5471BFE8-8071-466F-838E-5ADAA779E742}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{5471BFE8-8071-466F-838E-5ADAA779E742}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{5471BFE8-8071-466F-838E-5ADAA779E742}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{5471BFE8-8071-466F-838E-5ADAA779E742}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
-		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Unix_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Unix_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Unix_Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Unix_Release|Any CPU.Build.0 = Debug|Any CPU
-		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.net46_Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.net46_Release|Any CPU.Build.0 = Debug|Any CPU
-		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Windows_Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{ADF79DFD-4AC4-4A76-B472-93B86D3BD8E9}.Windows_Release|Any CPU.Build.0 = Debug|Any CPU
-		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.Unix_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.Unix_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.Unix_Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.Unix_Release|Any CPU.Build.0 = Release|Any CPU
-		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.net46_Release|Any CPU.Build.0 = Release|Any CPU
-		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BC2E1649-291D-412E-9529-EDDA94FA7AD6}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/System.Net.Sockets/System.Net.Sockets.sln
+++ b/src/System.Net.Sockets/System.Net.Sockets.sln
@@ -25,7 +25,7 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Unix_Debug|Any CPU = Unix_Debug|Any CPU
-		Unix_Release|Any CPU = Unix_Release|Any CPU CPU
+		Unix_Release|Any CPU = Unix_Release|Any CPU
 		Release|Any CPU = Release|Any CPU
 		Windows_Debug|Any CPU = Windows_Debug|Any CPU
 		Windows_Release|Any CPU = Windows_Release|Any CPU

--- a/src/System.Private.Uri/System.Private.Uri.sln
+++ b/src/System.Private.Uri/System.Private.Uri.sln
@@ -13,7 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTests", "UnitTests", "{
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FunctionalTests", "FunctionalTests", "{F4685A63-70C7-447C-A5E6-BAA26766A8B9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.Uri.Tests", "tests\FunctionalTests\System.Private.Uri.Tests.csproj", "{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.Uri.Tests", "tests\FunctionalTests\System.Private.Uri.Functional.Tests.csproj", "{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.Uri.Unit.Tests", "tests\UnitTests\System.Private.Uri.Unit.Tests.csproj", "{0D174EA9-9E61-4519-8D31-7BD2331A1982}"
 EndProject

--- a/src/System.Security.Cryptography.ProtectedData/System.Security.Cryptography.Protect.sln
+++ b/src/System.Security.Cryptography.ProtectedData/System.Security.Cryptography.Protect.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Cryptography.ProtectedData", "src\System.Security.Cryptography.ProtectedData.csproj", "{FB39F994-1504-4B96-9588-E0385D3B73F1}"
 EndProject
@@ -15,14 +15,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{FB39F994-1504-4B96-9588-E0385D3B73F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FB39F994-1504-4B96-9588-E0385D3B73F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB39F994-1504-4B96-9588-E0385D3B73F1}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{FB39F994-1504-4B96-9588-E0385D3B73F1}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{FB39F994-1504-4B96-9588-E0385D3B73F1}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
 		{FB39F994-1504-4B96-9588-E0385D3B73F1}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
 		{FB39F994-1504-4B96-9588-E0385D3B73F1}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
 		{FB39F994-1504-4B96-9588-E0385D3B73F1}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
-		{FB39F994-1504-4B96-9588-E0385D3B73F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FB39F994-1504-4B96-9588-E0385D3B73F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB39F994-1504-4B96-9588-E0385D3B73F1}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{FB39F994-1504-4B96-9588-E0385D3B73F1}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
 		{749ED7AD-E3C1-4611-99BD-C5D4B3934B3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{749ED7AD-E3C1-4611-99BD-C5D4B3934B3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{749ED7AD-E3C1-4611-99BD-C5D4B3934B3A}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/src/System.Threading.Overlapped/System.Threading.Overlapped.sln
+++ b/src/System.Threading.Overlapped/System.Threading.Overlapped.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading.Overlapped.CoreCLR", "src\System.Threading.Overlapped.CoreCLR.csproj", "{6A07CCB8-3E59-47E7-B3DD-DB1F6FC501D5}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading.Overlapped", "src\System.Threading.Overlapped.csproj", "{6A07CCB8-3E59-47E7-B3DD-DB1F6FC501D5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading.Overlapped.Tests", "tests\System.Threading.Overlapped.Tests.csproj", "{861A3318-35AD-46AC-8257-8D5D2479BAD9}"
 EndProject

--- a/src/System.Xml.XPath.XmlDocument/System.Xml.XPath.XmlDocument.sln
+++ b/src/System.Xml.XPath.XmlDocument/System.Xml.XPath.XmlDocument.sln
@@ -3,10 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XPath.XmlDocument", "src\System.Xml.XPath.XmlDocument.csproj", "{17CB2E3C-2904-4241-94DB-3894D24F35DA}"
-	ProjectSection(ProjectDependencies) = postProject
-		{16EE5522-F387-4C9E-9EF2-B5134B043F37} = {16EE5522-F387-4C9E-9EF2-B5134B043F37}
-		{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD} = {BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XPath.XmlDocument.Tests", "tests\System.Xml.XPath.XmlDocument.Tests.csproj", "{7B57D5F1-4E6C-4280-AD5B-C71C73B66B11}"
 EndProject


### PR DESCRIPTION
- corrected project paths
- removed configurations that don't build
- other small fixes

To find problematic solutions and then verify that they were fixed, I ran the following PS command in `src`:

```powershell
ls -r -filter '*.sln' | % { . 'C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe' /v:m $_.FullName }
```