### PR TITLE
Disable native build when updating dependencies

### DIFF
--- a/UpdateDependencies.ps1
+++ b/UpdateDependencies.ps1
@@ -53,7 +53,7 @@ function UpdateValidDependencyVersionsFile
 # Updates all the project.json files with out of date version numbers
 function RunUpdatePackageDependencyVersions
 {
-    cmd /c $PSScriptRoot\build.cmd /t:UpdateInvalidPackageVersions | Out-Host
+    cmd /c $PSScriptRoot\build.cmd managed /t:UpdateInvalidPackageVersions | Out-Host
 
     return $LASTEXITCODE -eq 0
 }


### PR DESCRIPTION
If a native build fails during auto-upgrade, it blocks an auto-upgrade PR from being created--and although it *shouldn't* fail, there's no benefit in running it anyway. The `managed` arg just means UpdateDependencies will skip the native build; it won't start doing a full managed build now.

Related: https://github.com/dotnet/versions/issues/24. That issue had a different cause, but a native build did fail and had me misdiagnosing the issue for a while.

/cc @eerhardt @jhendrixMSFT 