### PR TITLE
Remove some allocations from unix WebSocket client

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
@@ -1242,7 +1242,7 @@ namespace System.Net.WebSockets
                             localTcs.TrySetException(t.Exception.InnerExceptions);
                         }
                     }
-                }, tcs, token, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
+                }, tcs, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
 
                 return tcs.Task;
             }

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
@@ -236,6 +236,7 @@ namespace System.Net.WebSockets
                 }
 
                 // Establish connection to the server
+                CancellationTokenRegistration registration = cancellationToken.Register(s => ((ManagedClientWebSocket)s).Abort(), this);
                 try
                 {
                     // Connect over TCP to the remote server
@@ -296,6 +297,10 @@ namespace System.Net.WebSockets
                     }
                     throw new WebSocketException(SR.net_webstatus_ConnectFailure, exc);
                 }
+                finally
+                {
+                    registration.Dispose();
+                }
             }
 
             public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
@@ -312,10 +317,7 @@ namespace System.Net.WebSockets
 
                 Task t = SendFrameAsync(_lastSendWasFragment ? MessageOpcode.Continuation : ToMessageOpcode(messageType), endOfMessage, buffer, cancellationToken);
                 _lastSendWasFragment = !endOfMessage;
-
-                return t.Status == TaskStatus.RanToCompletion ?
-                    t :
-                    (_lastSendAsync = WithAbortAsync<int>(t, AbortErrorType.OperationCanceledException, cancellationToken));
+                return _lastSendAsync = t;
             }
 
             public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
@@ -330,10 +332,7 @@ namespace System.Net.WebSockets
                     return Task.FromException<WebSocketReceiveResult>(e);
                 }
 
-                Task<WebSocketReceiveResult> t = ReceiveAsyncPrivate(buffer, cancellationToken);
-                return t.Status == TaskStatus.RanToCompletion ?
-                    t :
-                    (_lastReceiveAsync = WithAbortAsync<WebSocketReceiveResult>(t, AbortErrorType.ClosedOrAbortedWebSocketException, cancellationToken));
+                return _lastReceiveAsync = ReceiveAsyncPrivate(buffer, cancellationToken);
             }
 
             public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
@@ -347,10 +346,7 @@ namespace System.Net.WebSockets
                     return Task.FromException(e);
                 }
 
-                Task t = CloseAsyncPrivate(closeStatus, statusDescription, cancellationToken);
-                return t.Status == TaskStatus.RanToCompletion ? 
-                    t :
-                    WithAbortAsync<WebSocketReceiveResult>(t, AbortErrorType.ClosedOrAbortedWebSocketException, cancellationToken);
+                return CloseAsyncPrivate(closeStatus, statusDescription, cancellationToken);
             }
 
             public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
@@ -364,10 +360,7 @@ namespace System.Net.WebSockets
                     return Task.FromException(e);
                 }
 
-                Task t = SendCloseFrameAsync(closeStatus, statusDescription, cancellationToken);
-                return t.Status == TaskStatus.RanToCompletion ? 
-                    t :
-                    WithAbortAsync<int>(t, AbortErrorType.ClosedOrAbortedWebSocketException, cancellationToken);
+                return SendCloseFrameAsync(closeStatus, statusDescription, cancellationToken);
             }
 
             public override void Abort()
@@ -573,15 +566,7 @@ namespace System.Net.WebSockets
             /// <param name="stream">The stream from which to read.</param>
             /// <param name="cancellationToken">The CancellationToken used to cancel the websocket.</param>
             /// <returns>The read line, or null if none could be read.</returns>
