### PR TITLE
Add several HttpClientHandler tests related to content

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -4,9 +4,11 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.IO;
+using System.Linq;
+using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Runtime.InteropServices;
 using System.Security.Authentication.ExtendedProtection;
 using System.Text;
 using System.Threading;
@@ -14,7 +16,6 @@ using System.Threading.Tasks;
 
 using Xunit;
 using Xunit.Abstractions;
-using System.Net.Sockets;
 
 namespace System.Net.Http.Functional.Tests
 {
@@ -61,8 +62,10 @@ namespace System.Net.Http.Functional.Tests
         public readonly static IEnumerable<object[]> HttpMethods =
             GetMethods("GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "TRACE", "CUSTOM1");
         public readonly static IEnumerable<object[]> HttpMethodsThatAllowContent =
-            GetMethods("GET", "POST", "PUT", "DELETE", "CUSTOM1");
-
+            GetMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "CUSTOM1");
+        public readonly static IEnumerable<object[]> HttpMethodsThatDontAllowContent =
+            GetMethods("HEAD", "TRACE");
+        
         private static IEnumerable<object[]> GetMethods(params string[] methods)
         {
             foreach (string method in methods)
@@ -997,6 +1000,143 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Fact]
+        public async Task PostAsync_ResponseContentRead_RequestContentDisposedAfterResponseBuffered()
+        {
+            using (var client = new HttpClient())
+            {
+                await LoopbackServer.CreateServerAsync(async (server, url) =>
+                {
+                    bool contentDisposed = false;
+                    Task<HttpResponseMessage> post = client.SendAsync(new HttpRequestMessage(HttpMethod.Post, url)
+                    {
+                        Content = new DelegateContent
+                        {
+                            SerializeToStreamAsyncDelegate = (contentStream, contentTransport) => contentStream.WriteAsync(new byte[100], 0, 100),
+                            TryComputeLengthDelegate = () => Tuple.Create<bool, long>(true, 100),
+                            DisposeDelegate = _ => contentDisposed = true
+                        }
+                    }, HttpCompletionOption.ResponseContentRead);
+
+                    await LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
+                    {
+                        // Read headers from client
+                        while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) ;
+
+                        // Send back all headers and some but not all of the response
+                        await writer.WriteAsync($"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 10\r\n\r\n");
+                        await writer.WriteAsync("abcd"); // less than contentLength
+
+                        // The request content should not be disposed of until all of the response has been sent
+                        await Task.Delay(1); // a little time to let data propagate
+                        Assert.False(contentDisposed, "Expected request content not to be disposed");
+
+                        // Send remaining response content
+                        await writer.WriteAsync("efghij");
+                        s.Shutdown(SocketShutdown.Send);
+
+                        // The task should complete and the request content should be disposed
+                        using (HttpResponseMessage response = await post)
+                        {
+                            Assert.True(contentDisposed, "Expected request content to be disposed");
+                            Assert.Equal("abcdefghij", await response.Content.ReadAsStringAsync());
+                        }
+                    });
+                });
+            }
+        }
+
+        [Fact]
+        public async Task PostAsync_ResponseHeadersRead_RequestContentDisposedAfterRequestFullySentAndResponseHeadersReceived()
+        {
+            using (var client = new HttpClient())
+            {
+                await LoopbackServer.CreateServerAsync(async (server, url) =>
+                {
+                    var trigger = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    bool contentDisposed = false;
+                    Task<HttpResponseMessage> post = client.SendAsync(new HttpRequestMessage(HttpMethod.Post, url)
+                    {
+                        Content = new DelegateContent
+                        {
+                            SerializeToStreamAsyncDelegate = async (contentStream, contentTransport) =>
+                            {
+                                await contentStream.WriteAsync(new byte[50], 0, 50);
+                                await trigger.Task;
+                                await contentStream.WriteAsync(new byte[50], 0, 50);
+                            },
+                            TryComputeLengthDelegate = () => Tuple.Create<bool, long>(true, 100),
+                            DisposeDelegate = _ => contentDisposed = true
+                        }
+                    }, HttpCompletionOption.ResponseHeadersRead);
+
+                    await LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
+                    {
+                        // Read headers from client
+                        while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) ;
+
+                        // Send back all headers and some but not all of the response
+                        await writer.WriteAsync($"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 10\r\n\r\n");
+                        await writer.WriteAsync("abcd"); // less than contentLength
+
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        {
+                            Assert.False(contentDisposed, "Expected request content to not be disposed while request data still being sent");
+                        }
+                        else // [ActiveIssue(9006, PlatformID.AnyUnix)]
+                        {
+                            await post;
+                            Assert.True(contentDisposed, "Current implementation will dispose of the request content once response headers arrive");
+                        }
+
+                        // Allow request content to complete
+                        trigger.SetResult(true);
+
+                        // Send remaining response content
+                        await writer.WriteAsync("efghij");
+                        s.Shutdown(SocketShutdown.Send);
+
+                        // The task should complete and the request content should be disposed
+                        using (HttpResponseMessage response = await post)
+                        {
+                            Assert.True(contentDisposed, "Expected request content to be disposed");
+                            Assert.Equal("abcdefghij", await response.Content.ReadAsStringAsync());
+                        }
+                    });
+                });
+            }
+        }
+
+        private sealed class DelegateContent : HttpContent
+        {
+            internal Func<Stream, TransportContext, Task> SerializeToStreamAsyncDelegate;
+            internal Func<Tuple<bool, long>> TryComputeLengthDelegate;
+            internal Action<bool> DisposeDelegate;
+
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                return SerializeToStreamAsyncDelegate != null ?
+                    SerializeToStreamAsyncDelegate(stream, context) :
+                    Task.CompletedTask;
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                if (TryComputeLengthDelegate != null)
+                {
+                    var result = TryComputeLengthDelegate();
+                    length = result.Item2;
+                    return result.Item1;
+                }
+
+                length = 0;
+                return false;
+            }
+
+            protected override void Dispose(bool disposing) =>
+                DisposeDelegate?.Invoke(disposing);
+        }
+
         [Theory]
         [InlineData(HttpStatusCode.MethodNotAllowed, "Custom description")]
         [InlineData(HttpStatusCode.MethodNotAllowed, "")]
