### PR TITLE
Allow Socket.Connect{Async} to be used with a string-based IP addresses

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Xunit;
-using System.Threading;
 
 namespace System.Net.Sockets.Tests
 {
@@ -719,12 +719,66 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        public async Task Socket_Connect_DnsEndPointWithIPAddressString_Supported()
+        {
+            using (Socket host = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                host.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                host.Listen(1);
+                Task accept = host.AcceptAsync();
+
+                using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    s.Connect(new DnsEndPoint(IPAddress.Loopback.ToString(), ((IPEndPoint)host.LocalEndPoint).Port));
+                }
+
+                await accept;
+            }
+        }
+
+        [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
         public void Socket_Connect_StringHost_NotSupported()
         {
             using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 Assert.Throws<PlatformNotSupportedException>(() => s.Connect("localhost", 12345));
+            }
+        }
+
+        [Fact]
+        public async Task Socket_Connect_IPv4AddressAsStringHost_Supported()
+        {
+            using (Socket host = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                host.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                host.Listen(1);
+                Task accept = host.AcceptAsync();
+
+                using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    s.Connect(IPAddress.Loopback.ToString(), ((IPEndPoint)host.LocalEndPoint).Port);
+                }
+
+                await accept;
+            }
+        }
+
+        [Fact]
+        public async Task Socket_Connect_IPv6AddressAsStringHost_Supported()
+        {
+            using (Socket host = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
+            {
+                host.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
+                host.Listen(1);
+                Task accept = host.AcceptAsync();
+
+                using (Socket s = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    s.Connect(IPAddress.IPv6Loopback.ToString(), ((IPEndPoint)host.LocalEndPoint).Port);
+                }
+
+                await accept;
             }
         }
 
@@ -749,12 +803,63 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        public async Task Socket_ConnectAsync_DnsEndPointWithIPAddressString_Supported()
+        {
+            using (Socket host = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                host.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                host.Listen(1);
+
+                using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    await Task.WhenAll(
+                        host.AcceptAsync(),
+                        s.ConnectAsync(new DnsEndPoint(IPAddress.Loopback.ToString(), ((IPEndPoint)host.LocalEndPoint).Port)));
+                }
+            }
+        }
+
+        [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
         public void Socket_ConnectAsync_StringHost_NotSupported()
         {
             using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 Assert.Throws<PlatformNotSupportedException>(() => { s.ConnectAsync("localhost", 12345); });
+            }
+        }
+
+        [Fact]
+        public async Task Socket_ConnectAsync_IPv4AddressAsStringHost_Supported()
+        {
+            using (Socket host = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                host.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                host.Listen(1);
+
+                using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    await Task.WhenAll(
+                        host.AcceptAsync(),
+                        s.ConnectAsync(IPAddress.Loopback.ToString(), ((IPEndPoint)host.LocalEndPoint).Port));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Socket_ConnectAsync_IPv6AddressAsStringHost_Supported()
+        {
+            using (Socket host = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
+            {
+                host.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
+                host.Listen(1);
+
+                using (Socket s = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    await Task.WhenAll(
+                        host.AcceptAsync(),
+                        s.ConnectAsync(IPAddress.IPv6Loopback.ToString(), ((IPEndPoint)host.LocalEndPoint).Port));
+                }
             }
         }
 

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -20,7 +20,7 @@ namespace System.Net.Sockets.Performance.Tests
             _log = TestLogging.GetInstance();
         }
 
-        [ActiveIssue(9189, PlatformID.AnyUnix)]
+        [ActiveIssue(8768, PlatformID.AnyUnix)]
         [OuterLoop]
         [Fact]
         public void SocketPerformance_SingleSocketClientAsync_LocalHostServerAsync()
@@ -42,7 +42,7 @@ namespace System.Net.Sockets.Performance.Tests
                 socket_instances);
         }
 
-        [ActiveIssue(9189, PlatformID.AnyUnix)]
+        [ActiveIssue(8768, PlatformID.AnyUnix)]
         [OuterLoop]
         [Fact]
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync()


### PR DESCRIPTION
As outlined in https://github.com/dotnet/corefx/issues/8768, on Unix we don't currently support using the instance Connect/ConnectAsync methods that take a string host or a DnsEndPoint, because they could map to multiple addresses, which means we might need to try reconnecting on the same socket after a failed attempt, and that's not supported with BSD sockets.  They are potential workarounds we can explore as outlined in that issue, but they're non-trivial and/or have undesirable ramifications.

However, one simple thing we can do is allow a string/DnsEndPoint version of an IPAddress, e.g. just as someone can provide an IPAddress, they can provide a string version of that IPAddress, such as "127.0.0.1".  This is a common thing to do, and we can make it work just by attempting to parse the address.

Fixes https://github.com/dotnet/corefx/issues/9189
Related to https://github.com/dotnet/corefx/issues/8768
cc: @ericeil, @cipop, @davidsh, @joshfree 