### PR TITLE
Dispose some X509 resources more aggressively

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
@@ -142,6 +142,7 @@ namespace Internal.Cryptography.Pal
 
             if (cert.IsInvalid)
             {
+                cert.Dispose();
                 certPal = null;
                 return false;
             }
@@ -167,6 +168,7 @@ namespace Internal.Cryptography.Pal
 
             if (cert.IsInvalid)
             {
+                cert.Dispose();
                 fromBio = null;
                 return false;
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -264,6 +264,7 @@ namespace Internal.Cryptography.Pal
                             if (uniqueRootCerts.Add(cert))
                             {
                                 rootStore.Add(cert);
+                                continue;
                             }
                         }
                         else
@@ -271,8 +272,11 @@ namespace Internal.Cryptography.Pal
                             if (uniqueIntermediateCerts.Add(cert))
                             {
                                 s_machineIntermediateStore.Add(cert);
+                                continue;
                             }
                         }
+
+                        cert.Dispose();
                     }
                 }
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -276,6 +276,8 @@ namespace Internal.Cryptography.Pal
                             }
                         }
 
+                        // There's a good chance we'll encounter duplicates on systems that have both one-cert-per-file
+                        // and one-big-file trusted certificate stores. Anything that wasn't unique will end up here.
                         cert.Dispose();
                     }
                 }


### PR DESCRIPTION
In a simple test on Unix that used an HttpClient to download https://bing.com with a server certificate custom validation callback (that just returned true), I saw a ton of memory in OpenSSL not being cleaned up.  Turns out it was being cleaned up, but only once the GC and finalizers ran, due to over 1500 SafeHandles from the X509Certificates library not being disposed of and instead left for finalization.

This commit addresses ~2/3rds of those, ones where it's clear that Dispose'ing is safe (the remaining 1/3, however, represent most of the memory being temporarily leaked).  The others should be looked at by @bartonjs, who can better determine where/when it's safe to clean up the remainder.  Most of the remainder of them are coming from:
```
   at Microsoft.Win32.SafeHandles.SafeX509Handle..ctor()
   at Interop.Crypto.X509Duplicate(IntPtr handle)
   at Internal.Cryptography.Pal.CertificatePal.FromHandle(IntPtr handle)
   at System.Security.Cryptography.X509Certificates.X509Certificate..ctor(IntPtr handle)
   at System.Security.Cryptography.X509Certificates.X509Certificate2..ctor(IntPtr handle)
   at Internal.Cryptography.Pal.StorePal.CloneStore(X509Certificate2Collection seed)
   at Internal.Cryptography.Pal.StorePal.FromSystemStore(String storeName, StoreLocation storeLocation, OpenFlags openFlags)
   at System.Security.Cryptography.X509Certificates.X509Store.Open(OpenFlags flags)
   at Internal.Cryptography.Pal.OpenSslX509ChainProcessor.FindCandidates(X509Certificate2 leaf, X509Certificate2Collection extraStore, HashSet`1 downloaded, HashSet`1 systemTrusted, TimeSpan& remainingDownloadTime)
   at Internal.Cryptography.Pal.ChainPal.BuildChain(Boolean useMachineContext, ICertificatePal cert, X509Certificate2Collection extraStore, OidCollection applicationPolicy, OidCollection certificatePolicy, X509RevocationMode revocationMode, X509RevocationFlag revocationFlag, DateTime verificationTime, TimeSpan timeout)
   at System.Security.Cryptography.X509Certificates.X509Chain.Build(X509Certificate2 certificate)
   at System.Net.Security.CertificateValidation.BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, Boolean checkCertName, String hostName)
   at System.Net.Http.CurlHandler.SslProvider.VerifyCertChain(IntPtr storeCtxPtr, IntPtr curlPtr)
   at Interop.Http.MultiPerform(SafeCurlMultiHandle multiHandle)
   at Interop.Http.MultiPerform(SafeCurlMultiHandle multiHandle)
   at System.Net.Http.CurlHandler.MultiAgent.WorkerBodyLoop()
   at System.Net.Http.CurlHandler.MultiAgent.WorkerBody()
   at System.Threading.Tasks.Task.Execute()
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
   at System.Threading.Tasks.Task.ExecuteEntry(Boolean bPreventDoubleExecution)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
```
and are being left for finalization due to https://github.com/dotnet/corefx/blob/d725f9f6a7232118f9179dc74f56af8ae54dc269/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs#L19-L21 not disposing of the ChainElement's certificates (I wasn't sure if ownership of these was transferred anywhere).

I also looked at using client certificates.  Similarly, in a simple test, several hundred SafeHandles are being left for finalization, coming from:
```
   at Microsoft.Win32.SafeHandles.SafeX509Handle..ctor()
   at Interop.Crypto.X509Duplicate(IntPtr handle)
   at Internal.Cryptography.Pal.CertificatePal.FromHandle(IntPtr handle)
   at System.Security.Cryptography.X509Certificates.X509Certificate..ctor(IntPtr handle)
   at System.Security.Cryptography.X509Certificates.X509Certificate2..ctor(IntPtr handle)
   at Internal.Cryptography.Pal.StorePal.CloneStore(X509Certificate2Collection seed)
   at Internal.Cryptography.Pal.StorePal.FromSystemStore(String storeName, StoreLocation storeLocation, OpenFlags openFlags)
   at System.Security.Cryptography.X509Certificates.X509Store.Open(OpenFlags flags)
   at Internal.Cryptography.Pal.OpenSslX509ChainProcessor.FindCandidates(X509Certificate2 leaf, X509Certificate2Collection extraStore, HashSet`1 downloaded, HashSet`1 systemTrusted, TimeSpan& remainingDownloadTime)
   at Internal.Cryptography.Pal.ChainPal.BuildChain(Boolean useMachineContext, ICertificatePal cert, X509Certificate2Collection extraStore, OidCollection applicationPolicy, OidCollection certificatePolicy, X509RevocationMode revocationMode, X509RevocationFlag revocationFlag, DateTime verificationTime, TimeSpan timeout)
   at System.Security.Cryptography.X509Certificates.X509Chain.Build(X509Certificate2 certificate)
   at System.Net.Http.TLSCertificateExtensions.BuildNewChain(X509Certificate2 certificate, Boolean includeClientApplicationPolicy)
   at System.Net.Http.CurlHandler.ClientCertificateProvider.TlsClientCertCallback(IntPtr ssl, IntPtr& certHandle, IntPtr& privateKeyHandle)
   at Interop.Http.MultiPerform(SafeCurlMultiHandle multiHandle)
   at Interop.Http.MultiPerform(SafeCurlMultiHandle multiHandle)
   at System.Net.Http.CurlHandler.MultiAgent.PerformCurlWork()
   at System.Net.Http.CurlHandler.MultiAgent.WorkerBodyLoop()
   at System.Net.Http.CurlHandler.MultiAgent.WorkerBody()
   at System.Net.Http.CurlHandler.MultiAgent.<>c.<EnsureWorkerIsRunning>b__19_0(Object s)
   at System.Threading.Tasks.Task.Execute()
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
   at System.Threading.Tasks.Task.ExecuteEntry(Boolean bPreventDoubleExecution)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
```
and are being left for finalization due to all of the certificates in these collections https://github.com/dotnet/corefx/blob/d725f9f6a7232118f9179dc74f56af8ae54dc269/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs#L495-L498 not being disposed of (again, some of these appear to be handed out, so I've not touched them because I'm unclear as to the lifetime and ownership).

Separately, we should also look at whether there's anything we can do about so many SafeHandles being created.

cc: @bartonjs 