-            private Task<string> ReadResponseHeaderLineAsync(CancellationToken cancellationToken)
-            {
-                Task<string> line = ReadResponseHeaderLineAsyncPrivate(cancellationToken);
-                return line.Status == TaskStatus.RanToCompletion ?
-                    line :
-                    WithAbortAsync<string>(line, AbortErrorType.ConnectFailureWebSocketException, cancellationToken);
-            }
-
-            private async Task<string> ReadResponseHeaderLineAsyncPrivate(CancellationToken cancellationToken)
+            private async Task<string> ReadResponseHeaderLineAsync(CancellationToken cancellationToken)
             {
                 StringBuilder sb = t_cachedStringBuilder;
                 if (sb != null)
@@ -645,32 +630,37 @@ namespace System.Net.WebSockets
                 await _sendFrameAsyncLock.WaitAsync().ConfigureAwait(false);
                 try
                 {
-                    // Grow our send buffer as needed.  We reuse the buffer for all messages, with it protected by the send frame lock.
-                    EnsureBufferLength(ref _sendBuffer, payloadBuffer.Count + MaxMessageHeaderLength);
-
-                    // Write the message header data to the buffer.  We need to know where the mask starts so that we can use
-                    // the mask to manipulate the payload data, and we need to know the total length for sending it on the wire.
-                    int maskOffset = WriteHeader(opcode, _sendBuffer, payloadBuffer, endOfMessage);
-                    int headerLength = maskOffset + MaskLength;
-
-                    // If there is payload data, XOR it with the mask.  We do the manipulation in the send buffer so as to avoid
-                    // changing the data in the caller-supplied payload buffer.
-                    if (payloadBuffer.Count > 0)
+                    using (cancellationToken.Register(s => ((ManagedClientWebSocket)s).Abort(), this))
                     {
-                        for (int i = 0; i < payloadBuffer.Count; i++)
-                        {
-                            _sendBuffer[i + headerLength] = (byte)
-                                (payloadBuffer.Array[payloadBuffer.Offset + i] ^
-                                _sendBuffer[maskOffset + (i & 3)]); // (i % MaskLength)
-                        }
-                    }
+                        // Grow our send buffer as needed.  We reuse the buffer for all messages, with it protected by the send frame lock.
+                        EnsureBufferLength(ref _sendBuffer, payloadBuffer.Count + MaxMessageHeaderLength);
 
-                    // Write the header to the network
-                    await _stream.WriteAsync(_sendBuffer, 0, headerLength + payloadBuffer.Count, cancellationToken).ConfigureAwait(false);
+                        // Write the message header data to the buffer.  We need to know where the mask starts so that we can use
+                        // the mask to manipulate the payload data, and we need to know the total length for sending it on the wire.
+                        int maskOffset = WriteHeader(opcode, _sendBuffer, payloadBuffer, endOfMessage);
+                        int headerLength = maskOffset + MaskLength;
+
+                        // If there is payload data, XOR it with the mask.  We do the manipulation in the send buffer so as to avoid
+                        // changing the data in the caller-supplied payload buffer.
+                        if (payloadBuffer.Count > 0)
+                        {
+                            for (int i = 0; i < payloadBuffer.Count; i++)
+                            {
+                                _sendBuffer[i + headerLength] = (byte)
+                                    (payloadBuffer.Array[payloadBuffer.Offset + i] ^
+                                    _sendBuffer[maskOffset + (i & 3)]); // (i % MaskLength)
+                            }
+                        }
+
+                        // Write the header to the network
+                        await _stream.WriteAsync(_sendBuffer, 0, headerLength + payloadBuffer.Count, cancellationToken).ConfigureAwait(false);
+                    }
                 }
                 catch (ObjectDisposedException ode)
                 {
-                    throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely, ode);
+                    throw _state == WebSocketState.Aborted ? (Exception)
+                        new OperationCanceledException(cancellationToken) :
+                        new WebSocketException(WebSocketError.ConnectionClosedPrematurely, ode);
                 }
                 finally
                 {
@@ -770,148 +760,162 @@ namespace System.Net.WebSockets
             /// <returns>Information about the received message.</returns>
             private async Task<WebSocketReceiveResult> ReceiveAsyncPrivate(ArraySegment<byte> payloadBuffer, CancellationToken cancellationToken)
             {
-                while (true) // in case we get control frames that should be ignored from the user's perspective
+                CancellationTokenRegistration registration = cancellationToken.Register(s => ((ManagedClientWebSocket)s).Abort(), this);
+                try
                 {
-                    // Get the last received header.  If its payload length is non-zero, that means we previously
-                    // received the header but were only able to read a part of the fragment, so we should skip
-                    // reading another header and just proceed to use that same header and read more data associated
-                    // with it.  If instead its payload length is zero, then we've completed the processing of
-                    // thta message, and we should read the next header.
-                    MessageHeader header = _lastReceiveHeader;
-                    if (header.PayloadLength == 0)
+                    while (true) // in case we get control frames that should be ignored from the user's perspective
                     {
-                        if (_receiveBufferCount < MaxMessageHeaderLength && // fast check to see if we have enough data for any possible header
-                            !await EnsureBufferContainsHeaderAsync(cancellationToken).ConfigureAwait(false))
+                        // Get the last received header.  If its payload length is non-zero, that means we previously
+                        // received the header but were only able to read a part of the fragment, so we should skip
+                        // reading another header and just proceed to use that same header and read more data associated
+                        // with it.  If instead its payload length is zero, then we've completed the processing of
+                        // thta message, and we should read the next header.
+                        MessageHeader header = _lastReceiveHeader;
+                        if (header.PayloadLength == 0)
                         {
-                            // The connection closed; nothing more to read.
-                            return new WebSocketReceiveResult(0, WebSocketMessageType.Text, true);
-                        }
-
-                        if (!TryParseMessageHeaderFromReceiveBuffer(out header))
-                        {
-                            await CloseWithErrorAndThrowAsync(WebSocketCloseStatus.ProtocolError, WebSocketError.Faulted, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-
-                    // If the header represents a ping or a pong, handle it.
-                    if (header.Opcode == MessageOpcode.Ping || header.Opcode == MessageOpcode.Pong)
-                    {
-                        // Consume any (optional) payload associated with the ping/pong
-                        if (header.PayloadLength > 0 && _receiveBufferCount < header.PayloadLength)
-                        {
-                            await EnsureBufferContainsAsync((int)header.PayloadLength, cancellationToken).ConfigureAwait(false);
-                        }
-
-                        // If this was a ping, send back a pong response
-                        if (header.Opcode == MessageOpcode.Ping)
-                        {
-                            await SendFrameAsync(
-                                MessageOpcode.Pong, true, 
-                                new ArraySegment<byte>(_receiveBuffer, _receiveBufferOffset, (int)header.PayloadLength), cancellationToken).ConfigureAwait(false);
-                        }
-
-                        // Regardless of whether it was a ping or pong, we no longer need the payload.
-                        if (header.PayloadLength > 0)
-                        {
-                            ConsumeFromBuffer((int)header.PayloadLength);
-                        }
-
-                        // Control message that's meant to be transparent to the user.  Loop around to read again.
-                        continue;
-                    }
-
-                    WebSocketMessageType messageType = ToMessageType(header.Opcode == MessageOpcode.Continuation ? _lastReceiveHeader.Opcode : header.Opcode);
-                    bool endOfMessage = header.Fin;
-
-                    // If the message is a close, handle it by reading and doing special processing of the payload.
-                    if (header.Opcode == MessageOpcode.Close)
-                    {
-                        lock (StateUpdateLock)
-                        {
-                            if (_state == WebSocketState.CloseSent)
+                            if (_receiveBufferCount < MaxMessageHeaderLength && // fast check to see if we have enough data for any possible header
+                                !await EnsureBufferContainsHeaderAsync(cancellationToken).ConfigureAwait(false))
                             {
-                                _state = WebSocketState.Closed;
-                            }
-                            else if (_state < WebSocketState.CloseReceived)
-                            {
-                                _state = WebSocketState.CloseReceived;
-                            }
-                        }
-
-                        WebSocketCloseStatus closeStatus = WebSocketCloseStatus.NormalClosure;
-                        string closeStatusDescription = string.Empty;
-
-                        // Handle any payload by parsing it into the close status and description
-                        if (header.PayloadLength > 0)
-                        {
-                            if (_receiveBufferCount < header.PayloadLength)
-                            {
-                                await EnsureBufferContainsAsync((int)header.PayloadLength, cancellationToken).ConfigureAwait(false);
+                                // The connection closed; nothing more to read.
+                                return new WebSocketReceiveResult(0, WebSocketMessageType.Text, true);
                             }
 
-                            closeStatus = (WebSocketCloseStatus)(_receiveBuffer[_receiveBufferOffset] << 8 | _receiveBuffer[_receiveBufferOffset + 1]);
-                            if (header.PayloadLength > 2)
-                            {
-                                closeStatusDescription = s_textEncoding.GetString(_receiveBuffer, _receiveBufferOffset + 2, (int)header.PayloadLength - 2);
-                            }
-                            ConsumeFromBuffer((int)header.PayloadLength);
-
-                            if (!IsValidCloseStatus(closeStatus))
+                            if (!TryParseMessageHeaderFromReceiveBuffer(out header))
                             {
                                 await CloseWithErrorAndThrowAsync(WebSocketCloseStatus.ProtocolError, WebSocketError.Faulted, cancellationToken).ConfigureAwait(false);
                             }
                         }
 
-                        // Store the close status and description onto the instance
-                        _closeStatus = closeStatus;
-                        _closeStatusDescription = closeStatusDescription;
+                        // If the header represents a ping or a pong, handle it.
+                        if (header.Opcode == MessageOpcode.Ping || header.Opcode == MessageOpcode.Pong)
+                        {
+                            // Consume any (optional) payload associated with the ping/pong
+                            if (header.PayloadLength > 0 && _receiveBufferCount < header.PayloadLength)
+                            {
+                                await EnsureBufferContainsAsync((int)header.PayloadLength, cancellationToken).ConfigureAwait(false);
+                            }
 
-                        // And return them as part of the result message
-                        return new WebSocketReceiveResult(0, messageType, true, closeStatus, closeStatusDescription);
-                    }
+                            // If this was a ping, send back a pong response
+                            if (header.Opcode == MessageOpcode.Ping)
+                            {
+                                await SendFrameAsync(
+                                    MessageOpcode.Pong, true,
+                                    new ArraySegment<byte>(_receiveBuffer, _receiveBufferOffset, (int)header.PayloadLength), cancellationToken).ConfigureAwait(false);
+                            }
 
-                    // The message should now be a binary or text message (or a continuation of one of those).  Handle it by reading
-                    // the payload and returning the contents.
-                    Debug.Assert(
-                        header.Opcode == MessageOpcode.Continuation || header.Opcode == MessageOpcode.Binary || header.Opcode == MessageOpcode.Text,
-                        $"Unexpected opcode {header.Opcode}");
+                            // Regardless of whether it was a ping or pong, we no longer need the payload.
+                            if (header.PayloadLength > 0)
+                            {
+                                ConsumeFromBuffer((int)header.PayloadLength);
+                            }
 
-                    // If this is a continuation, replace the opcode with the one of the message it's continuing
-                    if (header.Opcode == MessageOpcode.Continuation)
-                    {
-                        header.Opcode = _lastReceiveHeader.Opcode;
-                    }
+                            // Control message that's meant to be transparent to the user.  Loop around to read again.
+                            continue;
+                        }
 
-                    // If there's no data to read, return an appropriate result.
-                    int bytesToRead = (int)Math.Min(payloadBuffer.Count, header.PayloadLength);
-                    if (bytesToRead == 0)
-                    {
+                        WebSocketMessageType messageType = ToMessageType(header.Opcode == MessageOpcode.Continuation ? _lastReceiveHeader.Opcode : header.Opcode);
+                        bool endOfMessage = header.Fin;
+
+                        // If the message is a close, handle it by reading and doing special processing of the payload.
+                        if (header.Opcode == MessageOpcode.Close)
+                        {
+                            lock (StateUpdateLock)
+                            {
+                                if (_state == WebSocketState.CloseSent)
+                                {
+                                    _state = WebSocketState.Closed;
+                                }
+                                else if (_state < WebSocketState.CloseReceived)
+                                {
+                                    _state = WebSocketState.CloseReceived;
+                                }
+                            }
+
+                            WebSocketCloseStatus closeStatus = WebSocketCloseStatus.NormalClosure;
+                            string closeStatusDescription = string.Empty;
+
+                            // Handle any payload by parsing it into the close status and description
+                            if (header.PayloadLength > 0)
+                            {
+                                if (_receiveBufferCount < header.PayloadLength)
+                                {
+                                    await EnsureBufferContainsAsync((int)header.PayloadLength, cancellationToken).ConfigureAwait(false);
+                                }
+
+                                closeStatus = (WebSocketCloseStatus)(_receiveBuffer[_receiveBufferOffset] << 8 | _receiveBuffer[_receiveBufferOffset + 1]);
+                                if (header.PayloadLength > 2)
+                                {
+                                    closeStatusDescription = s_textEncoding.GetString(_receiveBuffer, _receiveBufferOffset + 2, (int)header.PayloadLength - 2);
+                                }
+                                ConsumeFromBuffer((int)header.PayloadLength);
+
+                                if (!IsValidCloseStatus(closeStatus))
+                                {
+                                    await CloseWithErrorAndThrowAsync(WebSocketCloseStatus.ProtocolError, WebSocketError.Faulted, cancellationToken).ConfigureAwait(false);
+                                }
+                            }
+
+                            // Store the close status and description onto the instance
+                            _closeStatus = closeStatus;
+                            _closeStatusDescription = closeStatusDescription;
+
+                            // And return them as part of the result message
+                            return new WebSocketReceiveResult(0, messageType, true, closeStatus, closeStatusDescription);
+                        }
+
+                        // The message should now be a binary or text message (or a continuation of one of those).  Handle it by reading
+                        // the payload and returning the contents.
+                        Debug.Assert(
+                            header.Opcode == MessageOpcode.Continuation || header.Opcode == MessageOpcode.Binary || header.Opcode == MessageOpcode.Text,
+                            $"Unexpected opcode {header.Opcode}");
+
+                        // If this is a continuation, replace the opcode with the one of the message it's continuing
+                        if (header.Opcode == MessageOpcode.Continuation)
+                        {
+                            header.Opcode = _lastReceiveHeader.Opcode;
+                        }
+
+                        // If there's no data to read, return an appropriate result.
+                        int bytesToRead = (int)Math.Min(payloadBuffer.Count, header.PayloadLength);
+                        if (bytesToRead == 0)
+                        {
+                            _lastReceiveHeader = header;
+                            return new WebSocketReceiveResult(0, messageType, header.PayloadLength == 0 ? endOfMessage : false);
+                        }
+
+                        // Otherwise, read as much of the payload as we can efficiently, and upate the header to reflect how much data
+                        // remains for future reads.
+
+                        if (_receiveBufferCount == 0)
+                        {
+                            await EnsureBufferContainsAsync(1, cancellationToken, throwOnPrematureClosure: false).ConfigureAwait(false);
+                        }
+
+                        int bytesToCopy = Math.Min(bytesToRead, _receiveBufferCount);
+                        Buffer.BlockCopy(_receiveBuffer, _receiveBufferOffset, payloadBuffer.Array, payloadBuffer.Offset, bytesToCopy);
+                        ConsumeFromBuffer(bytesToCopy);
+                        header.PayloadLength -= bytesToCopy;
+
+                        // If this a text message, validate that it contains valid UTF8.
+                        if (messageType == WebSocketMessageType.Text &&
+                            !TryValidateUtf8(new ArraySegment<byte>(payloadBuffer.Array, payloadBuffer.Offset, bytesToCopy), endOfMessage, _utf8TextState))
+                        {
+                            await CloseWithErrorAndThrowAsync(WebSocketCloseStatus.InvalidPayloadData, WebSocketError.Faulted, cancellationToken).ConfigureAwait(false);
+                        }
+
                         _lastReceiveHeader = header;
-                        return new WebSocketReceiveResult(0, messageType, header.PayloadLength == 0 ? endOfMessage : false);
+                        return new WebSocketReceiveResult(bytesToCopy, messageType, bytesToCopy == 0 || (endOfMessage && header.PayloadLength == 0));
                     }
-
-                    // Otherwise, read as much of the payload as we can efficiently, and upate the header to reflect how much data
-                    // remains for future reads.
-
-                    if (_receiveBufferCount == 0)
-                    {
-                        await EnsureBufferContainsAsync(1, cancellationToken, throwOnPrematureClosure: false).ConfigureAwait(false);
-                    }
-
-                    int bytesToCopy = Math.Min(bytesToRead, _receiveBufferCount);
-                    Buffer.BlockCopy(_receiveBuffer, _receiveBufferOffset, payloadBuffer.Array, payloadBuffer.Offset, bytesToCopy);
-                    ConsumeFromBuffer(bytesToCopy);
-                    header.PayloadLength -= bytesToCopy;
-
-                    // If this a text message, validate that it contains valid UTF8.
-                    if (messageType == WebSocketMessageType.Text &&
-                        !TryValidateUtf8(new ArraySegment<byte>(payloadBuffer.Array, payloadBuffer.Offset, bytesToCopy), endOfMessage, _utf8TextState))
-                    {
-                        await CloseWithErrorAndThrowAsync(WebSocketCloseStatus.InvalidPayloadData, WebSocketError.Faulted, cancellationToken).ConfigureAwait(false);
-                    }
-
-                    _lastReceiveHeader = header;
-                    return new WebSocketReceiveResult(bytesToCopy, messageType, bytesToCopy == 0 || (endOfMessage && header.PayloadLength == 0));
+                }
+                catch (ObjectDisposedException ode)
+                {
+                    throw _state == WebSocketState.Aborted ?
+                        new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState_ClosedOrAborted, "System.Net.WebSockets.InternalClientWebSocket", "Aborted")) :
+                        new WebSocketException(WebSocketError.ConnectionClosedPrematurely, ode);
+                }
+                finally
+                {
+                    registration.Dispose();
                 }
             }
 
@@ -1139,114 +1143,6 @@ namespace System.Net.WebSockets
                 }
             }
 
