### PR TITLE
Make the internal CookieComparer class static

### DIFF
--- a/src/System.Net.Http/src/netcore50/System/Net/cookie.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/cookie.cs
@@ -67,7 +67,6 @@ namespace System.Net
         internal static readonly char[] PortSplitDelimiters = new char[] { ' ', ',', '\"' };
         internal static readonly char[] Reserved2Name = new char[] { ' ', '\t', '\r', '\n', '=', ';', ',' };
         internal static readonly char[] Reserved2Value = new char[] { ';', ',' };
-        private static Comparer staticComparer = new Comparer();
 
         // fields
 
@@ -796,13 +795,6 @@ namespace System.Net
         }
 
         // methods
-
-
-        internal static IComparer GetComparer()
-        {
-            //the class don't have any members, it's safe reuse the instance
-            return staticComparer;
-        }
 
 
         /// <devdoc>
@@ -1901,39 +1893,6 @@ namespace System.Net
                 return value;
 
             return value.Length == 2 ? string.Empty : value.Substring(1, value.Length - 2);
-        }
-    }
-
-
-    internal class Comparer : IComparer
-    {
-        int IComparer.Compare(object ol, object or)
-        {
-            Cookie left = (Cookie)ol;
-            Cookie right = (Cookie)or;
-
-            int result;
-
-            if ((result = string.Compare(left.Name, right.Name, StringComparison.OrdinalIgnoreCase)) != 0)
-            {
-                return result;
-            }
-
-            if ((result = string.Compare(left.Domain, right.Domain, StringComparison.OrdinalIgnoreCase)) != 0)
-            {
-                return result;
-            }
-
-            //
-            //NB: The only path is case sensitive as per spec.
-            //    However, on Win Platform that may break some lazy applications.
-            //
-            if ((result = string.Compare(left.Path, right.Path, StringComparison.Ordinal)) != 0)
-            {
-                return result;
-            }
-            // They are equal here even if variants are still different.
-            return 0;
         }
     }
 }

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text;
-using System.Threading;
 
 // The NETNative_SystemNetHttp #define is used in some source files to indicate we are compiling classes
 // directly into the .NET Native System.Net.Http.dll implementation assembly in order to use internal class
@@ -1722,25 +1721,9 @@ namespace System.Net
         }
     }
 
-    internal sealed class CookieComparer : IComparer<Cookie>
+    internal static class CookieComparer
     {
-        private CookieComparer() { }
-
-        private static CookieComparer s_instance;
-
-        public static CookieComparer Instance
-        {
-            get
-            {
-                if (s_instance == null)
-                {
-                    Interlocked.CompareExchange(ref s_instance, new CookieComparer(), null);
-                }
-                return s_instance;
-            }
-        }
-
-        public int Compare(Cookie left, Cookie right)
+        internal static int Compare(Cookie left, Cookie right)
         {
             int result;
 

--- a/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -153,12 +153,10 @@ namespace System.Net
             int ret = 1;
             if (isStrict)
             {
-                CookieComparer comp = CookieComparer.Instance;
-
                 int idx = 0;
                 foreach (Cookie c in _list)
                 {
-                    if (comp.Compare(cookie, c) == 0)
+                    if (CookieComparer.Compare(cookie, c) == 0)
                     {
                         ret = 0; // Will replace or reject
 
@@ -189,12 +187,10 @@ namespace System.Net
 
         internal int IndexOf(Cookie cookie)
         {
-            CookieComparer comp = CookieComparer.Instance;
-
             int idx = 0;
             foreach (Cookie c in _list)
             {
-                if (comp.Compare(cookie, c) == 0)
+                if (CookieComparer.Compare(cookie, c) == 0)
                 {
                     return idx;
                 }


### PR DESCRIPTION
`CookieComparer` is never used as an `IComparer<Cookie>`, so there's no need for a singleton instance to be created on-demand and cached. Instead, a simple static `Compare` method is sufficient.

cc: @stephentoub, @davidsh, @CIPop