### PR TITLE
Fix for corefx issue #9060 visibility fix for EventSourceIndex method

### DIFF
--- a/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
+++ b/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
@@ -121,7 +121,7 @@ namespace System.Diagnostics.Tracing
         public void EnableEvents(System.Diagnostics.Tracing.EventSource eventSource, System.Diagnostics.Tracing.EventLevel level) { }
         public void EnableEvents(System.Diagnostics.Tracing.EventSource eventSource, System.Diagnostics.Tracing.EventLevel level, System.Diagnostics.Tracing.EventKeywords matchAnyKeyword) { }
         public void EnableEvents(System.Diagnostics.Tracing.EventSource eventSource, System.Diagnostics.Tracing.EventLevel level, System.Diagnostics.Tracing.EventKeywords matchAnyKeyword, System.Collections.Generic.IDictionary<string, string> arguments) { }
-        public static int EventSourceIndex(System.Diagnostics.Tracing.EventSource eventSource) { return default(int); }
+        protected static int EventSourceIndex(System.Diagnostics.Tracing.EventSource eventSource) { return default(int); }
         protected internal virtual void OnEventSourceCreated(System.Diagnostics.Tracing.EventSource eventSource) { }
         protected internal abstract void OnEventWritten(System.Diagnostics.Tracing.EventWrittenEventArgs eventData);
     }

--- a/src/System.Diagnostics.Tracing/src/ApiCompatBaseline.net462.txt
+++ b/src/System.Diagnostics.Tracing/src/ApiCompatBaseline.net462.txt
@@ -1,3 +1,0 @@
-CannotMakeMoreVisible : Visibility of member 'System.Diagnostics.Tracing.EventListener.EventSourceIndex(System.Diagnostics.Tracing.EventSource)' is 'Family' in the implementation but 'Public' in the contract.
-MembersMustExist : Member 'System.Diagnostics.Tracing.EventSource.add_EventCommandExecuted(System.EventHandler<System.Diagnostics.Tracing.EventCommandEventArgs>)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Diagnostics.Tracing.EventSource.remove_EventCommandExecuted(System.EventHandler<System.Diagnostics.Tracing.EventCommandEventArgs>)' does not exist in the implementation but it does exist in the contract.


### PR DESCRIPTION
Basically we wanted to make EventSourceIndex public(it used to be protected)  but in V4.6.2 the change did not make it, so we have to back out the change here until V4.6.3.   Thus we put it back to protected in the reference assembly.

See issue #9060.   

If this is not done, then it is possible that users building against CoreFX could create assemblies that will not run on Desktop.  