### PR TITLE
Add extra logging for TickCount test

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Xunit;
 
@@ -13,7 +15,16 @@ namespace System.Tests
         public void TickCountTest()
         {
             int start = Environment.TickCount;
-            Assert.True(SpinWait.SpinUntil(() => Environment.TickCount - start > 0, TimeSpan.FromSeconds(1)));
+            HashSet<int> times = new HashSet<int>();
+            Assert.True(
+                SpinWait.SpinUntil(() =>
+                {
+                    int time = Environment.TickCount;
+                    times.Add(time);
+                    return time - start > 0;
+                },
+                TimeSpan.FromSeconds(1)),
+                $"TickCount did not increase after one second. start: {start}, values tested: {string.Join(", ", times.ToArray())}.");
         }
     }
 }


### PR DESCRIPTION
This change adds extra logging when the `TickCount` test fails. We will now print out the "starting value", as well as all of the subsequent values we read from `Environment.TickCount`. This should help us identify what sort of conditions are leading to the intermittent failures we see.

@stephentoub