### PR TITLE
Build System.IO.Compression IL and runtime packages.

### DIFF
--- a/pkg/ExternalPackages/versions.props
+++ b/pkg/ExternalPackages/versions.props
@@ -2,19 +2,28 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
   <ItemGroup>
-    <ExternalPackage Include="runtime.win7-amd64.runtime.native.System.Data.SqlClient.sni">
+    <ExternalPackage Include="runtime.win7-x64.runtime.native.System.Data.SqlClient.sni">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
     </ExternalPackage>
     <ExternalPackage Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
     </ExternalPackage>
-    <ExternalPackage Include="runtime.win10-amd64.runtime.native.System.IO.Compression">
+    <ExternalPackage Include="runtime.win7-x64.runtime.native.System.IO.Compression">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
     </ExternalPackage>
-    <ExternalPackage Include="runtime.win10-arm.runtime.native.System.IO.Compression">
+    <ExternalPackage Include="runtime.win7-x86.runtime.native.System.IO.Compression">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
     </ExternalPackage>
-    <ExternalPackage Include="runtime.win10-x86.runtime.native.System.IO.Compression">
+    <ExternalPackage Include="runtime.win8-arm.runtime.native.System.IO.Compression">
+      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
+    </ExternalPackage>
+    <ExternalPackage Include="runtime.win10-x64-aot.runtime.native.System.IO.Compression">
+      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
+    </ExternalPackage>
+    <ExternalPackage Include="runtime.win10-arm-aot.runtime.native.System.IO.Compression">
+      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
+    </ExternalPackage>
+    <ExternalPackage Include="runtime.win10-x86-aot.runtime.native.System.IO.Compression">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
     </ExternalPackage>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -31,18 +31,6 @@
       <OSGroup>opensuse.13.2</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
-      <OSGroup>Windows_NT</OSGroup>
-      <Platform>x86</Platform>
-    </Project>
-    <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
-      <OSGroup>Windows_NT</OSGroup>
-      <Platform>amd64</Platform>
-    </Project>
-    <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
-      <OSGroup>Windows_NT</OSGroup>
-      <Platform>arm</Platform>
-    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -9,8 +9,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-  <RuntimeDependency Include="runtime.win10-amd64-aot.runtime.native.System.IO.Compression">
-      <TargetRuntime>win10-amd64-aot</TargetRuntime>
+    <RuntimeDependency Include="runtime.win7-x64.runtime.native.System.IO.Compression">
+      <TargetRuntime>win7-x64</TargetRuntime>
+      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
+    </RuntimeDependency>
+    <RuntimeDependency Include="runtime.win7-x86.runtime.native.System.IO.Compression">
+      <TargetRuntime>win7-x86</TargetRuntime>
+      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
+    </RuntimeDependency>
+    <RuntimeDependency Include="runtime.win8-arm.runtime.native.System.IO.Compression">
+      <TargetRuntime>win8-arm</TargetRuntime>
+      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
+    </RuntimeDependency>
+    <RuntimeDependency Include="runtime.win10-x64-aot.runtime.native.System.IO.Compression">
+      <TargetRuntime>win10-x64-aot</TargetRuntime>
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
     </RuntimeDependency>
     <RuntimeDependency Include="runtime.win10-arm-aot.runtime.native.System.IO.Compression">
@@ -45,15 +57,6 @@
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.04\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
-    </ProjectReference>
-    <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
-      <Platform>x86</Platform>
-    </ProjectReference>
-    <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
-      <Platform>amd64</Platform>
-    </ProjectReference>
-    <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
-      <Platform>arm</Platform>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -8,30 +8,13 @@
     <BuildAllOSGroups Condition="'$(FilterToOSGroup)' != ''">false</BuildAllOSGroups>
   </PropertyGroup>
 
-  <!--
-    the following packages are built and shipped from TFS, so while we still want
-    to build them we don't want to ship them.  by setting NonShippingPackage to true
-    the packages will still be built but placed in a different location.
-  -->
   <ItemGroup>
-    <NativeNonShippingPackage Include="Native\pkg\runtime.native.System.IO.Compression\*.builds" />
-    <NonShippingPackage Include="System.IO.Compression\pkg\*.builds" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Project Include="Native\pkg\**\*.builds" Exclude="@(NativeNonShippingPackage)" Condition="'$(SkipNativePackageBuild)' != 'true'">
+    <Project Include="Native\pkg\**\*.builds" Condition="'$(SkipNativePackageBuild)' != 'true'">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
       <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
     </Project>
-    <Project Include="*\pkg\*.builds" Exclude="@(NonShippingPackage)" Condition="'$(SkipManagedPackageBuild)' != 'true'">
+    <Project Include="*\pkg\*.builds" Condition="'$(SkipManagedPackageBuild)' != 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-    </Project>
-    <Project Include="@(NativeNonShippingPackage)" Condition="'$(SkipNativePackageBuild)' != 'true'">
-      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true;NonShippingPackage=true</AdditionalProperties>
-      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
-    </Project>
-    <Project Include="@(NonShippingPackage)" Condition="'$(SkipManagedPackageBuild)' != 'true'">
-      <AdditionalProperties>$(AdditionalProperties);NonShippingPackage=true</AdditionalProperties>
     </Project>
     <Project Include="..\pkg\*\*.builds" Condition="'$(SkipManagedPackageBuild)' != 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>


### PR DESCRIPTION
The change made in commit 2ce8c0bda0e1793fd732adea4e8b973239bc4533 was
incorrect, we should continue to build and ship the IL and runtime
packages from our "open" builds.  Only the runtime native packages for
Windows should come from the closed TFS build.
Fixed some bad RIDs for System.IO.Compression, replacing amd64 with x64.