### PR TITLE
Always use Release version of TestNativeService.

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
@@ -29,7 +29,7 @@
     <ProjectReference Include="..\System.ServiceProcess.ServiceController.TestNativeService\System.ServiceProcess.ServiceController.TestNativeService.vcxproj">
       <Project>{ceb0775c-4273-4ac4-b50e-4492718051ae}</Project>
       <Name>System.ServiceProcess.ServiceController.TestNativeService</Name>
-      <SetConfiguration>Configuration=$(ConfigurationGroup)</SetConfiguration>
+      <SetConfiguration>Configuration=Release</SetConfiguration>
       <SetPlatform Condition="'$(Platform)'=='AnyCPU'">Platform=x64</SetPlatform>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
fixes #9192 

cc @MattGal 