### PR TITLE
Override HttpContent.CreateContentReadStreamAsync in MultipartContent

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -3,13 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using System.IO;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Net.Http.Headers;
 using System.Diagnostics.Contracts;
+using System.IO;
+using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
@@ -184,35 +185,9 @@ namespace System.Net.Http
                 var output = new StringBuilder();
                 for (int contentIndex = 0; contentIndex < _nestedContent.Count; contentIndex++)
                 {
-                    output.Clear();
-                    HttpContent content = _nestedContent[contentIndex];
-
-                    // Add divider.
-                    if (contentIndex != 0) // Write divider for all but the first content.
-                    {
-                        output.Append(CrLf + "--"); // const strings
-                        output.Append(_boundary);
-                        output.Append(CrLf);
-                    }
-
-                    // Add headers.
-                    foreach (KeyValuePair<string, IEnumerable<string>> headerPair in content.Headers)
-                    {
-                        output.Append(headerPair.Key);
-                        output.Append(": ");
-                        string delim = string.Empty;
-                        foreach (string value in headerPair.Value)
-                        {
-                            output.Append(delim);
-                            output.Append(value);
-                            delim = ", ";
-                        }
-                        output.Append(CrLf);
-                    }
-                    output.Append(CrLf); // Extra CRLF to end headers (even if there are no headers).
-
                     // Write divider, headers, and content.
-                    await EncodeStringToStreamAsync(stream, output.ToString()).ConfigureAwait(false);
+                    HttpContent content = _nestedContent[contentIndex];
+                    await EncodeStringToStreamAsync(stream, SerializeHeadersToString(output, contentIndex, content)).ConfigureAwait(false);
                     await content.CopyToAsync(stream).ConfigureAwait(false);
                 }
 
@@ -229,10 +204,92 @@ namespace System.Net.Http
             }
         }
 
+        protected override async Task<Stream> CreateContentReadStreamAsync()
+        {
+            try
+            {
+                var streams = new Stream[2 + (_nestedContent.Count*2)];
+                var scratch = new StringBuilder();
+                int streamIndex = 0;
+
+                // Start boundary.
+                streams[streamIndex++] = EncodeStringToNewStream("--" + _boundary + CrLf);
+
+                // Each nested content.
+                for (int contentIndex = 0; contentIndex < _nestedContent.Count; contentIndex++)
+                {
+                    HttpContent nestedContent = _nestedContent[contentIndex];
+                    streams[streamIndex++] = EncodeStringToNewStream(SerializeHeadersToString(scratch, contentIndex, nestedContent));
+
+                    Stream readStream = (await nestedContent.ReadAsStreamAsync().ConfigureAwait(false)) ?? new MemoryStream();
+                    if (!readStream.CanSeek)
+                    {
+                        // Seekability impacts whether HttpClientHandlers are able to rewind.  To maintain compat
+                        // and to allow such use cases when a nested stream isn't seekable (which should be rare),
+                        // we fall back to the base behavior.  We don't dispose of the streams already obtained
+                        // as we don't necessarily own them yet.
+                        return await base.CreateContentReadStreamAsync().ConfigureAwait(false);
+                    }
+                    streams[streamIndex++] = readStream;
+                }
+
+                // Footer boundary.
+                streams[streamIndex] = EncodeStringToNewStream(CrLf + "--" + _boundary + "--" + CrLf);
+
+                return new ContentReadStream(streams);
+            }
+            catch (Exception ex)
+            {
+                if (NetEventSource.Log.IsEnabled())
+                {
+                    NetEventSource.Exception(NetEventSource.ComponentType.Http, this, nameof(CreateContentReadStreamAsync), ex);
+                }
+                throw;
+            }
+        }
+
+        private string SerializeHeadersToString(StringBuilder scratch, int contentIndex, HttpContent content)
+        {
+            scratch.Clear();
+
+            // Add divider.
+            if (contentIndex != 0) // Write divider for all but the first content.
+            {
+                scratch.Append(CrLf + "--"); // const strings
+                scratch.Append(_boundary);
+                scratch.Append(CrLf);
+            }
+
+            // Add headers.
+            foreach (KeyValuePair<string, IEnumerable<string>> headerPair in content.Headers)
+            {
+                scratch.Append(headerPair.Key);
+                scratch.Append(": ");
+                string delim = string.Empty;
+                foreach (string value in headerPair.Value)
+                {
+                    scratch.Append(delim);
+                    scratch.Append(value);
+                    delim = ", ";
+                }
+                scratch.Append(CrLf);
+            }
+
+            // Extra CRLF to end headers (even if there are no headers).
+            scratch.Append(CrLf);
+
+            return scratch.ToString();
+        }
+
         private static Task EncodeStringToStreamAsync(Stream stream, string input)
         {
             byte[] buffer = HttpRuleParser.DefaultHttpEncoding.GetBytes(input);
             return stream.WriteAsync(buffer, 0, buffer.Length);
+        }
+
+        private static Stream EncodeStringToNewStream(string input)
+        {
+            return new MemoryStream(HttpRuleParser.DefaultHttpEncoding.GetBytes(input), writable: false);
         }
 
         protected internal override bool TryComputeLength(out long length)
