### PR TITLE
Fix dependency in SqlClient package.

### DIFF
--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -10,14 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <RuntimeDependency Include="runtime.win7-amd64.runtime.native.System.Data.SqlClient.sni">
-      <TargetRuntime>win7-amd64</TargetRuntime>
+    <Dependency Include="runtime.win7-amd64.runtime.native.System.Data.SqlClient.sni">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
-    </RuntimeDependency>
-    <RuntimeDependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
-      <TargetRuntime>win7-x86</TargetRuntime>
+    </Dependency>
+    <Dependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
-    </RuntimeDependency>
+    </Dependency>
   </ItemGroup>
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
In commit 329de5ea298885637d01ae85186a42436a375b8b I incorrectly used
RuntimeDependency.  Since SqlClient is a "fat package" it cannot rely on
runtime.json to resolve its dependencies, so specify them with Dependency
instead.