### PR TITLE
Zlib-Intel Fixes 

### DIFF
--- a/src/Native/Windows/clrcompression/zlib-intel/deflate_medium.c
+++ b/src/Native/Windows/clrcompression/zlib-intel/deflate_medium.c
@@ -114,6 +114,12 @@ static void fizzle_matches(deflate_state *s, struct match *current, struct match
     if (current->match_length <= 1)
             return;
 
+	if (zunlikely(current->match_length > 1 + next->match_start))
+		return;
+
+	if (zunlikely(current->match_length > 1 + next->strstart))
+		return;
+
     match = s->window - current->match_length + 1 + next->match_start ;
     orig  = s->window - current->match_length + 1 + next->strstart ;
     

--- a/src/Native/Windows/clrcompression/zlib-intel/deflate_quick.c
+++ b/src/Native/Windows/clrcompression/zlib-intel/deflate_quick.c
@@ -254,7 +254,7 @@ block_state deflate_quick(deflate_state *s, int flush)
     if (flush == Z_FINISH) {
         static_emit_end_block(s, 1);
         if (s->strm->avail_out == 0)
-            return finish_started;
+			return s->strm->avail_in == 0 ? finish_started : need_more;
         else
             return finish_done;
     }


### PR DESCRIPTION
There were a couple of patches to Zlib-Intel that had not yet been merged into the Zlib-Intel master branch, which likely caused https://github.com/dotnet/corefx/issues/9265. This PR makes those changes in the Zlib-Intel source shipped with CoreFX.