### PR TITLE
Fix external update regexs

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -87,9 +87,9 @@
     <CoreClrExpectedPrerelease>rc4-24206-02</CoreClrExpectedPrerelease>
     <ExternalExpectedPrerelease>rc4-24201-00</ExternalExpectedPrerelease>
 
-    <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore\.Targets)|(Microsoft\.NETCore\.Platforms)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)(?&lt;!System\.Data\.SqlClient)(?&lt;!System\.IO\.Compression)$</CoreFxVersionsIdentityRegex>
+    <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore\.Targets)|(Microsoft\.NETCore\.Platforms)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)$</CoreFxVersionsIdentityRegex>
   </PropertyGroup>
-  
+
   <Import Project="$(MSBuildThisFileDirectory)pkg/ExternalPackages/versions.props" Condition="Exists('$(MSBuildThisFileDirectory)pkg/ExternalPackages/versions.props')" />
 
   <ItemGroup>
@@ -103,10 +103,6 @@
     </ValidationPattern>
     <ValidationPattern Include="CoreLibTargetingPackVersions">
       <IdentityRegex>^(?i)Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative)$</IdentityRegex>
-      <ExpectedPrerelease>$(ExternalExpectedPrerelease)</ExpectedPrerelease>
-    </ValidationPattern>
-    <ValidationPattern Include="ExternalVersions">
-      <IdentityRegex>^(?i)((System\.Data\.SqlClient)|(System\.IO\.Compression))$</IdentityRegex>
       <ExpectedPrerelease>$(ExternalExpectedPrerelease)</ExpectedPrerelease>
     </ValidationPattern>
     <ValidationPattern Include="TargetingPackVersions">

--- a/src/Common/net46-test-runtime/project.json
+++ b/src/Common/net46-test-runtime/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.IO.Compression": "4.1.0-rc4-24201-00",
+    "System.IO.Compression": "4.1.0-rc4-24206-03",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc4-24206-03",
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -5,7 +5,7 @@
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc4-24206-02",
     "NETStandard.Library": "1.6.0-rc4-24206-03",
     "System.Diagnostics.Contracts": "4.0.1-rc4-24206-03",
-    "System.IO.Compression": "4.1.0-rc4-24201-00",
+    "System.IO.Compression": "4.1.0-rc4-24206-03",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc4-24206-03",
     "System.Linq.Parallel": "4.0.1-rc4-24206-03",
     "coveralls.io": "1.4",

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.CSharp": "4.0.1-rc4-24206-03",
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24206-03",
     "System.Data.Common": "4.1.0-rc4-24206-03",
-    "System.Data.SqlClient": "4.1.0-rc4-24201-00",
+    "System.Data.SqlClient": "4.1.0-rc4-24206-03",
     "System.Text.Encoding.CodePages": "4.0.1-rc4-24206-03",
     "System.Text.RegularExpressions": "4.1.0-rc4-24206-03",
     "System.Collections": "4.0.11-rc4-24206-03",

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "Microsoft.CSharp": "4.0.1-rc4-24206-03",
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24206-03",
-    "runtime.native.System.Data.SqlClient.sni": "4.0.0-rc3-24131-00",
     "System.Data.Common": "4.1.0-rc4-24206-03",
     "System.Data.SqlClient": "4.1.0-rc4-24201-00",
     "System.Text.Encoding.CodePages": "4.0.1-rc4-24206-03",

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -6,7 +6,7 @@
     "System.Console": "4.0.0-rc4-24206-03",
     "System.Diagnostics.Debug": "4.0.11-rc4-24206-03",
     "System.IO": "4.1.0-rc4-24206-03",
-    "System.IO.Compression": "4.1.0-rc4-24201-00",
+    "System.IO.Compression": "4.1.0-rc4-24206-03",
     "System.IO.Compression.TestData": "1.0.1-prerelease",
     "System.IO.FileSystem": "4.0.1-rc4-24206-03",
     "System.IO.FileSystem.Primitives": "4.0.1-rc4-24206-03",

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -6,7 +6,7 @@
     "System.Console": "4.0.0-rc4-24206-03",
     "System.Diagnostics.Debug": "4.0.11-rc4-24206-03",
     "System.IO": "4.1.0-rc4-24206-03",
-    "System.IO.Compression": "4.1.0-rc4-24201-00",
+    "System.IO.Compression": "4.1.0-rc4-24206-03",
     "System.IO.Compression.TestData": "1.0.2-prerelease",
     "System.IO.FileSystem": "4.0.1-rc4-24206-03",
     "System.Linq": "4.1.0-rc4-24206-03",

--- a/src/System.Net.Http.WinHttpHandler/src/project.json
+++ b/src/System.Net.Http.WinHttpHandler/src/project.json
@@ -7,7 +7,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
-    "System.IO.Compression": "4.1.0-rc4-24201-00",
+    "System.IO.Compression": "4.1.0-rc4-24206-03",
     "System.Net.Http": "4.0.0",
     "System.Net.Primitives": "4.0.10",
     "System.Resources.ResourceManager": "4.0.0",

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24206-03",
     "Microsoft.Win32.Primitives": "4.0.1-rc4-24206-03",
     "System.Diagnostics.DiagnosticSource": "4.0.0-rc4-24206-03",
-    "System.IO.Compression": "4.1.0-rc4-24201-00",
+    "System.IO.Compression": "4.1.0-rc4-24206-03",
     "System.Linq.Expressions": "4.1.0-rc4-24206-03",
     "System.Net.Http": "4.1.0-rc4-24206-03",
     "System.Net.Primitives": "4.0.11-rc4-24206-03",

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -5,7 +5,7 @@
     "System.Diagnostics.DiagnosticSource": "4.0.0-rc4-24206-03",
     "System.Globalization": "4.0.11-rc4-24206-03",
     "System.IO": "4.1.0-rc4-24206-03",
-    "System.IO.Compression": "4.1.0-rc4-24201-00",
+    "System.IO.Compression": "4.1.0-rc4-24206-03",
     "System.Linq.Expressions": "4.1.0-rc4-24206-03",
     "System.Net.Http": "4.1.0-rc4-24206-03",
     "System.Net.Primitives": "4.0.11-rc4-24206-03",

--- a/src/System.Net.Requests/src/project.json
+++ b/src/System.Net.Requests/src/project.json
@@ -7,7 +7,7 @@
         "System.Diagnostics.Debug": "4.0.0",
         "System.Diagnostics.Tracing": "4.0.0",
         "System.IO": "4.0.10",
-        "System.IO.Compression": "4.1.0-rc4-24201-00",
+        "System.IO.Compression": "4.1.0-rc4-24206-03",
         "System.Net.Http": "4.0.0",
         "System.Net.Primitives": "4.0.10",
         "System.Net.WebHeaderCollection": "4.0.0",

--- a/src/System.Net.Requests/tests/project.json
+++ b/src/System.Net.Requests/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24206-03",
-    "System.IO.Compression": "4.1.0-rc4-24201-00",
+    "System.IO.Compression": "4.1.0-rc4-24206-03",
     "System.Linq.Expressions": "4.1.0-rc4-24206-03",
     "System.Net.Http": "4.1.0-rc4-24206-03",
     "System.Net.NetworkInformation": "4.1.0-rc4-24206-03",


### PR DESCRIPTION
cc @jhendrix @ericstj @ellismg @dagood

This will fix the System.IO.Compression and System.Data.SqlClient so they update with corefx now. 