### PR TITLE
System.Diagnostics.Debug.SymbolReader assembly for reading Portable PDB on Linux.

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -414,6 +414,13 @@
         ]
     },
     {
+        "Name": "System.Diagnostics.Debug.SymbolReader",
+        "Description": "Provides the System.Diagnostics.Debug.SymbolReader class, which allows extraction of a debug information from portable pdb files.",
+        "CommonTypes": [
+            "System.Diagnostics.Debug.SymbolReader"
+        ]
+    },
+    {
         "Name": "System.Diagnostics.FileVersionInfo",
         "Description": "Provides the System.Diagnostics.FileVersionInfo class, which allows access to Win32 version resource information for a physical file on disk.",
         "CommonTypes": [

--- a/src/System.Diagnostics.Debug.SymbolReader/pkg/System.Diagnostics.Debug.SymbolReader.builds
+++ b/src/System.Diagnostics.Debug.SymbolReader/pkg/System.Diagnostics.Debug.SymbolReader.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Diagnostics.Debug.SymbolReader.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Diagnostics.Debug.SymbolReader/pkg/System.Diagnostics.Debug.SymbolReader.pkgproj
+++ b/src/System.Diagnostics.Debug.SymbolReader/pkg/System.Diagnostics.Debug.SymbolReader.pkgproj
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Diagnostics.Debug.SymbolReader.csproj">
+      <SupportedFramework>net46;netcore50;netcoreapp1.0</SupportedFramework>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Debug.SymbolReader/src/System.Diagnostics.Debug.SymbolReader.builds
+++ b/src/System.Diagnostics.Debug.SymbolReader/src/System.Diagnostics.Debug.SymbolReader.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Diagnostics.Debug.SymbolReader.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Diagnostics.Debug.SymbolReader/src/System.Diagnostics.Debug.SymbolReader.csproj
+++ b/src/System.Diagnostics.Debug.SymbolReader/src/System.Diagnostics.Debug.SymbolReader.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Diagnostics.Debug.SymbolReader</AssemblyName>
+    <ProjectGuid>{1051B8A2-A157-4A17-8C70-5AC2DBD4F833}</ProjectGuid>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <!-- Disable 1685 (aka multiple type definitions) warning so it doesn't turn into an error -->
+    <NoWarn>$(NoWarn);1685</NoWarn>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <!-- Work around a bug that will be fixed by buildtools/#731 -->  
+  <PropertyGroup Condition="'$(TargetGroup)' == ''">  
+    <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>  
+  </PropertyGroup>  
+  <ItemGroup Condition="'$(TargetGroup)'!='netcore50aot'">
+    <TargetingPackReference Include="mscorlib" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netcore50aot'">
+    <TargetingPackReference Include="System.Private.CoreLib" />
+    <TargetingPackReference Include="System.Private.Reflection" />
+    <ProjectReference Include="..\..\System.Runtime\src\redist\System.Runtime.depproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System/Diagnostics/Debug/SymbolReader/SymbolReader.cs" />
+    <ProjectReference Include="..\..\System.Collections\src\System.Collections.csproj" />  
+    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">  
+      <OSGroup>Windows_NT</OSGroup>  
+    </ProjectReference>    
+    <ProjectReference Include="..\..\System.IO\src\System.IO.csproj" />  
+    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />  
+    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj">  
+      <Aliases>SRE</Aliases>  
+      <OSGroup>Windows_NT</OSGroup>  
+    </ProjectReference>  
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Debug.SymbolReader/src/System/Diagnostics/Debug/SymbolReader/SymbolReader.cs
+++ b/src/System.Diagnostics.Debug.SymbolReader/src/System/Diagnostics/Debug/SymbolReader/SymbolReader.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace System.Diagnostics.Debug.SymbolReader
+{
+
+    public class SymbolReader
+    {
+    
+        /// <summary>
+        /// Checks availability of debugging information for given assembly.
+        /// </summary>
+        /// <param name="assemblyName">file name of the assembly</param>
+        /// <returns>true if debugging information is available</returns>
+        public static bool LoadSymbolsForModule(string assemblyName)
+        {
+            MetadataReader peReader, pdbReader;
+            
+            return GetReaders(assemblyName, out peReader, out pdbReader);
+        }
+    
+        /// <summary>
+        /// Returns method token and IL offset for given source line number.
+        /// </summary>
+        /// <param name="assemblyName">file name of the assembly</param>
+        /// <param name="fileName">source file name</param>
+        /// <param name="lineNumber">source line number</param>
+        /// <param name="methToken">method token return</param>
+        /// <param name="ilOffset">IL offset return</param>
+        public static void ResolveSequencePoint(string assemblyName, string fileName, int lineNumber, out int methToken, out int ilOffset)
+        {
+            MetadataReader peReader, pdbReader;
+            methToken = 0;
+            ilOffset = 0;
+            
+            if(!GetReaders(assemblyName, out peReader, out pdbReader))
+                return;
+            
+            foreach(MethodDefinitionHandle methodDefHandle in peReader.MethodDefinitions)
+            {
+                MethodDebugInformation methodDebugInfo = pdbReader.GetMethodDebugInformation(methodDefHandle);
+                SequencePointCollection sequencePoints = methodDebugInfo.GetSequencePoints();
+                foreach(SequencePoint point in sequencePoints)
+                {
+                    string sourceName = pdbReader.GetString(pdbReader.GetDocument(point.Document).Name);
+                    if(Path.GetFileName(sourceName) == Path.GetFileName(fileName) && point.StartLine == lineNumber)
+                    {
+                        methToken = MetadataTokens.GetToken(peReader, methodDefHandle);
+                        ilOffset = point.Offset;
+                        Console.WriteLine("Found method " + methToken.ToString() + ", ILOffset " + ilOffset.ToString());
+                        return;
+                    }
+                }
+                
+            }
+        }
+    
+        /// <summary>
+        /// Returns metadata readers for assembly PE file and portable PDB.
+        /// </summary>
+        /// <param name="assemblyName">file name of the assembly</param>
+        /// <param name="peReader">PE metadata reader return</param>
+        /// <param name="pdbReader">PDB metadata reader return</param>
+        /// <returns>true if debugging information is available</returns>
+        private static bool GetReaders(string assemblyName, out MetadataReader peReader, out MetadataReader pdbReader)
+        {
+            peReader = null;
+            pdbReader = null;
+            
+            if(!File.Exists(assemblyName))
+            {
+                Console.WriteLine("Can't find assembly " + assemblyName);
+                return false;
+            }
+            Stream peStream = File.OpenRead(assemblyName);
+            PEReader reader = new PEReader(peStream);
+            string pdbPath = null;
+            
+            foreach(DebugDirectoryEntry entry in reader.ReadDebugDirectory())
+            {
+                if(entry.Type == DebugDirectoryEntryType.CodeView)
+                {
+                    CodeViewDebugDirectoryData codeViewData = reader.ReadCodeViewDebugDirectoryData(entry);
+                    pdbPath = codeViewData.Path;
+                    break;
+                }
+            }
+            if(pdbPath == null)
+            {
+                Console.WriteLine("Can't find debug info for assembly " + assemblyName);
+                return false;
+            }
+            if(!File.Exists(pdbPath))
+            {
+                pdbPath = Path.GetFileName(pdbPath);
+                if(!File.Exists(pdbPath))
+                {
+                    Console.WriteLine("Can't find debug info " + pdbPath);
+                    return false;
+                }
+            }
+            
+            peReader = reader.GetMetadataReader();
+            Stream pdbStream = File.OpenRead(pdbPath);
+            MetadataReaderProvider provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+            pdbReader = provider.GetMetadataReader();
+            
+            return true;
+            
+        }
+    }
+
+}

--- a/src/System.Diagnostics.Debug.SymbolReader/src/project.json
+++ b/src/System.Diagnostics.Debug.SymbolReader/src/project.json
@@ -1,0 +1,25 @@
+{
+  "frameworks": {
+    "netstandard1.3": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc4-24127-00",
+        "System.IO.FileSystem": "4.0.1-rc4-24127-00",
+        "System.Reflection.Metadata": "1.3.0-rc4-24127-00",
+        "System.Collections.Immutable": "1.2.0-rc4-24127-00"
+      },
+      "imports": [
+        "dotnet5.4"
+      ]
+    },
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24127-00"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This assembly allows SOS library on Linux read Portable PDB files and set breakpoints in managed code by source line. The interface was proposed in issue #8981. See also issue dotnet/coreclr#4798.
@mikem8361 @joshfree @lucenticus @seanshpark @chunseoklee  