### PR TITLE
Update split non-CoreFX dependencies to rc4-24201-00

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -83,8 +83,8 @@
     <ProhibitFloatingDependencies>true</ProhibitFloatingDependencies>
 
     <CoreFxExpectedPrerelease>rc4-24131-00</CoreFxExpectedPrerelease>
-    <CoreClrExpectedPrerelease>rc4-24131-00</CoreClrExpectedPrerelease>
-    <ExternalExpectedPrerelease>rc4-24131-00</ExternalExpectedPrerelease>
+    <CoreClrExpectedPrerelease>rc4-24201-00</CoreClrExpectedPrerelease>
+    <ExternalExpectedPrerelease>rc4-24201-00</ExternalExpectedPrerelease>
 
     <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore\.Targets)|(Microsoft\.NETCore\.Platforms)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)(?&lt;!System\.Data\.SqlClient)(?&lt;!System\.IO\.Compression)$</CoreFxVersionsIdentityRegex>
   </PropertyGroup>

--- a/src/Common/net46-test-runtime/project.json
+++ b/src/Common/net46-test-runtime/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.IO.Compression": "4.1.0-rc4-24131-00",
+    "System.IO.Compression": "4.1.0-rc4-24201-00",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc4-24131-00",
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -2,10 +2,10 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
     "Microsoft.NETCore.TestHost": "1.0.0-rc4-24131-00",
-    "Microsoft.NETCore.Runtime": "1.0.2-rc4-24131-00",
+    "Microsoft.NETCore.Runtime": "1.0.2-rc4-24201-00",
     "NETStandard.Library": "1.6.0-rc4-24131-00",
     "System.Diagnostics.Contracts": "4.0.1-rc4-24131-00",
-    "System.IO.Compression": "4.1.0-rc4-24131-00",
+    "System.IO.Compression": "4.1.0-rc4-24201-00",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc4-24131-00",
     "System.Linq.Parallel": "4.0.1-rc4-24131-00",
     "coveralls.io": "1.4",

--- a/src/System.AppContext/src/project.json
+++ b/src/System.AppContext/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.6"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net463": {

--- a/src/System.Collections/src/project.json
+++ b/src/System.Collections/src/project.json
@@ -3,7 +3,7 @@
     "netstandard1.3": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -4,7 +4,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
     "runtime.native.System.Data.SqlClient.sni": "4.0.0-rc3-24131-00",
     "System.Data.Common": "4.1.0-rc4-24131-00",
-    "System.Data.SqlClient": "4.1.0-rc4-24131-00",
+    "System.Data.SqlClient": "4.1.0-rc4-24201-00",
     "System.Text.Encoding.CodePages": "4.0.1-rc4-24131-00",
     "System.Text.RegularExpressions": "4.1.0-rc4-24131-00",
     "System.Collections": "4.0.11-rc4-24131-00",

--- a/src/System.Diagnostics.Contracts/src/netcore50aot/project.json
+++ b/src/System.Diagnostics.Contracts/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     }
   }

--- a/src/System.Diagnostics.Contracts/src/project.json
+++ b/src/System.Diagnostics.Contracts/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.0": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.1"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.Debug/src/project.json
+++ b/src/System.Diagnostics.Debug/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-    "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00",
+    "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00",
     "System.Linq.Expressions": "4.1.0-rc4-24131-00",
     "System.ObjectModel": "4.0.12-rc4-24131-00",
     "System.Text.RegularExpressions": "4.1.0-rc4-24131-00",

--- a/src/System.Diagnostics.StackTrace/src/project.json
+++ b/src/System.Diagnostics.StackTrace/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00",
         "System.IO.FileSystem": "4.0.1-rc4-24131-00",
         "System.Reflection.Metadata": "1.4.0-rc4-24131-00",
         "System.Collections.Immutable": "1.2.0-rc4-24131-00"
@@ -13,7 +13,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.Tools/src/project.json
+++ b/src/System.Diagnostics.Tools/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -15,7 +15,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     }
   }

--- a/src/System.Diagnostics.Tracing/src/project.json
+++ b/src/System.Diagnostics.Tracing/src/project.json
@@ -3,7 +3,7 @@
     "netstandard1.5": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.6"

--- a/src/System.Globalization.Calendars/src/netcore50aot/project.json
+++ b/src/System.Globalization.Calendars/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     }
   }

--- a/src/System.Globalization.Calendars/src/project.json
+++ b/src/System.Globalization.Calendars/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Globalization/src/netcore50aot/project.json
+++ b/src/System.Globalization/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     }
   }

--- a/src/System.Globalization/src/project.json
+++ b/src/System.Globalization/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -6,7 +6,7 @@
     "System.Console": "4.0.0-rc4-24131-00",
     "System.Diagnostics.Debug": "4.0.11-rc4-24131-00",
     "System.IO": "4.1.0-rc4-24131-00",