@@ -299,6 +356,201 @@ namespace System.Net.Http
         private static int GetEncodedLength(string input)
         {
             return HttpRuleParser.DefaultHttpEncoding.GetByteCount(input);
+        }
+
+        private sealed class ContentReadStream : Stream
+        {
+            private readonly Stream[] _streams;
+            private readonly long _length;
+
+            private int _next;
+            private Stream _current;
+            private long _position;
+
+            internal ContentReadStream(Stream[] streams)
+            {
+                Debug.Assert(streams != null);
+                _streams = streams;
+                foreach (Stream stream in streams)
+                {
+                    _length += stream.Length;
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    foreach (Stream s in _streams)
+                    {
+                        s.Dispose();
+                    }
+                }
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => true;
+            public override bool CanWrite => false;
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                ValidateReadArgs(buffer, offset, count);
+                if (count == 0)
+                {
+                    return 0;
+                }
+
+                while (true)
+                {
+                    if (_current != null)
+                    {
+                        int bytesRead = _current.Read(buffer, offset, count);
+                        if (bytesRead != 0)
+                        {
+                            _position += bytesRead;
+                            return bytesRead;
+                        }
+
+                        _current = null;
+                    }
+
+                    if (_next >= _streams.Length)
+                    {
+                        return 0;
+                    }
+
+                    _current = _streams[_next++];
+                }
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                ValidateReadArgs(buffer, offset, count);
+                return ReadAsyncPrivate(buffer, offset, count, cancellationToken);
+            }
+
+            public async Task<int> ReadAsyncPrivate(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                if (count == 0)
+                {
+                    return 0;
+                }
+
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (_current != null)
+                    {
+                        int bytesRead = await _current.ReadAsync(buffer, offset, count).ConfigureAwait(false);
+                        if (bytesRead != 0)
+                        {
+                            _position += bytesRead;
+                            return bytesRead;
+                        }
+
+                        _current = null;
+                    }
+
+                    if (_next >= _streams.Length)
+                    {
+                        return 0;
+                    }
+
+                    _current = _streams[_next++];
+                }
+            }
+
+            public override long Position
+            {
+                get { return _position; }
+                set
+                {
+                    if (value < 0)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(value));
+                    }
+
+                    long previousStreamsLength = 0;
+                    for (int i = 0; i < _streams.Length; i++)
+                    {
+                        Stream curStream = _streams[i];
+                        long curLength = curStream.Length;
+
+                        if (value < previousStreamsLength + curLength)
+                        {
+                            _current = curStream;
+                            i++;
+                            _next = i;
+
+                            curStream.Position = value - previousStreamsLength;
+                            for (; i < _streams.Length; i++)
+                            {
+                                _streams[i].Position = 0;
+                            }
+
+                            _position = value;
+                            return;
+                        }
+
+                        previousStreamsLength += curLength;
+                    }
+
+                    _current = null;
+                    _next = _streams.Length;
+                    _position = value;
+                }
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                switch (origin)
+                {
+                    case SeekOrigin.Begin:
+                        Position = offset;
+                        break;
+
+                    case SeekOrigin.Current:
+                        Position += offset;
+                        break;
+
+                    case SeekOrigin.End:
+                        Position = _length + offset;
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(origin));
+                }
+
+                return Position;
+            }
+
+            public override long Length => _length;
+
+            private static void ValidateReadArgs(byte[] buffer, int offset, int count)
+            {
+                if (buffer == null)
+                {
+                    throw new ArgumentNullException(nameof(buffer));
+                }
+                if (offset < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(offset));
+                }
+                if (count < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(count));
+                }
+                if (offset > buffer.Length - count)
+                {
+                    throw new ArgumentException(SR.net_http_buffer_insufficient_length, nameof(buffer));
+                }
+            }
+
+            public override void Flush() { }
+            public override void SetLength(long value) { throw new NotSupportedException(); }
+            public override void Write(byte[] buffer, int offset, int count) { throw new NotSupportedException(); }
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) { throw new NotSupportedException(); }
         }
         #endregion Serialization
     }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1002,6 +1002,15 @@ namespace System.Net.Http.Functional.Tests
                         yield return new object[] { server, new StreamContentWithSyncAsyncCopy(memStream, syncCopy: syncCopy), data };
                     }
 
