### PR TITLE
More perf improvements for managed WebSocket client on Unix

### DIFF
--- a/src/System.Net.WebSockets.Client/src/Resources/Strings.resx
+++ b/src/System.Net.WebSockets.Client/src/Resources/Strings.resx
@@ -129,59 +129,17 @@
   <data name="net_Websockets_AlreadyOneOutstandingOperation" xml:space="preserve">
     <value>There is already one outstanding '{0}' call for this WebSocket instance. ReceiveAsync and SendAsync can be called simultaneously, but at most one outstanding operation for each of them is allowed at the same time.</value>
   </data>
-  <data name="net_Websockets_WebSocketBaseFaulted" xml:space="preserve">
-    <value>An exception caused the WebSocket to enter the Aborted state. Please see the InnerException, if present, for more details.</value>
-  </data>
-  <data name="net_WebSockets_NativeSendResponseHeaders" xml:space="preserve">
-    <value>An error occurred when sending the WebSocket HTTP upgrade response during the {0} operation. The HRESULT returned is '{1}'</value>
-  </data>
   <data name="net_WebSockets_Generic" xml:space="preserve">
     <value>An internal WebSocket error occurred. Please see the innerException, if present, for more details. </value>
-  </data>
-  <data name="net_WebSockets_NotAWebSocket_Generic" xml:space="preserve">
-    <value>A WebSocket operation was called on a request or response that is not a WebSocket.</value>
-  </data>
-  <data name="net_WebSockets_UnsupportedWebSocketVersion_Generic" xml:space="preserve">
-    <value>Unsupported WebSocket version.</value>
-  </data>
-  <data name="net_WebSockets_HeaderError_Generic" xml:space="preserve">
-    <value>The WebSocket request or response contained unsupported header(s). </value>
-  </data>
-  <data name="net_WebSockets_UnsupportedProtocol_Generic" xml:space="preserve">
-    <value>The WebSocket request or response operation was called with unsupported protocol(s). </value>
   </data>
   <data name="net_WebSockets_UnsupportedPlatform" xml:space="preserve">
     <value>The WebSocket protocol is not supported on this platform.</value>
   </data>
-  <data name="net_WebSockets_AcceptNotAWebSocket" xml:space="preserve">
-    <value>The {0} operation was called on an incoming request that did not specify a '{1}: {2}' header or the {2} header not contain '{3}'. {2} specified by the client was '{4}'.</value>
-  </data>
-  <data name="net_WebSockets_AcceptUnsupportedWebSocketVersion" xml:space="preserve">
-    <value>The {0} operation was called on an incoming request with WebSocket version '{1}', expected '{2}'. </value>
-  </data>
-  <data name="net_WebSockets_AcceptHeaderNotFound" xml:space="preserve">
-    <value>The {0} operation was called on an incoming WebSocket request without required '{1}' header. </value>
-  </data>
   <data name="net_WebSockets_AcceptUnsupportedProtocol" xml:space="preserve">
     <value>The WebSocket client request requested '{0}' protocol(s), but server is only accepting '{1}' protocol(s).</value>
   </data>
-  <data name="net_WebSockets_ClientAcceptingNoProtocols" xml:space="preserve">
-    <value>The WebSocket client did not request any protocols, but server attempted to accept '{0}' protocol(s). </value>
-  </data>
-  <data name="net_WebSockets_ClientSecWebSocketProtocolsBlank" xml:space="preserve">
-    <value>The WebSocket client sent a blank '{0}' header; this is not allowed by the WebSocket protocol specification. The client should omit the header if the client is not negotiating any sub-protocols. </value>
-  </data>
   <data name="net_WebSockets_ArgumentOutOfRange_TooSmall" xml:space="preserve">
     <value>The argument must be a value greater than {0}.</value>
-  </data>
-  <data name="net_WebSockets_ArgumentOutOfRange_InternalBuffer" xml:space="preserve">
-    <value>The byte array must have a length of at least '{0}' bytes.  </value>
-  </data>
-  <data name="net_WebSockets_ArgumentOutOfRange_TooBig" xml:space="preserve">
-    <value>The value of the '{0}' parameter ({1}) must be less than or equal to {2}.</value>
-  </data>
-  <data name="net_WebSockets_InvalidState_Generic" xml:space="preserve">
-    <value>The WebSocket instance cannot be used for communication because it has been transitioned into an invalid state.</value>
   </data>
   <data name="net_WebSockets_InvalidState_ClosedOrAborted" xml:space="preserve">
     <value>The '{0}' instance cannot be used for communication because it has been transitioned into the '{1}' state.</value>
