### PR TITLE
Include package reference to System.Net.Security

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -9,6 +9,7 @@
     "System.IO.FileSystem": "4.0.1-rc3-24210-10",
     "System.Linq.Expressions": "4.1.0-rc3-24210-10",
     "System.Net.Primitives": "4.0.11-rc3-24210-10",
+    "System.Net.Security": "4.0.0-rc3-24210-10",
     "System.Net.Sockets": "4.1.0-rc3-24210-10",
     "System.Net.TestData": "1.0.0-prerelease",
     "System.ObjectModel": "4.0.12-rc3-24210-10",


### PR DESCRIPTION
Without an explicit package reference in the test project's project.json,
the native shim will not be included when producing the test output
folder, since the P2P reference between the test project and product
project does not imply that the native shim needs to come along for the
ride.

Fixes #9337