### PR TITLE
Port to release/1.0.0: Implement Console support for netcore50

### DIFF
--- a/src/System.Console/pkg/win/System.Console.pkgproj
+++ b/src/System.Console/pkg/win/System.Console.pkgproj
@@ -11,6 +11,10 @@
     <ProjectReference Include="..\..\src\System.Console.csproj" >
       <OSGroup>Windows_NT</OSGroup>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\System.Console.csproj" >
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
     <ExternalOnTargetFramework Include="net" />
   </ItemGroup>
 

--- a/src/System.Console/src/System.Console.builds
+++ b/src/System.Console/src/System.Console.builds
@@ -11,6 +11,10 @@
     <Project Include="System.Console.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>
+    <Project Include="System.Console.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'=='' AND '$(TargetGroup)' == ''">Windows_Debug</Configuration>
@@ -11,7 +11,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.3</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
@@ -19,6 +19,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
@@ -40,7 +42,12 @@
       <Link>Common\System\IO\EncodingHelper.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'net46' ">
+  <!-- Windows : WinRT -->
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'netcore50' ">
+    <Compile Include="System\ConsolePal.WinRT.cs" />
+  </ItemGroup>
+  <!-- Windows : Win32 -->
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == ''">
     <Compile Include="System\ConsolePal.Windows.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
@@ -151,6 +158,7 @@
       <Link>Common\System\IO\Win32Marshal.cs</Link>
     </Compile>
   </ItemGroup>
+  <!-- Unix -->
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And '$(TargetGroup)' != 'net46'">
     <Compile Include="System\ConsolePal.Unix.cs" />
     <Compile Include="System\TermInfo.cs" />

