### PR TITLE
Fixes for the official build.

### DIFF
--- a/UpdateDependencies.ps1
+++ b/UpdateDependencies.ps1
@@ -3,14 +3,15 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
-# This script updates all the project.json files with the latest CoreFX build version,
+# This script updates all the project.json files with the latest build version,
 # and then creates a Pull Request for the change.
 
 param(
     [Parameter(Mandatory=$true)][string]$GitHubUser,
     [Parameter(Mandatory=$true)][string]$GitHubEmail,
     [Parameter(Mandatory=$true)][string]$GitHubPassword,
-    [Parameter(Mandatory=$true)][string]$CoreFxVersionUrl, 
+    [Parameter(Mandatory=$true)][string]$VersionFileUrl,
+    [string[]]$DirPropsVersionElements = 'CoreFxExpectedPrerelease',
     [string]$GitHubUpstreamOwner='dotnet', 
     [string]$GitHubOriginOwner=$GitHubUser,
     [string]$GitHubProject='corefx',
@@ -18,22 +19,31 @@ param(
     # a semi-colon delimited list of GitHub users to notify on the PR
     [string]$GitHubPullRequestNotifications='')
 
-$CoreFxLatestVersion = Invoke-WebRequest $CoreFxVersionUrl -UseBasicParsing
-$CoreFxLatestVersion = $CoreFxLatestVersion.ToString().Trim()
+$LatestVersion = Invoke-WebRequest $VersionFileUrl -UseBasicParsing
+$LatestVersion = $LatestVersion.ToString().Trim()
 
-# Updates the dir.props file with the latest CoreFX build number
+# Make a nicely formatted string of the dir props version elements. Short names, joined by commas.
+$DirPropsVersionNames = ($DirPropsVersionElements | %{ $_ -replace 'ExpectedPrerelease', '' }) -join ', '
+
+# Updates the dir.props file with the latest build number
 function UpdateValidDependencyVersionsFile
 {
-    if (!$CoreFxLatestVersion)
+    if (!$LatestVersion)
     {
-        Write-Error "Unable to find latest CoreFX version at $CoreFxVersionUrl"
+        Write-Error "Unable to find latest dependency version at $VersionFileUrl ($DirPropsVersionNames)"
         return $false
     }
 
     $DirPropsPath = "$PSScriptRoot\dir.props"
     
-    $DirPropsContent = Get-Content $DirPropsPath | % { 
-        $_ -replace "<CoreFxExpectedPrerelease>.*</CoreFxExpectedPrerelease>","<CoreFxExpectedPrerelease>$CoreFxLatestVersion</CoreFxExpectedPrerelease>"
+    $DirPropsContent = Get-Content $DirPropsPath | % {
+        $line = $_
+        $DirPropsVersionElements | % {
+            $line = $line -replace `
+                "<$_>.*</$_>", `
+                "<$_>$LatestVersion</$_>"
+        }
+        $line
     }
     Set-Content $DirPropsPath $DirPropsContent
 
@@ -58,7 +68,7 @@ function CreatePullRequest
         return $true
     }
     
-    $CommitMessage = "Updating CoreFX dependencies to $CoreFxLatestVersion"
+    $CommitMessage = "Updating $DirPropsVersionNames dependencies to $LatestVersion"
 
     $env:GIT_COMMITTER_NAME = $GitHubUser
     $env:GIT_COMMITTER_EMAIL = $GitHubEmail

--- a/dir.props
+++ b/dir.props
@@ -82,7 +82,9 @@
     <ValidatePackageVersions>true</ValidatePackageVersions>
     <ProhibitFloatingDependencies>true</ProhibitFloatingDependencies>
     <CoreFxExpectedPrerelease>rc3-24203-00</CoreFxExpectedPrerelease>
-    <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore.*)|(Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative))|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)(?&lt;!System\.Data\.SqlClient)(?&lt;!System\.IO\.Compression)$</CoreFxVersionsIdentityRegex>
+    <CoreClrExpectedPrerelease>rc3-24203-00</CoreClrExpectedPrerelease>
+    <ExternalExpectedPrerelease>rc3-24203-00</ExternalExpectedPrerelease>
+    <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore\.Targets)|(Microsoft\.NETCore\.Platforms)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)(?&lt;!System\.Data\.SqlClient)(?&lt;!System\.IO\.Compression)$</CoreFxVersionsIdentityRegex>
   </PropertyGroup>
   
   <Import Project="$(MSBuildThisFileDirectory)pkg/ExternalPackages/versions.props" Condition="Exists('$(MSBuildThisFileDirectory)pkg/ExternalPackages/versions.props')" />
@@ -92,9 +94,17 @@
       <IdentityRegex>$(CoreFxVersionsIdentityRegex)</IdentityRegex>
       <ExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExpectedPrerelease>
     </ValidationPattern>