@@ -189,23 +147,11 @@
   <data name="net_WebSockets_InvalidState" xml:space="preserve">
     <value>The WebSocket is in an invalid state ('{0}') for this operation. Valid states are: '{1}'</value>
   </data>
-  <data name="net_WebSockets_ReceiveAsyncDisallowedAfterCloseAsync" xml:space="preserve">
-    <value>The WebSocket is in an invalid state for this operation. The '{0}' method has already been called before on this instance. Use '{1}' instead to keep being able to receive data but close the output channel.</value>
-  </data>
   <data name="net_WebSockets_InvalidMessageType" xml:space="preserve">
     <value>The received message type '{2}' is invalid after calling {0}. {0} should only be used if no more data is expected from the remote endpoint. Use '{1}' instead to keep being able to receive data but close the output channel.</value>
   </data>
-  <data name="net_WebSockets_InvalidBufferType" xml:space="preserve">
-    <value>The buffer type '{0}' is invalid. Valid buffer types are: '{1}', '{2}', '{3}', '{4}', '{5}'.</value>
-  </data>
-  <data name="net_WebSockets_InvalidMessageType_Generic" xml:space="preserve">
-    <value>The received  message type is invalid after calling {0}. {0} should only be used if no more data is expected from the remote endpoint. Use '{1}' instead to keep being able to receive data but close the output channel.</value>
-  </data>
   <data name="net_WebSockets_Argument_InvalidMessageType" xml:space="preserve">
     <value>The message type '{0}' is not allowed for the '{1}' operation. Valid message types are: '{2}, {3}'. To close the WebSocket, use the '{4}' operation instead. </value>
-  </data>
-  <data name="net_WebSockets_ConnectionClosedPrematurely_Generic" xml:space="preserve">
-    <value>The remote party closed the WebSocket connection without completing the close handshake.</value>
   </data>
   <data name="net_WebSockets_InvalidCharInProtocolString" xml:space="preserve">
     <value>The WebSocket protocol '{0}' is invalid because it contains the invalid character '{1}'.</value>
@@ -228,17 +174,11 @@
   <data name="net_WebSockets_AlreadyStarted" xml:space="preserve">
     <value>The WebSocket has already been started.</value>
   </data>
-  <data name="net_WebSockets_Connect101Expected" xml:space="preserve">
-    <value>The server returned status code '{0}' when status code '101' was expected.</value>
-  </data>
   <data name="net_WebSockets_InvalidResponseHeader" xml:space="preserve">
     <value>The '{0}' header value '{1}' is invalid.</value>
   </data>
   <data name="net_WebSockets_NotConnected" xml:space="preserve">
     <value>The WebSocket is not connected.</value>
-  </data>
-  <data name="net_WebSockets_InvalidRegistration" xml:space="preserve">
-    <value>The WebSocket schemes must be registered with the HttpWebRequest class.</value>
   </data>
   <data name="net_WebSockets_NoDuplicateProtocol" xml:space="preserve">
     <value>Duplicate protocols are not allowed: '{0}'.</value>

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocket.cs
@@ -162,7 +162,7 @@ namespace System.Net.WebSockets
             {
                 if (NetEventSource.Log.IsEnabled())
                 {
-                    NetEventSource.Exception(NetEventSource.ComponentType.WebSocket, this, "ConnectAsync", ex);
+                    NetEventSource.Exception(NetEventSource.ComponentType.WebSocket, this, nameof(ConnectAsync), ex);
                 }
                 throw;
             }
@@ -177,16 +177,16 @@ namespace System.Net.WebSockets
             {
                 string errorMessage = SR.Format(
                         SR.net_WebSockets_Argument_InvalidMessageType,
-                        "Close",
-                        "SendAsync",
-                        "Binary",
-                        "Text",
-                        "CloseOutputAsync");
+                        nameof(WebSocketMessageType.Close),
+                        nameof(SendAsync),
+                        nameof(WebSocketMessageType.Binary),
+                        nameof(WebSocketMessageType.Text),
+                        nameof(CloseOutputAsync));
 
                 throw new ArgumentException(errorMessage, nameof(messageType));
             }
 
