### PR TITLE
Port to release/1.0.0: Fix crash in HttpClient on Unix when using client certificates

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.ClientCertificateProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.ClientCertificateProvider.cs
@@ -108,8 +108,10 @@ namespace System.Net.Http
                             if (!Interop.Ssl.SslAddExtraChainCert(sslHandle, dupCertHandle))
                             {
                                 EventSourceTrace("Failed to add extra chain certificate");
+                                dupCertHandle.Dispose(); // we still own the safe handle; clean it up
                                 return SuspendHandshake;
                             }
+                            dupCertHandle.SetHandleAsInvalid(); // ownership has been transferred to sslHandle; do not free via this safe handle
                         }
                     }
 


### PR DESCRIPTION
Port #9131 to release/1.0.0