### PR TITLE
Fixing Socket async connect for connection-less protocols; Fixing and enabling Socket perf tests.

### DIFF
--- a/src/Common/tests/System/Net/Sockets/Performance/SocketPerformanceTests.cs
+++ b/src/Common/tests/System/Net/Sockets/Performance/SocketPerformanceTests.cs
@@ -28,13 +28,9 @@ namespace System.Net.Sockets.Performance.Tests
             int iterations,
             int bufferSize,
             int socketInstances,
-            long expectedMilliseconds)
+            long expectedMilliseconds = 0)
         {
             long milliseconds;
-
-#if arm
-            iterations /= 100;
-#endif
 
             int numConnections = socketInstances * 5;
             int receiveBufferSize = bufferSize * 2;
@@ -61,9 +57,12 @@ namespace System.Net.Sockets.Performance.Tests
                     socketInstances);
             }
 
-            Assert.True(
-                milliseconds < expectedMilliseconds,
-                "Test execution is expected to be shorter than " + expectedMilliseconds + " but was " + milliseconds);
+            if (expectedMilliseconds != 0)
+            {
+                Assert.True(
+                    milliseconds < expectedMilliseconds,
+                    "Test execution is expected to be shorter than " + expectedMilliseconds + " but was " + milliseconds);
+            }
         }
 
         public void ClientServerTest(
@@ -72,7 +71,7 @@ namespace System.Net.Sockets.Performance.Tests
             int iterations,
             int bufferSize,
             int socketInstances,
-            long expectedMilliseconds)
+            long expectedMilliseconds = 0)
         {
             // NOTE: port '0' below indicates that the server should bind to an anonymous port.
             ClientServerTest(0, serverType, clientType, iterations, bufferSize, socketInstances, expectedMilliseconds);

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="SocketOptionNameTest.cs" />
     <Compile Include="UdpClientTest.cs" />
     <Compile Include="UnixDomainSocketTest.cs" />
+    
     <!-- Common Sockets files -->
     <Compile Include="$(CommonTestPath)\System\Net\Sockets\Configuration.cs">
       <Link>SocketCommon\Configuration.cs</Link>

--- a/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -64,8 +64,9 @@ namespace System.Net.Sockets.Tests
                 Assert.Same(client, c.Client);
             }
         }
-
-        [Fact]    
+        
+        [Fact]
+        [ActiveIssue(9189, PlatformID.AnyUnix)]
         public async Task ConnectAsync_Success()
         {
             using (var c = new UdpClient())
@@ -75,6 +76,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(9189, PlatformID.AnyUnix)]
         public void Connect_Success()
         {
             using (var c = new UdpClient())

--- a/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -42,7 +42,6 @@ namespace System.Net.Sockets.Tests
             });
         }
 
-        [ActiveIssue(4071)]
         [Fact]
         public void BeginSend_AsyncOperationCompletes_Success()
         {
@@ -66,13 +65,21 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ActiveIssue(4968)]    
         [Fact]    
         public async Task ConnectAsync_Success()
         {
             using (var c = new UdpClient())
             {
                 await c.Client.ConnectAsync("114.114.114.114", 53);
+            }
+        }
+
+        [Fact]
+        public void Connect_Success()
+        {
+            using (var c = new UdpClient())
+            {
+                c.Client.Connect("114.114.114.114", 53);
             }
         }
 

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAPMTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAPMTests.cs
@@ -22,8 +22,9 @@ namespace System.Net.Sockets.Performance.Tests
             _log = TestLogging.GetInstance();
         }
 
+        [OuterLoop]
         [Fact]
-        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
+        [ActiveIssue(3635)]
         public void SocketPerformance_SingleSocketClientAPM_LocalHostServerAPM()
         {
             SocketImplementationType serverType = SocketImplementationType.APM;
@@ -44,8 +45,9 @@ namespace System.Net.Sockets.Performance.Tests
                 expectedMilliseconds);
         }
 
+        [OuterLoop]
         [Fact]
-        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
+        [ActiveIssue(3635)]
         public void SocketPerformance_MultipleSocketClientAPM_LocalHostServerAPM()
         {
             SocketImplementationType serverType = SocketImplementationType.APM;
@@ -66,8 +68,9 @@ namespace System.Net.Sockets.Performance.Tests
                 expectedMilliseconds);
         }
 
+        [OuterLoop]
         [Fact]
