### PR TITLE
Fix OpenSslCipher.OpenKey check for valid SafeHandle

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/OpenSslCipher.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/OpenSslCipher.cs
@@ -125,10 +125,7 @@ namespace Internal.Cryptography
                 IV,
                 _encrypting ? 1 : 0);
 
-            if (_ctx == null)
-            {
-                throw Interop.Crypto.CreateOpenSslCryptographicException();
-            }
+            Interop.Crypto.CheckValidOpenSslHandle(_ctx);
 
             // OpenSSL will happily do PKCS#7 padding for us, but since we support padding modes
             // that it doesn't (PaddingMode.Zeros) we'll just always pad the blocks ourselves.


### PR DESCRIPTION
If the CryptoNative_EvpCipherCreate function returns nullptr, the managed EvpCipherCreate will return a SafeEvpCipherCtxHandle instance that wraps the nullptr rather than returning null.

cc: @bartonjs, @steveharter 