+    <ValidationPattern Include="CoreClrVersions">
+      <IdentityRegex>^(?i)Microsoft\.NETCore\.Runtime.*$</IdentityRegex>
+      <ExpectedPrerelease>$(CoreClrExpectedPrerelease)</ExpectedPrerelease>
+    </ValidationPattern>
+    <ValidationPattern Include="CoreLibTargetingPackVersions">
+      <IdentityRegex>^(?i)Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative)$</IdentityRegex>
+      <ExpectedPrerelease>$(ExternalExpectedPrerelease)</ExpectedPrerelease>
+    </ValidationPattern>
     <ValidationPattern Include="ExternalVersions">
       <IdentityRegex>^(?i)((System\.Data\.SqlClient)|(System\.IO\.Compression))$</IdentityRegex>
-      <ExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExpectedPrerelease>
+      <ExpectedPrerelease>$(ExternalExpectedPrerelease)</ExpectedPrerelease>
     </ValidationPattern>
     <ValidationPattern Include="TargetingPackVersions">
       <IdentityRegex>^(?i)Microsoft\.TargetingPack\.(NetFramework.*|Private\.WinRT)$</IdentityRegex>

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -2,9 +2,12 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24203-00",
     "Microsoft.NETCore.TestHost": "1.0.0-rc3-24203-00",
-    "Microsoft.NETCore.Console": "1.0.0-rc3-24203-00",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc3-24203-00",
+    "NETStandard.Library": "1.6.0-rc3-24203-00",
+    "System.Diagnostics.Contracts": "4.0.1-rc3-24203-00",
     "System.IO.Compression": "4.1.0-rc3-24203-00",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-24203-00",
+    "System.Linq.Parallel": "4.0.1-rc3-24203-00",
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.3",

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -10,14 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <RuntimeDependency Include="runtime.win7-amd64.runtime.native.System.Data.SqlClient.sni">
-      <TargetRuntime>win7-amd64</TargetRuntime>
+    <Dependency Include="runtime.win7-amd64.runtime.native.System.Data.SqlClient.sni">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
-    </RuntimeDependency>
-    <RuntimeDependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
-      <TargetRuntime>win7-x86</TargetRuntime>
+    </Dependency>
+    <Dependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
-    </RuntimeDependency>
+    </Dependency>
   </ItemGroup>
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -2,6 +2,8 @@
   "dependencies": {
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0033",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24203-00",
+    "System.Collections.NonGeneric": "4.0.1-rc3-24203-00",
+    "System.Collections.Specialized": "4.0.1-rc3-24203-00",
     "System.ComponentModel.Primitives": "4.1.0-rc3-24203-00",
     "System.Globalization": "4.0.11-rc3-24203-00",
     "System.Linq.Expressions": "4.1.0-rc3-24203-00",

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -2,7 +2,10 @@
   "dependencies": {
     "Microsoft.CSharp": "4.0.1-rc3-24203-00",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24203-00",
+    "runtime.native.System.Data.SqlClient.sni": "4.0.0-rc3-24203-00",
     "System.Data.Common": "4.1.0-rc3-24203-00",
+    "System.Data.SqlClient": "4.1.0-rc3-24203-00",
+    "System.Text.Encoding.CodePages": "4.0.1-rc3-24203-00",
     "System.Text.RegularExpressions": "4.1.0-rc3-24203-00",
     "System.Collections": "4.0.11-rc3-24203-00",
     "System.Collections.Concurrent": "4.0.12-rc3-24203-00",

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24203-00",
+    "System.Diagnostics.FileVersionInfo": "4.0.0-rc3-24203-00",
     "System.Globalization": "4.0.11-rc3-24203-00",
     "System.IO.FileSystem": "4.0.1-rc3-24203-00",
     "System.Linq.Expressions": "4.1.0-rc3-24203-00",

--- a/src/System.Reflection.Metadata/tests/project.json
+++ b/src/System.Reflection.Metadata/tests/project.json
@@ -8,6 +8,7 @@
     "System.IO": "4.1.0-rc3-24203-00",
     "System.IO.FileSystem": "4.0.1-rc3-24203-00",
     "System.IO.FileSystem.Primitives": "4.0.1-rc3-24203-00",
+    "System.IO.MemoryMappedFiles": "4.0.0-rc3-24203-00",
     "System.Linq": "4.1.0-rc3-24203-00",
     "System.Linq.Expressions": "4.1.0-rc3-24203-00",
     "System.ObjectModel": "4.0.12-rc3-24203-00",

--- a/src/System.Threading.Tasks.Dataflow/tests/project.json
+++ b/src/System.Threading.Tasks.Dataflow/tests/project.json
@@ -5,6 +5,7 @@
     "System.Diagnostics.Contracts": "4.0.1-rc3-24203-00",
     "System.Diagnostics.Debug": "4.0.11-rc3-24203-00",
     "System.Diagnostics.Tracing": "4.1.0-rc3-24203-00",
+    "System.Dynamic.Runtime": "4.0.11-rc3-24203-00",
     "System.Linq": "4.1.0-rc3-24203-00",
     "System.Linq.Expressions": "4.1.0-rc3-24203-00",
     "System.ObjectModel": "4.0.12-rc3-24203-00",


### PR DESCRIPTION
For SqlClient, specify the runime package as a dependency instead of a
runtime dependency.
Port the following commits to unblock the official test build.

01c56fc2e5643068bf87e3dbce991a8a59644745
6753ec492e208638bdc2676a873e6ddc57262beb
7f051c9c057903905ee24596e4c7822f02386fcb