### PR TITLE
Fix dependency conflict warnings

### DIFF
--- a/src/System.Net.Http/src/unix/project.json
+++ b/src/System.Net.Http/src/unix/project.json
@@ -16,7 +16,7 @@
         "System.Diagnostics.Tools": "4.0.0",
         "System.Globalization": "4.0.10",
         "System.Globalization.Extensions": "4.0.0",
-        "System.IO": "4.0.10",
+        "System.IO": "4.1.0-rc4-24207-03",
         "System.IO.FileSystem": "4.0.0",
         "System.IO.Compression": "4.0.0",
         "System.Net.Primitives": "4.0.10",

--- a/src/System.Security.Cryptography.OpenSsl/ref/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/ref/project.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.0",
+    "System.Runtime": "4.1.0-rc4-24207-03",
     "System.Runtime.Handles": "4.0.0",
-    "System.IO": "4.0.0",
+    "System.IO": "4.1.0-rc4-24207-03",
     "System.Security.Cryptography.Algorithms": "4.2.0-rc4-24207-03",
     "System.Security.Cryptography.Primitives": "4.0.0-rc4-24207-03"
   },

--- a/src/System.Security.Cryptography.X509Certificates/src/unix/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/unix/project.json
@@ -8,7 +8,7 @@
     "System.Globalization.Calendars": "4.0.0",
     "System.IO.FileSystem": "4.0.0",
     "System.Resources.ResourceManager": "4.0.0",
-    "System.Runtime": "4.0.20",
+    "System.Runtime": "4.1.0-rc4-24207-03",
     "System.Runtime.Handles": "4.0.0",
     "System.Runtime.InteropServices": "4.0.20",
     "System.Runtime.Numerics": "4.0.0",

--- a/src/System.Security.Cryptography.X509Certificates/src/win/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/win/project.json
@@ -9,7 +9,7 @@
     "System.IO.FileSystem": "4.0.0",
     "System.IO.FileSystem.Watcher": "4.0.0-rc4-24207-03",
     "System.Resources.ResourceManager": "4.0.0",
-    "System.Runtime": "4.0.20",
+    "System.Runtime": "4.1.0-rc4-24207-03",
     "System.Runtime.Handles": "4.0.0",
     "System.Runtime.InteropServices": "4.0.20",
     "System.Runtime.Numerics": "4.0.0",


### PR DESCRIPTION
The upgrade to netstandard1.6 seems to have caused some newer libraries to be preferred.

With this change `build.cmd /p:SkipTests=true` comes back with 0 warnings (the occasional network test failure being the only other warning/error I saw without skipping tests)

The only json I was mildly concerned about was the OpenSsl ref; but the package dependency graph (https://dotnet.myget.org/feed/dotnet-core/package/nuget/System.Security.Cryptography.OpenSsl) says that we already have that dependency (which is what the warning was saying anyways).

@stephentoub 
Fixes #8979.