### PR TITLE
Use .builds for command line building instead of .sln

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -29,10 +29,10 @@ the Visual Studio IDE.
 ### Building individual DLLs of the CoreFX
 
 Under the src directory is a set of directories, each of which represents a particular assembly in CoreFX.  
-For example the src\System.Diagnostics.DiagnosticSource directory holds the source code for the System.Diagnostics.DiagnosticSource.dll assembly. Each of these directories has a .sln solution 
-file that typically includes two projects, one for the DLL being built and one for the tests.   Thus
-you can build both the DLL and tests for System.Diagnostics.DiagnosticSource.dll by going to 
-src\System.Diagnostics.DiagnosticSource and typing `msbuild`. You can build just the System.Diagnostics.DiagnosticSource.dll (without the tests) by going to the src\System.Diagnostics.DiagnosticsSource\src directory and again typing `msbuild`. The DLL ends up as  bin\AnyOS.AnyCPU.Debug\System.Diagnostics.DiagnosticSource\System.DiagnosticSource.dll.
+For example the src\System.Diagnostics.DiagnosticSource directory holds the source code for the System.Diagnostics.DiagnosticSource.dll assembly. Each of these directories includes two projects, one for the DLL being built and one for the tests, both specified by a .builds file.
+You can build the DLL for System.Diagnostics.DiagnosticSource.dll by going to the src\System.Diagnostics.DiagnosticsSource\src directory and typing `msbuild System.Diagnostics.DiagnosticSource.builds`. The DLL ends up as  bin\AnyOS.AnyCPU.Debug\System.Diagnostics.DiagnosticSource\System.DiagnosticSource.dll.
+You can build the tests for System.Diagnostics.DiagnosticSource.dll by going to 
+src\System.Diagnostics.DiagnosticSource\tests and typing `msbuild System.Diagnostics.DiagnosticSource.Tests.builds`.
 
 There is also a pkg directory for each project, and if you go into it and type `msbuild`, it will build the DLL (if needed)
 and then also build the NuGet package for it. The NuGet package ends up in the bin\packages directory.  


### PR DESCRIPTION
As recommended by @mellinoe in https://github.com/dotnet/corefx/pull/8961#issuecomment-222794058.