### PR TITLE
Use correct openSUSE RID

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/Common/tests/System/Xml/ModuleCore/project.json
+++ b/src/Common/tests/System/Xml/ModuleCore/project.json
@@ -20,7 +20,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/Common/tests/System/Xml/XmlCoreTest/project.json
+++ b/src/Common/tests/System/Xml/XmlCoreTest/project.json
@@ -22,7 +22,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/Common/tests/System/Xml/XmlDiff/project.json
+++ b/src/Common/tests/System/Xml/XmlDiff/project.json
@@ -19,7 +19,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/Common/tests/project.json
+++ b/src/Common/tests/project.json
@@ -41,7 +41,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/Microsoft.CSharp/tests/project.json
+++ b/src/Microsoft.CSharp/tests/project.json
@@ -40,7 +40,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/Microsoft.VisualBasic/tests/project.json
+++ b/src/Microsoft.VisualBasic/tests/project.json
@@ -42,7 +42,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/Microsoft.Win32.Primitives/tests/project.json
+++ b/src/Microsoft.Win32.Primitives/tests/project.json
@@ -26,7 +26,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/Microsoft.Win32.Registry/tests/project.json
+++ b/src/Microsoft.Win32.Registry/tests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.AppContext/tests/project.json
+++ b/src/System.AppContext/tests/project.json
@@ -26,7 +26,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Buffers/tests/project.json
+++ b/src/System.Buffers/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Collections.Concurrent/tests/project.json
+++ b/src/System.Collections.Concurrent/tests/project.json
@@ -35,7 +35,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Collections.Immutable/tests/project.json
+++ b/src/System.Collections.Immutable/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -35,7 +35,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Collections.Specialized/tests/project.json
+++ b/src/System.Collections.Specialized/tests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -33,7 +33,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.ComponentModel.Annotations/tests/project.json
+++ b/src/System.ComponentModel.Annotations/tests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.ComponentModel.EventBasedAsync/tests/project.json
+++ b/src/System.ComponentModel.EventBasedAsync/tests/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.ComponentModel.Primitives/tests/project.json
+++ b/src/System.ComponentModel.Primitives/tests/project.json
@@ -26,7 +26,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.ComponentModel/tests/project.json
+++ b/src/System.ComponentModel/tests/project.json
@@ -25,7 +25,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Composition.Convention/tests/project.json
+++ b/src/System.Composition.Convention/tests/project.json
@@ -24,7 +24,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Composition/perftests/project.json
+++ b/src/System.Composition/perftests/project.json
@@ -25,7 +25,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Composition/tests/project.json
+++ b/src/System.Composition/tests/project.json
@@ -24,7 +24,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -36,7 +36,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Data.Common/tests/project.json
+++ b/src/System.Data.Common/tests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -28,7 +28,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Data.SqlClient/tests/ManualTests/project.json
+++ b/src/System.Data.SqlClient/tests/ManualTests/project.json
@@ -64,7 +64,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Diagnostics.Contracts/tests/project.json
+++ b/src/System.Diagnostics.Contracts/tests/project.json
@@ -28,7 +28,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -25,7 +25,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Diagnostics.Process/tests/project.json
+++ b/src/System.Diagnostics.Process/tests/project.json
@@ -44,7 +44,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Diagnostics.Tools/tests/project.json
+++ b/src/System.Diagnostics.Tools/tests/project.json
@@ -25,7 +25,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Diagnostics.TraceSource/tests/project.json
+++ b/src/System.Diagnostics.TraceSource/tests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Diagnostics.Tracing/tests/project.json
+++ b/src/System.Diagnostics.Tracing/tests/project.json
@@ -36,7 +36,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Drawing.Primitives/tests/project.json
+++ b/src/System.Drawing.Primitives/tests/project.json
@@ -26,7 +26,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Dynamic.Runtime/tests/project.json
+++ b/src/System.Dynamic.Runtime/tests/project.json
@@ -38,7 +38,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Globalization.Calendars/tests/project.json
+++ b/src/System.Globalization.Calendars/tests/project.json
@@ -40,7 +40,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Globalization.Extensions/tests/project.json
+++ b/src/System.Globalization.Extensions/tests/project.json
@@ -43,7 +43,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -43,7 +43,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -39,7 +39,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -39,7 +39,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO.FileSystem.AccessControl/tests/project.json
+++ b/src/System.IO.FileSystem.AccessControl/tests/project.json
@@ -38,7 +38,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO.FileSystem.DriveInfo/tests/project.json
+++ b/src/System.IO.FileSystem.DriveInfo/tests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO.FileSystem.Primitives/tests/project.json
+++ b/src/System.IO.FileSystem.Primitives/tests/project.json
@@ -25,7 +25,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO.FileSystem.Watcher/tests/project.json
+++ b/src/System.IO.FileSystem.Watcher/tests/project.json
@@ -36,7 +36,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -42,7 +42,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO.MemoryMappedFiles/tests/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/project.json
@@ -35,7 +35,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO.Packaging/tests/project.json
+++ b/src/System.IO.Packaging/tests/project.json
@@ -31,7 +31,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO.Pipes/tests/project.json
+++ b/src/System.IO.Pipes/tests/project.json
@@ -37,7 +37,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO.UnmanagedMemoryStream/tests/project.json
+++ b/src/System.IO.UnmanagedMemoryStream/tests/project.json
@@ -33,7 +33,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.IO/tests/project.json
+++ b/src/System.IO/tests/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Linq.Expressions/tests/project.json
+++ b/src/System.Linq.Expressions/tests/project.json
@@ -34,7 +34,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Linq.Parallel/tests/project.json
+++ b/src/System.Linq.Parallel/tests/project.json
@@ -35,7 +35,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Linq.Queryable/tests/project.json
+++ b/src/System.Linq.Queryable/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -31,7 +31,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
@@ -31,7 +31,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -40,7 +40,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Http/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/unix/project.json
@@ -40,7 +40,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Http/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/win/project.json
@@ -41,7 +41,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Http/tests/UnitTests/project.json
+++ b/src/System.Net.Http/tests/UnitTests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.NameResolution/tests/FunctionalTests/project.json
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.NameResolution/tests/PalTests/project.json
+++ b/src/System.Net.NameResolution/tests/PalTests/project.json
@@ -44,7 +44,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.NetworkInformation/tests/UnitTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/UnitTests/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Ping/tests/FunctionalTests/project.json
+++ b/src/System.Net.Ping/tests/FunctionalTests/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Primitives/tests/FunctionalTests/project.json
+++ b/src/System.Net.Primitives/tests/FunctionalTests/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Primitives/tests/PalTests/project.json
+++ b/src/System.Net.Primitives/tests/PalTests/project.json
@@ -35,7 +35,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Primitives/tests/UnitTests/project.json
+++ b/src/System.Net.Primitives/tests/UnitTests/project.json
@@ -36,7 +36,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Requests/tests/project.json
+++ b/src/System.Net.Requests/tests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -38,7 +38,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -36,7 +36,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Security/tests/UnitTests/project.json
+++ b/src/System.Net.Security/tests/UnitTests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Sockets/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets/tests/FunctionalTests/project.json
@@ -35,7 +35,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.Sockets/tests/PerformanceTests/project.json
+++ b/src/System.Net.Sockets/tests/PerformanceTests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.WebHeaderCollection/tests/project.json
+++ b/src/System.Net.WebHeaderCollection/tests/project.json
@@ -22,7 +22,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.WebSockets.Client/tests/project.json
+++ b/src/System.Net.WebSockets.Client/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Net.WebSockets/tests/project.json
+++ b/src/System.Net.WebSockets/tests/project.json
@@ -26,7 +26,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Numerics.Vectors/tests/project.json
+++ b/src/System.Numerics.Vectors/tests/project.json
@@ -34,7 +34,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.ObjectModel/tests/project.json
+++ b/src/System.ObjectModel/tests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Private.Uri/tests/FunctionalTests/project.json
+++ b/src/System.Private.Uri/tests/FunctionalTests/project.json
@@ -26,7 +26,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Private.Uri/tests/UnitTests/project.json
+++ b/src/System.Private.Uri/tests/UnitTests/project.json
@@ -24,7 +24,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection.Context/tests/project.json
+++ b/src/System.Reflection.Context/tests/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection.DispatchProxy/tests/project.json
+++ b/src/System.Reflection.DispatchProxy/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection.Emit.ILGeneration/tests/project.json
+++ b/src/System.Reflection.Emit.ILGeneration/tests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection.Emit.Lightweight/tests/project.json
+++ b/src/System.Reflection.Emit.Lightweight/tests/project.json
@@ -28,7 +28,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection.Emit/tests/project.json
+++ b/src/System.Reflection.Emit/tests/project.json
@@ -31,7 +31,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection.Extensions/tests/project.json
+++ b/src/System.Reflection.Extensions/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection.Metadata/tests/project.json
+++ b/src/System.Reflection.Metadata/tests/project.json
@@ -41,7 +41,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
@@ -34,7 +34,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection.TypeExtensions/tests/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection/tests/CoreCLR/project.json
+++ b/src/System.Reflection/tests/CoreCLR/project.json
@@ -31,7 +31,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection/tests/TestExe/project.json
+++ b/src/System.Reflection/tests/TestExe/project.json
@@ -15,7 +15,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Reflection/tests/project.json
+++ b/src/System.Reflection/tests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Resources.Reader/tests/project.json
+++ b/src/System.Resources.Reader/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Resources.ResourceManager/tests/project.json
+++ b/src/System.Resources.ResourceManager/tests/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Resources.Writer/tests/project.json
+++ b/src/System.Resources.Writer/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/project.json
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/project.json
@@ -22,7 +22,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -34,7 +34,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.Handles/tests/project.json
+++ b/src/System.Runtime.Handles/tests/project.json
@@ -26,7 +26,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.InteropServices/tests/project.json
+++ b/src/System.Runtime.InteropServices/tests/project.json
@@ -25,7 +25,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.Loader/tests/DefaultContext/project.json
+++ b/src/System.Runtime.Loader/tests/DefaultContext/project.json
@@ -34,7 +34,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.Loader/tests/project.json
+++ b/src/System.Runtime.Loader/tests/project.json
@@ -34,7 +34,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.Numerics/tests/project.json
+++ b/src/System.Runtime.Numerics/tests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.Serialization.Formatters/tests/project.json
+++ b/src/System.Runtime.Serialization.Formatters/tests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.Serialization.Json/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/project.json
@@ -44,7 +44,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.Serialization.Json/tests/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/project.json
@@ -40,7 +40,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
@@ -43,7 +43,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -39,7 +39,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Runtime/tests/project.json
+++ b/src/System.Runtime/tests/project.json
@@ -35,7 +35,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.Claims/tests/project.json
+++ b/src/System.Security.Claims/tests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.Cryptography.Algorithms/tests/project.json
+++ b/src/System.Security.Cryptography.Algorithms/tests/project.json
@@ -33,7 +33,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.Cryptography.Cng/tests/project.json
+++ b/src/System.Security.Cryptography.Cng/tests/project.json
@@ -35,7 +35,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.Cryptography.Csp/tests/project.json
+++ b/src/System.Security.Cryptography.Csp/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.Cryptography.Encoding/tests/project.json
+++ b/src/System.Security.Cryptography.Encoding/tests/project.json
@@ -28,7 +28,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.Cryptography.OpenSsl/tests/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/tests/project.json
@@ -31,7 +31,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.Cryptography.Pkcs/tests/project.json
+++ b/src/System.Security.Cryptography.Pkcs/tests/project.json
@@ -28,7 +28,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.Cryptography.Primitives/tests/project.json
+++ b/src/System.Security.Cryptography.Primitives/tests/project.json
@@ -26,7 +26,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.Cryptography.ProtectedData/tests/project.json
+++ b/src/System.Security.Cryptography.ProtectedData/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.json
@@ -35,7 +35,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.Principal.Windows/tests/project.json
+++ b/src/System.Security.Principal.Windows/tests/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Security.SecureString/tests/project.json
+++ b/src/System.Security.SecureString/tests/project.json
@@ -23,7 +23,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Text.Encoding.CodePages/tests/project.json
+++ b/src/System.Text.Encoding.CodePages/tests/project.json
@@ -28,7 +28,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Text.Encoding.Extensions/tests/project.json
+++ b/src/System.Text.Encoding.Extensions/tests/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Text.Encoding/tests/project.json
+++ b/src/System.Text.Encoding/tests/project.json
@@ -31,7 +31,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Text.Encodings.Web/tests/project.json
+++ b/src/System.Text.Encodings.Web/tests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Text.RegularExpressions/tests/project.json
+++ b/src/System.Text.RegularExpressions/tests/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Threading.AccessControl/tests/project.json
+++ b/src/System.Threading.AccessControl/tests/project.json
@@ -33,7 +33,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Threading.Overlapped/tests/project.json
+++ b/src/System.Threading.Overlapped/tests/project.json
@@ -25,7 +25,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Threading.Tasks.Dataflow/tests/project.json
+++ b/src/System.Threading.Tasks.Dataflow/tests/project.json
@@ -35,7 +35,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Threading.Tasks.Extensions/tests/project.json
+++ b/src/System.Threading.Tasks.Extensions/tests/project.json
@@ -26,7 +26,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Threading.Tasks.Parallel/tests/project.json
+++ b/src/System.Threading.Tasks.Parallel/tests/project.json
@@ -33,7 +33,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Threading.Tasks/tests/project.json
+++ b/src/System.Threading.Tasks/tests/project.json
@@ -33,7 +33,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Threading.Timer/tests/project.json
+++ b/src/System.Threading.Timer/tests/project.json
@@ -28,7 +28,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Threading/tests/project.json
+++ b/src/System.Threading/tests/project.json
@@ -33,7 +33,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.ValueTuple/tests/project.json
+++ b/src/System.ValueTuple/tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
@@ -26,7 +26,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
@@ -31,7 +31,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XDocument/tests/Properties/project.json
+++ b/src/System.Xml.XDocument/tests/Properties/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XDocument/tests/SDMSample/project.json
+++ b/src/System.Xml.XDocument/tests/SDMSample/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XDocument/tests/Streaming/project.json
+++ b/src/System.Xml.XDocument/tests/Streaming/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XDocument/tests/TreeManipulation/project.json
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/project.json
@@ -31,7 +31,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XDocument/tests/XDocument.Common/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Common/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
@@ -31,7 +31,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XDocument/tests/axes/project.json
+++ b/src/System.Xml.XDocument/tests/axes/project.json
@@ -28,7 +28,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XDocument/tests/events/project.json
+++ b/src/System.Xml.XDocument/tests/events/project.json
@@ -29,7 +29,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XDocument/tests/misc/project.json
+++ b/src/System.Xml.XDocument/tests/misc/project.json
@@ -30,7 +30,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
@@ -33,7 +33,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XDocument/tests/xNodeReader/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeReader/project.json
@@ -31,7 +31,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XPath.XDocument/tests/project.json
+++ b/src/System.Xml.XPath.XDocument/tests/project.json
@@ -34,7 +34,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XPath.XmlDocument/tests/project.json
+++ b/src/System.Xml.XPath.XmlDocument/tests/project.json
@@ -34,7 +34,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XPath/tests/project.json
+++ b/src/System.Xml.XPath/tests/project.json
@@ -32,7 +32,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XmlDocument/tests/project.json
+++ b/src/System.Xml.XmlDocument/tests/project.json
@@ -27,7 +27,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XmlSerializer/tests/Performance/project.json
+++ b/src/System.Xml.XmlSerializer/tests/Performance/project.json
@@ -42,7 +42,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},

--- a/src/System.Xml.XmlSerializer/tests/project.json
+++ b/src/System.Xml.XmlSerializer/tests/project.json
@@ -38,7 +38,7 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "linux-x64": {},
-    "opensuse.13.2": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},


### PR DESCRIPTION
When I added the rid, I forgot to append the -x64 part, which prevented
the openSUSE build from restoring a runtime, since that part is platform
specific.