### PR TITLE
Fix Filesystem tests failing from path changes

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -38,7 +38,12 @@ namespace System.IO.Tests
             var paths = IOInputs.GetPathsWithInvalidCharacters();
             Assert.All(paths, (path) =>
             {
-                Assert.Throws<ArgumentException>(() => Create(path));
+                if (path.Equals(@"\\?\"))
+                    Assert.Throws<IOException>(() => Create(path));
+                else if (path.Contains(@"\\?\"))
+                    Assert.Throws<DirectoryNotFoundException>(() => Create(path));
+                else
+                    Assert.Throws<ArgumentException>(() => Create(path));
             });
         }
 

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -50,7 +50,10 @@ namespace System.IO.Tests
             testFile.Create().Dispose();
             Assert.All(IOInputs.GetPathsWithInvalidCharacters(), (invalid) =>
             {
-                Assert.Throws<ArgumentException>(() => Move(testFile.FullName, invalid));
+                if (invalid.Contains(@"\\?\"))
+                    Assert.Throws<IOException>(() => Move(testFile.FullName, invalid));
+                else
+                    Assert.Throws<ArgumentException>(() => Move(testFile.FullName, invalid));
             });
         }
 

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -180,11 +180,9 @@ internal static class IOInputs
             yield return "\0";
             yield return "middle\0path";
             yield return "trailing\0";
-
-            // TODO: #6931 Add these back in some fashion
-            //yield return @"\\?\";
-            //yield return @"\\?\UNC\";
-            //yield return @"\\?\UNC\LOCALHOST";
+            yield return @"\\?\";
+            yield return @"\\?\UNC\";
+            yield return @"\\?\UNC\LOCALHOST";
         }
         else
         {


### PR DESCRIPTION
Changes in path validation disabled some of the FileSystem tests. Re-enable them with the new path logic in place.

resolves #6931