### PR TITLE
Fix System.IO.Compression version to match the ExternalVersion

### DIFF
--- a/pkg/ExternalPackages/versions.props
+++ b/pkg/ExternalPackages/versions.props
@@ -3,10 +3,10 @@
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
   <ItemGroup>
     <ExternalPackage Include="System.IO.Compression">
-      <Version>4.1.0-rc3-24117-00</Version>
+      <Version>4.1.0-$(ExternalExpectedPrerelease)</Version>
     </ExternalPackage>
     <ExternalPackage Include="System.Data.SqlClient">
-      <Version>4.1.0-rc3-24117-00</Version>
+      <Version>4.1.0-$(ExternalExpectedPrerelease)</Version>
     </ExternalPackage>
   </ItemGroup>
 </Project>

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
+
   <PropertyGroup>
     <Version>1.0.1</Version>
     <IsLineupPackage>true</IsLineupPackage>
     <RuntimeFileSource>runtime.json</RuntimeFileSource>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
-  
+
   <Import Project="..\NETStandard.Library\NETStandard.Library.packages.targets" />
-  
+
   <ItemGroup>
     <!-- make this package installable and noop in a packages.config-based project -->
     <File Include="$(PlaceHolderFile)">
@@ -23,6 +23,11 @@
     <NativePackage Include="runtime.native.System.Net.Http" />
     <NativePackage Include="runtime.native.System.Security.Cryptography" />
     <NativePackage Include="runtime.native.System.Net.Security" />
+
+    <!-- Tempoarily hardcode the version of System.IO.Compression -->
+    <RuntimeDependency Include="System.IO.Compression">
+      <Version>4.1.0-$(ExternalExpectedPrerelease)</Version>
+    </RuntimeDependency>
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/NETStandard.Library/NETStandard.Library.packages.targets
+++ b/pkg/NETStandard.Library/NETStandard.Library.packages.targets
@@ -12,7 +12,6 @@
     <Package Include="System.Globalization" />
     <Package Include="System.Globalization.Calendars" />
     <Package Include="System.IO" />
-    <Package Include="System.IO.Compression" />
     <Package Include="System.IO.Compression.ZipFile" />
     <Package Include="System.IO.FileSystem" />
     <Package Include="System.IO.FileSystem.Primitives" />

--- a/pkg/NETStandard.Library/NETStandard.Library.pkgproj
+++ b/pkg/NETStandard.Library/NETStandard.Library.pkgproj
@@ -10,6 +10,11 @@
   <Import Project="NETStandard.Library.packages.targets" />
 
   <ItemGroup>
+    <!-- Tempoarily hardcode the version of System.IO.Compression -->
+    <Dependency Include="System.IO.Compression">
+      <Version>4.1.0-$(ExternalExpectedPrerelease)</Version>
+    </Dependency>
+
     <ProjectReference Include="..\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.pkgproj">
       <TargetFramework>netstandard1.0</TargetFramework>
     </ProjectReference>


### PR DESCRIPTION
Until we ship the System.IO.Compression package from the open
we need to pick the version of that package from the TFS build
to ensure our dependencies are correct.

@jhendrixMSFT @ericstj 