-        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
+        [ActiveIssue(3635)]
         public void SocketPerformance_SingleSocketClientAPM_LocalHostServerAsync()
         {
             SocketImplementationType serverType = SocketImplementationType.Async;
@@ -88,8 +91,9 @@ namespace System.Net.Sockets.Performance.Tests
                 expectedMilliseconds);
         }
 
+        [OuterLoop]
         [Fact]
-        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
+        [ActiveIssue(3635)]
         public void SocketPerformance_MultipleSocketClientAPM_LocalHostServerAsync()
         {
             SocketImplementationType serverType = SocketImplementationType.Async;
@@ -110,8 +114,9 @@ namespace System.Net.Sockets.Performance.Tests
                 expectedMilliseconds);
         }
 
+        [OuterLoop]
         [Fact]
-        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
+        [ActiveIssue(3635)]
         public void SocketPerformance_SingleSocketClientAsync_LocalHostServerAPM()
         {
             SocketImplementationType serverType = SocketImplementationType.APM;
@@ -132,8 +137,9 @@ namespace System.Net.Sockets.Performance.Tests
                 expectedMilliseconds);
         }
 
+        [OuterLoop]
         [Fact]
-        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
+        [ActiveIssue(3635)]
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAPM()
         {
             SocketImplementationType serverType = SocketImplementationType.APM;

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -20,48 +20,46 @@ namespace System.Net.Sockets.Performance.Tests
             _log = TestLogging.GetInstance();
         }
 
+        [OuterLoop]
         [Fact]
-        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
         public void SocketPerformance_SingleSocketClientAsync_LocalHostServerAsync()
         {
             SocketImplementationType serverType = SocketImplementationType.Async;
             SocketImplementationType clientType = SocketImplementationType.Async;
-            int iterations = 5000;
+            int iterations = 10000;
             int bufferSize = 256;
             int socket_instances = 1;
-            long expectedMilliseconds = 5000;
 
             var test = new SocketPerformanceTests(_log);
 
+            // Run in Stress mode no expected time to complete.
             test.ClientServerTest(
                 serverType,
                 clientType,
                 iterations,
                 bufferSize,
-                socket_instances,
-                expectedMilliseconds);
+                socket_instances);
         }
 
+        [OuterLoop]
         [Fact]
-        [ActiveIssue(3635)] // disabling perf tests until we have appropriate infrastructure with which to run them
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync()
         {
             SocketImplementationType serverType = SocketImplementationType.Async;
             SocketImplementationType clientType = SocketImplementationType.Async;
-            int iterations = 1000;
+            int iterations = 2000;
             int bufferSize = 256;
-            int socket_instances = 100;
-            long expectedMilliseconds = 10000;
+            int socket_instances = 500;
 
             var test = new SocketPerformanceTests(_log);
 
+            // Run in Stress mode no expected time to complete.
             test.ClientServerTest(
                 serverType,
                 clientType,
                 iterations,
                 bufferSize,
-                socket_instances,
-                expectedMilliseconds);
+                socket_instances);
         }
     }
 }

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -20,6 +20,7 @@ namespace System.Net.Sockets.Performance.Tests
             _log = TestLogging.GetInstance();
         }
 
+        [ActiveIssue(9189, PlatformID.AnyUnix)]
         [OuterLoop]
         [Fact]
         public void SocketPerformance_SingleSocketClientAsync_LocalHostServerAsync()
@@ -41,6 +42,7 @@ namespace System.Net.Sockets.Performance.Tests
                 socket_instances);
         }
 
+        [ActiveIssue(9189, PlatformID.AnyUnix)]
         [OuterLoop]
         [Fact]
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync()

--- a/src/System.Net.Sockets/tests/PerformanceTests/System.Net.Sockets.Async.Performance.Tests.csproj
+++ b/src/System.Net.Sockets/tests/PerformanceTests/System.Net.Sockets.Async.Performance.Tests.csproj
@@ -16,7 +16,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />
   <ItemGroup>
-    <Compile Include="SocketPerformanceAPMTests.cs" />
     <Compile Include="SocketPerformanceAsyncTests.cs" />
     <Compile Include="SocketTestClientAPMMock.cs" />    
     <Compile Include="SocketTestServerAPMMock.cs" />


### PR DESCRIPTION
Simulating an asynchronous Connect (APM/TPL) for connection-less protocols. 
Moving SocketPerformance to Outerloop and enabling the tests without an execution time expectation.

Fixes #4968, #3635
