### PR TITLE
Avoid box allocations when enumerating IDictionary

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -784,8 +784,11 @@ namespace System.ComponentModel
         {
             ArrayList typeList = new ArrayList(); ;
 
-            foreach (DictionaryEntry de in _typeData)
+            // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+            IDictionaryEnumerator e = _typeData.GetEnumerator();
+            while (e.MoveNext())
             {
+                DictionaryEntry de = e.Entry;
                 Type type = (Type)de.Key;
                 ReflectedTypeData typeData = (ReflectedTypeData)de.Value;
 
@@ -1349,8 +1352,11 @@ namespace System.ComponentModel
                 //
                 if (hashEntry == null)
                 {
-                    foreach (DictionaryEntry de in table)
+                    // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+                    IDictionaryEnumerator e = table.GetEnumerator();
+                    while (e.MoveNext())
                     {
+                        DictionaryEntry de = e.Entry;
                         Type keyType = de.Key as Type;
 
                         if (keyType != null && keyType.GetTypeInfo().IsInterface && keyType.GetTypeInfo().IsAssignableFrom(callingType))

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2219,8 +2219,12 @@ namespace System.ComponentModel
                     // ReflectTypeDescritionProvider is only bound to object, but we
                     // need go to through the entire table to try to find custom
                     // providers.  If we find one, will clear our cache.
-                    foreach (DictionaryEntry de in s_providerTable)
+                    // Manual use of IDictionaryEnumerator instead of foreach to avoid
+                    // DictionaryEntry box allocations.
+                    IDictionaryEnumerator e = s_providerTable.GetEnumerator();
+                    while (e.MoveNext())
                     {
+                        DictionaryEntry de = e.Entry;
                         Type nodeType = de.Key as Type;
                         if (nodeType != null && type.GetTypeInfo().IsAssignableFrom(nodeType) || nodeType == typeof(object))
                         {
@@ -2301,8 +2305,12 @@ namespace System.ComponentModel
                 // ReflectTypeDescritionProvider is only bound to object, but we
                 // need go to through the entire table to try to find custom
                 // providers.  If we find one, will clear our cache.
-                foreach (DictionaryEntry de in s_providerTable)
+                // Manual use of IDictionaryEnumerator instead of foreach to avoid
+                // DictionaryEntry box allocations.
+                IDictionaryEnumerator e = s_providerTable.GetEnumerator();
+                while (e.MoveNext())
                 {
+                    DictionaryEntry de = e.Entry;
                     Type nodeType = de.Key as Type;
                     if (nodeType != null && type.GetTypeInfo().IsAssignableFrom(nodeType) || nodeType == typeof(object))
                     {
@@ -2361,8 +2369,11 @@ namespace System.ComponentModel
 
             lock (s_providerTable)
             {
-                foreach (DictionaryEntry de in s_providerTable)
+                // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+                IDictionaryEnumerator e = s_providerTable.GetEnumerator();
+                while (e.MoveNext())
                 {
+                    DictionaryEntry de = e.Entry;
                     Type nodeType = de.Key as Type;
                     if (nodeType != null && nodeType.GetTypeInfo().Module.Equals(module) || nodeType == typeof(object))
                     {


### PR DESCRIPTION
Enumerating `IDictionary` using `foreach` results in box allocations for each entry in the dictionary because `Current` returns a `DictionaryEntry` struct but is typed as `object`.

These box allocations can be avoided by using `IDictionaryEnumerator` directly.

Related to #7539

cc: @stephentoub, @chlowell