@@ -1081,6 +1221,38 @@ namespace System.Net.Http.Functional.Tests
                         ExpectedContent);                    
                 }
             }        
+        }
+
+        [Theory, MemberData(nameof(HttpMethodsThatDontAllowContent))]
+        public async Task SendAsync_SendRequestUsingNoBodyMethodToEchoServerWithContent_NoBodySent(
+            string method,
+            bool secureServer)
+        {
+            using (var client = new HttpClient())
+            {
+                var request = new HttpRequestMessage(
+                    new HttpMethod(method),
+                    secureServer ? HttpTestServers.SecureRemoteEchoServer : HttpTestServers.RemoteEchoServer)
+                {
+                    Content = new StringContent(ExpectedContent)
+                };
+
+                using (HttpResponseMessage response = await client.SendAsync(request))
+                {
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && method == "TRACE")
+                    {
+                        // [ActiveIssue(9023, PlatformID.Windows)]
+                        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                    }
+                    else
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        TestHelper.VerifyRequestMethod(response, method);
+                        string responseContent = await response.Content.ReadAsStringAsync();
+                        Assert.False(responseContent.Contains(ExpectedContent));
+                    }
+                }
+            }
         }
         #endregion
 


### PR DESCRIPTION
- Verify that request content isn't disposed until after response content is buffered (https://github.com/dotnet/corefx/pull/8935)
- Verify that request content isn't disposed until after request content is sent and response headers are received (https://github.com/dotnet/corefx/issues/9006)
- Verify that verbs which shouldn't send request content don't (https://github.com/dotnet/corefx/issues/9023)

cc: @davidsh, @ericeil