### PR TITLE
Add supports clauses for new/old platforms

### DIFF
--- a/pkg/Microsoft.NETCore.Targets/runtime.json
+++ b/pkg/Microsoft.NETCore.Targets/runtime.json
@@ -10,11 +10,76 @@
                 "win10-arm-aot"
             ]
         },
-        "net46.app": {
-            "net46": [
+        "net45.app": {
+            "net45": [
+                "",
                 "win-x86",
                 "win-x64"
             ]
+        },
+        "net451.app": {
+            "net451": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "net452.app": {
+            "net452": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "net46.app": {
+            "net46": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "net461.app": {
+            "net461": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "net462.app": {
+            "net462": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "netcoreapp1.0.app": {
+            "netcoreapp1.0": [
+                "win7-x86",
+                "win7-x64",
+                "osx.10.11-x64",
+                "centos.7-x64",
+                "debian.8-x64",
+                "linuxmint.17-x64",
+                "opensuse.13.2-x64",
+                "rhel.7.2-x64",
+                "ubuntu.14.04-x64",
+                "ubuntu.16.04-x64"
+            ]
+        },
+        "win8.app": {
+          "win8": ""
+        },
+        "win81.app": {
+          "win81": ""
+        },
+        "wp8.app": {
+          "wp8": ""
+        },
+        "wp81.app": {
+          "wp81": ""
+        },
+        "wpa81.app": {
+          "wpa81": ""
         },
         "dnxcore50.app": {
             "dnxcore50": [


### PR DESCRIPTION
This enables folks to use the "supports" feature with new and old
platforms.  All of these platforms support contracts and some version
of NETStandard so we should enable folks to build package-based PCLs
against them as well as opt-in to gaurdrails if they'd like that
protection.

Port of https://github.com/dotnet/corefx/commit/66071ea1e30805f0268a92a07a55c811e5908d44

/cc @joshfree @weshaggard @Pilchie @rchande