### PR TITLE
Add xUnit AppX package to test runtime project.json.

### DIFF
--- a/src/Common/netcore50-test-runtime/project.json
+++ b/src/Common/netcore50-test-runtime/project.json
@@ -1,0 +1,27 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Runtime": "1.0.2-rc3-24026-00",
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-24026-00",
+    "Microsoft.NETCore.TestHost": "1.0.0-rc3-24026-00",
+    "System.IO.Compression": "4.1.0-rc3-24026-00",
+    "coveralls.io": "1.4",
+    "OpenCover": "4.6.519",
+    "ReportGenerator": "2.4.3",
+    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0029",
+    "xunit": "2.1.0",
+    "xunit.console.netcore": "1.0.2-prerelease-00120",
+    "xunit.runner.utility": "2.1.0",
+    "microsoft.xunit.runner.uwp": "1.0.2-prerelease-00507-0",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.0-rc3-24026-00"
+  },
+  "frameworks": {
+    "netcore50": {
+        "imports": "uap10.0"
+    }
+  },
+  "runtimes": {
+    "win10-x64": {},
+    "win10-x86": {}
+  }
+}

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -15,6 +15,7 @@
     "Microsoft.DotNet.xunit.performance.analysis.cli": "1.0.0-alpha-build0035",
     "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0035",
     "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0035",
+    "microsoft.xunit.runner.uwp": "1.0.2-prerelease-00507-0",
     "xunit": "2.1.0",
     "xunit.console.netcore": "1.0.2-prerelease-00120",
     "xunit.runner.utility": "2.1.0"


### PR DESCRIPTION
This is the changes to CoreFx that add the updated build tools to actually run the tests.
@karajas, @Chrisboh, @weshaggard, @roncain