--- a/src/System.Console/src/System/ConsolePal.WinRT.cs
+++ b/src/System.Console/src/System/ConsolePal.WinRT.cs
@@ -1,0 +1,203 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace System
+{
+    /// <summary>
+    /// UWP does not have a concept of StandardOutput on which to print Console output.
+    /// However, we don't want to throw an error for every instance of Console.WriteLine
+    /// so we instead just do nothing. 
+    /// </summary>
+    internal sealed class NoOpStream : ConsoleStream
+    {
+        public NoOpStream() : base(FileAccess.Write) { }
+
+        public override void Flush()
+        {
+            if (!CanWrite)
+                throw Error.GetFileNotOpen(); // ObjectDisposedException so Flush fails after disposal
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ValidateRead(buffer, offset, count); // will always throw since access = FileAccess.Write
+            return -1;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            ValidateWrite(buffer, offset, count);
+        }
+    }
+
+    /// <summary>
+    /// The UWP ConsolePal stubs out all methods with PlatformNotSupportedExceptions. The exception to this is
+    /// some methods return default values similar to those returned by Unix.
+    /// 
+    /// The end result of the stubs is that using the Console on UWP will fail unless input and/or output are
+    /// redirected.
+    /// </summary>
+    internal static class ConsolePal
+    {
+        internal static TextReader GetOrCreateReader() { throw new PlatformNotSupportedException(); }
+
+        internal sealed class ControlCHandlerRegistrar
+        {
+            internal void Register() { throw new PlatformNotSupportedException(); }
+
+            internal void Unregister() { throw new PlatformNotSupportedException(); }
+        }
+
+        public static Stream OpenStandardInput() { throw new PlatformNotSupportedException(); }
+
+        public static Stream OpenStandardOutput() { return new NoOpStream(); }
+
+        public static Stream OpenStandardError() { return new NoOpStream(); }
+
+        public static Encoding InputEncoding
+        {
+            get { return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false); }
+        }
+
+        public static Encoding OutputEncoding
+        {
+            get { return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false); }
+        }
+
+        public static bool KeyAvailable { get { throw new PlatformNotSupportedException(); } }
+
+        public static ConsoleKeyInfo ReadKey(bool intercept) { throw new PlatformNotSupportedException(); }
+
+        public static bool TreatControlCAsInput
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static ConsoleColor ForegroundColor
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static ConsoleColor BackgroundColor
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static void ResetColor() { throw new PlatformNotSupportedException(); }
+
+        public static bool NumberLock { get { throw new PlatformNotSupportedException(); } }
+
+        public static bool CapsLock { get { throw new PlatformNotSupportedException(); } }
+
+        public static int CursorSize
+        {
+            get { return 100; }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static string Title
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static void Beep() { throw new PlatformNotSupportedException(); }
+
+        public static void Beep(int frequency, int duration) { throw new PlatformNotSupportedException(); }
+
+        public static void Clear() { throw new PlatformNotSupportedException(); }
+
+        public static void SetCursorPosition(int left, int top) { throw new PlatformNotSupportedException(); }
+
+        public static int BufferWidth
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static int BufferHeight
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static void SetBufferSize(int width, int height) { throw new PlatformNotSupportedException(); }
+
+        public static int LargestWindowWidth
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static int LargestWindowHeight
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static int WindowLeft
+        {
+            get { return 0; }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static int WindowTop
+        {
+            get { return 0; }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static int WindowWidth
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static int WindowHeight
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static void SetWindowPosition(int left, int top) { throw new PlatformNotSupportedException(); }
+
+        public static void SetWindowSize(int width, int height) { throw new PlatformNotSupportedException(); }
+
+        public static bool CursorVisible
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        public static int CursorLeft { get { throw new PlatformNotSupportedException(); } }
+
+        public static int CursorTop { get { throw new PlatformNotSupportedException(); } }
+
+        public static void MoveBufferArea(int sourceLeft, int sourceTop, int sourceWidth, int sourceHeight, int targetLeft, int targetTop) { throw new PlatformNotSupportedException(); }
+
+        public static void MoveBufferArea(int sourceLeft, int sourceTop, int sourceWidth, int sourceHeight, int targetLeft, int targetTop, char sourceChar, ConsoleColor sourceForeColor, ConsoleColor sourceBackColor) { throw new PlatformNotSupportedException(); }
+
+        public static bool IsInputRedirectedCore() { throw new PlatformNotSupportedException(); }
+
+        public static bool IsOutputRedirectedCore() { throw new PlatformNotSupportedException(); }
+
+        public static bool IsErrorRedirectedCore() { throw new PlatformNotSupportedException(); }
+
+        public static void SetConsoleInputEncoding(Encoding enc) { }
+
+        public static void SetConsoleOutputEncoding(Encoding enc) { }
+
+        public static bool TryGetSpecialConsoleKey(char[] givenChars, int startIndex, int endIndex, out ConsoleKeyInfo key, out int keyLength) { throw new PlatformNotSupportedException(); }
+    }
+}

--- a/src/System.Console/src/project.json
+++ b/src/System.Console/src/project.json
@@ -26,6 +26,18 @@
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
+    },
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1-rc3-24131-00",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.IO.FileSystem.Primitives": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Text.Encoding.Extensions": "4.0.10",
+        "System.Threading.Tasks": "4.0.10"
+      }
     }
   }
 }


### PR DESCRIPTION
port https://github.com/dotnet/corefx/pull/8853:

The Windows implementation currently used for netcore50 will fail the WACK check as it calls a number of APIs unsupported by UWP. This commit adds a separate netcore50 build that stubs out the API calls and replaces them with PlatformNotSupportedExceptions or no-ops where appropriate. The result is a platform-agnostic version of System.Console that can be used anywhere but is severely stripped of functionality.

- Where possible the behavior of a redirected Console operation will attempt to mimic that of a Unix redirected Console operation. Otherwise it will throw.
- Encoding is fixed to UTF8. Attempting to set the Console encoding will no-op.
- Added a section in the packaging build for the new netcore50 specific binary
- Input/Output redirection and subsequent reads/writes work as expected.


@weshaggard @ericstj 