-            WebSocketValidate.ValidateArraySegment<byte>(buffer, "buffer");
+            WebSocketValidate.ValidateArraySegment<byte>(buffer, nameof(buffer));
             return _innerWebSocket.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
         }
 
@@ -194,7 +194,7 @@ namespace System.Net.WebSockets
             CancellationToken cancellationToken)
         {
             ThrowIfNotConnected();
-            WebSocketValidate.ValidateArraySegment<byte>(buffer, "buffer");
+            WebSocketValidate.ValidateArraySegment<byte>(buffer, nameof(buffer));
             return _innerWebSocket.ReceiveAsync(buffer, cancellationToken);
         }
 

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 
@@ -121,8 +118,7 @@ namespace System.Net.WebSockets
             {
                 if (string.Equals(item, subProtocol, StringComparison.OrdinalIgnoreCase))
                 {
-                    throw new ArgumentException(SR.Format(SR.net_WebSockets_NoDuplicateProtocol, subProtocol),
-nameof(subProtocol));
+                    throw new ArgumentException(SR.Format(SR.net_WebSockets_NoDuplicateProtocol, subProtocol), nameof(subProtocol));
                 }
             }
             _requestedSubProtocols.Add(subProtocol);

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
@@ -243,7 +243,7 @@ namespace System.Net.WebSockets
                 {
                     // Connect over TCP to the remote server
                     await _client.ConnectAsync(uri.Host, uri.Port).ConfigureAwait(false);
-                    _stream = _client.GetStream();
+                    _stream = new AsyncEventArgsNetworkStream(_client.Client);
 
                     // Upgrade to SSL if needed
                     if (uri.Scheme == UriScheme.Wss)
@@ -1358,7 +1358,123 @@ namespace System.Net.WebSockets
                 public bool Fin;
                 public long PayloadLength;
             }
+
+            /// <summary>
+            /// A custom network stream that stores and reuses a single SocketAsyncEventArgs instance
+            /// for reads and a single SocketAsyncEventArgs instance for writes.  This limits it to
+            /// supporting a single read and a single write at a time, but with much less per-operation
+            /// overhead than with System.Net.Sockets.NetworkStream.
+            /// </summary>
+            private sealed class AsyncEventArgsNetworkStream : NetworkStream
+            {
+                private readonly Socket _socket;
+                private readonly SocketAsyncEventArgs _readArgs;
+                private readonly SocketAsyncEventArgs _writeArgs;
+
+                private AsyncTaskMethodBuilder<int> _readTcs;
+                private AsyncTaskMethodBuilder _writeTcs;
+                private bool _disposed;
+
+                public AsyncEventArgsNetworkStream(Socket socket) : base(socket)
+                {
+                    _socket = socket;
+
+                    _readArgs = new SocketAsyncEventArgs();
+                    _readArgs.Completed += ReadCompleted;
+
+                    _writeArgs = new SocketAsyncEventArgs();
+                    _writeArgs.Completed += WriteCompleted;
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    base.Dispose(disposing);
+
+                    if (disposing && !_disposed)
+                    {
+                        _disposed = true;
+                        try
+                        {
+                            _readArgs.Dispose();
+                            _writeArgs.Dispose();
+                        }
+                        catch (ObjectDisposedException) { }
+                    }
+                }
+
+                public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return Task.FromCanceled<int>(cancellationToken);
+                    }
+
+                    _readTcs = new AsyncTaskMethodBuilder<int>();
+                    Task<int> t = _readTcs.Task;
+
+                    _readArgs.SetBuffer(buffer, offset, count);
+                    if (!_socket.ReceiveAsync(_readArgs))
+                    {
+                        ReadCompleted(null, _readArgs);
+                    }
+
+                    return t;
+                }
+
+                private void ReadCompleted(object sender, SocketAsyncEventArgs e)
+                {
+                    if (e.SocketError == SocketError.Success)
+                    {
+                        _readTcs.SetResult(e.BytesTransferred);
+                    }
+                    else
+                    {
+                        _readTcs.SetException(_disposed ? (Exception)
+                            new ObjectDisposedException(GetType().Name) :
+                            new IOException(SR.net_WebSockets_Generic, new SocketException((int)e.SocketError)));
+                    }
+                }
+
+                public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return Task.FromCanceled(cancellationToken);
+                    }
+
+                    _writeTcs = new AsyncTaskMethodBuilder();
+                    Task t = _writeTcs.Task;
+
+                    _writeArgs.SetBuffer(buffer, offset, count);
+                    if (!_socket.SendAsync(_writeArgs))
+                    {
+                        // TODO: #4900 This path should be hit very frequently (sends should very frequently simply
+                        // write into the kernel's send buffer), but it's practically never getting hit due to the current
+                        // System.Net.Sockets.dll implementation that always completing asynchronously on success :(
+                        // If that doesn't get fixed, we should try to come up with some alternative here.  This is
+                        // an important path, in part as it means the caller will complete awaits synchronously rather
+                        // than spending the costs associated with yielding in each async method up the call chain.
+                        // (This applies to ReadAsync as well, but typically to a much less extent.)
+                        WriteCompleted(null, _writeArgs);
+                    }
+
+                    return t;
+                }
+
+                private void WriteCompleted(object sender, SocketAsyncEventArgs e)
+                {
+                    if (e.SocketError == SocketError.Success)
+                    {
+                        _writeTcs.SetResult();
+                    }
+                    else
+                    {
+                        _writeTcs.SetException(_disposed ? (Exception)
+                            new ObjectDisposedException(GetType().Name) :
+                            new IOException(SR.net_WebSockets_Generic, new SocketException((int)e.SocketError)));
+                    }
+                }
+            }
         }
     }
 }
