### PR TITLE
Allow whitespace after HTTP response header name

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -742,7 +742,7 @@ namespace System.Net.Http.Functional.Tests
                             $"HTTP/1.1 200 OK\r\n" +
                             $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
                             $"Set-Cookie: {cookie1.Key}={cookie1.Value}; Path=/\r\n" +
-                            $"Set-Cookie: {cookie2.Key}={cookie2.Value}; Path=/\r\n" +
+                            $"Set-Cookie   : {cookie2.Key}={cookie2.Value}; Path=/\r\n" + // space before colon to verify header is trimmed and recognized
                             $"Set-Cookie: {cookie3.Key}={cookie3.Value}; Path=/\r\n" +
                             "\r\n");
 


### PR DESCRIPTION
Be a bit more lenient in what we allow in the formatting of response headers.

Fixes https://github.com/dotnet/corefx/issues/9201
cc: @davidsh, @ericeil, @RicardoRazz