### PR TITLE
Mark tests which require elevation

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -119,7 +119,7 @@
     </ValidationPattern>
     <ValidationPattern Include="xUnitExtensionsVersions">
       <IdentityRegex>^(?i)xunit\.netcore\.extensions$</IdentityRegex>
-      <ExpectedVersion>1.0.0-prerelease-00312-04</ExpectedVersion>
+      <ExpectedVersion>1.0.0-prerelease-00431-01</ExpectedVersion>
     </ValidationPattern>
   </ItemGroup>
 

--- a/src/Common/tests/project.json
+++ b/src/Common/tests/project.json
@@ -22,7 +22,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks.Parallel": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/Microsoft.CSharp/tests/project.json
+++ b/src/Microsoft.CSharp/tests/project.json
@@ -21,7 +21,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/Microsoft.VisualBasic/tests/project.json
+++ b/src/Microsoft.VisualBasic/tests/project.json
@@ -23,7 +23,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/Microsoft.Win32.Primitives/tests/project.json
+++ b/src/Microsoft.Win32.Primitives/tests/project.json
@@ -7,7 +7,7 @@
     "System.Runtime.InteropServices": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
@@ -13,7 +13,7 @@
     "System.Security.Principal.Windows": "4.0.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/Microsoft.Win32.Registry/tests/project.json
+++ b/src/Microsoft.Win32.Registry/tests/project.json
@@ -11,7 +11,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.AppContext/tests/project.json
+++ b/src/System.AppContext/tests/project.json
@@ -7,7 +7,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Buffers/tests/project.json
+++ b/src/System.Buffers/tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Collections.Concurrent/tests/project.json
+++ b/src/System.Collections.Concurrent/tests/project.json
@@ -16,7 +16,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Collections.Immutable/tests/project.json
+++ b/src/System.Collections.Immutable/tests/project.json
@@ -10,7 +10,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -16,7 +16,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Collections.Specialized/tests/project.json
+++ b/src/System.Collections.Specialized/tests/project.json
@@ -13,7 +13,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -14,7 +14,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ComponentModel.Annotations/tests/project.json
+++ b/src/System.ComponentModel.Annotations/tests/project.json
@@ -11,7 +11,7 @@
     "System.Runtime.Extensions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ComponentModel.EventBasedAsync/tests/project.json
+++ b/src/System.ComponentModel.EventBasedAsync/tests/project.json
@@ -8,7 +8,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ComponentModel.Primitives/tests/project.json
+++ b/src/System.ComponentModel.Primitives/tests/project.json
@@ -7,7 +7,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -12,7 +12,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ComponentModel/tests/project.json
+++ b/src/System.ComponentModel/tests/project.json
@@ -6,7 +6,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Composition.Convention/tests/project.json
+++ b/src/System.Composition.Convention/tests/project.json
@@ -5,7 +5,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Composition/tests/project.json
+++ b/src/System.Composition/tests/project.json
@@ -5,7 +5,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -17,7 +17,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks.Parallel": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Data.Common/tests/project.json
+++ b/src/System.Data.Common/tests/project.json
@@ -13,7 +13,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -12,7 +12,7 @@
     "System.Diagnostics.DiagnosticSource": "4.0.0-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Data.SqlClient/tests/ManualTests/project.json
+++ b/src/System.Data.SqlClient/tests/ManualTests/project.json
@@ -53,7 +53,7 @@
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "System.Xml.XmlDocument": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Diagnostics.Contracts/tests/project.json
+++ b/src/System.Diagnostics.Contracts/tests/project.json
@@ -9,7 +9,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -6,7 +6,7 @@
     "System.ObjectModel": "4.0.12-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.json
