### PR TITLE
Remove innerloop dependencies on www.ssllabs.com

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1176,32 +1176,7 @@ namespace System.Net.Http.Functional.Tests
             return receivedRequestVersion;
         }
         #endregion
-
-        #region SSL Version tests
-        [Theory]
-        [InlineData("SSLv2", HttpTestServers.SSLv2RemoteServer)]
-        [InlineData("SSLv3", HttpTestServers.SSLv3RemoteServer)]
-        public async Task GetAsync_UnsupportedSSLVersion_Throws(string name, string url)
-        {
-            using (HttpClient client = new HttpClient())
-            {
-                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
-            }
-        }
-
-        [Theory]
-        [InlineData("TLSv1.0", HttpTestServers.TLSv10RemoteServer)]
-        [InlineData("TLSv1.1", HttpTestServers.TLSv11RemoteServer)]
-        [InlineData("TLSv1.2", HttpTestServers.TLSv12RemoteServer)]
-        public async Task GetAsync_SupportedSSLVersion_Succeeds(string name, string url)
-        {
-            using (HttpClient client = new HttpClient())
-            using (await client.GetAsync(url))
-            {
-            }
-        }
-        #endregion
-
+        
         #region Proxy tests
         [Theory]
         [MemberData(nameof(CredentialsForProxy))]


### PR DESCRIPTION
We have several tests that make HTTP calls during System.Net.Http.Functional.Tests out to www.ssllabs.com, which has SSL endpoints for different SSL protocols.  This commit avoids using that server during innerloop tests.  Some of the dependencies are removed entirely, by using a localhost SSL server instead.  The remainder are made outerloop.

cc: @bartonjs, @davidsh, @cipop, @ericeil