### PR TITLE
Fix some memory leaks in WinHttpRequestState

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -16,6 +16,15 @@ namespace System.Net.Http
 {
     internal sealed class WinHttpRequestState : IDisposable
     {
+#if DEBUG
+        private static int s_dbg_allocated = 0;
+        private static int s_dbg_pin = 0;
+        private static int s_dbg_clearSendRequestState = 0;
+        private static int s_dbg_callDispose = 0;
+        private static int s_dbg_operationHandleFree = 0;
+
+        private IntPtr s_dbg_requestHandle;
+#endif        
         // TODO (Issue 2506): The current locking mechanism doesn't allow any two WinHttp functions executing at
         // the same time for the same handle. Enhance locking to prevent only WinHttpCloseHandle being called
         // during other API execution. E.g. using a Reader/Writer model or, even better, Interlocked functions.
@@ -26,13 +35,23 @@ namespace System.Net.Http
 
         // A GCHandle for this operation object.
         // This is owned by the callback and will be deallocated when the sessionHandle has been closed.
-        private GCHandle _operationHandle = new GCHandle();
+        private GCHandle _operationHandle;
 
         private volatile bool _disposed = false; // To detect redundant calls.
 
         public WinHttpRequestState()
         {
+#if DEBUG
+            Interlocked.Increment(ref s_dbg_allocated);
+#endif
             TransportContext = new WinHttpTransportContext();
+        }
+
+        public void Pin()
+        {
+#if DEBUG
+            Interlocked.Increment(ref s_dbg_pin);
+#endif
             _operationHandle = GCHandle.Alloc(this);
         }
 
@@ -57,6 +76,9 @@ namespace System.Net.Http
 
         public void ClearSendRequestState()
         {
+#if DEBUG
+            Interlocked.Increment(ref s_dbg_clearSendRequestState);
+#endif
             // Since WinHttpRequestState has a self-referenced strong GCHandle, we
             // need to clear out object references to break cycles and prevent leaks.
             Tcs = null;
@@ -64,14 +86,20 @@ namespace System.Net.Http
             TcsWriteToRequestStream = null;
             TcsInternalWriteDataToRequestStream = null;
             TcsReceiveResponseHeaders = null;
+            CancellationToken = default(CancellationToken);
             RequestMessage = null;
             Handler = null;
-            RequestHandle = null;
             ServerCertificateValidationCallback = null;
             TransportContext = null;
             Proxy = null;
             ServerCredentials = null;
             DefaultProxyCredentials = null;
+
+            if (RequestHandle != null)
+            {
+                RequestHandle.Dispose();
+                RequestHandle = null;
+            }
         }
 
         public TaskCompletionSource<HttpResponseMessage> Tcs { get; set; }
@@ -82,7 +110,25 @@ namespace System.Net.Http
 
         public WinHttpHandler Handler { get; set; }
 
-        public SafeWinHttpHandle RequestHandle { get; set; }
+        SafeWinHttpHandle _requestHandle;
+        public SafeWinHttpHandle RequestHandle
+        {
+            get
+            {
+                return _requestHandle;
+            }
+
+            set
+            {
+#if DEBUG
+                if (value != null)
+                {
+                    s_dbg_requestHandle = value.DangerousGetHandle();
+                }
+#endif
+                _requestHandle = value;
+            }
+        }
 
         public Exception SavedException { get; set; }
 
@@ -125,7 +171,7 @@ namespace System.Net.Http
         public long CurrentBytesRead { get; set; }
 
         // TODO (Issue 2505): temporary pinned buffer caches of 1 item. Will be replaced by PinnableBufferCache.
-        private GCHandle _cachedReceivePinnedBuffer = default(GCHandle);
+        private GCHandle _cachedReceivePinnedBuffer;
 
         public void PinReceiveBuffer(byte[] buffer)
         {
@@ -150,6 +196,9 @@ namespace System.Net.Http
         #region IDisposable Members
         private void Dispose(bool disposing)
         {
+#if DEBUG
+            Interlocked.Increment(ref s_dbg_callDispose);
+#endif
             if (WinHttpTraceHelper.IsTraceEnabled())
             {
                 WinHttpTraceHelper.Trace(
@@ -179,7 +228,9 @@ namespace System.Net.Http
                     _cachedReceivePinnedBuffer.Free();
                     _cachedReceivePinnedBuffer = default(GCHandle);
                 }
-
+#if DEBUG
+                Interlocked.Increment(ref s_dbg_operationHandleFree);
+#endif
                 _operationHandle.Free();
                 _operationHandle = default(GCHandle);
             }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -53,6 +53,7 @@ namespace System.Net.Http
 
             // Create response stream and wrap it in a StreamContent object.
             var responseStream = new WinHttpResponseStream(requestHandle, state);
+            state.RequestHandle = null; // ownership successfully transfered to WinHttpResponseStram.
             Stream decompressedStream = responseStream;
 
             if (doManualDecompressionCheck)

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
@@ -307,6 +307,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         internal Stream MakeRequestStream()
         {
             var state = new WinHttpRequestState();
+            state.Pin();
             var handle = new FakeSafeWinHttpHandle(true);
             handle.Callback = WinHttpRequestCallback.StaticCallbackDelegate;
             handle.Context = state.ToIntPtr();

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
@@ -371,6 +371,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         internal Stream MakeResponseStream()
         {
             var state = new WinHttpRequestState();
+            state.Pin();
             var handle = new FakeSafeWinHttpHandle(true);
             handle.Callback = WinHttpRequestCallback.StaticCallbackDelegate;
             handle.Context = state.ToIntPtr();


### PR DESCRIPTION
When HTTP requests are canceled, we are leaking WinHttpRequestState objects and some child objects. Since WInHttpRequestState is strongly pinned, it's important to release things as soon as possible.

This fix addresses part of the leaks involved in #8819 by removing references to some fields in the state object related to the request/response phase (CancellationToken).  In addition, this fix addresses some cases where the state object is created and pinned but the request is canceled before we hook up the state object to the WInHTTP status callback. Because of not being hooked up yet, the state object won't get HANDLE_CLOSING notifications and remains pinned forever.

We now pin the state object later when we're sure that we've hooked up the status callback.

I also added some DEBUG tracking to help diagnose the rest of the leaks of #8819.