@@ -11,7 +11,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
@@ -12,7 +12,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.Diagnostics.Tests
 {
@@ -77,7 +78,10 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Fact, PlatformSpecific(PlatformID.AnyUnix), OuterLoop] // This test requires admin elevation on Unix
+        [Fact] 
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [OuterLoop]
+        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         public void TestBasePriorityOnUnix()
         {
             ProcessPriorityClass originalPriority = _process.PriorityClass;
@@ -447,7 +451,10 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Fact, PlatformSpecific(PlatformID.AnyUnix), OuterLoop] // This test requires admin elevation on Unix
+        [Fact] 
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [OuterLoop]
+        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         public void TestPriorityClassUnix()
         {
             ProcessPriorityClass priorityClass = _process.PriorityClass;

--- a/src/System.Diagnostics.Process/tests/project.json
+++ b/src/System.Diagnostics.Process/tests/project.json
@@ -25,7 +25,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Thread": "4.0.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
@@ -13,7 +13,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Diagnostics.Tools/tests/project.json
+++ b/src/System.Diagnostics.Tools/tests/project.json
@@ -6,7 +6,7 @@
     "System.ObjectModel": "4.0.12-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Diagnostics.TraceSource/tests/project.json
+++ b/src/System.Diagnostics.TraceSource/tests/project.json
@@ -11,7 +11,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
@@ -11,7 +11,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Diagnostics.Tracing/tests/project.json
+++ b/src/System.Diagnostics.Tracing/tests/project.json
@@ -17,7 +17,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Thread": "4.0.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Drawing.Primitives/tests/project.json
+++ b/src/System.Drawing.Primitives/tests/project.json
@@ -7,7 +7,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Dynamic.Runtime/tests/project.json
+++ b/src/System.Dynamic.Runtime/tests/project.json
@@ -19,7 +19,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Globalization.Calendars/tests/project.json
+++ b/src/System.Globalization.Calendars/tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/System.Globalization.Extensions/tests/project.json
+++ b/src/System.Globalization.Extensions/tests/project.json
@@ -13,7 +13,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -3,7 +3,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0035",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24201-04"
   },
   "frameworks": {

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -20,7 +20,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -20,7 +20,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.IO.FileSystem.AccessControl/tests/project.json
+++ b/src/System.IO.FileSystem.AccessControl/tests/project.json
@@ -19,7 +19,7 @@
     "System.Security.Principal.Windows": "4.0.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.IO.FileSystem.DriveInfo/tests/project.json
+++ b/src/System.IO.FileSystem.DriveInfo/tests/project.json
@@ -11,7 +11,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.IO.FileSystem.Primitives/tests/project.json
+++ b/src/System.IO.FileSystem.Primitives/tests/project.json
@@ -6,7 +6,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.IO.FileSystem.Watcher/tests/project.json
+++ b/src/System.IO.FileSystem.Watcher/tests/project.json
@@ -17,7 +17,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Thread": "4.0.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -23,7 +23,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.IO.MemoryMappedFiles/tests/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/project.json
@@ -16,7 +16,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.IO.Packaging/tests/project.json
+++ b/src/System.IO.Packaging/tests/project.json
@@ -12,7 +12,7 @@
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "System.Xml.XDocument": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.IO.Pipes/tests/project.json
+++ b/src/System.IO.Pipes/tests/project.json
@@ -18,7 +18,7 @@
     "System.Threading.Overlapped": "4.0.1-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.IO.UnmanagedMemoryStream/tests/project.json
+++ b/src/System.IO.UnmanagedMemoryStream/tests/project.json
@@ -14,7 +14,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.IO/tests/project.json
+++ b/src/System.IO/tests/project.json
@@ -8,7 +8,7 @@
     "System.Text.Encoding.CodePages": "4.0.1-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Linq.Expressions/tests/project.json
+++ b/src/System.Linq.Expressions/tests/project.json
@@ -15,7 +15,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Linq.Parallel/tests/project.json
+++ b/src/System.Linq.Parallel/tests/project.json
@@ -16,7 +16,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Linq.Queryable/tests/project.json
+++ b/src/System.Linq.Queryable/tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -12,7 +12,7 @@
     "System.Runtime.Extensions": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
@@ -12,7 +12,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -21,7 +21,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Thread": "4.0.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Http/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/unix/project.json
@@ -21,7 +21,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks.Parallel": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Http/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/win/project.json
@@ -22,7 +22,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks.Parallel": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Http/tests/UnitTests/project.json
+++ b/src/System.Net.Http/tests/UnitTests/project.json
@@ -13,7 +13,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Resources.ResourceManager": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.NameResolution/tests/FunctionalTests/project.json
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/project.json
@@ -11,7 +11,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.NameResolution/tests/PalTests/project.json
+++ b/src/System.Net.NameResolution/tests/PalTests/project.json
@@ -25,7 +25,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Resources.ResourceManager": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.NetworkInformation/tests/UnitTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/UnitTests/project.json
@@ -8,7 +8,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Resources.ResourceManager": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Ping/tests/FunctionalTests/project.json
+++ b/src/System.Net.Ping/tests/FunctionalTests/project.json
@@ -8,7 +8,7 @@
     "System.ObjectModel": "4.0.12-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Primitives/tests/FunctionalTests/project.json
+++ b/src/System.Net.Primitives/tests/FunctionalTests/project.json
@@ -8,7 +8,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Primitives/tests/PalTests/project.json
+++ b/src/System.Net.Primitives/tests/PalTests/project.json
@@ -16,7 +16,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Primitives/tests/UnitTests/project.json
+++ b/src/System.Net.Primitives/tests/UnitTests/project.json
@@ -17,7 +17,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Requests/tests/project.json
+++ b/src/System.Net.Requests/tests/project.json
@@ -13,7 +13,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Resources.ResourceManager": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.NetCore.Extensions;
 
 namespace System.Net.Security.Tests
 {
@@ -112,6 +113,7 @@ namespace System.Net.Security.Tests
     }
 
     [PlatformSpecific(PlatformID.Linux)]
+    [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
     public class NegotiateStreamTest : IDisposable, IClassFixture<KDCSetup>
     {
         private readonly byte[] _firstMessage = Encoding.UTF8.GetBytes("Sample First Message");

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -19,7 +19,7 @@
     "System.Threading.Thread": "4.0.0-rc4-24201-04",
     "System.Resources.ResourceManager": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -17,7 +17,7 @@
     "System.Threading.Thread": "4.0.0-rc4-24201-04",
     "System.Resources.ResourceManager": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Security/tests/UnitTests/project.json
+++ b/src/System.Net.Security/tests/UnitTests/project.json
@@ -11,7 +11,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Resources.ResourceManager": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Sockets/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets/tests/FunctionalTests/project.json
@@ -16,7 +16,7 @@
     "System.Threading.Tasks.Parallel": "4.0.1-rc4-24201-04",
     "System.Threading.Thread": "4.0.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Sockets/tests/PerformanceTests/project.json
+++ b/src/System.Net.Sockets/tests/PerformanceTests/project.json
@@ -13,7 +13,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks.Parallel": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.WebHeaderCollection/tests/project.json
+++ b/src/System.Net.WebHeaderCollection/tests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24201-04",
     "System.Runtime": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.WebSockets.Client/tests/project.json
+++ b/src/System.Net.WebSockets.Client/tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Resources.ResourceManager": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.WebSockets/tests/project.json
+++ b/src/System.Net.WebSockets/tests/project.json
@@ -7,7 +7,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Numerics.Vectors/tests/project.json
+++ b/src/System.Numerics.Vectors/tests/project.json
@@ -15,7 +15,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ObjectModel/tests/project.json
+++ b/src/System.ObjectModel/tests/project.json
@@ -13,7 +13,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.Uri/tests/FunctionalTests/project.json
+++ b/src/System.Private.Uri/tests/FunctionalTests/project.json
@@ -7,7 +7,7 @@
     "System.Reflection.TypeExtensions": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.Uri/tests/UnitTests/project.json
+++ b/src/System.Private.Uri/tests/UnitTests/project.json
@@ -5,7 +5,7 @@
     "System.Resources.ResourceManager": "4.0.1-rc4-24201-04",
     "System.Text.Encoding": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Reflection.Context/tests/project.json
+++ b/src/System.Reflection.Context/tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Reflection.DispatchProxy/tests/project.json
+++ b/src/System.Reflection.DispatchProxy/tests/project.json
@@ -10,7 +10,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Reflection.Emit.ILGeneration/tests/project.json
+++ b/src/System.Reflection.Emit.ILGeneration/tests/project.json
@@ -13,7 +13,7 @@
     "System.Runtime.Extensions": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Reflection.Emit.Lightweight/tests/project.json
+++ b/src/System.Reflection.Emit.Lightweight/tests/project.json
@@ -9,7 +9,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Reflection.Emit/tests/project.json
+++ b/src/System.Reflection.Emit/tests/project.json
@@ -12,7 +12,7 @@
     "System.Runtime.Extensions": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Reflection.Extensions/tests/project.json
+++ b/src/System.Reflection.Extensions/tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Reflection.Metadata/tests/project.json
+++ b/src/System.Reflection.Metadata/tests/project.json
@@ -23,7 +23,7 @@
     "System.Threading.Tasks.Parallel": "4.0.1-rc4-24201-04",
     "System.Security.Cryptography.Algorithms": "4.2.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
@@ -15,7 +15,7 @@
     "System.Runtime.Extensions": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Reflection.TypeExtensions/tests/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/project.json
@@ -11,7 +11,7 @@
     "System.Runtime.Extensions": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Reflection/tests/CoreCLR/project.json
+++ b/src/System.Reflection/tests/CoreCLR/project.json
@@ -12,7 +12,7 @@
     "System.Runtime.Loader": "4.0.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Reflection/tests/project.json
+++ b/src/System.Reflection/tests/project.json
@@ -13,7 +13,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Resources.Reader/tests/project.json
+++ b/src/System.Resources.Reader/tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Resources.ResourceManager/tests/project.json
+++ b/src/System.Resources.ResourceManager/tests/project.json
@@ -8,7 +8,7 @@
     "System.Resources.ResourceManager": "4.0.1-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Resources.Writer/tests/project.json
+++ b/src/System.Resources.Writer/tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/project.json
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24201-04",
     "System.Runtime": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -15,7 +15,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.Handles/tests/project.json
+++ b/src/System.Runtime.Handles/tests/project.json
@@ -7,7 +7,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
@@ -8,7 +8,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.InteropServices/tests/project.json
+++ b/src/System.Runtime.InteropServices/tests/project.json
@@ -6,7 +6,7 @@
     "System.Runtime.InteropServices": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.Loader/tests/DefaultContext/project.json
+++ b/src/System.Runtime.Loader/tests/DefaultContext/project.json
@@ -15,7 +15,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.Loader/tests/project.json
+++ b/src/System.Runtime.Loader/tests/project.json
@@ -15,7 +15,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.Numerics/tests/project.json
+++ b/src/System.Runtime.Numerics/tests/project.json
@@ -11,7 +11,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.Serialization.Formatters/tests/project.json
+++ b/src/System.Runtime.Serialization.Formatters/tests/project.json
@@ -11,7 +11,7 @@
     "System.Runtime.Serialization.Primitives": "4.1.1-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.Serialization.Json/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/project.json
@@ -25,7 +25,7 @@
     "System.Xml.XmlDocument": "4.0.1-rc4-24201-04",
     "System.Xml.XmlSerializer": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.Serialization.Json/tests/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/project.json
@@ -21,7 +21,7 @@
     "System.Xml.XDocument": "4.0.11-rc4-24201-04",
     "System.Xml.XmlDocument": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
@@ -24,7 +24,7 @@
     "System.Xml.XmlDocument": "4.0.1-rc4-24201-04",
     "System.Xml.XmlSerializer": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -20,7 +20,7 @@
     "System.Xml.XDocument": "4.0.11-rc4-24201-04",
     "System.Xml.XmlDocument": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Runtime/tests/project.json
+++ b/src/System.Runtime/tests/project.json
@@ -16,7 +16,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.AccessControl/tests/project.json
+++ b/src/System.Security.AccessControl/tests/project.json
@@ -23,7 +23,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "System.Security.Principal": "4.0.0",
     "System.Security.Principal.Windows": "4.0.0-rc4-24201-04",
     "System.Security.AccessControl": "4.0.0-rc4-24201-04",

--- a/src/System.Security.Claims/tests/project.json
+++ b/src/System.Security.Claims/tests/project.json
@@ -13,7 +13,7 @@
     "System.Security.Principal": "4.0.1-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.Cryptography.Algorithms/tests/project.json
+++ b/src/System.Security.Cryptography.Algorithms/tests/project.json
@@ -14,7 +14,7 @@
     "System.Text.Encoding.Extensions": "4.0.11-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.Cryptography.Cng/tests/project.json
+++ b/src/System.Security.Cryptography.Cng/tests/project.json
@@ -16,7 +16,7 @@
     "System.Text.Encoding.Extensions": "4.0.11-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.Cryptography.Csp/tests/project.json
+++ b/src/System.Security.Cryptography.Csp/tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.Encoding.Extensions": "4.0.11-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.Cryptography.Encoding/tests/project.json
+++ b/src/System.Security.Cryptography.Encoding/tests/project.json
@@ -9,7 +9,7 @@
     "System.Security.Cryptography.Primitives": "4.0.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.Cryptography.OpenSsl/tests/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/tests/project.json
@@ -12,7 +12,7 @@
     "System.Text.Encoding.Extensions": "4.0.11-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.Cryptography.Pkcs/tests/project.json
+++ b/src/System.Security.Cryptography.Pkcs/tests/project.json
@@ -9,7 +9,7 @@
     "System.Security.Cryptography.Primitives": "4.0.0-rc4-24201-04",
     "System.Security.Cryptography.X509Certificates": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.Cryptography.Primitives/tests/project.json
+++ b/src/System.Security.Cryptography.Primitives/tests/project.json
@@ -7,7 +7,7 @@
     "System.Runtime.Extensions": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.Cryptography.ProtectedData/tests/project.json
+++ b/src/System.Security.Cryptography.ProtectedData/tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.Encoding.Extensions": "4.0.11-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.json
@@ -16,7 +16,7 @@
     "System.Security.Cryptography.X509Certificates.TestData": "1.0.2-prerelease",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.Principal.Windows/tests/project.json
+++ b/src/System.Security.Principal.Windows/tests/project.json
@@ -8,7 +8,7 @@
     "System.Security.Claims": "4.0.1-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Security.SecureString/tests/project.json
+++ b/src/System.Security.SecureString/tests/project.json
@@ -4,7 +4,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24201-04",
     "System.Runtime": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Text.Encoding.CodePages/tests/project.json
+++ b/src/System.Text.Encoding.CodePages/tests/project.json
@@ -9,7 +9,7 @@
     "System.Text.Encoding": "4.0.11-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Text.Encoding.Extensions/tests/project.json
+++ b/src/System.Text.Encoding.Extensions/tests/project.json
@@ -8,7 +8,7 @@
     "System.Text.Encoding.Extensions": "4.0.11-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Text.Encoding/tests/project.json
+++ b/src/System.Text.Encoding/tests/project.json
@@ -12,7 +12,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Text.Encodings.Web/tests/project.json
+++ b/src/System.Text.Encodings.Web/tests/project.json
@@ -11,7 +11,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Text.RegularExpressions/tests/project.json
+++ b/src/System.Text.RegularExpressions/tests/project.json
@@ -11,7 +11,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Threading.AccessControl/tests/project.json
+++ b/src/System.Threading.AccessControl/tests/project.json
@@ -14,7 +14,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Threading.Overlapped/tests/project.json
+++ b/src/System.Threading.Overlapped/tests/project.json
@@ -6,7 +6,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Overlapped": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Threading.Tasks.Dataflow/tests/project.json
+++ b/src/System.Threading.Tasks.Dataflow/tests/project.json
@@ -17,7 +17,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks.Parallel": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Threading.Tasks.Extensions/tests/project.json
+++ b/src/System.Threading.Tasks.Extensions/tests/project.json
@@ -7,7 +7,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Threading.Tasks.Parallel/tests/project.json
+++ b/src/System.Threading.Tasks.Parallel/tests/project.json
@@ -14,7 +14,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Threading.Tasks/tests/project.json
+++ b/src/System.Threading.Tasks/tests/project.json
@@ -14,7 +14,7 @@
     "System.Threading": "4.0.11-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Threading.Timer/tests/project.json
+++ b/src/System.Threading.Timer/tests/project.json
@@ -9,7 +9,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Timer": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Threading/tests/project.json
+++ b/src/System.Threading/tests/project.json
@@ -14,7 +14,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Threading.Thread": "4.0.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ValueTuple/tests/project.json
+++ b/src/System.ValueTuple/tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
@@ -8,7 +8,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
@@ -8,7 +8,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
@@ -8,7 +8,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
@@ -10,7 +10,7 @@
     "System.Runtime.Extensions": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
@@ -11,7 +11,7 @@
     "System.Text.Encoding": "4.0.11-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
@@ -8,7 +8,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
@@ -7,7 +7,7 @@
     "System.Runtime": "4.1.0-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
@@ -13,7 +13,7 @@
     "System.Text.Encoding": "4.0.11-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
@@ -13,7 +13,7 @@
     "System.Text.Encoding": "4.0.11-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.Extensions": "4.1.0-rc4-24201-04",
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
@@ -8,7 +8,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0-rc4-24201-04",
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
@@ -11,7 +11,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
@@ -10,7 +10,7 @@
     "System.Text.Encoding": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
@@ -12,7 +12,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XDocument/tests/Properties/project.json
+++ b/src/System.Xml.XDocument/tests/Properties/project.json
@@ -13,7 +13,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XDocument/tests/SDMSample/project.json
+++ b/src/System.Xml.XDocument/tests/SDMSample/project.json
@@ -11,7 +11,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XDocument/tests/Streaming/project.json
+++ b/src/System.Xml.XDocument/tests/Streaming/project.json
@@ -11,7 +11,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XDocument/tests/TreeManipulation/project.json
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/project.json
@@ -12,7 +12,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XDocument/tests/XDocument.Common/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Common/project.json
@@ -13,7 +13,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
@@ -12,7 +12,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XDocument/tests/axes/project.json
+++ b/src/System.Xml.XDocument/tests/axes/project.json
@@ -9,7 +9,7 @@
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "System.Xml.XDocument": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XDocument/tests/events/project.json
+++ b/src/System.Xml.XDocument/tests/events/project.json
@@ -10,7 +10,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XDocument/tests/misc/project.json
+++ b/src/System.Xml.XDocument/tests/misc/project.json
@@ -11,7 +11,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
@@ -14,7 +14,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XDocument/tests/xNodeReader/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeReader/project.json
@@ -12,7 +12,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XPath.XDocument/tests/project.json
+++ b/src/System.Xml.XPath.XDocument/tests/project.json
@@ -15,7 +15,7 @@
     "System.Xml.XDocument": "4.0.11-rc4-24201-04",
     "System.Xml.XmlDocument": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XPath.XmlDocument/tests/project.json
+++ b/src/System.Xml.XPath.XmlDocument/tests/project.json
@@ -15,7 +15,7 @@
     "System.Xml.XmlDocument": "4.0.1-rc4-24201-04",
     "System.Xml.XPath": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XPath/tests/project.json
+++ b/src/System.Xml.XPath/tests/project.json
@@ -13,7 +13,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XmlDocument/tests/project.json
+++ b/src/System.Xml.XmlDocument/tests/project.json
@@ -8,7 +8,7 @@
     "System.Threading.Tasks": "4.0.11-rc4-24201-04",
     "System.Xml.ReaderWriter": "4.0.11-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XmlSerializer/tests/Performance/project.json
+++ b/src/System.Xml.XmlSerializer/tests/Performance/project.json
@@ -23,7 +23,7 @@
     "System.Xml.XmlDocument": "4.0.1-rc4-24201-04",
     "System.Xml.XmlSerializer": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Xml.XmlSerializer/tests/project.json
+++ b/src/System.Xml.XmlSerializer/tests/project.json
@@ -19,7 +19,7 @@
     "System.Xml.XDocument": "4.0.11-rc4-24201-04",
     "System.Xml.XmlDocument": "4.0.1-rc4-24201-04",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00431-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"


### PR DESCRIPTION
Previously we conflated "Outer Loop" with "Running as Administrator/root".  Helix does not follow this convention (so we got test failures there) and we are seeing other cases where outer loop runs may not be running elevated (e.g. OSX).

This augments the existing tests I found that require elevation to have a new trait that can be ignored with `/p:WithoutCategories=RequiresElevation`.

/cc @stephentoub @MattGal 