### PR TITLE
Update versions in test project.json files to prevent failures due to downgrading

### DIFF
--- a/src/System.Private.Uri/tests/UnitTests/project.json
+++ b/src/System.Private.Uri/tests/UnitTests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24213-03",
     "System.ObjectModel": "4.0.12-rc4-24213-03",
     "System.Resources.ResourceManager": "4.0.1-rc4-24213-03",
-    "System.Text.Encoding": "4.0.10",
+    "System.Text.Encoding": "4.0.11-rc4-24213-03",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {

--- a/src/System.Runtime.Serialization.Json/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/project.json
@@ -23,7 +23,7 @@
     "System.Xml.ReaderWriter": "4.0.11-rc4-24213-03",
     "System.Xml.XDocument": "4.0.11-rc4-24213-03",
     "System.Xml.XmlDocument": "4.0.1-rc4-24213-03",
-    "System.Xml.XmlSerializer": "4.0.10",
+    "System.Xml.XmlSerializer": "4.0.11-rc4-24213-03",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
@@ -22,7 +22,7 @@
     "System.Xml.ReaderWriter": "4.0.11-rc4-24213-03",
     "System.Xml.XDocument": "4.0.11-rc4-24213-03",
     "System.Xml.XmlDocument": "4.0.1-rc4-24213-03",
-    "System.Xml.XmlSerializer": "4.0.10",
+    "System.Xml.XmlSerializer": "4.0.11-rc4-24213-03",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {

--- a/src/System.Security.AccessControl/tests/project.json
+++ b/src/System.Security.AccessControl/tests/project.json
@@ -24,11 +24,11 @@
     "System.Threading.Tasks": "4.0.11-rc4-24213-03",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
-    "System.Security.Principal": "4.0.0",
+    "System.Security.Principal": "4.0.1-rc4-24213-03",
     "System.Security.Principal.Windows": "4.0.0-rc4-24213-03",
     "System.Security.AccessControl": "4.0.0-rc4-24213-03",
     "System.Reflection": "4.1.0-rc4-24213-03",
-    "System.Threading": "4.0.10",
+    "System.Threading": "4.0.11-rc4-24213-03",
     "System.Threading.Thread": "4.0.0-rc4-24213-03",
     "test-runtime": {
       "target": "project",

--- a/src/System.Security.Cryptography.Encoding/tests/project.json
+++ b/src/System.Security.Cryptography.Encoding/tests/project.json
@@ -1,10 +1,11 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24213-03",
-    "System.Linq": "4.0.0",
+    "System.Linq": "4.1.0-rc4-24213-03",
     "System.Linq.Expressions": "4.1.0-rc4-24213-03",
     "System.ObjectModel": "4.0.12-rc4-24213-03",
     "System.Runtime": "4.1.0-rc4-24213-03",
+    "System.Resources.ResourceManager": "4.0.1-rc4-24213-03",
     "System.Runtime.Numerics": "4.0.1-rc4-24213-03",
     "System.Security.Cryptography.Primitives": "4.0.0-rc4-24213-03",
     "System.Text.RegularExpressions": "4.1.0-rc4-24213-03",

--- a/src/System.Security.Cryptography.Pkcs/tests/project.json
+++ b/src/System.Security.Cryptography.Pkcs/tests/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc4-24213-03",
-    "System.Collections": "4.0.10",
-    "System.Diagnostics.Debug": "4.0.10",
-    "System.Linq": "4.0.0",
+    "System.Collections": "4.0.11-rc4-24213-03",
+    "System.Diagnostics.Debug": "4.0.11-rc4-24213-03",
+    "System.Linq": "4.1.0-rc4-24213-03",
     "System.Runtime": "4.1.0-rc4-24213-03",
     "System.Security.Cryptography.Encoding": "4.0.0-rc4-24213-03",
     "System.Security.Cryptography.Primitives": "4.0.0-rc4-24213-03",

--- a/src/System.Xml.XmlSerializer/tests/Performance/project.json
+++ b/src/System.Xml.XmlSerializer/tests/Performance/project.json
@@ -21,7 +21,7 @@
     "System.Xml.ReaderWriter": "4.0.11-rc4-24213-03",
     "System.Xml.XDocument": "4.0.11-rc4-24213-03",
     "System.Xml.XmlDocument": "4.0.1-rc4-24213-03",
-    "System.Xml.XmlSerializer": "4.0.10",
+    "System.Xml.XmlSerializer": "4.0.11-rc4-24213-03",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {


### PR DESCRIPTION
Updating test dependency versions in project.json for test projects, per a conversation with @ericstj.  

We should also eventually also implement some sort of build-time validation.

*updated to bring all versions to exactly match https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest_Packages.txt