-    "System.IO.Compression": "4.1.0-rc4-24131-00",
+    "System.IO.Compression": "4.1.0-rc4-24201-00",
     "System.IO.Compression.TestData": "1.0.1-prerelease",
     "System.IO.FileSystem": "4.0.1-rc4-24131-00",
     "System.IO.FileSystem.Primitives": "4.0.1-rc4-24131-00",

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -6,7 +6,7 @@
     "System.Console": "4.0.0-rc4-24131-00",
     "System.Diagnostics.Debug": "4.0.11-rc4-24131-00",
     "System.IO": "4.1.0-rc4-24131-00",
-    "System.IO.Compression": "4.1.0-rc4-24131-00",
+    "System.IO.Compression": "4.1.0-rc4-24201-00",
     "System.IO.Compression.TestData": "1.0.2-prerelease",
     "System.IO.FileSystem": "4.0.1-rc4-24131-00",
     "System.Linq": "4.1.0-rc4-24131-00",

--- a/src/System.IO.FileSystem/src/netcore50/project.json
+++ b/src/System.IO.FileSystem/src/netcore50/project.json
@@ -23,7 +23,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Globalization": "4.0.10",
         "System.Reflection": "4.0.10",

--- a/src/System.IO.IsolatedStorage/src/project.json
+++ b/src/System.IO.IsolatedStorage/src/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
         "Microsoft.NETCore.Targets": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Collections": "4.0.0",
         "System.Diagnostics.Contracts": "4.0.0",

--- a/src/System.IO/src/project.json
+++ b/src/System.IO/src/project.json
@@ -3,7 +3,7 @@
     "netstandard1.5": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.6"
@@ -12,7 +12,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
@@ -34,7 +34,7 @@
       ],
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",

--- a/src/System.Linq.Expressions/src/netcore50/project.json
+++ b/src/System.Linq.Expressions/src/netcore50/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-    "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+    "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Net.Http.WinHttpHandler/src/project.json
+++ b/src/System.Net.Http.WinHttpHandler/src/project.json
@@ -7,7 +7,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
-    "System.IO.Compression": "4.1.0-rc4-24131-00",
+    "System.IO.Compression": "4.1.0-rc4-24201-00",
     "System.Net.Http": "4.0.0",
     "System.Net.Primitives": "4.0.10",
     "System.Resources.ResourceManager": "4.0.0",

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
     "Microsoft.Win32.Primitives": "4.0.1-rc4-24131-00",
     "System.Diagnostics.DiagnosticSource": "4.0.0-rc4-24131-00",
-    "System.IO.Compression": "4.1.0-rc4-24131-00",
+    "System.IO.Compression": "4.1.0-rc4-24201-00",
     "System.Linq.Expressions": "4.1.0-rc4-24131-00",
     "System.Net.Http": "4.1.0-rc4-24131-00",
     "System.Net.Primitives": "4.0.11-rc4-24131-00",

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -5,7 +5,7 @@
     "System.Diagnostics.DiagnosticSource": "4.0.0-rc4-24131-00",
     "System.Globalization": "4.0.11-rc4-24131-00",
     "System.IO": "4.1.0-rc4-24131-00",
-    "System.IO.Compression": "4.1.0-rc4-24131-00",
+    "System.IO.Compression": "4.1.0-rc4-24201-00",
     "System.Linq.Expressions": "4.1.0-rc4-24131-00",
     "System.Net.Http": "4.1.0-rc4-24131-00",
     "System.Net.Primitives": "4.0.11-rc4-24131-00",

--- a/src/System.Net.Requests/src/project.json
+++ b/src/System.Net.Requests/src/project.json
@@ -7,7 +7,7 @@
         "System.Diagnostics.Debug": "4.0.0",
         "System.Diagnostics.Tracing": "4.0.0",
         "System.IO": "4.0.10",
-        "System.IO.Compression": "4.1.0-rc4-24131-00",
+        "System.IO.Compression": "4.1.0-rc4-24201-00",
         "System.Net.Http": "4.0.0",
         "System.Net.Primitives": "4.0.10",
         "System.Net.WebHeaderCollection": "4.0.0",

--- a/src/System.Net.Requests/tests/project.json
+++ b/src/System.Net.Requests/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-    "System.IO.Compression": "4.1.0-rc4-24131-00",
+    "System.IO.Compression": "4.1.0-rc4-24201-00",
     "System.Linq.Expressions": "4.1.0-rc4-24131-00",
     "System.Net.Http": "4.1.0-rc4-24131-00",
     "System.Net.NetworkInformation": "4.1.0-rc4-24131-00",

--- a/src/System.Private.DataContractSerialization/src/netcore50aot/project.json
+++ b/src/System.Private.DataContractSerialization/src/netcore50aot/project.json
@@ -3,7 +3,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "System.Collections": "4.0.10",
         "System.Collections.Concurrent": "4.0.10",
         "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Private.Uri/src/project.json
+++ b/src/System.Private.Uri/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.0": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.1"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     },
     "netstandard1.3": {
@@ -18,7 +18,7 @@
         "netcore50"
       ],
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     }
   }