+                    // A multipart content that provides its own stream from CreateContentReadStreamAsync
+                    {
+                        var mc = new MultipartContent();
+                        mc.Add(new ByteArrayContent(data));
+                        var memStream = new MemoryStream();
+                        mc.CopyToAsync(memStream).GetAwaiter().GetResult();
+                        yield return new object[] { server, mc, memStream.ToArray() };
+                    }
+
                     // A stream that provides the data synchronously and has a known length
                     {
                         var wrappedMemStream = new MemoryStream(data, writable: false);

--- a/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
@@ -34,12 +34,12 @@ namespace System.Net.Http.Functional.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => new MultipartContent("Some",
                 "LongerThan70CharactersLongerThan70CharactersLongerThan70CharactersLongerThan70CharactersLongerThan70Characters"));
         }
-        
+
         [Fact]
         public void Ctor_BadBoundary_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "EndsInSpace "));
-            
+
             // Invalid chars CTLs HT < > @ ; \ " [ ] { } ! # $ % & ^ ~ `
             Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "a\t"));
             Assert.Throws<ArgumentException>(() => new MultipartContent("Some", "<"));
@@ -126,20 +126,24 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(1, mock.DisposeCount);
         }
 
-        [Fact]
-        public async Task ReadAsStringAsync_NoSubContent_MatchesExpected()
+        [Theory]
+        [InlineData(MultipartContentToStringMode.ReadAsStreamAsync)]
+        [InlineData(MultipartContentToStringMode.CopyToAsync)]
+        public async Task ReadAsStringAsync_NoSubContent_MatchesExpected(MultipartContentToStringMode mode)
         {
             var mc = new MultipartContent("someSubtype", "theBoundary");
 
             Assert.Equal(
                 "--theBoundary\r\n" +
                 "\r\n" +
-                "--theBoundary--\r\n", 
-                await mc.ReadAsStringAsync());
+                "--theBoundary--\r\n",
+                await MultipartContentToStringAsync(mc, mode));
         }
 
-        [Fact]
-        public async Task ReadAsStringAsync_OneSubContentWithHeaders_MatchesExpected()
+        [Theory]
+        [InlineData(MultipartContentToStringMode.ReadAsStreamAsync)]
+        [InlineData(MultipartContentToStringMode.CopyToAsync)]
+        public async Task ReadAsStringAsync_OneSubContentWithHeaders_MatchesExpected(MultipartContentToStringMode mode)
         {
             var subContent = new ByteArrayContent(Encoding.UTF8.GetBytes("This is a ByteArrayContent"));
             subContent.Headers.Add("someHeaderName", "andSomeHeaderValue");
@@ -156,12 +160,14 @@ namespace System.Net.Http.Functional.Tests
                 "oneMoreHeader: withNotOne, AndNotTwo, butThreeValues\r\n" +
                 "\r\n" +
                 "This is a ByteArrayContent\r\n" +
-                "--theBoundary--\r\n", 
-                await mc.ReadAsStringAsync());
+                "--theBoundary--\r\n",
+                await MultipartContentToStringAsync(mc, mode));
         }
 
