### PR TITLE
Fix crash in HttpClient on Unix when using client certificates

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.ClientCertificateProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.ClientCertificateProvider.cs
@@ -108,8 +108,10 @@ namespace System.Net.Http
                             if (!Interop.Ssl.SslAddExtraChainCert(sslHandle, dupCertHandle))
                             {
                                 EventSourceTrace("Failed to add extra chain certificate");
+                                dupCertHandle.Dispose(); // we still own the safe handle; clean it up
                                 return SuspendHandshake;
                             }
+                            dupCertHandle.SetHandleAsInvalid(); // ownership has been transferred to sslHandle; do not free via this safe handle
                         }
                     }
 


### PR DESCRIPTION
In HttpClient on Unix when a client certificate is used, we add the intermediate certificates for the client authentication cert's chain so that the server can chain-verify.  When we add the extra chain certificate to the SSL handle, we're transferring ownership to that handle, which we subequently dispose... but we don't mark the original SafeHandle as invalid, so it eventually gets finalized and we end up double-free'ing, leading to seg faults and other badness.  This commit simply cleans up the handle appropriately.

cc: @bartonjs, @billwert 