--- a/src/System.Reflection.DispatchProxy/src/project.json
+++ b/src/System.Reflection.DispatchProxy/src/project.json
@@ -21,7 +21,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "System.Runtime": "4.0.20"
       }
     }

--- a/src/System.Reflection.Emit.ILGeneration/src/project.json
+++ b/src/System.Reflection.Emit.ILGeneration/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Reflection.Emit.Lightweight/src/project.json
+++ b/src/System.Reflection.Emit.Lightweight/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Reflection.Emit/src/project.json
+++ b/src/System.Reflection.Emit/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Reflection.Extensions/src/project.json
+++ b/src/System.Reflection.Extensions/src/project.json
@@ -3,7 +3,7 @@
     "netstandard1.3": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -12,7 +12,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.IO": "4.0.10",

--- a/src/System.Reflection.Primitives/src/project.json
+++ b/src/System.Reflection.Primitives/src/project.json
@@ -3,7 +3,7 @@
     "netstandard1.0": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.1"

--- a/src/System.Reflection.TypeExtensions/src/project.json
+++ b/src/System.Reflection.TypeExtensions/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net462": {
@@ -13,7 +13,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "System.Collections": "4.0.0",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Linq": "4.0.0",

--- a/src/System.Reflection/src/netcore50aot/project.json
+++ b/src/System.Reflection/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     }
   }

--- a/src/System.Reflection/src/project.json
+++ b/src/System.Reflection/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.6"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net462": {

--- a/src/System.Resources.ResourceManager/src/netcore50aot/project.json
+++ b/src/System.Resources.ResourceManager/src/netcore50aot/project.json
@@ -3,7 +3,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Diagnostics.Debug": "4.0.0",
         "System.Diagnostics.Tools": "4.0.0",

--- a/src/System.Resources.ResourceManager/src/project.json
+++ b/src/System.Resources.ResourceManager/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Runtime.CompilerServices.VisualC/src/project.json
+++ b/src/System.Runtime.CompilerServices.VisualC/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dnxcore50"
@@ -15,7 +15,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1"
       }
     },
@@ -24,7 +24,7 @@
         "netcore50"
       ],
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     }
   }

--- a/src/System.Runtime.Handles/src/project.json
+++ b/src/System.Runtime.Handles/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "System.Runtime": "4.0.20"
       }
     },

--- a/src/System.Runtime.InteropServices/src/project.json
+++ b/src/System.Runtime.InteropServices/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.6"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     },
     "net462": {

--- a/src/System.Runtime.Loader/src/project.json
+++ b/src/System.Runtime.Loader/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.6"

--- a/src/System.Runtime.WindowsRuntime/src/netcore50aot/project.json
+++ b/src/System.Runtime.WindowsRuntime/src/netcore50aot/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
         "Microsoft.NETCore.Targets": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Collections": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Runtime.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.WindowsRuntime/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1"
       },
       "imports": [

--- a/src/System.Runtime/src/project.json
+++ b/src/System.Runtime/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.6"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     },
     "net462": {

--- a/src/System.Text.Encoding.Extensions/src/netcore50aot/project.json
+++ b/src/System.Text.Encoding.Extensions/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     }
   }

--- a/src/System.Text.Encoding.Extensions/src/project.json
+++ b/src/System.Text.Encoding.Extensions/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Text.Encoding/src/netcore50aot/project.json
+++ b/src/System.Text.Encoding/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     }
   }

--- a/src/System.Text.Encoding/src/project.json
+++ b/src/System.Text.Encoding/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Threading.Overlapped/src/project.json
+++ b/src/System.Threading.Overlapped/src/project.json
@@ -3,7 +3,7 @@
     "netstandard1.3": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc4-24131-00",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "netcore50": {

--- a/src/System.Threading.Tasks/src/project.json
+++ b/src/System.Threading.Tasks/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -15,7 +15,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00"
       }
     }
   }

--- a/src/System.Threading.Thread/src/project.json
+++ b/src/System.Threading.Thread/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Threading.ThreadPool/src/project.json
+++ b/src/System.Threading.ThreadPool/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Threading.Timer/src/netcore50aot/project.json
+++ b/src/System.Threading.Timer/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "System.Runtime": "4.0.20"
       }
     }

--- a/src/System.Threading.Timer/src/project.json
+++ b/src/System.Threading.Timer/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       }
     },
     "net46": {

--- a/src/System.Threading/src/project.json
+++ b/src/System.Threading/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24131-00"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24201-00"
       },
       "imports": [
         "dotnet5.4"
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24131-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24201-00",
         "System.Runtime": "4.0.20"
       }
     },


### PR DESCRIPTION
Part of the same "cycle" as https://github.com/dotnet/corefx/pull/9028's update, but for packages made by TFS: CoreCLR and some edge cases.

Submitting parallel to https://github.com/dotnet/corefx/pull/9028 because that's what will happen when these PRs are done automatically. If it causes problems we can combine the updates for today but it's something we'll need to fix.

/cc @dotnet/corefx-contrib 