### PR TITLE
[release/1.0.0] Disable X509FilesystemTests on Fedora23

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -860,7 +860,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Fact]
+        // This test can cause an intermediate certificate to be written to disk,
+        // but creating that intermediate store directory can fail on Fedora23 CI due to an unsupported filesystem
+        private static bool IsReliableInCI { get; } = !PlatformDetection.IsFedora23;
+        [ConditionalFact(nameof(IsReliableInCI))]
         public static void X509ChainElementCollection_CopyTo_NonZeroLowerBound_ThrowsIndexOutOfRangeException()
         {
             using (X509Certificate2 microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -47,6 +47,9 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>CommonTest\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="X509FilesystemTests.Unix.cs" />

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
@@ -16,6 +16,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     [Collection("X509Filesystem")]
     public static class X509FilesystemTests
     {
+        // Our Fedora23 CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
+        private static bool IsReliableInCI { get; } = !PlatformDetection.IsFedora23;
+
         [Fact]
         [OuterLoop]
         public static void VerifyCrlCache()
@@ -116,7 +119,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddOne()
         {
@@ -144,7 +147,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddOneAfterUpgrade()
         {
@@ -181,7 +184,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_DowngradePermissions()
         {
@@ -204,7 +207,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
+        [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddAfterDispose()
         {
             RunX509StoreTest(
@@ -226,7 +230,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddAndClear()
         {
@@ -250,7 +254,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddDuplicate()
         {
@@ -272,7 +276,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddTwo()
         {
@@ -303,7 +307,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddTwo_UpgradePrivateKey()
         {
@@ -365,7 +369,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddTwo_UpgradePrivateKey_NoDowngrade()
         {
@@ -425,7 +429,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_DistinctCollections()
         {
@@ -466,7 +470,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_Add4_Remove1()
         {
@@ -515,7 +519,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(IsReliableInCI))]
         [OuterLoop(/* Alters user/machine state */)]
         [InlineData(false)]
         [InlineData(true)]


### PR DESCRIPTION
The innerloop debug, innerloop release, and outerloop debug runs on Fedora23 in Jenkins fail in the X509FilesystemTests with a directory permissions error. Since this does not seem to be endemic to Fedora23 itself, but our machine configuration, we're disabling these tests to switch the overall status to passing.  The other distros will still guard for regressions.

This also marks the X509Store_AddAfterDispose test as OuterLoop, which it always should have been.  With all the store-creating tests marked as OuterLoop any other such machine state problem won't foul up the inner loop test results.

Fixes #9248.  This is a release-branch-only test-only change.
cc: @ellismg @joshfree @stephentoub