### PR TITLE
Remove debian.8.2 and centos.7.1 rids

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -249,13 +249,6 @@
             "#import": [ "centos.7", "centos-x64", "rhel.7-x64" ]
         },
 
-        "centos.7.1": {
-            "#import": [ "centos.7" ]
-        },
-        "centos.7.1-x64": {
-            "#import": [ "centos.7", "centos.7-x64" ]
-        },
-
         "debian": {
             "#import": [ "linux" ]
         },
@@ -268,13 +261,6 @@
         },
         "debian.8-x64": {
             "#import": [ "debian.8", "debian-x64" ]
-        },
-
-        "debian.8.2": {
-            "#import": [ "debian" ]
-        },
-        "debian.8.2-x64": {
-            "#import": [ "debian.8.2", "debian.8-x64" ]
         },
 
         "ubuntu": {


### PR DESCRIPTION
The CLI would never generate these rids and none of our packages use them.
It's very confusing to have them around, espically given that we don't
have minor version number rids for any other versions of debian or centos.