### PR TITLE
Add some HttpClientHandler client certificate tests

### DIFF
--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -94,12 +94,12 @@ namespace System.Net.Test.Common
                 Stream stream = new NetworkStream(s, ownsSocket: false);
                 if (options.UseSsl)
                 {
-                    var sslStream = new SslStream(stream);
+                    var sslStream = new SslStream(stream, false, delegate { return true; });
                     using (var cert = CertificateConfiguration.GetServerCertificate())
                     {
                         await sslStream.AuthenticateAsServerAsync(
                             cert, 
-                            clientCertificateRequired: false, 
+                            clientCertificateRequired: true, // allowed but not required
                             enabledSslProtocols: options.SslProtocols, 
                             checkCertificateRevocation: false).ConfigureAwait(false);
                     }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -237,6 +237,12 @@ namespace System.Net.Http
             get { return _clientCertificateOption; }
             set
             {
+                if (value != ClientCertificateOption.Manual &&
+                    value != ClientCertificateOption.Automatic)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
                 CheckDisposedOrStarted();
                 _clientCertificateOption = value;
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Net.Test.Common;
+using System.Net.Tests;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class HttpClientHandler_ClientCertificates_Test
+    {
+        [Fact]
+        public void ClientCertificateOptions_Default()
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                Assert.Equal(ClientCertificateOption.Manual, handler.ClientCertificateOptions);
+            }
+        }
+
+        [Theory]
+        [InlineData((ClientCertificateOption)2)]
+        [InlineData((ClientCertificateOption)(-1))]
+        public void ClientCertificateOptions_InvalidArg_ThrowsException(ClientCertificateOption option)
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => handler.ClientCertificateOptions = option);
+            }
+        }
+
+        [Theory]
+        [InlineData(ClientCertificateOption.Automatic)]
+        [InlineData(ClientCertificateOption.Manual)]
+        public void ClientCertificateOptions_ValueArg_Roundtrips(ClientCertificateOption option)
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                handler.ClientCertificateOptions = option;
+                Assert.Equal(option, handler.ClientCertificateOptions);
+            }
+        }
+
+        [ConditionalFact(nameof(BackendDoesNotSupportCustomCertificateHandling))]
+        public async Task Automatic_SSLBackendNotSupported_ThrowsPlatformNotSupportedException()
+        {
+            using (var client = new HttpClient(new HttpClientHandler() { ClientCertificateOptions = ClientCertificateOption.Automatic }))
+            {
+                await Assert.ThrowsAsync<PlatformNotSupportedException>(() => client.GetAsync(HttpTestServers.SecureRemoteEchoServer));
+            }
+        }
+
+        [ConditionalFact(nameof(BackendDoesNotSupportCustomCertificateHandling))]
+        public async Task Manual_SSLBackendNotSupported_ThrowsPlatformNotSupportedException()
+        {
+            var handler = new HttpClientHandler();
+            handler.ClientCertificates.Add(CertificateConfiguration.GetClientCertificate());
+            using (var client = new HttpClient(handler))
+            {
+                await Assert.ThrowsAsync<PlatformNotSupportedException>(() => client.GetAsync(HttpTestServers.SecureRemoteEchoServer));
+            }
+        }
+
+        [ConditionalTheory(nameof(BackendSupportsCustomCertificateHandling))]
+        [InlineData(6, false)]
+        [InlineData(3, true)]
+        public async Task Manual_CertificateSentMatchesCertificateReceived_Success(
+            int numberOfRequests,
+            bool reuseClient) // validate behavior with and without connection pooling, which impacts client cert usage
+        {
+            var options = new LoopbackServer.Options { UseSsl = true };
+            using (var cert = CertificateConfiguration.GetClientCertificate())
+            {
+                Func<HttpClient> createClient = () =>
+                {
+                    var handler = new HttpClientHandler() { ServerCertificateCustomValidationCallback = delegate { return true; } };
+                    handler.ClientCertificates.Add(cert);
+                    return new HttpClient(handler);
+                };
+
+                Func<HttpClient, Socket, Uri, Task> makeAndValidateRequest = async (client, server, url) =>
+                {
+                    await TestHelper.WhenAllCompletedOrAnyFailed(
+                        client.GetStringAsync(url),
+                        LoopbackServer.AcceptSocketAsync(server, async (socket, stream, reader, writer) =>
+                        {
+                            SslStream sslStream = Assert.IsType<SslStream>(stream);
+                            Assert.Equal(cert, sslStream.RemoteCertificate);
+                            await LoopbackServer.ReadWriteAcceptedAsync(socket, reader, writer);
+                        }, options));
+                };
+
+                await LoopbackServer.CreateServerAsync(async (server, url) =>
+                {
+                    if (reuseClient)
+                    {
+                        using (var client = createClient())
+                        {
+                            for (int i = 0; i < numberOfRequests; i++)
+                            {
+                                await makeAndValidateRequest(client, server, url);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        for (int i = 0; i < numberOfRequests; i++)
+                        {
+                            using (var client = createClient())
+                            {
+                                await makeAndValidateRequest(client, server, url);
+                            }
+                        }
+                    }
+                }, options);
+            }
+        }
+
+        private static bool BackendSupportsCustomCertificateHandling =>
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+            (CurlSslVersionDescription()?.StartsWith("OpenSSL") ?? false);
+
+        private static bool BackendDoesNotSupportCustomCertificateHandling => !BackendSupportsCustomCertificateHandling;
+
+        [DllImport("System.Net.Http.Native", EntryPoint = "HttpNative_GetSslVersionDescription")]
+        private static extern string CurlSslVersionDescription();
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -199,26 +199,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalFact(nameof(BackendDoesNotSupportCustomCertificateHandling))]
-        public async Task SSLBackendNotSupported_AutomaticClientCerts_ThrowsPlatformNotSupportedException()
-        {
-            using (var client = new HttpClient(new HttpClientHandler() { ClientCertificateOptions = ClientCertificateOption.Automatic }))
-            {
-                await Assert.ThrowsAsync<PlatformNotSupportedException>(() => client.GetAsync(HttpTestServers.SecureRemoteEchoServer));
-            }
-        }
-
-        [ConditionalFact(nameof(BackendDoesNotSupportCustomCertificateHandling))]
-        public async Task SSLBackendNotSupported_ManualClientCerts_ThrowsPlatformNotSupportedException()
-        {
-            var handler = new HttpClientHandler();
-            handler.ClientCertificates.Add(new X509Certificate2());
-            using (var client = new HttpClient(handler))
-            {
-                await Assert.ThrowsAsync<PlatformNotSupportedException>(() => client.GetAsync(HttpTestServers.SecureRemoteEchoServer));
-            }
-        }
-
         [Fact]
         public async Task PostAsync_Post_ChannelBinding_ConfiguredCorrectly()
         {

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="FakeDiagnosticSourceListenerObserver.cs" />
     <Compile Include="FormUrlEncodedContentTest.cs" />
     <Compile Include="HttpClientHandlerTest.cs" />
+    <Compile Include="HttpClientHandlerTest.ClientCertificates.cs" />
     <Compile Include="HttpClientHandlerTest.DefaultProxyCredentials.cs" />
     <Compile Include="HttpClientHandlerTest.MaxConnectionsPerServer.cs" />
     <Compile Include="HttpClientHandlerTest.MaxResponseHeadersLength.cs" />


### PR DESCRIPTION
We didn't previously have any.

And fix a small bug discovered from this, lack of argument validation when setting the enum value.

cc: @davidsh, @cipop, @bartonjs, @ericeil
