### PR TITLE
Fix HttpClientMiniStressTests tests

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -213,9 +213,9 @@ namespace System.Net.Http.Functional.Tests
             $"HTTP/1.1 200 OK\r\n" +
             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
             "Content-Type: text/plain\r\n" +
-            "Content-Length: {asciiBody.Length}\r\n" +
+            $"Content-Length: {asciiBody.Length}\r\n" +
             "\r\n" +
-            "{asciiBody}\r\n";
+            $"{asciiBody}\r\n";
 
         private static Task ForCountAsync(int count, int dop, Func<int, Task> bodyAsync)
         {


### PR DESCRIPTION
These were broken at some point (almost all of the tests fail, complaining about invalid responses from the server), but we didn't notice because they're not enabled by default.

cc: @davidsh