### PR TITLE
Allow writing an ASCII ZipArchive

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -429,21 +429,6 @@ namespace System.IO.Compression
             }
         }
 
-        private Encoding DefaultSystemEncoding
-        {
-            // On the desktop, this was Encoding.GetEncoding(0), which gives you the encoding object
-            // that corresponds too the default system codepage.
-            // However, in ProjectN, not only Encoding.GetEncoding(Int32) is not exposed, but there is also
-            // no guarantee that a notion of a default system code page exists on the OS.
-            // In fact, we can really only rely on UTF8 and UTF16 being present on all platforms.
-            // We fall back to UTF8 as this is what is used by ZIP when as the "unicode encoding".
-            get
-            {
-                return Encoding.UTF8;
-                // return Encoding.GetEncoding(0);
-            }
-        }
-
         private String DecodeEntryName(Byte[] entryNameBytes)
         {
             Debug.Assert(entryNameBytes != null);
@@ -452,8 +437,8 @@ namespace System.IO.Compression
             if ((_generalPurposeBitFlag & BitFlagValues.UnicodeFileName) == 0)
             {
                 readEntryNameEncoding = (_archive == null)
-                                            ? DefaultSystemEncoding
-                                            : _archive.EntryNameEncoding ?? DefaultSystemEncoding;
+                                            ? Encoding.UTF8
+                                            : _archive.EntryNameEncoding ?? Encoding.UTF8;
             }
             else
             {
@@ -473,7 +458,7 @@ namespace System.IO.Compression
             else
                 writeEntryNameEncoding = ZipHelper.RequiresUnicode(entryName)
                                             ? Encoding.UTF8
-                                            : DefaultSystemEncoding;
+                                            : Encoding.ASCII;
 
             isUTF8 = writeEntryNameEncoding.Equals(Encoding.UTF8);
             return writeEntryNameEncoding.GetBytes(entryName);
@@ -662,10 +647,10 @@ namespace System.IO.Compression
 
             Boolean leaveCompressorStreamOpenOnClose = leaveBackingStreamOpen && !isIntermediateStream;
             var checkSumStream = new CheckSumAndSizeWriteStream(
-                compressorStream, 
-                backingStream, 
-                leaveCompressorStreamOpenOnClose, 
-                this, 
+                compressorStream,
+                backingStream,
+                leaveCompressorStreamOpenOnClose,
+                this,
                 onClose,
                 (Int64 initialPosition, Int64 currentPosition, UInt32 checkSum, Stream backing, ZipArchiveEntry thisRef, EventHandler closeHandler) =>
                 {
@@ -743,14 +728,14 @@ namespace System.IO.Compression
             _currentlyOpenForWrite = true;
             //always put it at the beginning for them
             UncompressedData.Seek(0, SeekOrigin.Begin);
-            return new WrappedStream(UncompressedData, this, thisRef => 
-                                     {
-                                         //once they close, we know uncompressed length, but still not compressed length
-                                         //so we don't fill in any size information
-                                         //those fields get figured out when we call GetCompressor as we write it to
-                                         //the actual archive
-                                         thisRef._currentlyOpenForWrite = false;
-                                     });
+            return new WrappedStream(UncompressedData, this, thisRef =>
+            {
+                //once they close, we know uncompressed length, but still not compressed length
+                //so we don't fill in any size information
+                //those fields get figured out when we call GetCompressor as we write it to
+                //the actual archive
+                thisRef._currentlyOpenForWrite = false;
+            });
         }
 
         private Boolean IsOpenable(Boolean needToUncompress, Boolean needToLoadIntoMemory, out String message)

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
@@ -25,7 +25,11 @@ namespace System.IO.Compression
 
             foreach (Char c in test)
             {
-                if (c > 127) return true;
+                // The Zip Format uses code page 437 when the Unicode bit is not set. This format
+                // is the same as ASCII for characters 32-126 but differs otherwise. If we can fit 
+                // the string into CP437 then we treat ASCII as acceptable.
+                if (c > 126 || c < 32)
+                    return true;
             }
 
             return false;


### PR DESCRIPTION
ZipArchive currently always sets the Zip header Unicode bit. This is a regression from the net46 version that set the bit based on the current default encoding page set. This commit modifies the behavior to default write ASCII whenever possible and only write/set Unicode when it is necessary or explicitly asked for.

- When encoding an entry name, we check if it contains any characters outside 32-126. If it does, we encode it as UTF8. If it doesn't, we encode it as ASCII.
- Decoding is unchanged. If the encoding isn't set, then we assume UTF8. This is so we have the widest range of effective readability and because we cannot represent values outside of the ASCII 32-126 range from CP437

@ericstj 

resolves #8995