### PR TITLE
Fixed misleading comment about tail index of Queue.

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -24,8 +24,8 @@ namespace System.Collections.Generic
         IReadOnlyCollection<T>
     {
         private T[] _array;
-        private int _head;       // First valid element in the queue
-        private int _tail;       // Last valid element in the queue
+        private int _head;       // Index of the first valid element in the queue.
+        private int _tail;       // Index of the first invalid element (or index of the last valid + 1) in the queue.
         private int _size;       // Number of elements.
         private int _version;
         private Object _syncRoot;

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -24,8 +24,8 @@ namespace System.Collections.Generic
         IReadOnlyCollection<T>
     {
         private T[] _array;
-        private int _head;       // Index of the first valid element in the queue.
-        private int _tail;       // Index of the first invalid element (or index of the last valid + 1) in the queue.
+        private int _head;       // The index from which to dequeue if the queue isn't empty.
+        private int _tail;       // The index at which to enqueue if the queue isn't full.
         private int _size;       // Number of elements.
         private int _version;
         private Object _syncRoot;


### PR DESCRIPTION
Original comment about `_tail` was claiming incorrectly that it is index of the last valid element whereas it is index of the first invalid (last valid + 1).