### PR TITLE
Split dependency validation/upgrade to take from multiple sources

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -82,8 +82,8 @@
     <ValidatePackageVersions>true</ValidatePackageVersions>
     <ProhibitFloatingDependencies>true</ProhibitFloatingDependencies>
     <CoreFxExpectedPrerelease>rc3-24206-00</CoreFxExpectedPrerelease>
-    <CoreClrExpectedPrerelease>$(CoreFxExpectedPrerelease)</CoreClrExpectedPrerelease>
-    <ExternalExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExternalExpectedPrerelease>
+    <CoreClrExpectedPrerelease>rc3-24206-00</CoreClrExpectedPrerelease>
+    <ExternalExpectedPrerelease>rc3-24206-00</ExternalExpectedPrerelease>
     <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore\.Targets)|(Microsoft\.NETCore\.Platforms)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)(?&lt;!System\.Data\.SqlClient)(?&lt;!System\.IO\.Compression)$</CoreFxVersionsIdentityRegex>
   </PropertyGroup>
   

--- a/dir.props
+++ b/dir.props
@@ -84,9 +84,9 @@
     <CoreFxExpectedPrerelease>rc3-24206-00</CoreFxExpectedPrerelease>
     <CoreClrExpectedPrerelease>rc3-24206-00</CoreClrExpectedPrerelease>
     <ExternalExpectedPrerelease>rc3-24206-00</ExternalExpectedPrerelease>
-    <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore\.Targets)|(Microsoft\.NETCore\.Platforms)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)(?&lt;!System\.Data\.SqlClient)(?&lt;!System\.IO\.Compression)$</CoreFxVersionsIdentityRegex>
+    <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore\.Targets)|(Microsoft\.NETCore\.Platforms)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)$</CoreFxVersionsIdentityRegex>
   </PropertyGroup>
-  
+
   <Import Project="$(MSBuildThisFileDirectory)pkg/ExternalPackages/versions.props" Condition="Exists('$(MSBuildThisFileDirectory)pkg/ExternalPackages/versions.props')" />
 
   <ItemGroup>
@@ -100,10 +100,6 @@
     </ValidationPattern>
     <ValidationPattern Include="CoreLibTargetingPackVersions">
       <IdentityRegex>^(?i)Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative)$</IdentityRegex>
-      <ExpectedPrerelease>$(ExternalExpectedPrerelease)</ExpectedPrerelease>
-    </ValidationPattern>
-    <ValidationPattern Include="ExternalVersions">
-      <IdentityRegex>^(?i)((System\.Data\.SqlClient)|(System\.IO\.Compression))$</IdentityRegex>
       <ExpectedPrerelease>$(ExternalExpectedPrerelease)</ExpectedPrerelease>
     </ValidationPattern>
     <ValidationPattern Include="TargetingPackVersions">

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "Microsoft.CSharp": "4.0.1-rc3-24206-00",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24206-00",
-    "runtime.native.System.Data.SqlClient.sni": "4.0.0-rc3-24203-00",
     "System.Data.Common": "4.1.0-rc3-24206-00",
     "System.Data.SqlClient": "4.1.0-rc3-24206-00",
     "System.Text.Encoding.CodePages": "4.0.1-rc3-24206-00",


### PR DESCRIPTION
Now that the build pipeline is switching on for release builds, we need to take dependencies from CoreFX, CoreCLR, and TFS independently. Reverts dir.props change in https://github.com/dotnet/corefx/pull/9141.

/cc @weshaggard @ellismg @joshfree @ericstj 