### PR TITLE
Fixed a Bug with Using PreserveObjectReferences with IsReference=true

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerWriteContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerWriteContext.cs
@@ -232,7 +232,7 @@ namespace System.Runtime.Serialization
 
         internal bool OnHandleIsReference(XmlWriterDelegator xmlWriter, DataContract contract, object obj)
         {
-            if (!contract.IsReference || _isGetOnlyCollection)
+            if (preserveObjectReferences || !contract.IsReference || _isGetOnlyCollection)
             {
                 return false;
             }

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2892,3 +2892,19 @@ public class TypeWithXmlNodeArrayProperty
     [XmlText]
     public XmlNode[] CDATA { get; set; }
 }
+
+[DataContract]
+public class TypeWithListOfReferenceChildren
+{
+    [DataMember]
+    public List<TypeOfReferenceChild> Children { get; set; }
+}
+
+[DataContract(IsReference = true)]
+public class TypeOfReferenceChild
+{
+    [DataMember]
+    public TypeWithListOfReferenceChildren Root { get; set; }
+    [DataMember]
+    public string Name { get; set; }
+}


### PR DESCRIPTION
Fixed a bug with using PreserveObjectReferences with IsReference=true Type.

The root cause of issue #9397 is a bug we have when using PreserveObjectReferences with types having IsReference=true. The fix is to respect PreserveObjectReferences only if both PreserveObjectReferences and IsReference are true.

Added 4 test cases for using PreserveObjectReferences.

Fixed #9397