### PR TITLE
Implement missing data access members on MetadataReader, PEMemoryBlock

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ByteArrayMemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ByteArrayMemoryBlock.cs
@@ -29,25 +29,12 @@ namespace System.Reflection.Internal
             _provider = null;
         }
 
-        public unsafe override byte* Pointer
-        {
-            get
-            {
-                return _provider.Pointer + _start;
-            }
-        }
+        public unsafe override byte* Pointer => _provider.Pointer + _start;
+        public override int Size => _size;
 
-        public override int Size
+        public override ImmutableArray<byte> GetContentUnchecked(int start, int length)
         {
-            get
-            {
-                return _size;
-            }
-        }
-
-        public override ImmutableArray<byte> GetContent(int offset)
-        {
-            return ImmutableArray.Create(_provider.array, _start + offset, _size - offset);
+            return ImmutableArray.Create(_provider.Array, _start + start, length);
         }
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ByteArrayMemoryProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ByteArrayMemoryProvider.cs
@@ -3,21 +3,23 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Runtime.CompilerServices;
 
 namespace System.Reflection.Internal
 {
     internal sealed class ByteArrayMemoryProvider : MemoryBlockProvider
     {
-        internal readonly ImmutableArray<byte> array;
+        private readonly ImmutableArray<byte> _array;
         private StrongBox<GCHandle> _pinned;
 
         public ByteArrayMemoryProvider(ImmutableArray<byte> array)
         {
-            this.array = array;
+            Debug.Assert(!array.IsDefault);
+            _array = array;
         }
 
         ~ByteArrayMemoryProvider()
@@ -27,20 +29,12 @@ namespace System.Reflection.Internal
 
         protected override void Dispose(bool disposing)
         {
-            if (_pinned != null)
-            {
-                _pinned.Value.Free();
-                _pinned = null;
-            }
+            _pinned?.Value.Free();
+            _pinned = null;
         }
 
-        public override int Size
-        {
-            get
-            {
-                return array.Length;
-            }
-        }
+        public override int Size => _array.Length;
+        public ImmutableArray<byte> Array => _array;
 
         protected override AbstractMemoryBlock GetMemoryBlockImpl(int start, int size)
         {
@@ -50,7 +44,7 @@ namespace System.Reflection.Internal
         public override Stream GetStream(out StreamConstraints constraints)
         {
             constraints = new StreamConstraints(null, 0, Size);
-            return new ImmutableMemoryStream(array);
+            return new ImmutableMemoryStream(_array);
         }
 
         internal unsafe byte* Pointer
@@ -60,7 +54,7 @@ namespace System.Reflection.Internal
                 if (_pinned == null)
                 {
                     var newPinned = new StrongBox<GCHandle>(
-                        GCHandle.Alloc(ImmutableByteArrayInterop.DangerousGetUnderlyingArray(array), GCHandleType.Pinned));
+                        GCHandle.Alloc(ImmutableByteArrayInterop.DangerousGetUnderlyingArray(_array), GCHandleType.Pinned));
 
                     if (Interlocked.CompareExchange(ref _pinned, newPinned, null) != null)
                     {

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ExternalMemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ExternalMemoryBlock.cs
@@ -32,21 +32,7 @@ namespace System.Reflection.Internal
             _size = 0;
         }
 
-        public override byte* Pointer
-        {
-            get { return _buffer; }
-        }
-
-        public override int Size
-        {
-            get { return _size; }
-        }
-
-        public override ImmutableArray<byte> GetContent(int offset)
-        {
-            var result = CreateImmutableArray((_buffer + offset), _size - offset);
-            GC.KeepAlive(_memoryOwner);
-            return result;
-        }
+        public override byte* Pointer => _buffer;
+        public override int Size => _size;
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
@@ -44,21 +44,7 @@ namespace System.Reflection.Internal
             _pointer = null;
         }
 
-        public override byte* Pointer
-        {
-            get { return _pointer; }
-        }
-
-        public override int Size
-        {
-            get { return _size; }
-        }
-
-        public override ImmutableArray<byte> GetContent(int offset)
-        {
-            var result = CreateImmutableArray(this.Pointer + offset, this.Size - offset);
-            GC.KeepAlive(this);
-            return result;
-        }
+        public override byte* Pointer => _pointer;
+        public override int Size => _size;
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/NativeHeapMemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/NativeHeapMemoryBlock.cs
@@ -35,21 +35,7 @@ namespace System.Reflection.Internal
             _pointer = null;
         }
 
-        public override byte* Pointer
-        {
-            get { return _pointer; }
-        }
-
-        public override int Size
-        {
-            get { return _size; }
-        }
-
-        public override ImmutableArray<byte> GetContent(int offset)
-        {
-            var result = CreateImmutableArray(_pointer + offset, _size - offset);
-            GC.KeepAlive(this);
-            return result;
-        }
+        public override byte* Pointer => _pointer;
+        public override int Size => _size;
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryBlock.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace System.Reflection.Internal
@@ -510,15 +509,7 @@ namespace System.Reflection.Internal
         internal byte[] PeekBytes(int offset, int byteCount)
         {
             CheckBounds(offset, byteCount);
-
-            if (byteCount == 0)
-            {
-                return EmptyArray<byte>.Instance;
-            }
-
-            byte[] result = new byte[byteCount];
-            Marshal.Copy((IntPtr)(Pointer + offset), result, 0, byteCount);
-            return result;
+            return BlobUtilities.ReadBytes(Pointer + offset, byteCount);
         }
 
         internal int IndexOf(byte b, int start)

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -279,7 +279,7 @@ namespace System.Reflection.Metadata
         /// <exception cref="InvalidOperationException">Content is not available, the builder has been linked with another one.</exception>
         public byte[] ToArray(int start, int byteCount)
         {
-            BlobUtilities.ValidateRange(Count, start, byteCount);
+            BlobUtilities.ValidateRange(Count, start, byteCount, nameof(byteCount));
 
             var result = new byte[byteCount];
 
@@ -761,7 +761,7 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentNull(nameof(buffer));
             }
 
-            BlobUtilities.ValidateRange(buffer.Length, start, byteCount);
+            BlobUtilities.ValidateRange(buffer.Length, start, byteCount, nameof(byteCount));
 
             if (!IsHead)
             {

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
@@ -89,7 +89,7 @@ namespace System.Reflection.Metadata
         /// <exception cref="ArgumentOutOfRangeException">Range specified by <paramref name="start"/> and <paramref name="byteCount"/> falls outside of the bounds of the buffer content.</exception>
         public byte[] ToArray(int start, int byteCount)
         {
-            BlobUtilities.ValidateRange(Length, start, byteCount);
+            BlobUtilities.ValidateRange(Length, start, byteCount, nameof(byteCount));
 
             var result = new byte[byteCount];
             Array.Copy(_buffer, _start + start, result, 0, byteCount);
@@ -223,7 +223,7 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentNull(nameof(buffer));
             }
 
-            BlobUtilities.ValidateRange(buffer.Length, start, byteCount);
+            BlobUtilities.ValidateRange(buffer.Length, start, byteCount, nameof(byteCount));
 
             // an empty array has no element pointer:
             if (buffer.Length == 0)

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
@@ -1010,138 +1010,66 @@ namespace System.Reflection.Metadata
 
         #region Public APIs
 
-        public MetadataReaderOptions Options
-        {
-            get { return _options; }
-        }
+        /// <summary>
+        /// Pointer to the underlying data.
+        /// </summary>
+        public unsafe byte* MetadataPointer => Block.Pointer;
 
-        public string MetadataVersion
-        {
-            get { return _versionString; }
-        }
+        /// <summary>
+        /// Length of the underlying data.
+        /// </summary>
+        public int MetadataLength => Block.Length;
+
+        /// <summary>
+        /// Options passed to the constructor.
+        /// </summary>
+        public MetadataReaderOptions Options => _options;
+
+        /// <summary>
+        /// Version string read from metadata header.
+        /// </summary>
+        public string MetadataVersion => _versionString;
 
         /// <summary>
         /// Information decoded from #Pdb stream, or null if the stream is not present.
         /// </summary>
-        public DebugMetadataHeader DebugMetadataHeader
-        {
-            get { return _debugMetadataHeader; }
-        }
+        public DebugMetadataHeader DebugMetadataHeader => _debugMetadataHeader;
 
-        public MetadataKind MetadataKind
-        {
-            get { return _metadataKind; }
-        }
+        /// <summary>
+        /// The kind of the metadata (plain ECMA335, WinMD, etc.).
+        /// </summary>
+        public MetadataKind MetadataKind => _metadataKind;
 
-        public MetadataStringComparer StringComparer
-        {
-            get { return new MetadataStringComparer(this); }
-        }
+        /// <summary>
+        /// Comparer used to compare strings stored in metadata.
+        /// </summary>
+        public MetadataStringComparer StringComparer => new MetadataStringComparer(this);
 
-        public bool IsAssembly
-        {
-            get { return this.AssemblyTable.NumberOfRows == 1; }
-        }
+        /// <summary>
+        /// Returns true if the metadata represent an assembly.
+        /// </summary>
+        public bool IsAssembly => AssemblyTable.NumberOfRows == 1;
 
-        public AssemblyReferenceHandleCollection AssemblyReferences
-        {
-            get { return new AssemblyReferenceHandleCollection(this); }
-        }
-
-        public TypeDefinitionHandleCollection TypeDefinitions
-        {
-            get { return new TypeDefinitionHandleCollection(TypeDefTable.NumberOfRows); }
-        }
-
-        public TypeReferenceHandleCollection TypeReferences
-        {
-            get { return new TypeReferenceHandleCollection(TypeRefTable.NumberOfRows); }
-        }
-
-        public CustomAttributeHandleCollection CustomAttributes
-        {
-            get { return new CustomAttributeHandleCollection(this); }
-        }
-
-        public DeclarativeSecurityAttributeHandleCollection DeclarativeSecurityAttributes
-        {
-            get { return new DeclarativeSecurityAttributeHandleCollection(this); }
-        }
-
-        public MemberReferenceHandleCollection MemberReferences
-        {
-            get { return new MemberReferenceHandleCollection(MemberRefTable.NumberOfRows); }
-        }
-
-        public ManifestResourceHandleCollection ManifestResources
-        {
-            get { return new ManifestResourceHandleCollection(ManifestResourceTable.NumberOfRows); }
-        }
-
-        public AssemblyFileHandleCollection AssemblyFiles
-        {
-            get { return new AssemblyFileHandleCollection(FileTable.NumberOfRows); }
-        }
-
-        public ExportedTypeHandleCollection ExportedTypes
-        {
-            get { return new ExportedTypeHandleCollection(ExportedTypeTable.NumberOfRows); }
-        }
-
-        public MethodDefinitionHandleCollection MethodDefinitions
-        {
-            get { return new MethodDefinitionHandleCollection(this); }
-        }
-
-        public FieldDefinitionHandleCollection FieldDefinitions
-        {
-            get { return new FieldDefinitionHandleCollection(this); }
-        }
-
-        public EventDefinitionHandleCollection EventDefinitions
-        {
-            get { return new EventDefinitionHandleCollection(this); }
-        }
-
-        public PropertyDefinitionHandleCollection PropertyDefinitions
-        {
-            get { return new PropertyDefinitionHandleCollection(this); }
-        }
-
-        public DocumentHandleCollection Documents
-        {
-            get { return new DocumentHandleCollection(this); }
-        }
-
-        public MethodDebugInformationHandleCollection MethodDebugInformation
-        {
-            get { return new MethodDebugInformationHandleCollection(this); }
-        }
-
-        public LocalScopeHandleCollection LocalScopes
-        {
-            get { return new LocalScopeHandleCollection(this, 0); }
-        }
-
-        public LocalVariableHandleCollection LocalVariables
-        {
-            get { return new LocalVariableHandleCollection(this, default(LocalScopeHandle)); }
-        }
-
-        public LocalConstantHandleCollection LocalConstants
-        {
-            get { return new LocalConstantHandleCollection(this, default(LocalScopeHandle)); }
-        }
-
-        public ImportScopeCollection ImportScopes
-        {
-            get { return new ImportScopeCollection(this); }
-        }
-
-        public CustomDebugInformationHandleCollection CustomDebugInformation
-        {
-            get { return new CustomDebugInformationHandleCollection(this); }
-        }
+        public AssemblyReferenceHandleCollection AssemblyReferences => new AssemblyReferenceHandleCollection(this);
+        public TypeDefinitionHandleCollection TypeDefinitions => new TypeDefinitionHandleCollection(TypeDefTable.NumberOfRows);
+        public TypeReferenceHandleCollection TypeReferences => new TypeReferenceHandleCollection(TypeRefTable.NumberOfRows);
+        public CustomAttributeHandleCollection CustomAttributes => new CustomAttributeHandleCollection(this);
+        public DeclarativeSecurityAttributeHandleCollection DeclarativeSecurityAttributes => new DeclarativeSecurityAttributeHandleCollection(this);
+        public MemberReferenceHandleCollection MemberReferences => new MemberReferenceHandleCollection(MemberRefTable.NumberOfRows);
+        public ManifestResourceHandleCollection ManifestResources => new ManifestResourceHandleCollection(ManifestResourceTable.NumberOfRows);
+        public AssemblyFileHandleCollection AssemblyFiles => new AssemblyFileHandleCollection(FileTable.NumberOfRows);
+        public ExportedTypeHandleCollection ExportedTypes => new ExportedTypeHandleCollection(ExportedTypeTable.NumberOfRows);
+        public MethodDefinitionHandleCollection MethodDefinitions => new MethodDefinitionHandleCollection(this);
+        public FieldDefinitionHandleCollection FieldDefinitions => new FieldDefinitionHandleCollection(this);
+        public EventDefinitionHandleCollection EventDefinitions => new EventDefinitionHandleCollection(this);
+        public PropertyDefinitionHandleCollection PropertyDefinitions => new PropertyDefinitionHandleCollection(this);
+        public DocumentHandleCollection Documents => new DocumentHandleCollection(this);
+        public MethodDebugInformationHandleCollection MethodDebugInformation => new MethodDebugInformationHandleCollection(this);
+        public LocalScopeHandleCollection LocalScopes => new LocalScopeHandleCollection(this, 0);
+        public LocalVariableHandleCollection LocalVariables => new LocalVariableHandleCollection(this, default(LocalScopeHandle));
+        public LocalConstantHandleCollection LocalConstants => new LocalConstantHandleCollection(this, default(LocalScopeHandle));
+        public ImportScopeCollection ImportScopes => new ImportScopeCollection(this);
+        public CustomDebugInformationHandleCollection CustomDebugInformation => new CustomDebugInformationHandleCollection(this);
 
         public AssemblyDefinition GetAssemblyDefinition()
         {

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEMemoryBlockTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEMemoryBlockTests.cs
@@ -1,0 +1,138 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Reflection.Internal;
+using System.Reflection.Metadata.Tests;
+using Xunit;
+
+namespace System.Reflection.PortableExecutable.Tests
+{
+    public class PEMemoryBlockTests
+    {
+        [Fact]
+        public unsafe void Default()
+        {
+            var peBlock = default(PEMemoryBlock);
+            Assert.True(peBlock.Pointer == null);
+            Assert.Equal(0, peBlock.Length);
+
+            var reader1 = peBlock.GetReader();
+            Assert.Equal(0, reader1.Length);
+
+            var reader2 = peBlock.GetReader(0, 0);
+            Assert.Equal(0, reader2.Length);
+
+            AssertEx.Equal(new byte[0], peBlock.GetContent());
+            AssertEx.Equal(new byte[0], peBlock.GetContent(0, 0));
+        }
+
+        [Fact]
+        public void Default_Errors()
+        {
+            var peBlock = default(PEMemoryBlock);
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetContent(1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetContent(0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetContent(-1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetContent(0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetContent(-1, -1));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetReader(1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetReader(0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetReader(-1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetReader(0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetReader(-1, -1));
+        }
+
+        [Fact]
+        public unsafe void GetReader_NoOffset()
+        {
+            var array = ImmutableArray.Create(new byte[] { 1, 2, 3, 4 });
+            var provider = new ByteArrayMemoryProvider(array);
+            var block = provider.GetMemoryBlock();
+
+            var peBlock = new PEMemoryBlock(block);
+
+            var reader1 = peBlock.GetReader();
+            Assert.Equal(4, reader1.Length);
+            AssertEx.Equal(new byte[] { 1, 2, 3 }, reader1.ReadBytes(3));
+            AssertEx.Equal(new byte[] { 4 }, reader1.ReadBytes(1));
+
+            var reader2 = peBlock.GetReader(1, 2);
+            Assert.Equal(2, reader2.Length);
+            AssertEx.Equal(new byte[] { 2, 3 }, reader2.ReadBytes(2));
+
+            var reader3 = peBlock.GetReader(4, 0);
+            Assert.Equal(0, reader3.Length);
+            AssertEx.Equal(new byte[] { }, reader3.ReadBytes(0));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetReader(0, 5));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetReader(4, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetReader(5, 0));
+        }
+
+        [Fact]
+        public unsafe void GetReader_Offset()
+        {
+            var array = ImmutableArray.Create(new byte[] { 0, 1, 2, 3, 4 });
+            var provider = new ByteArrayMemoryProvider(array);
+            var block = provider.GetMemoryBlock();
+
+            var peBlock = new PEMemoryBlock(block, offset: 1);
+
+            var reader1 = peBlock.GetReader();
+            Assert.Equal(4, reader1.Length);
+            AssertEx.Equal(new byte[] { 1, 2, 3 }, reader1.ReadBytes(3));
+            AssertEx.Equal(new byte[] { 4 }, reader1.ReadBytes(1));
+
+            var reader2 = peBlock.GetReader(1, 2);
+            Assert.Equal(2, reader2.Length);
+            AssertEx.Equal(new byte[] { 2, 3 }, reader2.ReadBytes(2));
+
+            var reader3 = peBlock.GetReader(4, 0);
+            Assert.Equal(0, reader3.Length);
+            AssertEx.Equal(new byte[] { }, reader3.ReadBytes(0));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetReader(0, 5));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetReader(4, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetReader(5, 0));
+        }
+
+        [Fact]
+        public unsafe void GetContent_NoOffset()
+        {
+            var array = ImmutableArray.Create(new byte[] { 1, 2, 3, 4 });
+            var provider = new ByteArrayMemoryProvider(array);
+            var block = provider.GetMemoryBlock();
+
+            var peBlock = new PEMemoryBlock(block);
+
+            AssertEx.Equal(new byte[] { 1, 2, 3, 4 }, peBlock.GetContent());
+            AssertEx.Equal(new byte[] { 2, 3 }, peBlock.GetContent(1, 2));
+            AssertEx.Equal(new byte[] { }, peBlock.GetContent(4, 0));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetContent(0, 5));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetContent(4, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetContent(5, 0));
+        }
+
+        [Fact]
+        public unsafe void GetContent_Offset()
+        {
+            var array = ImmutableArray.Create(new byte[] { 0, 1, 2, 3, 4 });
+            var provider = new ByteArrayMemoryProvider(array);
+            var block = provider.GetMemoryBlock();
+
+            var peBlock = new PEMemoryBlock(block, offset: 1);
+
+            AssertEx.Equal(new byte[] { 1, 2, 3, 4 }, peBlock.GetContent());
+            AssertEx.Equal(new byte[] { 2, 3 }, peBlock.GetContent(1, 2));
+            AssertEx.Equal(new byte[] { }, peBlock.GetContent(4, 0));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetContent(0, 5));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetContent(4, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => peBlock.GetContent(5, 0));
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Metadata\TagToTokenTests.cs" />
     <Compile Include="Metadata\PortablePdb\DocumentNameTests.cs" />
     <Compile Include="PortableExecutable\DebugDirectoryBuilderTests.cs" />
+    <Compile Include="PortableExecutable\PEMemoryBlockTests.cs" />
     <Compile Include="TestUtilities\PinnedBlob.cs" />
     <Compile Include="TestUtilities\SigningUtilities.cs" />
     <Compile Include="Utilities\AbstractMemoryBlockTests.cs" />

--- a/src/System.Reflection.Metadata/tests/TestUtilities/PinnedBlob.cs
+++ b/src/System.Reflection.Metadata/tests/TestUtilities/PinnedBlob.cs
@@ -29,10 +29,10 @@ namespace System.Reflection.Metadata.Tests
             return CreateReader(0, _blob.Length);
         }
 
-        public unsafe BlobReader CreateReader(int start, int count)
+        public unsafe BlobReader CreateReader(int start, int byteCount)
         {
-            BlobUtilities.ValidateRange(_blob.Length, start, count);
-            return new BlobReader((byte*)_bytes.AddrOfPinnedObject() + start, count);
+            BlobUtilities.ValidateRange(_blob.Length, start, byteCount, nameof(byteCount));
+            return new BlobReader((byte*)_bytes.AddrOfPinnedObject() + start, byteCount);
         }
 
         public void Dispose()

--- a/src/System.Reflection.Metadata/tests/Utilities/StreamExtensionsTests.cs
+++ b/src/System.Reflection.Metadata/tests/Utilities/StreamExtensionsTests.cs
@@ -26,9 +26,7 @@ namespace System.Reflection.Internal.Tests
                 p--;
             }
 
-            byte[] result = new byte[p + 1 - buffer];
-            Marshal.Copy((IntPtr)buffer, result, 0, result.Length);
-            return result;
+            return BlobUtilities.ReadBytes(buffer, (int)(p + 1 - buffer));
         }
 
         [Fact]


### PR DESCRIPTION
MetadataReader:

```C#
byte* MetadataPointer { get; }
int MetadataLength { get; }
```

PEMemoryBlock:

```C#
public BlobReader GetReader()
public BlobReader GetReader(int start, int length)
public ImmutableArray<byte> GetContent() // already shipped
public ImmutableArray<byte> GetContent(int start, int length)
```