### PR TITLE
Include new platforms in runtime list

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/Common/tests/System/Xml/ModuleCore/project.json
+++ b/src/Common/tests/System/Xml/ModuleCore/project.json
@@ -18,10 +18,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/Common/tests/System/Xml/XmlCoreTest/project.json
+++ b/src/Common/tests/System/Xml/XmlCoreTest/project.json
@@ -20,10 +20,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/Common/tests/System/Xml/XmlDiff/project.json
+++ b/src/Common/tests/System/Xml/XmlDiff/project.json
@@ -17,10 +17,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/Common/tests/project.json
+++ b/src/Common/tests/project.json
@@ -39,10 +39,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/Microsoft.CSharp/tests/project.json
+++ b/src/Microsoft.CSharp/tests/project.json
@@ -38,10 +38,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/Microsoft.VisualBasic/tests/project.json
+++ b/src/Microsoft.VisualBasic/tests/project.json
@@ -40,10 +40,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/Microsoft.Win32.Primitives/tests/project.json
+++ b/src/Microsoft.Win32.Primitives/tests/project.json
@@ -24,10 +24,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/Microsoft.Win32.Registry/tests/project.json
+++ b/src/Microsoft.Win32.Registry/tests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.AppContext/tests/project.json
+++ b/src/System.AppContext/tests/project.json
@@ -24,10 +24,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Buffers/tests/project.json
+++ b/src/System.Buffers/tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Collections.Concurrent/tests/project.json
+++ b/src/System.Collections.Concurrent/tests/project.json
@@ -33,10 +33,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Collections.Immutable/tests/project.json
+++ b/src/System.Collections.Immutable/tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -33,10 +33,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Collections.Specialized/tests/project.json
+++ b/src/System.Collections.Specialized/tests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -31,10 +31,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.ComponentModel.Annotations/tests/project.json
+++ b/src/System.ComponentModel.Annotations/tests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.ComponentModel.EventBasedAsync/tests/project.json
+++ b/src/System.ComponentModel.EventBasedAsync/tests/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.ComponentModel.Primitives/tests/project.json
+++ b/src/System.ComponentModel.Primitives/tests/project.json
@@ -24,10 +24,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.ComponentModel/tests/project.json
+++ b/src/System.ComponentModel/tests/project.json
@@ -23,10 +23,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Composition.Convention/tests/project.json
+++ b/src/System.Composition.Convention/tests/project.json
@@ -22,10 +22,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Composition/perftests/project.json
+++ b/src/System.Composition/perftests/project.json
@@ -23,10 +23,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Composition/tests/project.json
+++ b/src/System.Composition/tests/project.json
@@ -22,10 +22,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -34,10 +34,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Data.Common/tests/project.json
+++ b/src/System.Data.Common/tests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Data.SqlClient/tests/ManualTests/project.json
+++ b/src/System.Data.SqlClient/tests/ManualTests/project.json
@@ -62,10 +62,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Diagnostics.Contracts/tests/project.json
+++ b/src/System.Diagnostics.Contracts/tests/project.json
@@ -26,10 +26,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -23,10 +23,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Diagnostics.Process/tests/project.json
+++ b/src/System.Diagnostics.Process/tests/project.json
@@ -42,10 +42,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Diagnostics.Tools/tests/project.json
+++ b/src/System.Diagnostics.Tools/tests/project.json
@@ -23,10 +23,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Diagnostics.TraceSource/tests/project.json
+++ b/src/System.Diagnostics.TraceSource/tests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Diagnostics.Tracing/tests/project.json
+++ b/src/System.Diagnostics.Tracing/tests/project.json
@@ -34,10 +34,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Drawing.Primitives/tests/project.json
+++ b/src/System.Drawing.Primitives/tests/project.json
@@ -24,10 +24,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Dynamic.Runtime/tests/project.json
+++ b/src/System.Dynamic.Runtime/tests/project.json
@@ -36,10 +36,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Globalization.Calendars/tests/project.json
+++ b/src/System.Globalization.Calendars/tests/project.json
@@ -37,10 +37,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Globalization.Extensions/tests/project.json
+++ b/src/System.Globalization.Extensions/tests/project.json
@@ -41,10 +41,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -40,10 +40,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -37,10 +37,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -37,10 +37,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO.FileSystem.AccessControl/tests/project.json
+++ b/src/System.IO.FileSystem.AccessControl/tests/project.json
@@ -36,10 +36,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO.FileSystem.DriveInfo/tests/project.json
+++ b/src/System.IO.FileSystem.DriveInfo/tests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO.FileSystem.Primitives/tests/project.json
+++ b/src/System.IO.FileSystem.Primitives/tests/project.json
@@ -23,10 +23,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO.FileSystem.Watcher/tests/project.json
+++ b/src/System.IO.FileSystem.Watcher/tests/project.json
@@ -34,10 +34,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -40,10 +40,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO.MemoryMappedFiles/tests/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/project.json
@@ -33,10 +33,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO.Packaging/tests/project.json
+++ b/src/System.IO.Packaging/tests/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO.Pipes/tests/project.json
+++ b/src/System.IO.Pipes/tests/project.json
@@ -35,10 +35,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO.UnmanagedMemoryStream/tests/project.json
+++ b/src/System.IO.UnmanagedMemoryStream/tests/project.json
@@ -31,10 +31,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.IO/tests/project.json
+++ b/src/System.IO/tests/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Linq.Expressions/tests/project.json
+++ b/src/System.Linq.Expressions/tests/project.json
@@ -32,10 +32,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Linq.Parallel/tests/project.json
+++ b/src/System.Linq.Parallel/tests/project.json
@@ -33,10 +33,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Linq.Queryable/tests/project.json
+++ b/src/System.Linq.Queryable/tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -38,10 +38,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Http/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/unix/project.json
@@ -38,10 +38,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Http/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/win/project.json
@@ -39,10 +39,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Http/tests/UnitTests/project.json
+++ b/src/System.Net.Http/tests/UnitTests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.NameResolution/tests/FunctionalTests/project.json
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.NameResolution/tests/PalTests/project.json
+++ b/src/System.Net.NameResolution/tests/PalTests/project.json
@@ -42,10 +42,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.NetworkInformation/tests/UnitTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/UnitTests/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Ping/tests/FunctionalTests/project.json
+++ b/src/System.Net.Ping/tests/FunctionalTests/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Primitives/tests/FunctionalTests/project.json
+++ b/src/System.Net.Primitives/tests/FunctionalTests/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Primitives/tests/PalTests/project.json
+++ b/src/System.Net.Primitives/tests/PalTests/project.json
@@ -33,10 +33,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Primitives/tests/UnitTests/project.json
+++ b/src/System.Net.Primitives/tests/UnitTests/project.json
@@ -34,10 +34,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Requests/tests/project.json
+++ b/src/System.Net.Requests/tests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -36,10 +36,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -34,10 +34,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Security/tests/UnitTests/project.json
+++ b/src/System.Net.Security/tests/UnitTests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Sockets/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets/tests/FunctionalTests/project.json
@@ -33,10 +33,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.Sockets/tests/PerformanceTests/project.json
+++ b/src/System.Net.Sockets/tests/PerformanceTests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.WebHeaderCollection/tests/project.json
+++ b/src/System.Net.WebHeaderCollection/tests/project.json
@@ -20,10 +20,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.WebSockets.Client/tests/project.json
+++ b/src/System.Net.WebSockets.Client/tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Net.WebSockets/tests/project.json
+++ b/src/System.Net.WebSockets/tests/project.json
@@ -24,10 +24,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Numerics.Vectors/tests/project.json
+++ b/src/System.Numerics.Vectors/tests/project.json
@@ -32,10 +32,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.ObjectModel/tests/project.json
+++ b/src/System.ObjectModel/tests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Private.Uri/tests/FunctionalTests/project.json
+++ b/src/System.Private.Uri/tests/FunctionalTests/project.json
@@ -24,10 +24,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Private.Uri/tests/UnitTests/project.json
+++ b/src/System.Private.Uri/tests/UnitTests/project.json
@@ -22,10 +22,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection.Context/tests/project.json
+++ b/src/System.Reflection.Context/tests/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection.DispatchProxy/tests/project.json
+++ b/src/System.Reflection.DispatchProxy/tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection.Emit.ILGeneration/tests/project.json
+++ b/src/System.Reflection.Emit.ILGeneration/tests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection.Emit.Lightweight/tests/project.json
+++ b/src/System.Reflection.Emit.Lightweight/tests/project.json
@@ -26,10 +26,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection.Emit/tests/project.json
+++ b/src/System.Reflection.Emit/tests/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection.Extensions/tests/project.json
+++ b/src/System.Reflection.Extensions/tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection.Metadata/tests/project.json
+++ b/src/System.Reflection.Metadata/tests/project.json
@@ -40,10 +40,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
@@ -32,10 +32,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection.TypeExtensions/tests/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection/tests/CoreCLR/project.json
+++ b/src/System.Reflection/tests/CoreCLR/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection/tests/TestExe/project.json
+++ b/src/System.Reflection/tests/TestExe/project.json
@@ -13,10 +13,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Reflection/tests/project.json
+++ b/src/System.Reflection/tests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Resources.Reader/tests/project.json
+++ b/src/System.Resources.Reader/tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Resources.ResourceManager/tests/project.json
+++ b/src/System.Resources.ResourceManager/tests/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Resources.Writer/tests/project.json
+++ b/src/System.Resources.Writer/tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/project.json
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/project.json
@@ -20,10 +20,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -32,10 +32,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.Handles/tests/project.json
+++ b/src/System.Runtime.Handles/tests/project.json
@@ -24,10 +24,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.InteropServices/tests/project.json
+++ b/src/System.Runtime.InteropServices/tests/project.json
@@ -23,10 +23,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.Loader/tests/DefaultContext/project.json
+++ b/src/System.Runtime.Loader/tests/DefaultContext/project.json
@@ -32,10 +32,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.Loader/tests/project.json
+++ b/src/System.Runtime.Loader/tests/project.json
@@ -32,10 +32,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.Numerics/tests/project.json
+++ b/src/System.Runtime.Numerics/tests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.Serialization.Formatters/tests/project.json
+++ b/src/System.Runtime.Serialization.Formatters/tests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.Serialization.Json/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/project.json
@@ -42,10 +42,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.Serialization.Json/tests/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/project.json
@@ -38,10 +38,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
@@ -41,10 +41,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -37,10 +37,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Runtime/tests/project.json
+++ b/src/System.Runtime/tests/project.json
@@ -33,10 +33,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.Claims/tests/project.json
+++ b/src/System.Security.Claims/tests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.Cryptography.Algorithms/tests/project.json
+++ b/src/System.Security.Cryptography.Algorithms/tests/project.json
@@ -31,10 +31,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.Cryptography.Cng/tests/project.json
+++ b/src/System.Security.Cryptography.Cng/tests/project.json
@@ -33,10 +33,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.Cryptography.Csp/tests/project.json
+++ b/src/System.Security.Cryptography.Csp/tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.Cryptography.Encoding/tests/project.json
+++ b/src/System.Security.Cryptography.Encoding/tests/project.json
@@ -26,10 +26,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.Cryptography.OpenSsl/tests/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/tests/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.Cryptography.Pkcs/tests/project.json
+++ b/src/System.Security.Cryptography.Pkcs/tests/project.json
@@ -26,10 +26,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.Cryptography.Primitives/tests/project.json
+++ b/src/System.Security.Cryptography.Primitives/tests/project.json
@@ -24,10 +24,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.Cryptography.ProtectedData/tests/project.json
+++ b/src/System.Security.Cryptography.ProtectedData/tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.json
@@ -33,10 +33,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.Principal.Windows/tests/project.json
+++ b/src/System.Security.Principal.Windows/tests/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Security.SecureString/tests/project.json
+++ b/src/System.Security.SecureString/tests/project.json
@@ -21,10 +21,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Text.Encoding.CodePages/tests/project.json
+++ b/src/System.Text.Encoding.CodePages/tests/project.json
@@ -26,10 +26,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Text.Encoding.Extensions/tests/project.json
+++ b/src/System.Text.Encoding.Extensions/tests/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Text.Encoding/tests/project.json
+++ b/src/System.Text.Encoding/tests/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Text.Encodings.Web/tests/project.json
+++ b/src/System.Text.Encodings.Web/tests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Text.RegularExpressions/tests/project.json
+++ b/src/System.Text.RegularExpressions/tests/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Threading.AccessControl/tests/project.json
+++ b/src/System.Threading.AccessControl/tests/project.json
@@ -31,10 +31,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Threading.Overlapped/tests/project.json
+++ b/src/System.Threading.Overlapped/tests/project.json
@@ -23,10 +23,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Threading.Tasks.Dataflow/tests/project.json
+++ b/src/System.Threading.Tasks.Dataflow/tests/project.json
@@ -34,10 +34,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Threading.Tasks.Extensions/tests/project.json
+++ b/src/System.Threading.Tasks.Extensions/tests/project.json
@@ -24,10 +24,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Threading.Tasks.Parallel/tests/project.json
+++ b/src/System.Threading.Tasks.Parallel/tests/project.json
@@ -31,10 +31,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Threading.Tasks/tests/project.json
+++ b/src/System.Threading.Tasks/tests/project.json
@@ -31,10 +31,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Threading.Timer/tests/project.json
+++ b/src/System.Threading.Timer/tests/project.json
@@ -26,10 +26,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Threading/tests/project.json
+++ b/src/System.Threading/tests/project.json
@@ -31,10 +31,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.ValueTuple/tests/project.json
+++ b/src/System.ValueTuple/tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
@@ -24,10 +24,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XDocument/tests/Properties/project.json
+++ b/src/System.Xml.XDocument/tests/Properties/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XDocument/tests/SDMSample/project.json
+++ b/src/System.Xml.XDocument/tests/SDMSample/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XDocument/tests/Streaming/project.json
+++ b/src/System.Xml.XDocument/tests/Streaming/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XDocument/tests/TreeManipulation/project.json
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XDocument/tests/XDocument.Common/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Common/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XDocument/tests/axes/project.json
+++ b/src/System.Xml.XDocument/tests/axes/project.json
@@ -26,10 +26,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XDocument/tests/events/project.json
+++ b/src/System.Xml.XDocument/tests/events/project.json
@@ -27,10 +27,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XDocument/tests/misc/project.json
+++ b/src/System.Xml.XDocument/tests/misc/project.json
@@ -28,10 +28,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
@@ -31,10 +31,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XDocument/tests/xNodeReader/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeReader/project.json
@@ -29,10 +29,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XPath.XDocument/tests/project.json
+++ b/src/System.Xml.XPath.XDocument/tests/project.json
@@ -32,10 +32,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XPath.XmlDocument/tests/project.json
+++ b/src/System.Xml.XPath.XmlDocument/tests/project.json
@@ -32,10 +32,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XPath/tests/project.json
+++ b/src/System.Xml.XPath/tests/project.json
@@ -30,10 +30,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XmlDocument/tests/project.json
+++ b/src/System.Xml.XmlDocument/tests/project.json
@@ -25,10 +25,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XmlSerializer/tests/Performance/project.json
+++ b/src/System.Xml.XmlSerializer/tests/Performance/project.json
@@ -40,10 +40,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }

--- a/src/System.Xml.XmlSerializer/tests/project.json
+++ b/src/System.Xml.XmlSerializer/tests/project.json
@@ -36,10 +36,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }


### PR DESCRIPTION
This allows the test builds to restore a runtime for each of the new platforms. Before this, CoreCLR and other native components would not be included and none of tests would run.