### PR TITLE
Flow HttpClient timeouts and cancellation to the response stream

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -83,7 +83,15 @@ namespace System.Net.Http
                 }
             }
 
+#if HTTP_DLL
+            var content = new StreamContent(decompressedStream, state.CancellationToken);
+#else
+            // TODO: Issue https://github.com/dotnet/corefx/issues/9071
+            // We'd like to be able to pass state.CancellationToken into the StreamContent so that its
+            // SerializeToStreamAsync method can use it, but that ctor isn't public, nor is there a
+            // SerializeToStreamAsync override that takes a CancellationToken.
             var content = new StreamContent(decompressedStream);
+#endif
 
             response.Content = content;
             response.RequestMessage = request;


### PR DESCRIPTION
(This is the same PR as #9041, which was already signed-off on; Jenkins wasn't responding to requests on it.)

When using a timeout and/or a cancellation token with a buffered HttpClient operation, the cancellation/timeout doesn't flow through to the actual read/write operations on the underlying streams. This means that on Windows, doing a basic operation like GetStringAsync with a server that pauses for arbitrarily long periods of time while sending the response body won't cancel or timeout until it sends more data. (We don't need to do this on Unix, as on Unix we already handle this case differently, with a single registration for the duration of the SendAsync operation.)