-

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
@@ -57,7 +57,7 @@ namespace System.Net.WebSockets
         public void Abort() => _webSocket.Abort();
 
         /// <summary>A managed implementation of a client web socket.</summary>
-        private sealed class ManagedClientWebSocket : WebSocket
+        private sealed class ManagedClientWebSocket
         {
             /// <summary>Per-thread cached StringBuilder for building of strings to send on the connection.</summary>
             [ThreadStatic]
@@ -205,7 +205,7 @@ namespace System.Net.WebSockets
                 }, this);
             }
 
-            public override void Dispose()
+            public void Dispose()
             {
                 if (!_disposed)
                 {
@@ -217,13 +217,13 @@ namespace System.Net.WebSockets
                 }
             }
 
-            public override WebSocketCloseStatus? CloseStatus => _closeStatus;
+            public WebSocketCloseStatus? CloseStatus => _closeStatus;
 
-            public override string CloseStatusDescription => _closeStatusDescription;
+            public string CloseStatusDescription => _closeStatusDescription;
 
-            public override WebSocketState State => _state;
+            public WebSocketState State => _state;
 
-            public override string SubProtocol => _subprotocol;
+            public string SubProtocol => _subprotocol;
 
             public async Task ConnectAsync(Uri uri, CancellationToken cancellationToken, ClientWebSocketOptions options)
             {
@@ -305,7 +305,7 @@ namespace System.Net.WebSockets
                 }
             }
 
