### PR TITLE
Fix package ID for x64 sni package dependency

### DIFF
--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Dependency Include="runtime.win7-amd64.runtime.native.System.Data.SqlClient.sni">
+    <Dependency Include="runtime.win7-x64.runtime.native.System.Data.SqlClient.sni">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
     </Dependency>
     <Dependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">


### PR DESCRIPTION
Port of
https://github.com/dotnet/corefx/commit/3290b3dbcb00cde4defe70f8ca53150654e2f779

Fixes the issue pointed out after merging #9123
/cc @weshaggard @ellismg @jhendrixMSFT