### PR TITLE
Remove two asserts from SystemNative_ForkAndExecProcess

### DIFF
--- a/src/Native/System.Native/pal_process.cpp
+++ b/src/Native/System.Native/pal_process.cpp
@@ -130,7 +130,6 @@ extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
     if ((redirectStdin && pipe(stdinFds) != 0) || (redirectStdout && pipe(stdoutFds) != 0) ||
         (redirectStderr && pipe(stderrFds) != 0))
     {
-        assert(false && "pipe() failed.");
         success = false;
         goto done;
     }
@@ -148,7 +147,6 @@ extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
     // Fork the child process
     if ((processId = fork()) == -1)
     {
-        assert(false && "fork() failed.");
         success = false;
         goto done;
     }

--- a/src/Native/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/System.Security.Cryptography.Native/openssl.c
@@ -1323,7 +1323,6 @@ extern int32_t CryptoNative_EnsureOpenSslInitialized()
     g_locks = (pthread_mutex_t*)malloc(sizeof(pthread_mutex_t) * (unsigned int)numLocks);
     if (g_locks == NULL)
     {
-        assert(0 && "malloc failed.");
         ret = 2;
         goto done;
     }
@@ -1333,7 +1332,6 @@ extern int32_t CryptoNative_EnsureOpenSslInitialized()
     {
         if (pthread_mutex_init(&g_locks[locksInitialized], NULL) != 0)
         {
-            assert(0 && "pthread_mutex_init failed.");
             ret = 3;
             goto done;
         }
@@ -1351,7 +1349,6 @@ extern int32_t CryptoNative_EnsureOpenSslInitialized()
     randPollResult = RAND_poll();
     if (randPollResult < 1)
     {
-        assert(0 && "RAND_poll() failed.");
         ret = 4;
         goto done;
     }
@@ -1371,10 +1368,7 @@ done:
         {
             for (int i = locksInitialized - 1; i >= 0; i--)
             {
-                if (pthread_mutex_destroy(&g_locks[i]) != 0)
-                {
-                    assert(0 && "Unable to pthread_mutex_destroy while cleaning up.");
-                }
+                pthread_mutex_destroy(&g_locks[i]); // ignore failures
             }
             free(g_locks);
             g_locks = NULL;

--- a/src/Native/System.Security.Cryptography.Native/pal_evp.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp.cpp
@@ -13,7 +13,7 @@ extern "C" EVP_MD_CTX* CryptoNative_EvpMdCtxCreate(const EVP_MD* type)
     EVP_MD_CTX* ctx = EVP_MD_CTX_create();
     if (ctx == nullptr)
     {
-        assert(false && "Allocation failed.");
+        // Allocation failed
         return nullptr;
     }
 

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.cpp
@@ -16,7 +16,7 @@ CryptoNative_EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char
     std::unique_ptr<EVP_CIPHER_CTX> ctx(new (std::nothrow) EVP_CIPHER_CTX);
     if (ctx == nullptr)
     {
-        assert(false && "Allocation failed.");
+        // Allocation failed
         return nullptr;
     }
 

--- a/src/Native/System.Security.Cryptography.Native/pal_hmac.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_hmac.cpp
@@ -19,7 +19,7 @@ extern "C" HMAC_CTX* CryptoNative_HmacCreate(const uint8_t* key, int32_t keyLen,
     std::unique_ptr<HMAC_CTX> ctx(new (std::nothrow) HMAC_CTX);
     if (ctx == nullptr)
     {
-        assert(false && "Allocation failed.");
+        // Allocation failed
         return nullptr;
     }
 


### PR DESCRIPTION
While rare, these can fire for valid error paths at run time.
Fixes https://github.com/dotnet/corefx/issues/9180
cc: @schaabs, @ellismg 