-            public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+            public Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
             {
                 try
                 {
@@ -323,7 +323,7 @@ namespace System.Net.WebSockets
                 return t;
             }
 
-            public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+            public Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
             {
                 try
                 {
@@ -340,7 +340,7 @@ namespace System.Net.WebSockets
                 return t;
             }
 
-            public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+            public Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
             {
                 try
                 {
@@ -354,7 +354,7 @@ namespace System.Net.WebSockets
                 return CloseAsyncPrivate(closeStatus, statusDescription, cancellationToken);
             }
 
-            public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+            public Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
             {
                 try
                 {
@@ -368,7 +368,7 @@ namespace System.Net.WebSockets
                 return SendCloseFrameAsync(closeStatus, statusDescription, cancellationToken);
             }
 
-            public override void Abort()
+            public void Abort()
             {
                 _abortSource.Cancel();
                 Dispose(); // forcibly tear down connection

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
@@ -478,7 +478,7 @@ namespace System.Net.WebSockets
                 // If the status line doesn't begin with "HTTP/1.1" or isn't long enough to contain a status code, fail.
                 if (!statusLine.StartsWith(ExpectedStatusStart, StringComparison.Ordinal) || statusLine.Length < ExpectedStatusStatWithCode.Length)
                 {
-                    throw new WebSocketException(WebSocketError.HeaderError, SR.net_WebSockets_HeaderError_Generic);
+                    throw new WebSocketException(WebSocketError.HeaderError);
                 }
 
                 // If the status line doesn't contain a status code 101, or if it's long enough to have a status description
@@ -500,7 +500,7 @@ namespace System.Net.WebSockets
                     int colonIndex = line.IndexOf(':');
                     if (colonIndex == -1)
                     {
-                        throw new WebSocketException(WebSocketError.HeaderError, SR.net_WebSockets_HeaderError_Generic);
+                        throw new WebSocketException(WebSocketError.HeaderError);
                     }
 
                     string headerName = line.SubstringTrim(0, colonIndex);

--- a/src/System.Net.WebSockets.Client/src/unix/project.json
+++ b/src/System.Net.WebSockets.Client/src/unix/project.json
@@ -13,6 +13,7 @@
         "System.Diagnostics.Tools": "4.0.0",
         "System.Diagnostics.Tracing": "4.0.20",
         "System.Globalization": "4.0.10",
+        "System.Net.NameResolution": "4.0.0",
         "System.Net.Primitives": "4.0.10",
         "System.Net.Sockets": "4.1.0-rc4-24215-01",
         "System.Net.Security": "4.0.0-rc4-24215-01",

--- a/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketException.cs
+++ b/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketException.cs
@@ -137,8 +137,8 @@ namespace System.Net.WebSockets
             {
                 case WebSocketError.InvalidMessageType:
                     return SR.Format(SR.net_WebSockets_InvalidMessageType_Generic,
-                        typeof(WebSocket).Name + "CloseAsync",
-                        typeof(WebSocket).Name + "CloseOutputAsync");
+                        $"{nameof(WebSocket)}.{nameof(WebSocket.CloseAsync)}",
+                        $"{nameof(WebSocket)}.{nameof(WebSocket.CloseOutputAsync)}");
                 case WebSocketError.Faulted:
                     return SR.net_Websockets_WebSocketBaseFaulted;
                 case WebSocketError.NotAWebSocket:

--- a/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketReceiveResult.cs
+++ b/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketReceiveResult.cs
@@ -31,23 +31,10 @@ namespace System.Net.WebSockets
             CloseStatusDescription = closeStatusDescription;
         }
 
-        public int Count { get; private set; }
-        public bool EndOfMessage { get; private set; }
-        public WebSocketMessageType MessageType { get; private set; }
-        public WebSocketCloseStatus? CloseStatus { get; private set; }
-        public string CloseStatusDescription { get; private set; }
-
-        internal WebSocketReceiveResult Copy(int count)
-        {
-            Debug.Assert(count >= 0, "'count' MUST NOT be negative.");
-            Debug.Assert(count <= Count, "'count' MUST NOT be bigger than 'this.Count'.");
-
-            Count -= count;
-            return new WebSocketReceiveResult(count,
-                MessageType,
-                Count == 0 && this.EndOfMessage,
-                CloseStatus,
-                CloseStatusDescription);
-        }
+        public int Count { get; }
+        public bool EndOfMessage { get; }
+        public WebSocketMessageType MessageType { get; }
+        public WebSocketCloseStatus? CloseStatus { get; }
+        public string CloseStatusDescription { get; }
     }
 }


### PR DESCRIPTION
Primary changes:
- NetworkStream's Read/WriteAsync simply uses the underlying Socket's Begin/EndReceive/Send methods, wrapped in tasks.  While that could be optimized further, we have a more constrained scenario in WebSockets, in that we only support a single read at a time and a single write at a time.  As a result, we can create, cache, and reuse a single SocketAsyncEventArgs instance for reading and another for writing, using the socket's Send/ReceiveAsync methods with that cached args instance.  This avoids a bunch of per operation allocation.
- Due to #4900 (and the behavior that was made to match on Unix), successful socket operations never complete synchronously.  This means that code which awaits them typically ends up needing to yield, due to the callbacks being invoked asynchronously, even if the socket operation completed synchronously, which is very likely in the case of a send.  Our SendFrameAsync method suffers from this, as it really just delegates to the socket's send method, albeit with a tiny amount of pre- and post-work.  The real solution is to make it so that Socket.SendAsync can complete synchronously, after which SendFrameAsync will also typically complete synchronously and generally be allocation-free.  Until then, though, since this is a hot path, we can optimize it for the common case to reduce the amount of allocation and general work involved when the socket operation does complete asynchronously.
- For chatty cases where each send expects a receive, it's likely that each receive needs to read from the network.  This means we end up going through several layers of async methods (ReceiveAsyncPrivate, EnsureBufferContainsHeaderAsync, EnsureBufferContainsAsync), which will all end up yielding and allocating when the read on the network doesn't complete synchronously.  Since EnsureBufferContainsHeaderAsync is small and only used from one place, we can avoid all of the allocations associated with it by simply inlining it into its caller (ReceiveAsyncPrivate).

Other miscellaneous:
- Removed the base class from the internal ManagedWebSocket.  It's unnecessary and leads to virtual methods on the instance.  More importantly, though, we end up potentially handing out this instance via a Task's AsyncState, and we don't want folks to be able to cast to the base class and call methods without going through the thin ClientWebSocket wrapper.
- A bunch of resources weren't being used. I deleted them.
- WebSocketReceiveResult had non-readonly backing fields for each of its properties, which had private setters purely to be able to set the properties in the constructor.  Now that we're using C# 6, we can simply make these get-only properties, eliminating the setters and allowing the compiler to make the backing fields readonly.
- Used nameof in a few more places.

Results:
I ran a simple test with a local echo server, where I'd repeatedly send a message and receive its echo.  As a baseline, with the Windows WinHTTP implementation sending and receiving 20,000 messages, I get the following.  Each line is a run of the 20,000 messages, with the first number being the elapsed time and the second number being the number of gen 0 GCs.
```
> corerun WSPerf.exe 28745 20000 1
2.6906097, 5
2.7209642, 5
2.6802832, 5
2.7098154, 5
2.7061351, 6
2.6964876, 5
2.7943476, 5
2.7638309, 5
2.7918148, 5
2.744804, 6
```
Instead using the managed implementation on Windows, before these changes, I got:
```
> corerun WSPerf.exe 28745 20000 1
3.1177403, 22
3.2149994, 22
2.6798198, 23
2.8078613, 23
2.6670316, 24
2.6744515, 23
2.6619906, 24
2.7596847, 23
2.6485313, 24
2.6559615, 23
```
After these changes, using the managed implementation on Windows, I get:
```
> corerun WSPerf.exe 28745 20000 1
2.576682, 9
2.6461474, 9
2.5376302, 9
2.5192637, 9
2.5189807, 10
2.5227088, 9
2.5305238, 9
2.5696738, 9
2.5766855, 9
2.5433629, 9
```

On Linux, I'm using a different local echo server, so the timing numbers aren't directly comparable to the ones on Windows, however before the changes I got:
```
$ ./corerun WSPerf.exe 7681 20000 1
1.6772411, 16
1.2316513, 11
1.1890394, 10
1.7308767, 19
1.1968002, 11
1.5696637, 19
1.5461821, 18
1.2686805, 12
1.1765528, 10
1.124586, 11
```
and after the changes I got:
```
$ ./corerun WSPerf.exe 7681 20000 1
1.2716779, 5
1.0913687, 5
1.0198689, 5
1.1038351, 4
1.0823826, 4
1.0074977, 4
1.0132344, 5
1.0704005, 4
1.1775556, 6
1.0341026, 6
1.0462667, 4
```

At this point I'm not planning to do any more proactive work on improving the send/receive performance, as the performance after these changes on Linux looks to be on par with the Windows implementation.  There are likely more opportunities which can be addressed individually and reactively, including once #4900 is addressed.  There may also be opportunities to improve scenarios other than lots of sending/receiving with the same websocket, e.g. minimizing the overhead associated with creating lots of websockets that each do relatively little work.

cc: @ericeil, @bartonjs, @davidsh, @cipop
Also fixes #9408 and fixes #9407