### PR TITLE
Fix hanging System.Net.Http test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -893,9 +893,6 @@ namespace System.Net.Http.Functional.Tests
                         {
                             Assert.Equal("12345678901234567890", await response3.Content.ReadAsStringAsync());
                         }
-
-                        try { await Task.WhenAll(server1, server2, server3); }
-                        catch { } // Ignore errors: we expect this may fail, as the clients may hang up on the servers
                     });
                 });
             });


### PR DESCRIPTION
We've been plagued for the last few weeks by CI jobs on Windows that hang in System.Net.Http.Functional.Tests, causing the whole job to fail after it eventually times out after two hours. I managed to find a CI server that had a process still alive after having experienced the hang and was able to debug it.  The Dispose_DisposingHandlerCancelsActiveOperationsWithoutResponses test is creating three loopback servers and using HttpClient.GetAsync to access each of them.  It's then Disposing of the HttpClient to verify that requests which should have been canceled are canceled.  The problem is that there's a race condition.  We may end up canceling one of the requests before it even gets a chance to connect to the server.  As a result, the server remains stuck in an asynchronous accept on it socket, and at the end of the test, we're waiting for all of the servers to shutdown... deadlock.  The fix is simple: don't wait for the servers... we don't care about their results, and they'll all be torn down when we exit the inner delegate.

Fixes #8926 
cc: @davidsh, @ericeil 