### PR TITLE
Add separate expected prerelease for external versions

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -81,7 +81,11 @@
   <PropertyGroup>
     <ValidatePackageVersions>true</ValidatePackageVersions>
     <ProhibitFloatingDependencies>true</ProhibitFloatingDependencies>
+
     <CoreFxExpectedPrerelease>rc4-24131-00</CoreFxExpectedPrerelease>
+    <CoreClrExpectedPrerelease>rc4-24131-00</CoreClrExpectedPrerelease>
+    <ExternalExpectedPrerelease>rc4-24131-00</ExternalExpectedPrerelease>
+
     <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore\.Targets)|(Microsoft\.NETCore\.Platforms)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)(?&lt;!System\.Data\.SqlClient)(?&lt;!System\.IO\.Compression)$</CoreFxVersionsIdentityRegex>
   </PropertyGroup>
   
@@ -94,15 +98,15 @@
     </ValidationPattern>
     <ValidationPattern Include="CoreClrVersions">
       <IdentityRegex>^(?i)Microsoft\.NETCore\.Runtime.*$</IdentityRegex>
-      <ExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExpectedPrerelease>
+      <ExpectedPrerelease>$(CoreClrExpectedPrerelease)</ExpectedPrerelease>
     </ValidationPattern>
     <ValidationPattern Include="CoreLibTargetingPackVersions">
       <IdentityRegex>^(?i)Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative)$</IdentityRegex>
-      <ExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExpectedPrerelease>
+      <ExpectedPrerelease>$(ExternalExpectedPrerelease)</ExpectedPrerelease>
     </ValidationPattern>
     <ValidationPattern Include="ExternalVersions">
       <IdentityRegex>^(?i)((System\.Data\.SqlClient)|(System\.IO\.Compression))$</IdentityRegex>
-      <ExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExpectedPrerelease>
+      <ExpectedPrerelease>$(ExternalExpectedPrerelease)</ExpectedPrerelease>
     </ValidationPattern>
     <ValidationPattern Include="TargetingPackVersions">
       <IdentityRegex>^(?i)Microsoft\.TargetingPack\.(NetFramework.*|Private\.WinRT)$</IdentityRegex>


### PR DESCRIPTION
Add elements for external dependency versions (built in TFS/elsewhere rather than the CoreFX build pipeline) and add an UpdateDependencies.ps1 parameter that specifies which property is updated.

This lets us switch over to more flexible dependencies and auto-update both from the versions repo. (Auto-updating the non-CoreFX dependencies is work TODO in the versions repo and update build.)

/cc @jhendrixMSFT @chcosta @weshaggard @eerhardt 