-        [Fact]
-        public async Task ReadAsStringAsync_TwoSubContents_MatchesExpected()
+        [Theory]
+        [InlineData(MultipartContentToStringMode.ReadAsStreamAsync)]
+        [InlineData(MultipartContentToStringMode.CopyToAsync)]
+        public async Task ReadAsStringAsync_TwoSubContents_MatchesExpected(MultipartContentToStringMode mode)
         {
             var mc = new MultipartContent("someSubtype", "theBoundary");
             mc.Add(new ByteArrayContent(Encoding.UTF8.GetBytes("This is a ByteArrayContent")));
@@ -176,10 +182,207 @@ namespace System.Net.Http.Functional.Tests
                 "\r\n" +
                 "This is a StringContent\r\n" +
                 "--theBoundary--\r\n",
-                await mc.ReadAsStringAsync());
+                await MultipartContentToStringAsync(mc, mode));
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_LargeContent_AllBytesRead()
+        {
+            var form = new MultipartFormDataContent();
+
+            const long PerContent = 1024 * 1024;
+            const long ContentCount = 2048;
+
+            var bytes = new byte[PerContent];
+            for (int i = 0; i < ContentCount; i++)
+            {
+                form.Add(new ByteArrayContent(bytes), "file", Guid.NewGuid().ToString());
+            }
+
+            long totalAsyncRead = 0, totalSyncRead = 0;
+            int bytesRead;
+
+            using (Stream s = await form.ReadAsStreamAsync())
+            {
+                s.Position = 0;
+                while ((bytesRead = await s.ReadAsync(bytes, 0, bytes.Length)) > 0)
+                {
+                    totalAsyncRead += bytesRead;
+                }
+
+                s.Position = 0;
+                while ((bytesRead = s.Read(bytes, 0, bytes.Length)) > 0)
+                {
+                    totalSyncRead += bytesRead;
+                }
+            }
+
+            Assert.Equal(totalAsyncRead, totalSyncRead);
+            Assert.InRange(totalAsyncRead, PerContent * ContentCount, long.MaxValue); 
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task ReadAsStreamAsync_CanSeekEvenIfAllStreamsNotSeekale(bool firstContentSeekable, bool secondContentSeekable)
+        {
+            var c = new MultipartContent();
+            c.Add(new StreamContent(firstContentSeekable ? new MemoryStream(new byte[42]) : new NonSeekableMemoryStream(new byte[42])));
+            c.Add(new StreamContent(secondContentSeekable ? new MemoryStream(new byte[42]) : new NonSeekableMemoryStream(new byte[1])));
+            using (Stream s = await c.ReadAsStreamAsync())
+            {
+                Assert.True(s.CanSeek);
+                Assert.InRange(s.Length, 43, int.MaxValue);
+
+                s.Position = 1;
+                Assert.Equal(1, s.Position);
+
+                s.Seek(20, SeekOrigin.Current);
+                Assert.Equal(21, s.Position);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ReadAsStreamAsync_Seek_JumpsToSpecifiedPosition(bool nestedContent)
+        {
+            var mc = new MultipartContent();
+            if (nestedContent)
+            {
+                mc.Add(new ByteArrayContent(Encoding.UTF8.GetBytes("This is a ByteArrayContent")));
+                mc.Add(new StringContent("This is a StringContent"));
+                mc.Add(new ByteArrayContent(Encoding.UTF8.GetBytes("Another ByteArrayContent :-)")));
+            }
+
+            var memStream = new MemoryStream();
+            await mc.CopyToAsync(memStream);
+
+            byte[] buf1 = new byte[1], buf2 = new byte[1];
+            using (Stream s = await mc.ReadAsStreamAsync())
+            {
+                var targets = new[]
+                {
+                    new { Origin = SeekOrigin.Begin, Offset = memStream.Length / 2 },
+                    new { Origin = SeekOrigin.Begin, Offset = memStream.Length - 1 },
+                    new { Origin = SeekOrigin.Begin, Offset = memStream.Length },
+                    new { Origin = SeekOrigin.Begin, Offset = memStream.Length + 1 },
+                    new { Origin = SeekOrigin.Begin, Offset = 0L },
+                    new { Origin = SeekOrigin.Begin, Offset = 1L },
+
+                    new { Origin = SeekOrigin.Current, Offset = 1L },
+                    new { Origin = SeekOrigin.Current, Offset = 2L },
+                    new { Origin = SeekOrigin.Current, Offset = -2L },
+                    new { Origin = SeekOrigin.Current, Offset = 0L },
+                    new { Origin = SeekOrigin.Current, Offset = 1000L },
+
+                    new { Origin = SeekOrigin.End, Offset = 0L },
+                    new { Origin = SeekOrigin.End, Offset = memStream.Length },
+                    new { Origin = SeekOrigin.End, Offset = memStream.Length / 2 },
+                };
+                foreach (var target in targets)
+                {
+                    memStream.Seek(target.Offset, target.Origin);
+                    s.Seek(target.Offset, target.Origin);
+                    Assert.Equal(memStream.Position, s.Position);
+
+                    Assert.Equal(memStream.Read(buf1, 0, 1), s.Read(buf2, 0, 1));
+                    Assert.Equal(buf1[0], buf2[0]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_InvalidArgs_Throw()
+        {
+            var mc = new MultipartContent();
+            using (Stream s = await mc.ReadAsStreamAsync())
+            {
+                Assert.True(s.CanRead);
+                Assert.False(s.CanWrite);
+                Assert.True(s.CanSeek);
+
+                Assert.Throws<ArgumentNullException>("buffer", () => s.Read(null, 0, 0));
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => s.Read(new byte[1], -1, 0));
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => s.Read(new byte[1], 0, -1));
+                Assert.Throws<ArgumentException>("buffer", () => s.Read(new byte[1], 1, 1));
+
+                Assert.Throws<ArgumentNullException>("buffer", () => { s.ReadAsync(null, 0, 0); });
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => { s.ReadAsync(new byte[1], -1, 0); });
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => { s.ReadAsync(new byte[1], 0, -1); });
+                Assert.Throws<ArgumentException>("buffer", () => { s.ReadAsync(new byte[1], 1, 1); });
+
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => s.Position = -1);
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => s.Seek(-1, SeekOrigin.Begin));
+                Assert.Throws<ArgumentOutOfRangeException>("origin", () => s.Seek(0, (SeekOrigin)42));
+
+                Assert.Throws<NotSupportedException>(() => s.Write(new byte[1], 0, 0));
+                Assert.Throws<NotSupportedException>(() => { s.WriteAsync(new byte[1], 0, 0); });
+                Assert.Throws<NotSupportedException>(() => s.SetLength(1));
+            }
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_OperationsThatDontChangePosition()
+        {
+            var mc = new MultipartContent();
+            using (Stream s = await mc.ReadAsStreamAsync())
+            {
+                Assert.Equal(0, s.Read(new byte[1], 0, 0));
+                Assert.Equal(0, s.Position);
+
+                Assert.Equal(0, await s.ReadAsync(new byte[1], 0, 0));
+                Assert.Equal(0, s.Position);
+
+                s.Flush();
+                Assert.Equal(0, s.Position);
+
+                await s.FlushAsync();
+                Assert.Equal(0, s.Position);
+            }
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_CreateContentReadStreamAsyncThrows_ExceptionStoredInTask()
+        {
+            var mc = new MultipartContent();
+            mc.Add(new MockContent());
+            Task t = mc.ReadAsStreamAsync();
+            await Assert.ThrowsAsync<NotImplementedException>(() => t);
         }
 
         #region Helpers
+
+        private static async Task<string> MultipartContentToStringAsync(MultipartContent content, MultipartContentToStringMode mode)
+        {
+            Stream stream;
+
+            switch (mode)
+            {
+                case MultipartContentToStringMode.ReadAsStreamAsync:
+                    stream = await content.ReadAsStreamAsync();
+                    break;
+
+                default:
+                    stream = new MemoryStream();
+                    await content.CopyToAsync(stream);
+                    stream.Position = 0;
+                    break;
+            }
+
+            using (var reader = new StreamReader(stream))
+            {
+                return await reader.ReadToEndAsync();
+            }
+        }
+
+        public enum MultipartContentToStringMode
+        {
+            ReadAsStreamAsync,
+            CopyToAsync
+        }
 
         private class MockContent : HttpContent
         {
@@ -202,6 +405,17 @@ namespace System.Net.Http.Functional.Tests
             {
                 throw new NotImplementedException();
             }
+
+            protected override Task<Stream> CreateContentReadStreamAsync()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private sealed class NonSeekableMemoryStream : MemoryStream
+        {
+            public NonSeekableMemoryStream(byte[] data) : base(data) { }
+            public override bool CanSeek => false;
         }
 
         #endregion Helpers


### PR DESCRIPTION
MultipartContent doesn't override CreateContentReadStreamAsync.  This means that a ReadAsStreamAsync operation will end up serializing all of the content to a MemoryStream, which can be problematic for very large content, preventing such content from being uploaded with some HttpClientHandlers.  This change overrides CreateContentReadStreamAsync to use a custom stream that delegates to all of the inner streams from each content.

Fixes https://github.com/dotnet/corefx/issues/9370
cc: @davidsh, @cipop, @ericeil