### PR TITLE
[master] Add win8 and wpa81 support to RuntimeInformation

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -263,6 +263,8 @@
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net46'))">net46</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net45'))">net45</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net451'))">net451</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('win8'))">win8</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('wpa81'))">wpa81</TargetGroup>
   </PropertyGroup>
 
   <!-- Set up Default symbol and optimization for Configuration -->
@@ -473,6 +475,18 @@
         <PackageTargetFramework>net45</PackageTargetFramework>
         <TargetingPackNugetPackageId>Microsoft.TargetingPack.NETFramework.v4.5</TargetingPackNugetPackageId>
         <NuGetTargetMoniker>.NETFramework,Version=v4.5</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetGroup)'=='win8'">
+      <PropertyGroup>
+        <PackageTargetFramework>win8</PackageTargetFramework>
+        <NuGetTargetMoniker>Windows,Version=v8.0</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetGroup)'=='wpa81'">
+      <PropertyGroup>
+        <PackageTargetFramework>wpa81</PackageTargetFramework>
+        <NuGetTargetMoniker>WindowsPhoneApp,Version=v8.1</NuGetTargetMoniker>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/src/System.Runtime.InteropServices.RuntimeInformation/pkg/System.Runtime.InteropServices.RuntimeInformation.pkgproj
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/pkg/System.Runtime.InteropServices.RuntimeInformation.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.InteropServices.RuntimeInformation.csproj">
-      <SupportedFramework>net45;netcore50;netcoreapp1.0</SupportedFramework>
+      <SupportedFramework>net45;netcore45;wpa81;netcoreapp1.0</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.InteropServices.RuntimeInformation.builds" />
   </ItemGroup>

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/PinvokeAnalyzer_win8-wpa81-APIs.txt
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/PinvokeAnalyzer_win8-wpa81-APIs.txt
@@ -1,0 +1,1 @@
+api-ms-win-core-sysinfo-l1-2-0.dll!GetNativeSystemInfo

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.builds
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.builds
@@ -10,6 +10,14 @@
     </Project>
     <Project Include="System.Runtime.InteropServices.RuntimeInformation.csproj">
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>win8</TargetGroup>
+    </Project>
+    <Project Include="System.Runtime.InteropServices.RuntimeInformation.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>wpa81</TargetGroup>
+    </Project>
+    <Project Include="System.Runtime.InteropServices.RuntimeInformation.csproj">
+      <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>net45</TargetGroup>
     </Project>
     <Project Include="System.Runtime.InteropServices.RuntimeInformation.csproj">

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
@@ -14,9 +14,14 @@
     <ProjectGuid>{F9DF2357-81B4-4317-908E-512DA9395583}</ProjectGuid>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.1</PackageTargetFramework>
     <DefineConstants Condition="'$(TargetGroup)'=='net45'">net45</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='wpa81'">wpa81</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='win8'">win8</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='netcore50'">netcore50</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='netcore50aot'">netcore50;netcore50aot</DefineConstants>
     <NuGetTargetMoniker>.NETStandard,Version=v1.1</NuGetTargetMoniker>
+    <!-- Clear runtime for wpa81 & win8: these project types don't use project.json and need to resolve without a runtime -->
+    <PackageTargetRuntime Condition="'$(TargetGroup)'=='wpa81' OR '$(TargetGroup)'=='win8'"></PackageTargetRuntime>
+    <ValidPinvokeMappings Condition="'$(TargetGroup)'=='wpa81' OR '$(TargetGroup)'=='win8'">$(MSBuildThisFileDirectory)PinvokeAnalyzer_win8-wpa81-APIs.txt</ValidPinvokeMappings>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
@@ -29,6 +34,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'win8_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'win8_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'wpa81_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'wpa81_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetUnixName.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.GetUnixName.cs</Link>
@@ -50,7 +59,7 @@
     </Compile>
     <Compile Include="System\Runtime\InteropServices\RuntimeInformation\RuntimeInformation.Unix.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)'=='true' And '$(TargetGroup)'!='netcore50' And '$(TargetGroup)'!='netcore50aot'">
+  <ItemGroup Condition="'$(TargetsWindows)'=='true' And ('$(TargetGroup)'=='' OR '$(TargetGroup)'=='net45')">
     <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RtlGetVersion.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.RtlGetVersion.cs</Link>
     </Compile>
@@ -69,6 +78,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SYSTEM_INFO.cs">
       <Link>Common\Interop\Windows\mincore\Interop.SYSTEM_INFO.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)'=='true' AND '$(TargetGroup)' != 'win8' AND '$(TargetGroup)' != 'wpa81'">
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetSystemInfo.cs">
       <Link>Common\Interop\Windows\mincore\Interop.GetSystemInfo.cs</Link>
     </Compile>

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
@@ -25,8 +25,10 @@ namespace System.Runtime.InteropServices
             {
                 if (null == s_osDescription)
                 {
-#if netcore50
+#if netcore50 || win8
                     s_osDescription = "Microsoft Windows";
+#elif wpa81
+                    s_osDescription = "Microsoft Windows Phone";
 #else
                     s_osDescription = Interop.NtDll.RtlGetVersion();
 #endif
@@ -80,7 +82,12 @@ namespace System.Runtime.InteropServices
                     if (null == s_processArch)
                     {
                         Interop.mincore.SYSTEM_INFO sysInfo;
+#if win8 || wpa81
+                        // GetSystemInfo is not avaialable
+                        Interop.mincore.GetNativeSystemInfo(out sysInfo);
+#else
                         Interop.mincore.GetSystemInfo(out sysInfo);
+#endif
 
                         switch((Interop.mincore.ProcessorArchitecture)sysInfo.wProcessorArchitecture)
                         {
@@ -92,6 +99,12 @@ namespace System.Runtime.InteropServices
                                 break;
                             case Interop.mincore.ProcessorArchitecture.Processor_Architecture_AMD64:
                                 s_processArch = Architecture.X64;
+#if win8 || wpa81
+                                if (IntPtr.Size == 4)
+                                {
+                                    s_processArch = Architecture.X86;
+                                }
+#endif
                                 break;
                             case Interop.mincore.ProcessorArchitecture.Processor_Architecture_INTEL:
                                 s_processArch = Architecture.X86;

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
@@ -10,9 +10,9 @@ namespace System.Runtime.InteropServices
     {
 #if netcore50aot
         private const string FrameworkName = ".NET Native";
-#elif net45
+#elif net45 || win8
         private const string FrameworkName = ".NET Framework";
-#else
+#else // netcore50 || wpa81 || other
         private const string FrameworkName = ".NET Core";
 #endif
 


### PR DESCRIPTION
Currently restoring NETStandard.Library package on win8, win81, and
wpa81 will fail even though these platforms support NETStandard.

The reason for the failure is that S.R.Interop.RuntimeInformation didn't
include support for these platforms.

I have added two new configurations for this library that return the
right information on these platforms and pass the WACK.