### PR TITLE
Switch to Microsoft.NETCore.Runtime.CoreCLR package.

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24201-04",
     "Microsoft.NETCore.TestHost": "1.0.0-rc4-24131-00",
-    "Microsoft.NETCore.Runtime": "1.0.2-rc4-24201-00",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc4-24201-00",
     "NETStandard.Library": "1.6.0-rc4-24201-04",
     "System.Diagnostics.Contracts": "4.0.1-rc4-24201-04",
     "System.IO.Compression": "4.1.0-rc4-24201-00",


### PR DESCRIPTION
We are no longer going to be producing the Microsoft.NETCore.Runtime
wrapper project as it is just an empty package. Instead we are going
to directly reference Microsoft.NETCore.Runtime.CoreCLR.

cc @ericstj @gkhanna79 