### PR TITLE
[release/1.0.0] Allow the HTTP2 protocol test to pass with untrusted chains on Debian.

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -21,6 +21,7 @@ namespace System
 
         public static int WindowsVersion { get; } = GetWindowsVersion();
 
+        public static bool IsDebian8 { get; } = IsDistroAndVersion("debian", "8");
         public static bool IsUbuntu1404 { get; } = IsDistroAndVersion("ubuntu", "14.04");
         public static bool IsUbuntu1510 { get; } = IsDistroAndVersion("ubuntu", "15.10");
         public static bool IsUbuntu1604 { get; } = IsDistroAndVersion("ubuntu", "16.04");

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.IO;
+using System.Net.Security;
 using System.Net.Test.Common;
 using System.Security.Authentication.ExtendedProtection;
 using System.Text;
@@ -15,6 +16,7 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net.Http.Functional.Tests
 {
@@ -1233,14 +1235,39 @@ namespace System.Net.Http.Functional.Tests
             var request = new HttpRequestMessage(HttpMethod.Get, server);
             request.Version = new Version(2, 0);
 
-            using (var client = new HttpClient())
-            using (HttpResponseMessage response = await client.SendAsync(request))
+            using (var handler = new HttpClientHandler())
+            using (var client = new HttpClient(handler, false))
             {
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                Assert.True(
-                    response.Version == new Version(2, 0) || 
-                    response.Version == new Version(1, 1),
-                    "Response version " + response.Version);
+                // It is generally expected that the test hosts will be trusted, so we don't register a validation
+                // callback in the usual case.
+                // 
+                // However, on our Debian 8 test machines, a combination of a server side TLS chain,
+                // the client chain processor, and the distribution's CA bundle results in an incomplete/untrusted
+                // certificate chain. See https://github.com/dotnet/corefx/issues/9244 for more details.
+                if (PlatformDetection.IsDebian8)
+                {
+                    // Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool>
+                    handler.ServerCertificateCustomValidationCallback = (msg, cert, chain, errors) =>
+                    {
+                        Assert.InRange(chain.ChainStatus.Length, 0, 1);
+
+                        if (chain.ChainStatus.Length > 0)
+                        {
+                            Assert.Equal(X509ChainStatusFlags.PartialChain, chain.ChainStatus[0].Status);
+                        }
+
+                        return true;
+                    };
+                }
+
+                using (HttpResponseMessage response = await client.SendAsync(request))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    Assert.True(
+                        response.Version == new Version(2, 0) ||
+                        response.Version == new Version(1, 1),
+                        "Response version " + response.Version);
+                }
             }
         }
 


### PR DESCRIPTION
The TLS context is set up to make this chain:
  CN=http2.akamai.com, O=Akamai Technologies Inc., L=Santa Clara, S=CA, C=US
  CN=Verizon Akamai SureServer CA G14-SHA2, OU=Cybertrust, O=Verizon Enterprise Solutions, L=Amsterdam, C=NL
  CN=Baltimore CyberTrust Root, OU=CyberTrust, O=Baltimore, C=IE
  CN=GTE CyberTrust Global Root, OU="GTE CyberTrust Solutions, Inc.", O=GTE Corporation, C=US

making use of the cross-signed Baltimore CyberTrust Root certificate.
Unfortunately, that chain is not trusted on Debian 8.4 (GTE CyberTrust Global Root was removed), and a combination of data and installed software results in the valid chain using the self-signed Baltimore root is never built.

To prevent this situation from making the tests show as a failure, selectively allow Debian 8 to succeed on an incomplete chain.

Fixes #9244.
cc: @joshfree @stephentoub 