### PR TITLE
Fixed a Bug in Exception Deserialization.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExceptionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExceptionDataContract.cs
@@ -850,7 +850,7 @@ namespace System.Runtime.Serialization
             Read();
             if (_reader.NodeType == XmlNodeType.Text)
             {
-                _sb.Append(_reader.Value);
+                _sb.Append(GetEscapedElementString(_reader.Value));
                 Read();
                 _reader.ReadEndElement();
             }
@@ -871,6 +871,43 @@ namespace System.Runtime.Serialization
             {
                 throw new InvalidOperationException();
             }
+        }
+
+        private string GetEscapedElementString(string stringToEscape)
+        {
+            var sb = new StringBuilder();
+            foreach (char ch in stringToEscape)
+            {
+                string escaped;
+                switch (ch)
+                {
+                    case '<':
+                        escaped = "&lt;";
+                        break;
+                    case '>':
+                        escaped = "&gt;";
+                        break;
+                    case '&':
+                        escaped = "&amp;";
+                        break;
+                    default:
+                        // We didn't escape ', ", or hex chars as there was no valid use case,
+                        // consider to escape them if necessary.
+                        escaped = null;
+                        break;
+                }
+
+                if (escaped != null)
+                {
+                    sb.Append(escaped);
+                }
+                else
+                {
+                    sb.Append(ch);
+                }
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1358,6 +1358,20 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
+    public static void DCS_ExceptionMesageWithSpecialChars()
+    {
+        var value = new ArgumentException("Test Exception<>&'\"");
+        var actual = SerializeAndDeserialize<ArgumentException>(value, @"<ArgumentException xmlns=""http://schemas.datacontract.org/2004/07/System"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema""><ClassName i:type=""x:string"" xmlns="""">System.ArgumentException</ClassName><Message i:type=""x:string"" xmlns="""">Test Exception&lt;&gt;&amp;'""</Message><Data i:nil=""true"" xmlns=""""/><InnerException i:nil=""true"" xmlns=""""/><HelpURL i:nil=""true"" xmlns=""""/><StackTraceString i:nil=""true"" xmlns=""""/><RemoteStackTraceString i:nil=""true"" xmlns=""""/><RemoteStackIndex i:type=""x:int"" xmlns="""">0</RemoteStackIndex><ExceptionMethod i:nil=""true"" xmlns=""""/><HResult i:type=""x:int"" xmlns="""">-2147024809</HResult><Source i:nil=""true"" xmlns=""""/><WatsonBuckets i:nil=""true"" xmlns=""""/><ParamName i:nil=""true"" xmlns=""""/></ArgumentException>");
+
+        Assert.StrictEqual(value.Message, actual.Message);
+        Assert.StrictEqual(value.ParamName, actual.ParamName);
+        Assert.StrictEqual(value.Source, actual.Source);
+        Assert.StrictEqual(value.StackTrace, actual.StackTrace);
+        Assert.StrictEqual(value.HResult, actual.HResult);
+        Assert.StrictEqual(value.HelpLink, actual.HelpLink);
+    }
+
+    [Fact]
     public static void DCS_TypeWithUriTypeProperty()
     {
         var value = new TypeWithUriTypeProperty() { ConfigUri = new Uri("http://www.bing.com") };


### PR DESCRIPTION
The bug is that if any property of an exception contains any special characters,  <, >, &, ', or, " , the de-serialization of the exception would fail. 

When de-serializing an exception's payload, in order for ExceptionDataContract to deserialize using ClassDataContract, we need to replace the name of the xml elements corresponding to private fields with the name of the property they map to. This operation, however, decode the special chars in element content as a side effect. The fix is to escape those characters again.

Porting https://github.com/dotnet/corefx/pull/9125.
Ref #8968.