-            /// <summary>Ensures that if the task fails, the websocket will abort.</summary>
-            /// <param name="task">The task representing the asynchronous operation.</param>
-            /// <param name="abortError">The error type associated with this operation.</param>
-            /// <param name="cancellationToken">The CancellationToken to use to cancel the websocket.</param>
-            /// <returns>The task that should be used in place of the original.</returns>
-            private Task<T> WithAbortAsync<T>(Task task, AbortErrorType abortError, CancellationToken cancellationToken)
-            {
-                // When any operation gets canceled or experiences an error, we need to abort the whole instance
-                // in addition to failing the task.  Further, to match the Windows behavior, different operations
-                // result in different exceptions to be used for failing the task.  Some of this may be simplified
-                // if/when NetworkStream and SslStream get better cancellation support; right now, they only do
-                // up-front checks in Read/WriteAsync, but during the actual I/O the cancellation token doesn't apply,
-                // so to ensure we avoid deadlocks and can return promptly in the case of cancellation.
-
-                // Create the task to act as the proxy for the original
-                var tcs = new AbortTaskCompletionSource<T>() { _webSocket = this };
-
-                // Determine which exception-producing function we should use if a failure occurs.
-                switch (abortError)
-                {
-                    case AbortErrorType.ConnectFailureWebSocketException:
-                        tcs._createExceptionFunc = () => new WebSocketException(SR.net_webstatus_ConnectFailure);
-                        break;
-
-                    case AbortErrorType.ClosedOrAbortedWebSocketException:
-                        tcs._createExceptionFunc = () => new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState_ClosedOrAborted, "System.Net.WebSockets.InternalClientWebSocket", "Aborted"));
-                        break;
-
-                    default:
-                        Debug.Assert(abortError == AbortErrorType.OperationCanceledException, $"Unexpected abort error type: {abortError}");
-                        tcs._createExceptionFunc = () => new OperationCanceledException();
-                        break;
-                }
-
-                // Register for cancellation both with the supplied cancellation token and with the abort cancellation token.
-                // If we only have the abort token, we can register with it directly.  If we have both, we created a linked source
-                // over both and register with that.
-                CancellationToken token;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    tcs._cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(_abortSource.Token, cancellationToken);
-                    token = tcs._cancellationSource.Token;
-                }
-                else
-                {
-                    token = _abortSource.Token;
-                }
-                token.Register(s =>
-                {
-                    var localTcs = (AbortTaskCompletionSource<T>)s;
-                    Exception e = localTcs._webSocket._abortSource.IsCancellationRequested ? localTcs._createExceptionFunc?.Invoke() : null;
-                    if (localTcs.OwnCompletion())
-                    {
-                        localTcs._registration.Dispose();
-                        localTcs._cancellationSource?.Dispose();
-
-                        localTcs._webSocket.Abort();
-
-                        if (e != null)
-                        {
-                            localTcs.TrySetException(e);
-                        }
-                        else
-                        {
-                            localTcs.TrySetCanceled();
-                        }
-                    }
-                }, tcs);
-
-                // Register for the task's completion.
-                task.ContinueWith((t, s) =>
-                {
-                    var localTcs = (AbortTaskCompletionSource<T>)s;
-                    bool ownCompletion = localTcs.OwnCompletion();
-
-                    if (ownCompletion)
-                    {
-                        localTcs._registration.Dispose();
-                        localTcs._cancellationSource?.Dispose();
-                    }
-
-                    if (t.Status == TaskStatus.RanToCompletion)
-                    {
-                        Task<T> localTaskT = t as Task<T>;
-                        localTcs.TrySetResult(localTaskT != null ? localTaskT.Result : default(T));
-                    }
-                    else
-                    {
-                        if (ownCompletion)
-                        {
-                            localTcs._webSocket.Abort();
-                        }
-
-                        if (t.IsCanceled)
-                        {
-                            localTcs.TrySetCanceled();
-                        }
-                        else
-                        {
-                            Debug.Assert(t.IsFaulted, $"Expected task to be faulted, got {t.Status}");
-                            localTcs.TrySetException(t.Exception.InnerExceptions);
-                        }
-                    }
-                }, tcs, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
-
-                return tcs.Task;
-            }
-
             private void ConsumeFromBuffer(int count)
             {
                 Debug.Assert(count >= 0, $"Expected non-negative count, got {count}");
@@ -1454,23 +1350,6 @@ namespace System.Net.WebSockets
                 public MessageOpcode Opcode;
                 public bool Fin;
                 public long PayloadLength;
-            }
-
-            private enum AbortErrorType
-            {
-                ConnectFailureWebSocketException,
-                ClosedOrAbortedWebSocketException,
-                OperationCanceledException
-            }
-
-            private sealed class AbortTaskCompletionSource<T> : TaskCompletionSource<T>
-            {
-                internal ManagedClientWebSocket _webSocket;
-                internal CancellationTokenRegistration _registration;
-                internal CancellationTokenSource _cancellationSource;
-                internal Func<Exception> _createExceptionFunc;
-
-                internal bool OwnCompletion() => Interlocked.Exchange(ref _createExceptionFunc, null) != null;
             }
         }
     }


### PR DESCRIPTION
Some low-hanging fruit.  (I have another change that gets rid of many more allocations coming from the networking stack, but I'm seeing an odd behavior I wasn't expecting and am following up on that before submitting it.)

- Change how we read message headers.  Rather than using a ```Task<MessageHeader?> ReadMessageHeaderAsync``` method, we now separate the buffering and the reading of the header, saving several allocations.
- Removing the WithAbortAsync method.  I'd initially added this when it wasn't clear to me that any operation getting canceled is meant to trigger the whole websocket getting aborted.  Since that is the behavior, this method is no longer needed and we can do something much simpler, resulting in many fewer allocations per operation.

This change modifies indentation in several places, so it's most easily reviewed ignoring whitespace changes:
https://github.com/dotnet/corefx/pull/9371/files?w=1

cc: @ericeil, @bartonjs, @davidsh, @cipop