### PR TITLE
Flow HttpClient timeouts and cancellation to the response stream

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -83,7 +83,15 @@ namespace System.Net.Http
                 }
             }
 
+#if HTTP_DLL
+            var content = new StreamContent(decompressedStream, state.CancellationToken);
+#else
+            // TODO: Issue https://github.com/dotnet/corefx/issues/9071
+            // We'd like to be able to pass state.CancellationToken into the StreamContent so that its
+            // SerializeToStreamAsync method can use it, but that ctor isn't public, nor is there a
+            // SerializeToStreamAsync override that takes a CancellationToken.
             var content = new StreamContent(decompressedStream);
+#endif
 
             response.Content = content;
             response.RequestMessage = request;


### PR DESCRIPTION
When using a timeout and/or a cancellation token with a buffered HttpClient operation, the cancellation/timeout doesn't flow through to the actual read/write operations on the underlying streams.  This fixes that.

cc: @davidsh, @cipop, @ericeil, @bartonjs 
Fixes #8663 