### PR TITLE
Revert "Port to release/1.0.0: Flow HttpClient timeouts and cancellation to the response stream"

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -83,15 +83,7 @@ namespace System.Net.Http
                 }
             }
 
-#if HTTP_DLL
-            var content = new StreamContent(decompressedStream, state.CancellationToken);
-#else
-            // TODO: Issue https://github.com/dotnet/corefx/issues/9071
-            // We'd like to be able to pass state.CancellationToken into the StreamContent so that its
-            // SerializeToStreamAsync method can use it, but that ctor isn't public, nor is there a
-            // SerializeToStreamAsync override that takes a CancellationToken.
             var content = new StreamContent(decompressedStream);
-#endif
 
             response.Content = content;
             response.RequestMessage = request;

--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,30 +12,19 @@ namespace System.Net.Http
 {
     public class StreamContent : HttpContent
     {
-        private const int DefaultBufferSize = 4096;
+        private const int defaultBufferSize = 4096;
 
         private Stream _content;
         private int _bufferSize;
-        private CancellationToken _cancellationToken;
         private bool _contentConsumed;
         private long _start;
 
         public StreamContent(Stream content)
-            : this(content, DefaultBufferSize)
+            : this(content, defaultBufferSize)
         {
         }
 
         public StreamContent(Stream content, int bufferSize)
-            : this(content, bufferSize, CancellationToken.None)
-        {
-        }
-
-        internal StreamContent(Stream content, CancellationToken cancellationToken)
-            : this(content, DefaultBufferSize, cancellationToken)
-        {
-        }
-
-        private StreamContent(Stream content, int bufferSize, CancellationToken cancellationToken)
         {
             if (content == null)
             {
@@ -47,7 +37,6 @@ namespace System.Net.Http
 
             _content = content;
             _bufferSize = bufferSize;
-            _cancellationToken = cancellationToken;
             if (content.CanSeek)
             {
                 _start = content.Position;
@@ -61,7 +50,7 @@ namespace System.Net.Http
 
             PrepareContent();
             // If the stream can't be re-read, make sure that it gets disposed once it is consumed.
-            return StreamToStreamCopy.CopyAsync(_content, stream, _bufferSize, !_content.CanSeek, _cancellationToken);
+            return StreamToStreamCopy.CopyAsync(_content, stream, _bufferSize, !_content.CanSeek);
         }
 
         protected internal override bool TryComputeLength(out long length)

--- a/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.Net.Http
@@ -21,17 +20,11 @@ namespace System.Net.Http
         /// <param name="destination">The destination stream to which to copy.</param>
         /// <param name="bufferSize">The size of the buffer to allocate if one needs to be allocated.</param>
         /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
-        /// <param name="cancellationToken">CancellationToken used to cancel the copy operation.</param>
-        public static Task CopyAsync(Stream source, Stream destination, int bufferSize, bool disposeSource, CancellationToken cancellationToken = default(CancellationToken))
+        public static Task CopyAsync(Stream source, Stream destination, int bufferSize, bool disposeSource)
         {
             Debug.Assert(source != null);
             Debug.Assert(destination != null);
             Debug.Assert(bufferSize > 0);
-
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled(cancellationToken);
-            }
 
             try
             {
@@ -62,7 +55,7 @@ namespace System.Net.Http
                         // Now write the buffer to the destination stream. This will complete synchronously if the 
                         // destination's WriteAsync completes synchronously, such as if destination is also a MemoryStream.  
                         // Thus we don't need to special case it.
-                        return WriteToAnyStreamAsync(sourceBuffer, source, destination, disposeSource, cancellationToken);
+                        return WriteToAnyStreamAsync(sourceBuffer, source, destination, disposeSource);
                     }
                 }
 
@@ -84,7 +77,7 @@ namespace System.Net.Http
                     int capacity = destinationLimitStream.Capacity;
                     if (capacity > 0 && capacity <= destinationLimitStream.MaxSize)
                     {
-                        return CopyAsyncToPreSizedLimitMemoryStream(source, destinationLimitStream, bufferSize, disposeSource, cancellationToken);
+                        return CopyAsyncToPreSizedLimitMemoryStream(source, destinationLimitStream, bufferSize, disposeSource);
                     }
                 }
 
@@ -99,7 +92,7 @@ namespace System.Net.Http
                 {
                     var buffer = new ArraySegment<byte>(sourceMemoryStream.ToArray());
                     sourceMemoryStream.Position = buffer.Count; // Update position to simulate reading all the data
-                    return WriteToAnyStreamAsync(buffer, sourceMemoryStream, destination, disposeSource, cancellationToken);
+                    return WriteToAnyStreamAsync(buffer, sourceMemoryStream, destination, disposeSource);
                 }
 
                 // No special-stream cases worked, so we need to fall back to doing a normal copy, involving
@@ -110,8 +103,8 @@ namespace System.Net.Http
                 // async method wrapper and its potential allocations, so we fall back to our own read/write loop that 
                 // does the copy and the disposal in a single async method.
                 return disposeSource ?
-                    CopyAsyncAnyStreamToAnyStreamCore(source, destination, bufferSize, disposeSource, cancellationToken) :
-                    source.CopyToAsync(destination, bufferSize, cancellationToken);
+                    CopyAsyncAnyStreamToAnyStreamCore(source, destination, bufferSize, disposeSource) :
+                    source.CopyToAsync(destination, bufferSize);
             }
             catch (Exception e)
             {
@@ -126,9 +119,9 @@ namespace System.Net.Http
         /// <param name="source">The source stream with which <paramref name="buffer"/> is associated.</param>
         /// <param name="destination">The destination stream to which to write.</param>
         /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
-        private static async Task WriteToAnyStreamAsync(ArraySegment<byte> buffer, Stream source, Stream destination, bool disposeSource, CancellationToken cancellationToken)
+        private static async Task WriteToAnyStreamAsync(ArraySegment<byte> buffer, Stream source, Stream destination, bool disposeSource)
         {
-            await destination.WriteAsync(buffer.Array, buffer.Offset, buffer.Count, cancellationToken).ConfigureAwait(false);
+            await destination.WriteAsync(buffer.Array, buffer.Offset, buffer.Count).ConfigureAwait(false);
             DisposeSource(disposeSource, source);
         }
 
@@ -137,7 +130,7 @@ namespace System.Net.Http
         /// <param name="destination">The destination LimitMemoryStream to write to.</param>
         /// <param name="bufferSize">The size of the buffer to allocate if one needs to be allocated.</param>
         /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
-        private static async Task CopyAsyncToPreSizedLimitMemoryStream(Stream source, HttpContent.LimitMemoryStream destination, int bufferSize, bool disposeSource, CancellationToken cancellationToken)
+        private static async Task CopyAsyncToPreSizedLimitMemoryStream(Stream source, HttpContent.LimitMemoryStream destination, int bufferSize, bool disposeSource)
         {
             // When a LimitMemoryStream is constructed to represent a response with a particular ContentLength, its
             // Capacity is set to that amount in order to pre-size it.  We can take advantage of that in this copy
@@ -175,7 +168,7 @@ namespace System.Net.Http
                 while (spaceRemaining > 0)
                 {
                     // Read into the buffer
-                    bytesRead = await source.ReadAsync(entireBuffer.Array, (int)destination.Position, spaceRemaining, cancellationToken).ConfigureAwait(false);
+                    bytesRead = await source.ReadAsync(entireBuffer.Array, (int)destination.Position, spaceRemaining).ConfigureAwait(false);
                     if (bytesRead == 0)
                     {
                         DisposeSource(disposeSource, source);
@@ -200,7 +193,7 @@ namespace System.Net.Http
             // we need a buffer to read into.  Use a cached single-byte array to do a read for 1-byte.
             // Ideally this read returns 0, and we're done.
             byte[] singleByteArray = RentCachedSingleByteArray();
-            bytesRead = await source.ReadAsync(singleByteArray, 0, 1, cancellationToken).ConfigureAwait(false);
+            bytesRead = await source.ReadAsync(singleByteArray, 0, 1).ConfigureAwait(false);
             if (bytesRead == 0)
             {
                 ReturnCachedSingleByteArray(singleByteArray);
@@ -211,11 +204,11 @@ namespace System.Net.Http
             // The read actually returned data, which means there was more data available then
             // the capacity of the LimitMemoryStream.  This is likely an error condition, but
             // regardless we need to finish the copy.  First, we write out the byte we read...
-            await destination.WriteAsync(singleByteArray, 0, 1, cancellationToken).ConfigureAwait(false);
+            await destination.WriteAsync(singleByteArray, 0, 1).ConfigureAwait(false);
             ReturnCachedSingleByteArray(singleByteArray);
 
             // ...then we fall back to doing the normal read/write loop.
-            await CopyAsyncAnyStreamToAnyStreamCore(source, destination, bufferSize, disposeSource, cancellationToken).ConfigureAwait(false);
+            await CopyAsyncAnyStreamToAnyStreamCore(source, destination, bufferSize, disposeSource).ConfigureAwait(false);
         }
 
         /// <summary>Copies a source stream to a destination stream via a standard read/write loop.</summary>
@@ -223,14 +216,14 @@ namespace System.Net.Http
         /// <param name="destination">The destination stream to which to copy.</param>
         /// <param name="bufferSize">The size of the buffer to allocate if one needs to be allocated.</param>
         /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
-        private static async Task CopyAsyncAnyStreamToAnyStreamCore(Stream source, Stream destination, int bufferSize, bool disposeSource, CancellationToken cancellationToken)
+        private static async Task CopyAsyncAnyStreamToAnyStreamCore(Stream source, Stream destination, int bufferSize, bool disposeSource)
         {
             var buffer = new byte[bufferSize];
 
             int bytesRead;
-            while ((bytesRead = await source.ReadAsync(buffer, 0, bufferSize, cancellationToken).ConfigureAwait(false)) > 0)
+            while ((bytesRead = await source.ReadAsync(buffer, 0, bufferSize).ConfigureAwait(false)) > 0)
             {
-                await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+                await destination.WriteAsync(buffer, 0, bytesRead).ConfigureAwait(false);
             }
 
             DisposeSource(disposeSource, source);

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -23,19 +23,6 @@ namespace System.Net.Http
                 RequestMessage = easy._requestMessage;
                 ResponseStream = new CurlResponseStream(easy);
                 Content = new StreamContent(ResponseStream);
-
-                // On Windows, we pass the equivalent of the easy._cancellationToken
-                // in to StreamContent's ctor.  This in turn passes that token through
-                // to ReadAsync operations on the stream response stream when HttpClient
-                // reads from the response stream to buffer it with ResponseContentRead.
-                // We don't need to do that here in the Unix implementation as, until the
-                // SendAsync task completes, the handler will have registered with the
-                // CancellationToken with an action that will cancel all work related to
-                // the easy handle if cancellation occurs, and that includes canceling any
-                // pending reads on the response stream.  It wouldn't hurt anything functionally
-                // to still pass easy._cancellationToken here, but it will increase costs
-                // a bit, as each read will then need to allocate a larger state object as
-                // well as register with and unregister from the cancellation token.
             }
 
             internal CurlResponseStream ResponseStream { get; }

--- a/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
@@ -15,123 +15,110 @@ namespace System.Net.Http.Functional.Tests
 {
     public class CancellationTest
     {
+        // TODO: Issue #8692. Move this test server capability to Azure test server or Loopback server.
+        private const string FastHeadersSlowBodyHost = "<TODO>";
+        private const int FastHeadersSlowBodyPort = 1337;
+        private const int ResponseBodyReadDelayInMilliseconds = 15000; // 15 seconds.
+        private const int ResponseBodyLength = 1024;
+
+        private static Uri s_fastHeadersSlowBodyServer = new Uri(string.Format(
+            "http://{0}:{1}/?slow={2}&length={3}",
+            FastHeadersSlowBodyHost,
+            FastHeadersSlowBodyPort,
+            ResponseBodyReadDelayInMilliseconds,
+            ResponseBodyLength));
+            
         private readonly ITestOutputHelper _output;
 
         public CancellationTest(ITestOutputHelper output)
         {
             _output = output;
+            _output.WriteLine(s_fastHeadersSlowBodyServer.ToString());
         }
 
-        [OuterLoop] // includes seconds of delay
-        [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public async Task GetAsync_ResponseContentRead_CancelUsingTimeoutOrToken_TaskCanceledQuickly(
-            bool useTimeout, bool startResponseBody)
+        [ActiveIssue(8663)]
+        [Fact]
+        public async Task GetIncludesReadingResponseBody_CancelUsingTimeout_TaskCanceledQuickly()
         {
-            var cts = new CancellationTokenSource(); // ignored if useTimeout==true
-            TimeSpan timeout = useTimeout ? new TimeSpan(0, 0, 1) : Timeout.InfiniteTimeSpan;
-            CancellationToken cancellationToken = useTimeout ? CancellationToken.None : cts.Token;
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
 
-            using (var client = new HttpClient() { Timeout = timeout })
+            using (var client = new HttpClient())
             {
-                var triggerResponseWrite = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                var triggerRequestCancel = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                client.Timeout = new TimeSpan(0, 0, 1);
 
-                await LoopbackServer.CreateServerAsync(async (server, url) =>
-                {
-                    Task serverTask = LoopbackServer.AcceptSocketAsync(server, async (socket, stream, reader, writer) =>
-                    {
-                        while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) ;
-                        await writer.WriteAsync(
-                            "HTTP/1.1 200 OK\r\n" +
-                            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                            "Content-Length: 16000\r\n" +
-                            "\r\n" +
-                            (startResponseBody ? "less than 16000 bytes" : ""));
+                Task<HttpResponseMessage> getResponse =
+                    client.GetAsync(s_fastHeadersSlowBodyServer, HttpCompletionOption.ResponseContentRead);
 
-                        await Task.Delay(1000);
-                        triggerRequestCancel.SetResult(true); // allow request to cancel
-                        await triggerResponseWrite.Task; // pause until we're released
-                    });
-
-                    var stopwatch = Stopwatch.StartNew();
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
-                    {
-                        Task<HttpResponseMessage> getResponse = client.GetAsync(url, HttpCompletionOption.ResponseContentRead, cancellationToken);
-                        await triggerRequestCancel.Task;
-                        cts.Cancel();
-                        await getResponse;
-                    });
-                    stopwatch.Stop();
-                    _output.WriteLine("GetAsync() completed at: {0}", stopwatch.Elapsed.ToString());
-
-                    triggerResponseWrite.SetResult(true);
-                    Assert.True(stopwatch.Elapsed < new TimeSpan(0, 0, 10), "Elapsed time should be short");
-                });
+                stopwatch.Restart();
+                await Assert.ThrowsAsync<TaskCanceledException>(
+                    () => getResponse);
+                stopwatch.Stop();
+                _output.WriteLine("GetAsync() completed at: {0}", stopwatch.Elapsed.ToString());
+                Assert.True(stopwatch.Elapsed < new TimeSpan(0,0,3), "Elapsed time should be short");
             }
         }
 
-        [ActiveIssue(9075, PlatformID.AnyUnix)] // recombine this test into the subsequent one when issue is fixed
-        [OuterLoop] // includes seconds of delay
+        [ActiveIssue(8663)]
         [Fact]
-        public Task ReadAsStreamAsync_ReadAsync_Cancel_BodyNeverStarted_TaskCanceledQuickly()
+        public async Task GetIncludesReadingResponseBody_CancelUsingToken_TaskCanceledQuickly()
         {
-            return ReadAsStreamAsync_ReadAsync_Cancel_TaskCanceledQuickly(false);
-        }
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
 
-        [OuterLoop] // includes seconds of delay
-        [Theory]
-        [InlineData(true)]
-        public async Task ReadAsStreamAsync_ReadAsync_Cancel_TaskCanceledQuickly(bool startResponseBody)
-        {
+            var cts = new CancellationTokenSource();
             using (var client = new HttpClient())
             {
-                await LoopbackServer.CreateServerAsync(async (server, url) =>
+                Task<HttpResponseMessage> getResponse =
+                    client.GetAsync(s_fastHeadersSlowBodyServer, HttpCompletionOption.ResponseContentRead, cts.Token);
+
+                Task ignore = Task.Delay(new TimeSpan(0, 0, 1)).ContinueWith(_ =>
                 {
-                    var triggerResponseWrite = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-                    Task serverTask = LoopbackServer.AcceptSocketAsync(server, async (socket, stream, reader, writer) =>
-                    {
-                        while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) ;
-                        await writer.WriteAsync(
-                            "HTTP/1.1 200 OK\r\n" +
-                            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                            "Content-Length: 16000\r\n" +
-                            "\r\n" +
-                            (startResponseBody ? "20 bytes of the body" : ""));
-
-                        await triggerResponseWrite.Task; // pause until we're released
-                    });
-
-                    using (HttpResponseMessage response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead))
-                    using (Stream responseStream = await response.Content.ReadAsStreamAsync())
-                    {
-                        // Read all expected content
-                        byte[] buffer = new byte[20];
-                        if (startResponseBody)
-                        {
-                            int totalRead = 0;
-                            int bytesRead;
-                            while (totalRead < 20 && (bytesRead = await responseStream.ReadAsync(buffer, 0, buffer.Length)) > 0)
-                            {
-                                totalRead += bytesRead;
-                            }
-                        }
-
-                        // Now do a read that'll need to be canceled
-                        var stopwatch = Stopwatch.StartNew();
-                        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-                            () => responseStream.ReadAsync(buffer, 0, buffer.Length, new CancellationTokenSource(1000).Token));
-                        stopwatch.Stop();
-
-                        triggerResponseWrite.SetResult(true);
-                        _output.WriteLine("ReadAsync() completed at: {0}", stopwatch.Elapsed.ToString());
-                        Assert.True(stopwatch.Elapsed < new TimeSpan(0, 0, 10), "Elapsed time should be short");
-                    }
+                    _output.WriteLine("Calling cts.Cancel() at: {0}", stopwatch.Elapsed.ToString());
+                    cts.Cancel();
                 });
+
+                stopwatch.Restart();
+                await Assert.ThrowsAsync<TaskCanceledException>(
+                    () => getResponse);
+                stopwatch.Stop();
+                _output.WriteLine("GetAsync() completed at: {0}", stopwatch.Elapsed.ToString());
+                Assert.True(stopwatch.Elapsed < new TimeSpan(0,0,3), "Elapsed time should be short");
+            }
+        }
+
+        [ActiveIssue(8692)]
+        [Fact]
+        public async Task ResponseStreamRead_CancelUsingToken_TaskCanceledQuickly()
+        {
+            var stopwatch = new Stopwatch();
+
+            stopwatch.Start();
+            using (var client = new HttpClient())
+            using (HttpResponseMessage response =
+                await client.GetAsync(s_fastHeadersSlowBodyServer, HttpCompletionOption.ResponseHeadersRead))
+            {
+                stopwatch.Stop();
+                _output.WriteLine("Time to get headers: {0}", stopwatch.Elapsed.ToString());
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var cts = new CancellationTokenSource();
+
+                Stream stream = await response.Content.ReadAsStreamAsync();
+                byte[] buffer = new byte[ResponseBodyLength];
+                
+                Task ignore = Task.Delay(new TimeSpan(0,0,1)).ContinueWith(_ =>
+                {
+                    _output.WriteLine("Calling cts.Cancel() at: {0}", stopwatch.Elapsed.ToString());
+                    cts.Cancel();
+                });
+
+                stopwatch.Restart();
+                await Assert.ThrowsAsync<TaskCanceledException>(
+                    () => stream.ReadAsync(buffer, 0, buffer.Length, cts.Token));
+                stopwatch.Stop();
+                _output.WriteLine("ReadAsync() completed at: {0}", stopwatch.Elapsed.ToString());
+                Assert.True(stopwatch.Elapsed < new TimeSpan(0,0,3), "Elapsed time should be short");
             }
         }
     }


### PR DESCRIPTION
In internal test systems, this change is causing a failure due to:
https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Threading/CancellationTokenSource.cs#L626
which shouldn't be hit but is.  To play it safe until we figure it out, I'm backing out this change.

cc: @cipop, @davidsh