### PR TITLE
mscorlib facade: first cut

### DIFF
--- a/src/mscorlib/mscorlib.sln
+++ b/src/mscorlib/mscorlib.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6DF80DBD-B979-4B4D-89F1-5C35273809A6}"
+	ProjectSection(SolutionItems) = preProject
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mscorlib", "src\mscorlib.csproj", "{1B8337CE-3B0A-4447-9620-D9B5EE3E552D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1B8337CE-3B0A-4447-9620-D9B5EE3E552D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B8337CE-3B0A-4447-9620-D9B5EE3E552D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B8337CE-3B0A-4447-9620-D9B5EE3E552D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B8337CE-3B0A-4447-9620-D9B5EE3E552D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/mscorlib/ref/mscorlib.depproj
+++ b/src/mscorlib/ref/mscorlib.depproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>net46</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETFramework,Version=v4.6</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/mscorlib/ref/project.json
+++ b/src/mscorlib/ref/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+  },
+  "frameworks": {
+    "net46": { }
+  }
+}

--- a/src/mscorlib/src/ApiCompatBaseline.txt
+++ b/src/mscorlib/src/ApiCompatBaseline.txt
@@ -1,0 +1,2709 @@
+Compat issues with assembly mscorlib:
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey Microsoft.Win32.Registry.DynData' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryHive Microsoft.Win32.RegistryHive.DynData' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'Microsoft.Win32.RegistryKey' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.Close()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.CreateSubKey(System.String, Microsoft.Win32.RegistryKeyPermissionCheck)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.CreateSubKey(System.String, Microsoft.Win32.RegistryKeyPermissionCheck, Microsoft.Win32.RegistryOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.CreateSubKey(System.String, Microsoft.Win32.RegistryKeyPermissionCheck, Microsoft.Win32.RegistryOptions, System.Security.AccessControl.RegistrySecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.CreateSubKey(System.String, Microsoft.Win32.RegistryKeyPermissionCheck, System.Security.AccessControl.RegistrySecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.GetAccessControl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.GetAccessControl(System.Security.AccessControl.AccessControlSections)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.OpenRemoteBaseKey(Microsoft.Win32.RegistryHive, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.OpenRemoteBaseKey(Microsoft.Win32.RegistryHive, System.String, Microsoft.Win32.RegistryView)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.OpenSubKey(System.String, Microsoft.Win32.RegistryKeyPermissionCheck)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.OpenSubKey(System.String, Microsoft.Win32.RegistryKeyPermissionCheck, System.Security.AccessControl.RegistryRights)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.RegistryKey.SetAccessControl(System.Security.AccessControl.RegistrySecurity)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'Microsoft.Win32.RegistryKeyPermissionCheck' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'Microsoft.Win32.SafeHandles.CriticalHandleMinusOneIsInvalid' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'Microsoft.Win32.SafeHandles.CriticalHandleZeroOrMinusOneIsInvalid' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'Microsoft.Win32.SafeHandles.SafeAccessTokenHandle' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'Microsoft.Win32.SafeHandles.SafeFileHandle' does not inherit from base type 'Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid' in the implementation but it does in the contract.
+TypesMustExist : Type 'Microsoft.Win32.SafeHandles.SafeHandleMinusOneIsInvalid' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'Microsoft.Win32.SafeHandles.SafeRegistryHandle' does not inherit from base type 'Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'Microsoft.Win32.SafeHandles.SafeWaitHandle' does not inherit from base type 'Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid' in the implementation but it does in the contract.
+TypesMustExist : Type 'System._AppDomain' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.AccessViolationException' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Action' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Action<T>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Action<T1, T2>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Action<T1, T2, T3>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Action<T1, T2, T3, T4>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Action<T1, T2, T3, T4, T5>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Action<T1, T2, T3, T4, T5, T6>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Action<T1, T2, T3, T4, T5, T6, T7, T8>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.ActivationContext' does not exist in the implementation but it does exist in the contract.
+CannotMakeTypeAbstract : Type 'System.Activator' is abstract in the implementation but is not abstract in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Activator' does not implement interface 'System.Runtime.InteropServices._Activator' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Activator.CreateComInstanceFrom(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateComInstanceFrom(System.String, System.String, System.Byte[], System.Configuration.Assemblies.AssemblyHashAlgorithm)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.ActivationContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.ActivationContext, System.String[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.AppDomain, System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.AppDomain, System.String, System.String, System.Boolean, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo, System.Object[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.AppDomain, System.String, System.String, System.Boolean, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo, System.Object[], System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.String, System.String, System.Boolean, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo, System.Object[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.String, System.String, System.Boolean, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo, System.Object[], System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.String, System.String, System.Object[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.Type, System.Object[], System.Object[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.Type, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstance(System.Type, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo, System.Object[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.AppDomain, System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.AppDomain, System.String, System.String, System.Boolean, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo, System.Object[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.AppDomain, System.String, System.String, System.Boolean, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo, System.Object[], System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.String, System.String, System.Boolean, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo, System.Object[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.String, System.String, System.Boolean, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo, System.Object[], System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.String, System.String, System.Object[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.GetObject(System.Type, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Activator.GetObject(System.Type, System.String, System.Object)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.AggregateException' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.AggregateException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.AggregateException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.AppDomain' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.AppDomainInitializer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.AppDomainManager' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.AppDomainManagerInitializationOptions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.AppDomainSetup' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.AppDomainUnloadedException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ApplicationException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ApplicationId' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ApplicationIdentity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ArgIterator' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.ArgumentException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.ArgumentException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ArgumentException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.ArgumentNullException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.ArgumentNullException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.ArgumentOutOfRangeException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.ArgumentOutOfRangeException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ArgumentOutOfRangeException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.ArithmeticException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.ArithmeticException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Array' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Array.AsReadOnly<T>(T[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.ConvertAll<TInput, TOutput>(TInput[], System.Converter<TInput, TOutput>)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.Copy(System.Array, System.Array, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.Copy(System.Array, System.Int64, System.Array, System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.CopyTo(System.Array, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.CreateInstance(System.Type, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.CreateInstance(System.Type, System.Int32, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.CreateInstance(System.Type, System.Int64[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.ForEach<T>(T[], System.Action<T>)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.GetLongLength(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.GetValue(System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.GetValue(System.Int32, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.GetValue(System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.GetValue(System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.GetValue(System.Int64, System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.GetValue(System.Int64[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.IsFixedSize.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.IsReadOnly.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.IsSynchronized.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.LongLength.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.SetValue(System.Object, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.SetValue(System.Object, System.Int32, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.SetValue(System.Object, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.SetValue(System.Object, System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.SetValue(System.Object, System.Int64, System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.SetValue(System.Object, System.Int64[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Array.SyncRoot.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.ArrayTypeMismatchException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.ArrayTypeMismatchException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.AssemblyLoadEventArgs' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.AssemblyLoadEventHandler' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.AsyncCallback' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Attribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttribute(System.Reflection.Assembly, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttribute(System.Reflection.Assembly, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttribute(System.Reflection.MemberInfo, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttribute(System.Reflection.MemberInfo, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttribute(System.Reflection.Module, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttribute(System.Reflection.Module, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttribute(System.Reflection.ParameterInfo, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttribute(System.Reflection.ParameterInfo, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.Assembly)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.Assembly, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.Assembly, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.Assembly, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.MemberInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.MemberInfo, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.MemberInfo, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.MemberInfo, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.Module)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.Module, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.Module, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.Module, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.ParameterInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.ParameterInfo, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.ParameterInfo, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.GetCustomAttributes(System.Reflection.ParameterInfo, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.IsDefaultAttribute()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.IsDefined(System.Reflection.Assembly, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.IsDefined(System.Reflection.Assembly, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.IsDefined(System.Reflection.MemberInfo, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.IsDefined(System.Reflection.MemberInfo, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.IsDefined(System.Reflection.Module, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.IsDefined(System.Reflection.Module, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.IsDefined(System.Reflection.ParameterInfo, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.IsDefined(System.Reflection.ParameterInfo, System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.Match(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Attribute.TypeId.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.AttributeUsageAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.BadImageFormatException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.BadImageFormatException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.BadImageFormatException.FusionLog.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.BadImageFormatException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Base64FormattingOptions' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Boolean.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Boolean.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Boolean.ToString(System.IFormatProvider)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Byte.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Byte.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.CannotUnloadAppDomainException' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Char.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Char.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Char.GetUnicodeCategory(System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Char.GetUnicodeCategory(System.String, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Char.ToLower(System.Char, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Char.ToString(System.IFormatProvider)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Char.ToUpper(System.Char, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.CharEnumerator' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.CLSCompliantAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Comparison<T>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Console.OpenStandardError(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Console.OpenStandardInput(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Console.OpenStandardOutput(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Console.Write(System.String, System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Console.WriteLine(System.String, System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.ConsoleCancelEventHandler' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.Applications' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.Attention' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.BrowserBack' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.BrowserFavorites' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.BrowserForward' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.BrowserHome' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.BrowserRefresh' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.BrowserSearch' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.BrowserStop' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.CrSel' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.EraseEndOfFile' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.ExSel' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.LaunchApp1' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.LaunchApp2' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.LaunchMail' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.LaunchMediaSelect' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.LeftWindows' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.MediaNext' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.MediaPlay' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.MediaPrevious' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.MediaStop' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.NoName' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.Oem102' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.Pa1' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.Packet' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.Play' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.Process' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.RightWindows' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.VolumeDown' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.VolumeMute' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.VolumeUp' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ConsoleKey System.ConsoleKey.Zoom' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ContextBoundObject' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ContextMarshalException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ContextStaticAttribute' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Object System.Convert.DBNull' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ChangeType(System.Object, System.TypeCode)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.IsDBNull(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToBase64CharArray(System.Byte[], System.Int32, System.Int32, System.Char[], System.Int32, System.Base64FormattingOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToBase64String(System.Byte[], System.Base64FormattingOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToBase64String(System.Byte[], System.Int32, System.Int32, System.Base64FormattingOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToBoolean(System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToBoolean(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToByte(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToChar(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToChar(System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToChar(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToChar(System.Decimal)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToChar(System.Double)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToChar(System.Single)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.Byte)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.Decimal)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.Double)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.Int16)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.SByte)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.Single)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.UInt16)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.UInt32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDateTime(System.UInt64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDecimal(System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDecimal(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDouble(System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToDouble(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToInt16(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToInt32(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToInt64(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToSByte(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToSingle(System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToSingle(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToString(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToString(System.String, System.IFormatProvider)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToUInt16(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToUInt32(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Convert.ToUInt64(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Converter<TInput, TOutput>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.CrossAppDomainDelegate' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.DataMisalignedException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.DateTime' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.DateTime..ctor(System.Int32, System.Int32, System.Int32, System.Globalization.Calendar)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.DateTime..ctor(System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Globalization.Calendar)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.DateTime..ctor(System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Globalization.Calendar)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.DateTime..ctor(System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Globalization.Calendar, System.DateTimeKind)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.DateTime.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.DateTime.FromOADate(System.Double)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.DateTime.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.DateTime.ToLongDateString()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.DateTime.ToLongTimeString()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.DateTime.ToOADate()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.DateTime.ToShortDateString()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.DateTime.ToShortTimeString()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.DateTimeOffset' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.DateTimeOffset..ctor(System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Globalization.Calendar, System.TimeSpan)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.DBNull' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Decimal' does not implement interface 'System.Runtime.Serialization.IDeserializationCallback' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Decimal.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Decimal.FromOACurrency(System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Decimal.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Decimal.Round(System.Decimal)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Decimal.Round(System.Decimal, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Decimal.Round(System.Decimal, System.Int32, System.MidpointRounding)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Decimal.Round(System.Decimal, System.MidpointRounding)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Decimal.ToOACurrency(System.Decimal)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Delegate' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Delegate' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Delegate..ctor(System.Object, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate..ctor(System.Type, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.Clone()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.CombineImpl(System.Delegate)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.CreateDelegate(System.Type, System.Object, System.Reflection.MethodInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.CreateDelegate(System.Type, System.Object, System.Reflection.MethodInfo, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.CreateDelegate(System.Type, System.Object, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.CreateDelegate(System.Type, System.Object, System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.CreateDelegate(System.Type, System.Object, System.String, System.Boolean, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.CreateDelegate(System.Type, System.Reflection.MethodInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.CreateDelegate(System.Type, System.Reflection.MethodInfo, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.CreateDelegate(System.Type, System.Type, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.CreateDelegate(System.Type, System.Type, System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.CreateDelegate(System.Type, System.Type, System.String, System.Boolean, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.DynamicInvokeImpl(System.Object[])' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Delegate.Equals(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Delegate.GetHashCode()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Delegate.GetInvocationList()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Delegate.GetMethodImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.Method.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Delegate.RemoveImpl(System.Delegate)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.DivideByZeroException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.DivideByZeroException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.DllNotFoundException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.DllNotFoundException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Double.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Double.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.DuplicateWaitObjectException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.EntryPointNotFoundException' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Enum.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Enum.ToObject(System.Type, System.Byte)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Enum.ToObject(System.Type, System.Int16)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Enum.ToObject(System.Type, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Enum.ToObject(System.Type, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Enum.ToObject(System.Type, System.SByte)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Enum.ToObject(System.Type, System.UInt16)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Enum.ToObject(System.Type, System.UInt32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Enum.ToObject(System.Type, System.UInt64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Enum.ToString(System.IFormatProvider)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Enum.ToString(System.String, System.IFormatProvider)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.CommandLine.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.CurrentDirectory.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.CurrentDirectory.set(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.ExitCode.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.ExitCode.set(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.GetEnvironmentVariable(System.String, System.EnvironmentVariableTarget)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.GetEnvironmentVariables(System.EnvironmentVariableTarget)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.GetFolderPath(System.Environment.SpecialFolder)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.GetFolderPath(System.Environment.SpecialFolder, System.Environment.SpecialFolderOption)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.GetLogicalDrives()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.Is64BitOperatingSystem.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.Is64BitProcess.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.OSVersion.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.SetEnvironmentVariable(System.String, System.String, System.EnvironmentVariableTarget)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.SystemDirectory.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.SystemPageSize.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.UserDomainName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.UserInteractive.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.UserName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.Version.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Environment.WorkingSet.get()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Environment.SpecialFolder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Environment.SpecialFolderOption' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.EnvironmentVariableTarget' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.EventHandler' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.EventHandler<TEventArgs>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Exception' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Exception..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Exception.add_SerializeObjectState(System.EventHandler<System.Runtime.Serialization.SafeSerializationEventArgs>)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Exception.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Exception.remove_SerializeObjectState(System.EventHandler<System.Runtime.Serialization.SafeSerializationEventArgs>)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Exception.TargetSite.get()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ExecutionEngineException' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.FieldAccessException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.FieldAccessException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.FlagsAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.FormatException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.FormatException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Func<TResult>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Func<T, TResult>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Func<T1, T2, TResult>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Func<T1, T2, T3, TResult>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Func<T1, T2, T3, T4, TResult>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Func<T1, T2, T3, T4, T5, TResult>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Func<T1, T2, T3, T4, T5, T6, TResult>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, TResult>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.GC.CancelFullGCNotification()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.Collect(System.Int32, System.GCCollectionMode, System.Boolean, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.EndNoGCRegion()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.GetGeneration(System.WeakReference)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.RegisterForFullGCNotification(System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.TryStartNoGCRegion(System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.TryStartNoGCRegion(System.Int64, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.TryStartNoGCRegion(System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.TryStartNoGCRegion(System.Int64, System.Int64, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.WaitForFullGCApproach()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.WaitForFullGCApproach(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.WaitForFullGCComplete()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.GC.WaitForFullGCComplete(System.Int32)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.GCNotificationStatus' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Guid.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Guid.ToString(System.String, System.IFormatProvider)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IAppDomainSetup' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ICloneable' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IndexOutOfRangeException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.InsufficientExecutionStackException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.InsufficientMemoryException' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Int16.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Int16.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Int32.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Int32.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Int64.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Int64.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IntPtr' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.InvalidCastException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.InvalidCastException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.InvalidOperationException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.InvalidOperationException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.InvalidProgramException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.InvalidTimeZoneException' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.InvalidTimeZoneException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IServiceProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.LoaderOptimization' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.LoaderOptimizationAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.LocalDataStoreSlot' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.MarshalByRefObject' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Math.BigMul(System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Math.DivRem(System.Int32, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Math.DivRem(System.Int64, System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.MemberAccessException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.MemberAccessException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.MethodAccessException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.MethodAccessException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.MissingFieldException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.MissingFieldException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.MissingFieldException..ctor(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.MissingMemberException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Byte[] System.MissingMemberException.Signature' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String System.MissingMemberException.ClassName' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String System.MissingMemberException.MemberName' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.MissingMemberException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.MissingMemberException..ctor(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.MissingMemberException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.MissingMethodException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.MissingMethodException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.MissingMethodException..ctor(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ModuleHandle' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.MTAThreadAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.MulticastDelegate' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotSealType : Type 'System.MulticastDelegate' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.MulticastDelegate..ctor(System.Object, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.MulticastDelegate..ctor(System.Type, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.MulticastDelegate.CombineImpl(System.Delegate)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.MulticastDelegate.GetMethodImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.MulticastDelegate.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.MulticastDelegate.RemoveImpl(System.Delegate)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.MulticastNotSupportedException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.NonSerializedAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.NotFiniteNumberException' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.NotImplementedException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.NotImplementedException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.NotSupportedException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.NotSupportedException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.NullReferenceException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.NullReferenceException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.ObjectDisposedException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.ObjectDisposedException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.ObjectDisposedException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.ObsoleteAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.OperatingSystem' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.OperationCanceledException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.OperationCanceledException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.OutOfMemoryException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.OutOfMemoryException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.OverflowException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.OverflowException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.ParamArrayAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.PlatformID' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.PlatformNotSupportedException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.PlatformNotSupportedException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Predicate<T>' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.RankException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.RankException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ResolveEventArgs' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.ResolveEventHandler' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.RuntimeArgumentHandle' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.RuntimeFieldHandle' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.RuntimeFieldHandle.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.RuntimeFieldHandle.Value.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.RuntimeMethodHandle' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.RuntimeMethodHandle.GetFunctionPointer()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.RuntimeMethodHandle.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.RuntimeMethodHandle.Value.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.RuntimeTypeHandle' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.RuntimeTypeHandle.GetModuleHandle()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.RuntimeTypeHandle.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.RuntimeTypeHandle.Value.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.SByte.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.SByte.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.SerializableAttribute' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Single.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Single.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.StackOverflowException' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.STAThreadAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.String' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.String..ctor(System.SByte*)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String..ctor(System.SByte*, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String..ctor(System.SByte*, System.Int32, System.Int32, System.Text.Encoding)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Clone()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Compare(System.String, System.Int32, System.String, System.Int32, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Compare(System.String, System.Int32, System.String, System.Int32, System.Int32, System.Boolean, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Compare(System.String, System.Int32, System.String, System.Int32, System.Int32, System.Globalization.CultureInfo, System.Globalization.CompareOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Compare(System.String, System.String, System.Boolean, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Compare(System.String, System.String, System.Globalization.CultureInfo, System.Globalization.CompareOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Concat(System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Copy(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.EndsWith(System.String, System.Boolean, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.GetEnumerator()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Intern(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.IsInterned(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.IsNormalized()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.IsNormalized(System.Text.NormalizationForm)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Normalize()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Normalize(System.Text.NormalizationForm)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.StartsWith(System.String, System.Boolean, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.ToLower(System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.ToString(System.IFormatProvider)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.ToUpper(System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.StringComparer.Compare(System.Object, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.StringComparer.Create(System.Globalization.CultureInfo, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.StringComparer.GetHashCode(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.StringComparer.InvariantCulture.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.StringComparer.InvariantCultureIgnoreCase.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.StringComparison System.StringComparison.InvariantCulture' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.StringComparison System.StringComparison.InvariantCultureIgnoreCase' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.SystemException' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.ThreadStaticAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.TimeoutException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.TimeoutException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeSpan.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.TimeZone' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.TimeZoneInfo' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.ClearCachedData()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeBySystemTimeZoneId(System.DateTime, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeBySystemTimeZoneId(System.DateTime, System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeBySystemTimeZoneId(System.DateTimeOffset, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeFromUtc(System.DateTime, System.TimeZoneInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeToUtc(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeToUtc(System.DateTime, System.TimeZoneInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.CreateCustomTimeZone(System.String, System.TimeSpan, System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.CreateCustomTimeZone(System.String, System.TimeSpan, System.String, System.String, System.String, System.TimeZoneInfo.AdjustmentRule[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.CreateCustomTimeZone(System.String, System.TimeSpan, System.String, System.String, System.String, System.TimeZoneInfo.AdjustmentRule[], System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.FromSerializedString(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.GetAdjustmentRules()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.HasSameRules(System.TimeZoneInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TimeZoneInfo.ToSerializedString()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.TimeZoneInfo.AdjustmentRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.TimeZoneInfo.TransitionTime' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.TimeZoneNotFoundException' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Type' does not inherit from base type 'System.Reflection.MemberInfo' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Type' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Reflection.MemberFilter System.Type.FilterAttribute' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MemberFilter System.Type.FilterName' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MemberFilter System.Type.FilterNameIgnoreCase' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.AssemblyQualifiedName' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.DeclaringType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.DeclaringType' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.FullName' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.GenericParameterPosition' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.GenericParameterPosition' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.GenericTypeArguments' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.GenericTypeArguments' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.IsConstructedGenericType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.IsConstructedGenericType' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.IsGenericParameter' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.IsGenericParameter' is abstract in the implementation but is not abstract in the contract.
+CannotAddAbstractMembers : Member 'System.Type.Name' is abstract in the implementation but is missing in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.Namespace' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.TypeHandle' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Type.Assembly.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.AssemblyQualifiedName.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Type.Attributes.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.BaseType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.ContainsGenericParameters.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.DeclaringMethod.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.DeclaringType.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.DeclaringType.get()' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Type.DefaultBinder.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.Equals(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.Equals(System.Type)' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Type.FindInterfaces(System.Reflection.TypeFilter, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.FindMembers(System.Reflection.MemberTypes, System.Reflection.BindingFlags, System.Reflection.MemberFilter, System.Object)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.FullName.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Type.GenericParameterAttributes.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.GenericParameterPosition.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.GenericParameterPosition.get()' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.GenericTypeArguments.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.GenericTypeArguments.get()' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.GetArrayRank()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.GetArrayRank()' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Type.GetAttributeFlagsImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetConstructor(System.Reflection.BindingFlags, System.Reflection.Binder, System.Reflection.CallingConventions, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetConstructor(System.Reflection.BindingFlags, System.Reflection.Binder, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetConstructor(System.Type[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetConstructorImpl(System.Reflection.BindingFlags, System.Reflection.Binder, System.Reflection.CallingConventions, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetConstructors()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetConstructors(System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetDefaultMembers()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.GetElementType()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Type.GetEnumName(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetEnumNames()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetEnumUnderlyingType()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetEnumValues()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetEvent(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetEvent(System.String, System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetEvents()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetEvents(System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetField(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetField(System.String, System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetFields()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetFields(System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetGenericArguments()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetGenericParameterConstraints()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.GetGenericTypeDefinition()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.GetGenericTypeDefinition()' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.GetHashCode()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Type.GetInterface(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetInterface(System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetInterfaceMap(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetInterfaces()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMember(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMember(System.String, System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMember(System.String, System.Reflection.MemberTypes, System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMembers()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMembers(System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMethod(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMethod(System.String, System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMethod(System.String, System.Reflection.BindingFlags, System.Reflection.Binder, System.Reflection.CallingConventions, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMethod(System.String, System.Reflection.BindingFlags, System.Reflection.Binder, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMethod(System.String, System.Type[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMethod(System.String, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMethodImpl(System.String, System.Reflection.BindingFlags, System.Reflection.Binder, System.Reflection.CallingConventions, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMethods()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetMethods(System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetNestedType(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetNestedType(System.String, System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetNestedTypes()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetNestedTypes(System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetProperties()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetProperties(System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetProperty(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetProperty(System.String, System.Reflection.BindingFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetProperty(System.String, System.Reflection.BindingFlags, System.Reflection.Binder, System.Type, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetProperty(System.String, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetProperty(System.String, System.Type, System.Type[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetProperty(System.String, System.Type, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetProperty(System.String, System.Type[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetPropertyImpl(System.String, System.Reflection.BindingFlags, System.Reflection.Binder, System.Type, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetType(System.String, System.Func<System.Reflection.AssemblyName, System.Reflection.Assembly>, System.Func<System.Reflection.Assembly, System.String, System.Boolean, System.Type>)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetType(System.String, System.Func<System.Reflection.AssemblyName, System.Reflection.Assembly>, System.Func<System.Reflection.Assembly, System.String, System.Boolean, System.Type>, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetType(System.String, System.Func<System.Reflection.AssemblyName, System.Reflection.Assembly>, System.Func<System.Reflection.Assembly, System.String, System.Boolean, System.Type>, System.Boolean, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetTypeArray(System.Object[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetTypeCodeImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetTypeFromCLSID(System.Guid)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetTypeFromCLSID(System.Guid, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetTypeFromCLSID(System.Guid, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetTypeFromCLSID(System.Guid, System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetTypeFromProgID(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetTypeFromProgID(System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetTypeFromProgID(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetTypeFromProgID(System.String, System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GetTypeHandle(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.GUID.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.HasElementTypeImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.InvokeMember(System.String, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object, System.Object[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.InvokeMember(System.String, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object, System.Object[], System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.InvokeMember(System.String, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object, System.Object[], System.Reflection.ParameterModifier[], System.Globalization.CultureInfo, System.String[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsAbstract.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsAnsiClass.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsArrayImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsAssignableFrom(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsAutoClass.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsAutoLayout.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsByRefImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsClass.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsCOMObject.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsCOMObjectImpl()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.IsConstructedGenericType.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.IsConstructedGenericType.get()' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Type.IsContextful.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsContextfulImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsEnum.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsEnumDefined(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsEquivalentTo(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsExplicitLayout.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.IsGenericParameter.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.IsGenericParameter.get()' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Type.IsGenericType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsGenericTypeDefinition.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsImport.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsInstanceOfType(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsInterface.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsLayoutSequential.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsMarshalByRef.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsMarshalByRefImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsNestedAssembly.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsNestedFamANDAssem.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsNestedFamily.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsNestedFamORAssem.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsNestedPrivate.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsNestedPublic.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsNotPublic.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsPointerImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsPrimitive.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsPrimitiveImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsPublic.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsSealed.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsSecurityCritical.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsSecuritySafeCritical.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsSecurityTransparent.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsSerializable.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsSpecialName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsSubclassOf(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsUnicodeClass.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsValueType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsValueTypeImpl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.IsVisible.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.MakeArrayType()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.MakeArrayType()' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.MakeArrayType(System.Int32)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.MakeArrayType(System.Int32)' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.MakeByRefType()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.MakeByRefType()' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.MakeGenericType(System.Type[])' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.MakeGenericType(System.Type[])' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.MakePointerType()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Type.MakePointerType()' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Type.MemberType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.Module.get()' does not exist in the implementation but it does exist in the contract.
+CannotAddAbstractMembers : Member 'System.Type.Name.get()' is abstract in the implementation but is missing in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.Namespace.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Type.op_Equality(System.Type, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.op_Inequality(System.Type, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.ReflectedType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.ReflectionOnlyGetType(System.String, System.Boolean, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.StructLayoutAttribute.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.ToString()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Type.TypeHandle.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Type.TypeInitializer.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type.UnderlyingSystemType.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.TypeAccessException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.TypeAccessException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TypeCode System.TypeCode.DBNull' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.TypedReference' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.TypeInitializationException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.TypeInitializationException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.TypeLoadException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.TypeLoadException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.TypeLoadException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.TypeUnloadedException' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.UInt16.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.UInt16.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.UInt32.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.UInt32.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.UInt64.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.UInt64.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.UIntPtr' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.UnauthorizedAccessException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.UnauthorizedAccessException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.UnhandledExceptionEventArgs' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.UnhandledExceptionEventHandler' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Version' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Version..ctor()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Version.Clone()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Version.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.WeakReference' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.WeakReference..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.WeakReference.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.WeakReference<T>' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.WeakReference<T>.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.ArrayList' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Collections.BitArray' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Collections.BitArray.Clone()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Collections.BitArray.CopyTo(System.Array, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Collections.BitArray.Count.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Collections.BitArray.IsReadOnly.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Collections.BitArray.IsSynchronized.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Collections.BitArray.SyncRoot.get()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.CaseInsensitiveComparer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.CaseInsensitiveHashCodeProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.CollectionBase' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.Comparer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.DictionaryBase' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.Hashtable' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.IHashCodeProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.Queue' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.ReadOnlyCollectionBase' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.SortedList' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Collections.Stack' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Collections.Generic.Dictionary<TKey, TValue>' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Collections.Generic.Dictionary<TKey, TValue>..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Collections.Generic.Dictionary<TKey, TValue>.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Collections.Generic.Dictionary<TKey, TValue>.OnDeserialization(System.Object)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Collections.Generic.KeyNotFoundException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Collections.Generic.KeyNotFoundException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Collections.Generic.List<T>.ConvertAll<TOutput>(System.Converter<T, TOutput>)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Configuration.Assemblies.AssemblyHash' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Configuration.Assemblies.AssemblyHashAlgorithm' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Configuration.Assemblies.AssemblyVersionCompatibility' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Deployment.Internal.InternalActivationContextHelper' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Deployment.Internal.InternalApplicationIdentityHelper' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.ConditionalAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.DebuggableAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Diagnostics.DebuggableAttribute..ctor(System.Boolean, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Diagnostics.DebuggableAttribute.DebuggingFlags.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Diagnostics.DebuggableAttribute.IsJITOptimizerDisabled.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Diagnostics.DebuggableAttribute.IsJITTrackingEnabled.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeTypeAbstract : Type 'System.Diagnostics.Debugger' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.String System.Diagnostics.Debugger.DefaultCategory' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Diagnostics.Debugger..ctor()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Diagnostics.Debugger.IsLogging()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Diagnostics.Debugger.Log(System.Int32, System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Diagnostics.Debugger.NotifyOfCrossThreadDependency()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.DebuggerBrowsableAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.DebuggerDisplayAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.DebuggerHiddenAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.DebuggerNonUserCodeAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Diagnostics.DebuggerStepperBoundaryAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.DebuggerStepThroughAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.DebuggerTypeProxyAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Diagnostics.DebuggerVisualizerAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.StackFrame' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.StackTrace' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.CodeAnalysis.SuppressMessageAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.Contract' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractAbbreviatorAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractArgumentValidatorAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractClassAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractClassForAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractFailedEventArgs' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractFailureKind' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractInvariantMethodAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractOptionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractPublicPropertyNameAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractReferenceAssemblyAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractRuntimeIgnoredAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.ContractVerificationAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.PureAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.Contracts.Internal.ContractHelper' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.ISymbolBinder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.ISymbolBinder1' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.ISymbolDocument' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.ISymbolDocumentWriter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.ISymbolMethod' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.ISymbolNamespace' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.ISymbolReader' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.ISymbolScope' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.ISymbolVariable' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.ISymbolWriter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.SymAddressKind' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.SymbolToken' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.SymDocumentType' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.SymLanguageType' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Diagnostics.SymbolStore.SymLanguageVendor' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.Tracing.EventAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.Tracing.EventDataAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.Tracing.EventFieldAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.Tracing.EventIgnoreAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Diagnostics.Tracing.EventKeywords System.Diagnostics.Tracing.EventKeywords.MicrosoftTelemetry' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.Tracing.EventSourceAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.Tracing.EventSourceException' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Diagnostics.Tracing.EventSourceException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.Tracing.NonEventAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.Calendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Globalization.Calendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.Calendar.Clone()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.Calendar.DaysInYearBeforeMinSupportedYear.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.Calendar.GetLeapMonth(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.Calendar.ReadOnly(System.Globalization.Calendar)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Globalization.CalendarAlgorithmType' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CharUnicodeInfo.GetDecimalDigitValue(System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CharUnicodeInfo.GetDecimalDigitValue(System.String, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CharUnicodeInfo.GetDigitValue(System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CharUnicodeInfo.GetDigitValue(System.String, System.Int32)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.ChineseLunisolarCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Globalization.ChineseLunisolarCalendar.ChineseEra' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.ChineseLunisolarCalendar.DaysInYearBeforeMinSupportedYear.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.CompareInfo' does not implement interface 'System.Runtime.Serialization.IDeserializationCallback' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.GetCompareInfo(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.GetCompareInfo(System.Int32, System.Reflection.Assembly)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.GetCompareInfo(System.String, System.Reflection.Assembly)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.GetSortKey(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.GetSortKey(System.String, System.Globalization.CompareOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.IndexOf(System.String, System.Char, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.IndexOf(System.String, System.String, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.IsSortable(System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.IsSortable(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.LastIndexOf(System.String, System.Char, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.LastIndexOf(System.String, System.String, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.LCID.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CompareInfo.Version.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.CultureInfo' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo..ctor(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo..ctor(System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo..ctor(System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.ClearCachedData()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.CreateSpecificCulture(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.CultureTypes.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.GetConsoleFallbackUICulture()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.GetCultureInfo(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.GetCultureInfo(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.GetCultureInfo(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.GetCultureInfoByIetfLanguageTag(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.GetCultures(System.Globalization.CultureTypes)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.IetfLanguageTag.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.InstalledUICulture.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.KeyboardLayoutId.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.LCID.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.ThreeLetterISOLanguageName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.ThreeLetterWindowsLanguageName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureInfo.UseUserOverride.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.CultureNotFoundException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Globalization.CultureNotFoundException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureNotFoundException..ctor(System.String, System.Int32, System.Exception)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureNotFoundException..ctor(System.String, System.Int32, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.CultureNotFoundException.InvalidCultureId.get()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Globalization.CultureTypes' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.DateTimeFormatInfo' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Globalization.DateTimeFormatInfo.DateSeparator.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.DateTimeFormatInfo.DateSeparator.set(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.DateTimeFormatInfo.GetAllDateTimePatterns()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.DateTimeFormatInfo.GetAllDateTimePatterns(System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.DateTimeFormatInfo.GetShortestDayName(System.DayOfWeek)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.DateTimeFormatInfo.NativeCalendarName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.DateTimeFormatInfo.SetAllDateTimePatterns(System.String[], System.Char)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.DateTimeFormatInfo.TimeSeparator.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.DateTimeFormatInfo.TimeSeparator.set(System.String)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Globalization.DaylightTime' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Globalization.DigitShapes' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.EastAsianLunisolarCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Globalization.EastAsianLunisolarCalendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.GregorianCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Globalization.GregorianCalendar.ADEra' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.GregorianCalendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.HebrewCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Globalization.HebrewCalendar.HebrewEra' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.HebrewCalendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.HijriCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Globalization.HijriCalendar.HijriEra' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.HijriCalendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.HijriCalendar.DaysInYearBeforeMinSupportedYear.get()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Globalization.IdnMapping' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.JapaneseCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Globalization.JapaneseCalendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.JapaneseLunisolarCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Globalization.JapaneseLunisolarCalendar.JapaneseEra' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.JapaneseLunisolarCalendar.DaysInYearBeforeMinSupportedYear.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.JulianCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Globalization.JulianCalendar.JulianEra' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.JulianCalendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.KoreanCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Globalization.KoreanCalendar.KoreanEra' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.KoreanCalendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.KoreanLunisolarCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Globalization.KoreanLunisolarCalendar.GregorianEra' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.KoreanLunisolarCalendar.DaysInYearBeforeMinSupportedYear.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.NumberFormatInfo' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Globalization.NumberFormatInfo.DigitSubstitution.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.NumberFormatInfo.DigitSubstitution.set(System.Globalization.DigitShapes)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.NumberFormatInfo.NativeDigits.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.NumberFormatInfo.NativeDigits.set(System.String[])' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.PersianCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Globalization.PersianCalendar.PersianEra' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.PersianCalendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.RegionInfo..ctor(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.RegionInfo.CurrencyEnglishName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.RegionInfo.CurrencyNativeName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.RegionInfo.GeoId.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.RegionInfo.ThreeLetterISORegionName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.RegionInfo.ThreeLetterWindowsRegionName.get()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Globalization.SortKey' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Globalization.SortVersion' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.StringInfo.SubstringByTextElements(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.StringInfo.SubstringByTextElements(System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.TaiwanCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Globalization.TaiwanCalendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.TaiwanLunisolarCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Globalization.TaiwanLunisolarCalendar.DaysInYearBeforeMinSupportedYear.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.TextInfo' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Globalization.TextInfo.ANSICodePage.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.TextInfo.Clone()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.TextInfo.EBCDICCodePage.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.TextInfo.LCID.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.TextInfo.MacCodePage.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.TextInfo.OEMCodePage.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.TextInfo.ReadOnly(System.Globalization.TextInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.TextInfo.ToTitleCase(System.String)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.ThaiBuddhistCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Globalization.ThaiBuddhistCalendar.ThaiBuddhistEra' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.ThaiBuddhistCalendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.UmAlQuraCalendar' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Globalization.UmAlQuraCalendar.UmAlQuraEra' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.UmAlQuraCalendar.AlgorithmType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Globalization.UmAlQuraCalendar.DaysInYearBeforeMinSupportedYear.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.BinaryReader.Close()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.BinaryWriter.Close()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.BufferedStream' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.BufferedStream.BeginRead(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.BufferedStream.BeginWrite(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.BufferedStream.EndRead(System.IAsyncResult)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.BufferedStream.EndWrite(System.IAsyncResult)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Directory.CreateDirectory(System.String, System.Security.AccessControl.DirectorySecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Directory.GetAccessControl(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Directory.GetAccessControl(System.String, System.Security.AccessControl.AccessControlSections)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Directory.GetLogicalDrives()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Directory.SetAccessControl(System.String, System.Security.AccessControl.DirectorySecurity)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.DirectoryInfo' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.DirectoryInfo.Create(System.Security.AccessControl.DirectorySecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.DirectoryInfo.CreateSubdirectory(System.String, System.Security.AccessControl.DirectorySecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.DirectoryInfo.GetAccessControl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.DirectoryInfo.GetAccessControl(System.Security.AccessControl.AccessControlSections)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.DirectoryInfo.SetAccessControl(System.Security.AccessControl.DirectorySecurity)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.DirectoryNotFoundException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.DirectoryNotFoundException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.DriveInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.DriveNotFoundException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.DriveType' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.EndOfStreamException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.EndOfStreamException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.File.Create(System.String, System.Int32, System.IO.FileOptions, System.Security.AccessControl.FileSecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.File.Decrypt(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.File.Encrypt(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.File.GetAccessControl(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.File.GetAccessControl(System.String, System.Security.AccessControl.AccessControlSections)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.File.Replace(System.String, System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.File.Replace(System.String, System.String, System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.File.SetAccessControl(System.String, System.Security.AccessControl.FileSecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.File.WriteAllLines(System.String, System.String[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.File.WriteAllLines(System.String, System.String[], System.Text.Encoding)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.FileInfo' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.FileInfo.Decrypt()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileInfo.Encrypt()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileInfo.GetAccessControl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileInfo.GetAccessControl(System.Security.AccessControl.AccessControlSections)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileInfo.Replace(System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileInfo.Replace(System.String, System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileInfo.SetAccessControl(System.Security.AccessControl.FileSecurity)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.FileLoadException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.FileLoadException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileLoadException.FusionLog.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileLoadException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.FileNotFoundException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.FileNotFoundException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileNotFoundException.FusionLog.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.FileStream' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.FileStream..ctor(System.IntPtr, System.IO.FileAccess)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream..ctor(System.IntPtr, System.IO.FileAccess, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream..ctor(System.IntPtr, System.IO.FileAccess, System.Boolean, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream..ctor(System.IntPtr, System.IO.FileAccess, System.Boolean, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream..ctor(System.String, System.IO.FileMode, System.Security.AccessControl.FileSystemRights, System.IO.FileShare, System.Int32, System.IO.FileOptions)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream..ctor(System.String, System.IO.FileMode, System.Security.AccessControl.FileSystemRights, System.IO.FileShare, System.Int32, System.IO.FileOptions, System.Security.AccessControl.FileSecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream.BeginRead(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream.BeginWrite(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream.EndRead(System.IAsyncResult)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream.EndWrite(System.IAsyncResult)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream.GetAccessControl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream.Handle.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream.Lock(System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream.SetAccessControl(System.Security.AccessControl.FileSecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileStream.Unlock(System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.FileSystemInfo' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.FileSystemInfo..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileSystemInfo.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.IOException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.IOException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.MemoryStream' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.MemoryStream.GetBuffer()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Char[] System.IO.Path.InvalidPathChars' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Path.Combine(System.String, System.String, System.String, System.String)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.PathTooLongException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.PathTooLongException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.Stream' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.Stream.BeginRead(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.BeginWrite(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.Close()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.CreateWaitHandle()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.EndRead(System.IAsyncResult)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.EndWrite(System.IAsyncResult)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.ObjectInvariant()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.Synchronized(System.IO.Stream)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.StreamReader' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.StreamReader..ctor(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamReader..ctor(System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamReader..ctor(System.String, System.Text.Encoding)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamReader..ctor(System.String, System.Text.Encoding, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamReader..ctor(System.String, System.Text.Encoding, System.Boolean, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamReader.Close()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.StreamWriter' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.StreamWriter..ctor(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamWriter..ctor(System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamWriter..ctor(System.String, System.Boolean, System.Text.Encoding)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamWriter..ctor(System.String, System.Boolean, System.Text.Encoding, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamWriter.Close()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.StringReader' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.StringReader.Close()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.StringWriter' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.StringWriter.Close()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.TextReader' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.TextReader.Close()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.TextReader.Synchronized(System.IO.TextReader)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.IO.TextWriter' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.IO.TextWriter.Close()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.TextWriter.Synchronized(System.IO.TextWriter)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberAbstract : Member 'System.IO.TextWriter.Write(System.Char)' is abstract in the implementation but is not abstract in the contract.
+TypesMustExist : Type 'System.IO.UnmanagedMemoryAccessor' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.UnmanagedMemoryStream' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.IsolatedStorage.INormalizeForIsolatedStorage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.IsolatedStorage.IsolatedStorage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.IsolatedStorage.IsolatedStorageException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.IsolatedStorage.IsolatedStorageFile' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.IsolatedStorage.IsolatedStorageFileStream' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.IsolatedStorage.IsolatedStorageScope' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.IsolatedStorage.IsolatedStorageSecurityOptions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.IO.IsolatedStorage.IsolatedStorageSecurityState' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AmbiguousMatchException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Assembly' does not implement interface 'System.Runtime.InteropServices._Assembly' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Reflection.Assembly' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.CodeBase' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.CustomAttributes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.DefinedTypes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Reflection.Assembly.DefinedTypes' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.EntryPoint' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.ExportedTypes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.FullName' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.ImageRuntimeVersion' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.IsDynamic' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.Location' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.ManifestModule' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.Modules' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Reflection.Assembly.Modules' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.add_ModuleResolve(System.Reflection.ModuleResolveEventHandler)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.CodeBase.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.CreateInstance(System.String, System.Boolean, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo, System.Object[])' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.CustomAttributes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.DefinedTypes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Reflection.Assembly.DefinedTypes.get()' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.EntryPoint.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.Equals(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.EscapedCodeBase.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.Evidence.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.ExportedTypes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.FullName.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetAssembly(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetCallingAssembly()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetCustomAttributes(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetCustomAttributes(System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetCustomAttributesData()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetExecutingAssembly()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.GetExportedTypes()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetFile(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetFiles()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetFiles(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.GetHashCode()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetLoadedModules()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetLoadedModules(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.GetManifestResourceInfo(System.String)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.GetManifestResourceNames()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.GetManifestResourceStream(System.String)' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetManifestResourceStream(System.Type, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetModule(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetModules()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetModules(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.GetName()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetName(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.GetReferencedAssemblies()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetSatelliteAssembly(System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetSatelliteAssembly(System.Globalization.CultureInfo, System.Version)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.GetType(System.String)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.GetType(System.String, System.Boolean)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.GetType(System.String, System.Boolean, System.Boolean)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.GetTypes()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GlobalAssemblyCache.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.HostContext.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.ImageRuntimeVersion.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.IsDefined(System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.IsDynamic.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.IsFullyTrusted.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.Load(System.Byte[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.Load(System.Byte[], System.Byte[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.Load(System.Byte[], System.Byte[], System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.Load(System.Byte[], System.Byte[], System.Security.SecurityContextSource)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.Load(System.Reflection.AssemblyName, System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.Load(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.Load(System.String, System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.LoadFile(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.LoadFile(System.String, System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.LoadFrom(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.LoadFrom(System.String, System.Byte[], System.Configuration.Assemblies.AssemblyHashAlgorithm)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.LoadFrom(System.String, System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.LoadFrom(System.String, System.Security.Policy.Evidence, System.Byte[], System.Configuration.Assemblies.AssemblyHashAlgorithm)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.LoadModule(System.String, System.Byte[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.LoadModule(System.String, System.Byte[], System.Byte[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.LoadWithPartialName(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.LoadWithPartialName(System.String, System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.Location.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.ManifestModule.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.Modules.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Reflection.Assembly.Modules.get()' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.op_Equality(System.Reflection.Assembly, System.Reflection.Assembly)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.op_Inequality(System.Reflection.Assembly, System.Reflection.Assembly)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.PermissionSet.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.ReflectionOnly.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.ReflectionOnlyLoad(System.Byte[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.ReflectionOnlyLoad(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.ReflectionOnlyLoadFrom(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.remove_ModuleResolve(System.Reflection.ModuleResolveEventHandler)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.SecurityRuleSet.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Assembly.ToString()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.UnsafeLoadFrom(System.String)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.AssemblyAlgorithmIdAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyCompanyAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyConfigurationAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyCopyrightAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyCultureAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyDefaultAliasAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyDelaySignAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyDescriptionAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyFileVersionAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyFlagsAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyFlagsAttribute..ctor(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyFlagsAttribute..ctor(System.UInt32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyFlagsAttribute.Flags.get()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyInformationalVersionAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyKeyFileAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyKeyNameAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyMetadataAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyName' does not implement interface 'System.Runtime.InteropServices._AssemblyName' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.Clone()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.CodeBase.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.CodeBase.set(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.CultureInfo.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.CultureInfo.set(System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.EscapedCodeBase.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.GetAssemblyName(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.HashAlgorithm.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.HashAlgorithm.set(System.Configuration.Assemblies.AssemblyHashAlgorithm)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.KeyPair.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.KeyPair.set(System.Reflection.StrongNameKeyPair)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.OnDeserialization(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.ReferenceMatchesDefinition(System.Reflection.AssemblyName, System.Reflection.AssemblyName)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.VersionCompatibility.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.VersionCompatibility.set(System.Configuration.Assemblies.AssemblyVersionCompatibility)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyNameFlags System.Reflection.AssemblyNameFlags.EnableJITcompileOptimizer' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyNameFlags System.Reflection.AssemblyNameFlags.EnableJITcompileTracking' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.AssemblyNameProxy' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyProductAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblySignatureKeyAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyTitleAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyTrademarkAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.AssemblyVersionAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Reflection.Binder' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.BindingFlags System.Reflection.BindingFlags.ExactBinding' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.BindingFlags System.Reflection.BindingFlags.IgnoreReturn' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.BindingFlags System.Reflection.BindingFlags.OptionalParamBinding' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.BindingFlags System.Reflection.BindingFlags.PutDispProperty' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.BindingFlags System.Reflection.BindingFlags.PutRefDispProperty' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.BindingFlags System.Reflection.BindingFlags.SuppressChangeType' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.ConstructorInfo' does not implement interface 'System.Runtime.InteropServices._ConstructorInfo' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Reflection.ConstructorInfo' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Reflection.ConstructorInfo..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ConstructorInfo.MemberType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ConstructorInfo.Equals(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ConstructorInfo.GetHashCode()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.ConstructorInfo.Invoke(System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ConstructorInfo.MemberType.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.ConstructorInfo.op_Equality(System.Reflection.ConstructorInfo, System.Reflection.ConstructorInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.ConstructorInfo.op_Inequality(System.Reflection.ConstructorInfo, System.Reflection.ConstructorInfo)' does not exist in the implementation but it does exist in the contract.
+CannotSealType : Type 'System.Reflection.CustomAttributeData' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Reflection.CustomAttributeData..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.CustomAttributeData.Constructor' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.CustomAttributeData.ConstructorArguments' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.CustomAttributeData.NamedArguments' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.CustomAttributeData.Constructor.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.CustomAttributeData.ConstructorArguments.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.CustomAttributeData.NamedArguments.get()' is non-virtual in the implementation but is virtual in the contract.
+TypesMustExist : Type 'System.Reflection.CustomAttributeFormatException' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.CustomAttributeNamedArgument..ctor(System.Reflection.MemberInfo, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.CustomAttributeNamedArgument..ctor(System.Reflection.MemberInfo, System.Reflection.CustomAttributeTypedArgument)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.CustomAttributeNamedArgument.MemberInfo.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.CustomAttributeTypedArgument..ctor(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.CustomAttributeTypedArgument..ctor(System.Type, System.Object)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.DefaultMemberAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Reflection.EventAttributes System.Reflection.EventAttributes.ReservedMask' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.EventInfo' does not implement interface 'System.Runtime.InteropServices._EventInfo' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Reflection.EventInfo' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Reflection.EventInfo..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.AddMethod' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.Attributes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.EventHandlerType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.IsMulticast' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.MemberType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.RaiseMethod' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.RemoveMethod' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.AddEventHandler(System.Object, System.Delegate)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.AddMethod.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.Attributes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.Equals(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.EventHandlerType.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.GetAddMethod(System.Boolean)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.GetHashCode()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.EventInfo.GetOtherMethods()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.EventInfo.GetOtherMethods(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.GetRaiseMethod(System.Boolean)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.GetRemoveMethod(System.Boolean)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.IsMulticast.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.MemberType.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.EventInfo.op_Equality(System.Reflection.EventInfo, System.Reflection.EventInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.EventInfo.op_Inequality(System.Reflection.EventInfo, System.Reflection.EventInfo)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.RaiseMethod.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.RemoveEventHandler(System.Object, System.Delegate)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.EventInfo.RemoveMethod.get()' is non-virtual in the implementation but is virtual in the contract.
+TypesMustExist : Type 'System.Reflection.ExceptionHandlingClause' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.ExceptionHandlingClauseOptions' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldAttributes System.Reflection.FieldAttributes.ReservedMask' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.FieldInfo' does not implement interface 'System.Runtime.InteropServices._FieldInfo' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Reflection.FieldInfo' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.Attributes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.FieldType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.MemberType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.Attributes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.Equals(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.FieldHandle.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.FieldType.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.GetHashCode()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.GetOptionalCustomModifiers()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.GetRawConstantValue()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.GetRequiredCustomModifiers()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.GetValue(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.GetValueDirect(System.TypedReference)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.IsNotSerialized.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.IsPinvokeImpl.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.IsSecurityCritical.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.IsSecuritySafeCritical.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.IsSecurityTransparent.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.FieldInfo.MemberType.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.op_Equality(System.Reflection.FieldInfo, System.Reflection.FieldInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.op_Inequality(System.Reflection.FieldInfo, System.Reflection.FieldInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.SetValue(System.Object, System.Object, System.Reflection.BindingFlags, System.Reflection.Binder, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.SetValueDirect(System.TypedReference, System.Object)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.ImageFileMachine' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.InvalidFilterCriteriaException' does not inherit from base type 'System.ApplicationException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Reflection.InvalidFilterCriteriaException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.IReflect' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.MemberFilter' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.MemberInfo' does not implement interface 'System.Runtime.InteropServices._MemberInfo' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Reflection.MemberInfo' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Reflection.MemberInfo..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.CustomAttributes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.DeclaringType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.MemberType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.MetadataToken' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.Module' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.Name' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.CustomAttributes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.DeclaringType.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.Equals(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.MemberInfo.GetCustomAttributes(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MemberInfo.GetCustomAttributes(System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MemberInfo.GetCustomAttributesData()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.GetHashCode()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.MemberInfo.IsDefined(System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.MemberType.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.MetadataToken.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.Module.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MemberInfo.Name.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.MemberInfo.op_Equality(System.Reflection.MemberInfo, System.Reflection.MemberInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MemberInfo.op_Inequality(System.Reflection.MemberInfo, System.Reflection.MemberInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MemberInfo.ReflectedType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MethodAttributes System.Reflection.MethodAttributes.ReservedMask' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.MethodBase' does not implement interface 'System.Runtime.InteropServices._MethodBase' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Reflection.MethodBase' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.Attributes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.CallingConvention' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.ContainsGenericParameters' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.IsGenericMethod' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.IsGenericMethodDefinition' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.MethodImplementationFlags' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Reflection.MethodBase.MethodImplementationFlags' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.Attributes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.CallingConvention.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.ContainsGenericParameters.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.Equals(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase.GetCurrentMethod()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.GetGenericArguments()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.GetHashCode()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase.GetMethodBody()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.GetMethodImplementationFlags()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.GetParameters()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase.Invoke(System.Object, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.IsGenericMethod.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.IsGenericMethodDefinition.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase.IsSecurityCritical.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase.IsSecuritySafeCritical.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase.IsSecurityTransparent.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase.MethodHandle.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodBase.MethodImplementationFlags.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberAbstract : Member 'System.Reflection.MethodBase.MethodImplementationFlags.get()' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase.op_Equality(System.Reflection.MethodBase, System.Reflection.MethodBase)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase.op_Inequality(System.Reflection.MethodBase, System.Reflection.MethodBase)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.MethodBody' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MethodImplAttributes System.Reflection.MethodImplAttributes.MaxMethodImplVal' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.MethodInfo' does not implement interface 'System.Runtime.InteropServices._MethodInfo' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Reflection.MethodInfo' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Reflection.MethodInfo..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.MemberType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.ReturnParameter' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.ReturnType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.ReturnTypeCustomAttributes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.CreateDelegate(System.Type)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.CreateDelegate(System.Type, System.Object)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.Equals(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.GetBaseDefinition()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.GetGenericArguments()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.GetGenericMethodDefinition()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.GetHashCode()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.MakeGenericMethod(System.Type[])' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.MemberType.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.MethodInfo.op_Equality(System.Reflection.MethodInfo, System.Reflection.MethodInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MethodInfo.op_Inequality(System.Reflection.MethodInfo, System.Reflection.MethodInfo)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.ReturnParameter.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.ReturnType.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.MethodInfo.ReturnTypeCustomAttributes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Missing' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Module' does not implement interface 'System.Runtime.InteropServices._Module' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Reflection.Module' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Reflection.Module..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.Assembly' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.CustomAttributes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.FullyQualifiedName' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.ModuleVersionId' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.Name' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.ScopeName' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.Assembly.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.CustomAttributes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.Equals(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.FindTypes(System.Reflection.TypeFilter, System.Object)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.FullyQualifiedName.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Module.GetCustomAttributes(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.GetCustomAttributes(System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.GetCustomAttributesData()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.GetField(System.String, System.Reflection.BindingFlags)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.GetFields(System.Reflection.BindingFlags)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.GetHashCode()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Module.GetMethod(System.String, System.Reflection.BindingFlags, System.Reflection.Binder, System.Reflection.CallingConventions, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.GetMethodImpl(System.String, System.Reflection.BindingFlags, System.Reflection.Binder, System.Reflection.CallingConventions, System.Type[], System.Reflection.ParameterModifier[])' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.GetMethods(System.Reflection.BindingFlags)' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Module.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.GetPEKind(System.Reflection.PortableExecutableKinds, System.Reflection.ImageFileMachine)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.GetSignerCertificate()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.GetType(System.String)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.GetType(System.String, System.Boolean)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.GetType(System.String, System.Boolean, System.Boolean)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.GetTypes()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Module.IsDefined(System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.IsResource()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.MDStreamVersion.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.MetadataToken.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.ModuleHandle.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.ModuleVersionId.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.Name.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.Module.op_Equality(System.Reflection.Module, System.Reflection.Module)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.op_Inequality(System.Reflection.Module, System.Reflection.Module)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.ResolveField(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.ResolveField(System.Int32, System.Type[], System.Type[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.ResolveMember(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.ResolveMember(System.Int32, System.Type[], System.Type[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.ResolveMethod(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.ResolveMethod(System.Int32, System.Type[], System.Type[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.ResolveSignature(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.ResolveString(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.ResolveType(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Module.ResolveType(System.Int32, System.Type[], System.Type[])' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.ScopeName.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.Module.ToString()' is non-virtual in the implementation but is virtual in the contract.
+TypesMustExist : Type 'System.Reflection.ModuleResolveEventHandler' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.ObfuscateAssemblyAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.ObfuscationAttribute' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterAttributes System.Reflection.ParameterAttributes.Reserved3' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterAttributes System.Reflection.ParameterAttributes.Reserved4' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterAttributes System.Reflection.ParameterAttributes.ReservedMask' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.ParameterInfo' does not implement interface 'System.Runtime.InteropServices._ParameterInfo' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Reflection.ParameterInfo' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Int32 System.Reflection.ParameterInfo.PositionImpl' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Object System.Reflection.ParameterInfo.DefaultValueImpl' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MemberInfo System.Reflection.ParameterInfo.MemberImpl' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterAttributes System.Reflection.ParameterInfo.AttrsImpl' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String System.Reflection.ParameterInfo.NameImpl' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Type System.Reflection.ParameterInfo.ClassImpl' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterInfo..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.Attributes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.CustomAttributes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.DefaultValue' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.HasDefaultValue' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.Member' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.Name' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.ParameterType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.Position' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.RawDefaultValue' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.Attributes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.CustomAttributes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.DefaultValue.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterInfo.GetCustomAttributes(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterInfo.GetCustomAttributes(System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterInfo.GetCustomAttributesData()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.GetOptionalCustomModifiers()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterInfo.GetRealObject(System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.GetRequiredCustomModifiers()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.HasDefaultValue.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterInfo.IsDefined(System.Type, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterInfo.IsLcid.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.Member.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.ParameterInfo.MetadataToken.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.Name.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.ParameterType.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.Position.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.ParameterInfo.RawDefaultValue.get()' is non-virtual in the implementation but is virtual in the contract.
+TypesMustExist : Type 'System.Reflection.Pointer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.PortableExecutableKinds' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.PropertyAttributes System.Reflection.PropertyAttributes.Reserved2' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.PropertyAttributes System.Reflection.PropertyAttributes.Reserved3' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.PropertyAttributes System.Reflection.PropertyAttributes.Reserved4' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.PropertyAttributes System.Reflection.PropertyAttributes.ReservedMask' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.PropertyInfo' does not implement interface 'System.Runtime.InteropServices._PropertyInfo' in the implementation but it does in the contract.
+CannotSealType : Type 'System.Reflection.PropertyInfo' is sealed in the implementation but not sealed in the contract.
+MembersMustExist : Member 'System.Reflection.PropertyInfo..ctor()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.Attributes' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.CanRead' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.CanWrite' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetMethod' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.MemberType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.PropertyType' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.SetMethod' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.Attributes.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.CanRead.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.CanWrite.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.Equals(System.Object)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetAccessors(System.Boolean)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetConstantValue()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetGetMethod(System.Boolean)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetHashCode()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetIndexParameters()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetMethod.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetOptionalCustomModifiers()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetRawConstantValue()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetRequiredCustomModifiers()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetSetMethod(System.Boolean)' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.GetValue(System.Object, System.Object[])' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.PropertyInfo.GetValue(System.Object, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.MemberType.get()' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.PropertyInfo.op_Equality(System.Reflection.PropertyInfo, System.Reflection.PropertyInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.PropertyInfo.op_Inequality(System.Reflection.PropertyInfo, System.Reflection.PropertyInfo)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.PropertyType.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.SetMethod.get()' is non-virtual in the implementation but is virtual in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Reflection.PropertyInfo.SetValue(System.Object, System.Object, System.Object[])' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Reflection.PropertyInfo.SetValue(System.Object, System.Object, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.ReflectionTypeLoadException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Reflection.ReflectionTypeLoadException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.ResourceAttributes' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.StrongNameKeyPair' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.TargetException' does not inherit from base type 'System.ApplicationException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Reflection.TargetException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.TargetInvocationException' does not inherit from base type 'System.ApplicationException' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.TargetParameterCountException' does not inherit from base type 'System.ApplicationException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Reflection.TypeAttributes System.Reflection.TypeAttributes.ReservedMask' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.TypeDelegator' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.TypeFilter' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.TypeInfo' does not inherit from base type 'System.Type' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.AssemblyBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.AssemblyBuilderAccess' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.ConstructorBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.CustomAttributeBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.DynamicILInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.DynamicMethod' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.EnumBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.EventBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.EventToken' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.ExceptionHandler' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.FieldBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.FieldToken' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Emit.FlowControl System.Reflection.Emit.FlowControl.Phi' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.GenericTypeParameterBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.ILGenerator' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.Label' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.LocalBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.MethodBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.MethodRental' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.MethodToken' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.ModuleBuilder' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Emit.OpCodeType System.Reflection.Emit.OpCodeType.Annotation' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Emit.OperandType System.Reflection.Emit.OperandType.InlinePhi' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.ParameterBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.ParameterToken' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.PEFileKinds' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.PropertyBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.PropertyToken' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.SignatureHelper' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.SignatureToken' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.StringToken' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.TypeBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.TypeToken' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Reflection.Emit.UnmanagedMarshal' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Resources.IResourceReader' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Resources.IResourceWriter' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Resources.MissingManifestResourceException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Resources.MissingManifestResourceException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Resources.MissingSatelliteAssemblyException' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Resources.NeutralResourcesLanguageAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Resources.NeutralResourcesLanguageAttribute..ctor(System.String, System.Resources.UltimateResourceFallbackLocation)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.NeutralResourcesLanguageAttribute.Location.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Collections.Hashtable System.Resources.ResourceManager.ResourceSets' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Int32 System.Resources.ResourceManager.HeaderVersionNumber' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Int32 System.Resources.ResourceManager.MagicNumber' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly System.Resources.ResourceManager.MainAssembly' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String System.Resources.ResourceManager.BaseNameField' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager..ctor()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager..ctor(System.String, System.Reflection.Assembly, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.BaseName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.CreateFileBasedResourceManager(System.String, System.String, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.FallbackLocation.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.FallbackLocation.set(System.Resources.UltimateResourceFallbackLocation)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.GetNeutralResourcesLanguage(System.Reflection.Assembly)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.GetObject(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.GetObject(System.String, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.GetResourceFileName(System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.GetResourceSet(System.Globalization.CultureInfo, System.Boolean, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.GetSatelliteContractVersion(System.Reflection.Assembly)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.GetStream(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.GetStream(System.String, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberNonVirtual : Member 'System.Resources.ResourceManager.GetString(System.String)' is non-virtual in the implementation but is virtual in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.IgnoreCase.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.IgnoreCase.set(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.InternalGetResourceSet(System.Globalization.CultureInfo, System.Boolean, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.ReleaseAllResources()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Resources.ResourceManager.ResourceSetType.get()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Resources.ResourceReader' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Resources.ResourceSet' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Resources.ResourceWriter' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Resources.SatelliteContractVersionAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Resources.UltimateResourceFallbackLocation' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.AssemblyTargetedPatchBandAttribute' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.GCLatencyMode System.Runtime.GCLatencyMode.NoGCRegion' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.MemoryFailPoint' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.ProfileOptimization' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.TargetedPatchingOptOutAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.AccessedThroughPropertyAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.AsyncStateMachineAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.CallConvCdecl' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.CallConvFastcall' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.CallConvStdcall' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.CallConvThiscall' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.CallerFilePathAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.CallerLineNumberAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.CallerMemberNameAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.CompilationRelaxations' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.CompilationRelaxationsAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.CompilationRelaxationsAttribute..ctor(System.Runtime.CompilerServices.CompilationRelaxations)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.CompilerGeneratedAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.CompilerGlobalScopeAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.CompilerMarshalOverride' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.ContractHelper' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.CustomConstantAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.DateTimeConstantAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.DecimalConstantAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.DefaultDependencyAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.DependencyAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.DisablePrivateReflectionAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.DiscardableAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.ExtensionAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.FixedAddressValueTypeAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.FixedBufferAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.HasCopySemanticsAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IDispatchConstantAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.IndexerNameAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.InternalsVisibleToAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.InternalsVisibleToAttribute.AllInternalsVisible.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.InternalsVisibleToAttribute.AllInternalsVisible.set(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IsBoxed' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IsByValue' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IsCopyConstructed' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IsExplicitlyDereferenced' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IsImplicitlyDereferenced' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IsJitIntrinsic' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IsLong' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IsPinned' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IsSignUnspecifiedByte' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IsUdtReturn' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.IteratorStateMachineAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.IUnknownConstantAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.LoadHint' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.MethodCodeType' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.MethodImplAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.MethodCodeType System.Runtime.CompilerServices.MethodImplAttribute.MethodCodeType' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.MethodImplAttribute..ctor()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.MethodImplAttribute..ctor(System.Int16)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.MethodImplOptions System.Runtime.CompilerServices.MethodImplOptions.ForwardRef' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.MethodImplOptions System.Runtime.CompilerServices.MethodImplOptions.InternalCall' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.MethodImplOptions System.Runtime.CompilerServices.MethodImplOptions.Synchronized' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.MethodImplOptions System.Runtime.CompilerServices.MethodImplOptions.Unmanaged' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.NativeCppClassAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.ReferenceAssemblyAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.RequiredAttributeAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.RuntimeCompatibilityAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.RuntimeHelpers.ExecuteCodeWithGuaranteedCleanup(System.Runtime.CompilerServices.RuntimeHelpers.TryCode, System.Runtime.CompilerServices.RuntimeHelpers.CleanupCode, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.RuntimeHelpers.PrepareConstrainedRegions()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.RuntimeHelpers.PrepareConstrainedRegionsNoOP()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.RuntimeHelpers.PrepareContractedDelegate(System.Delegate)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.RuntimeHelpers.PrepareDelegate(System.Delegate)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(System.RuntimeMethodHandle)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(System.RuntimeMethodHandle, System.RuntimeTypeHandle[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.RuntimeHelpers.ProbeForSufficientStack()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.CompilerServices.RuntimeHelpers.RunModuleConstructor(System.ModuleHandle)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.RuntimeHelpers.CleanupCode' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.RuntimeHelpers.TryCode' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.RuntimeWrappedException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.ScopelessEnumAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.SpecialNameAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.StateMachineAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.StringFreezingAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.CompilerServices.SuppressIldasmAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.TypeForwardedFromAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.TypeForwardedToAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.UnsafeValueTypeAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.ConstrainedExecution.Cer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.ConstrainedExecution.Consistency' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.ConstrainedExecution.CriticalFinalizerObject' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.ConstrainedExecution.ReliabilityContractAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.DesignerServices.WindowsRuntimeDesignerContext' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptionsAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Hosting.ActivationArguments' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Hosting.ApplicationActivator' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._Activator' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._Assembly' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._AssemblyBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._AssemblyName' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._Attribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._ConstructorBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._ConstructorInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._CustomAttributeBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._EnumBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._EventBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._EventInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._Exception' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._FieldBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._FieldInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._ILGenerator' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._LocalBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._MemberInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._MethodBase' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._MethodBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._MethodInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._MethodRental' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._Module' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._ModuleBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._ParameterBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._ParameterInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._PropertyBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._PropertyInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._SignatureHelper' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._Thread' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._Type' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices._TypeBuilder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.AllowReversePInvokeCallsAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.AssemblyRegistrationFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.AutomationProxyAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.BestFitMappingAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.BIND_OPTS' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.BINDPTR' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.CALLCONV' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.CallingConvention System.Runtime.InteropServices.CallingConvention.FastCall' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.CharSet System.Runtime.InteropServices.CharSet.Auto' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.CharSet System.Runtime.InteropServices.CharSet.None' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.ClassInterfaceAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.CoClassAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ComAliasNameAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ComCompatibleVersionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ComConversionLossAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.ComDefaultInterfaceAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.ComEventInterfaceAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.COMException' does not inherit from base type 'System.Runtime.InteropServices.ExternalException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.COMException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.ComImportAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ComRegisterFunctionAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.ComSourceInterfacesAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ComUnregisterFunctionAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.ComVisibleAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.CONNECTDATA' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.CriticalHandle' does not inherit from base type 'System.Runtime.ConstrainedExecution.CriticalFinalizerObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.CriticalHandle.Close()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.DefaultCharSetAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.DESCKIND' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.DispIdAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.DISPPARAMS' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.DllImportAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ELEMDESC' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.EXCEPINFO' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ExporterEventKind' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ExtensibleClassFactory' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ExternalException' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.FieldOffsetAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.FILETIME' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.FUNCDESC' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.FUNCFLAGS' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.FUNCKIND' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.GuidAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.HandleRef' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ICustomFactory' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ICustomMarshaler' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.IDispatchImplAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.IDispatchImplType' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.IDLDESC' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.IDLFLAG' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.IMPLTYPEFLAGS' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ImportedFromTypeLibAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ImporterEventKind' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.InAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.InterfaceTypeAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.InvalidComObjectException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.InvalidComObjectException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.InvalidOleVariantTypeException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.InvalidOleVariantTypeException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.INVOKEKIND' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.IRegistrationServices' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ITypeLibConverter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ITypeLibExporterNameProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ITypeLibExporterNotifySink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ITypeLibImporterNotifySink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.LCIDConversionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.LIBFLAGS' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ManagedToNativeComInteropStubAttribute' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.BindToMoniker(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.ChangeWrapperHandleStrength(System.Object, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.CleanupUnusedObjectsInCurrentContext()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GenerateGuidForType(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GenerateProgIdForType(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetActiveObject(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetComInterfaceForObjectInContext(System.Object, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetComObjectData(System.Object, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetComSlotForMethodInfo(System.Reflection.MemberInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetEndComSlot(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetExceptionPointers()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetHINSTANCE(System.Reflection.Module)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetIDispatchForObject(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetIDispatchForObjectInContext(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetITypeInfoForType(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetIUnknownForObjectInContext(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetManagedThunkForUnmanagedMethodPtr(System.IntPtr, System.IntPtr, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetMethodInfoForComSlot(System.Type, System.Int32, System.Runtime.InteropServices.ComMemberType)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetThreadFromFiberCookie(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypedObjectForIUnknown(System.IntPtr, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypeForITypeInfo(System.IntPtr)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypeInfoName(System.Runtime.InteropServices.UCOMITypeInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypeLibGuid(System.Runtime.InteropServices.ComTypes.ITypeLib)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypeLibGuid(System.Runtime.InteropServices.UCOMITypeLib)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypeLibGuidForAssembly(System.Reflection.Assembly)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypeLibLcid(System.Runtime.InteropServices.ComTypes.ITypeLib)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypeLibLcid(System.Runtime.InteropServices.UCOMITypeLib)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypeLibName(System.Runtime.InteropServices.ComTypes.ITypeLib)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypeLibName(System.Runtime.InteropServices.UCOMITypeLib)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypeLibVersionForAssembly(System.Reflection.Assembly, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetUnmanagedThunkForManagedMethodPtr(System.IntPtr, System.IntPtr, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.IsTypeVisibleFromCom(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.NumParamBytes(System.Reflection.MethodInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.Prelink(System.Reflection.MethodInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.PrelinkAll(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.PtrToStringAuto(System.IntPtr)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.PtrToStringAuto(System.IntPtr, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.ReleaseThreadCache()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.SecureStringToBSTR(System.Security.SecureString)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemAnsi(System.Security.SecureString)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemUnicode(System.Security.SecureString)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocAnsi(System.Security.SecureString)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocUnicode(System.Security.SecureString)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.SetComObjectData(System.Object, System.Object, System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.StringToCoTaskMemAuto(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.StringToHGlobalAuto(System.String)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.MarshalAsAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.MarshalDirectiveException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.MarshalDirectiveException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ObjectCreationDelegate' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.OptionalAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.OutAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.PARAMDESC' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.PARAMFLAG' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.PreserveSigAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.PrimaryInteropAssemblyAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.ProgIdAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.RegistrationClassContext' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.RegistrationConnectionType' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.RegistrationServices' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.RuntimeEnvironment' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.SafeArrayRankMismatchException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.SafeArrayRankMismatchException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.SafeArrayTypeMismatchException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.SafeArrayTypeMismatchException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.SafeBuffer' does not inherit from base type 'Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.SafeHandle' does not inherit from base type 'System.Runtime.ConstrainedExecution.CriticalFinalizerObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.SafeHandle.Close()' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.SEHException' does not inherit from base type 'System.Runtime.InteropServices.ExternalException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.SEHException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.SetWin32ContextInIDispatchAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.STATSTG' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.StructLayoutAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.StructLayoutAttribute..ctor(System.Int16)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.SYSKIND' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TYPEATTR' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TYPEDESC' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TYPEFLAGS' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.TypeIdentifierAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TYPEKIND' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TYPELIBATTR' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TypeLibConverter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TypeLibExporterFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TypeLibFuncAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TypeLibFuncFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TypeLibImportClassAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TypeLibImporterFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TypeLibTypeAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TypeLibTypeFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TypeLibVarAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TypeLibVarFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.TypeLibVersionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIBindCtx' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIConnectionPoint' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIConnectionPointContainer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIEnumConnectionPoints' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIEnumConnections' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIEnumMoniker' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIEnumString' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIEnumVARIANT' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIMoniker' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIPersistFile' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIRunningObjectTable' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMIStream' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMITypeComp' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMITypeInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.UCOMITypeLib' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.UnmanagedType System.Runtime.InteropServices.UnmanagedType.CustomMarshaler' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.VARDESC' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.VARFLAGS' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.Expando.IExpando' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.DefaultInterfaceAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.DesignerNamespaceResolveEventArgs' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.IActivationFactory' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.InterfaceImplementedInVersionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.NamespaceResolveEventArgs' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.ReadOnlyArrayAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.ReturnValueNameAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMetadata' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.WriteOnlyArrayAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.ActivatedClientTypeEntry' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.ActivatedServiceTypeEntry' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.CustomErrorsModes' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.IChannelInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.IEnvoyInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.InternalRemotingServices' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.IObjectHandle' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.IRemotingTypeInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.ObjectHandle' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.ObjRef' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.RemotingConfiguration' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.RemotingException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.RemotingServices' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.RemotingTimeoutException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.ServerException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.SoapServices' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.TypeEntry' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.WellKnownClientTypeEntry' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.WellKnownObjectMode' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.WellKnownServiceTypeEntry' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Activation.ActivatorLevel' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Activation.IActivator' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Activation.IConstructionCallMessage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Activation.IConstructionReturnMessage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Activation.UrlAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.BaseChannelObjectWithProperties' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.BaseChannelSinkWithProperties' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.BaseChannelWithProperties' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.ChannelDataStore' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.ChannelServices' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.ClientChannelSinkStack' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IChannel' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IChannelDataStore' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IChannelReceiver' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IChannelReceiverHook' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IChannelSender' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IChannelSinkBase' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IClientChannelSink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IClientChannelSinkProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IClientChannelSinkStack' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IClientFormatterSink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IClientFormatterSinkProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IClientResponseChannelSinkStack' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.ISecurableChannel' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IServerChannelSink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IServerChannelSinkProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IServerChannelSinkStack' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IServerFormatterSinkProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.IServerResponseChannelSinkStack' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.ITransportHeaders' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.ServerChannelSinkStack' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.ServerProcessing' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.SinkProviderData' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Channels.TransportHeaders' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.Context' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.ContextAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.ContextProperty' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.CrossContextDelegate' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.IContextAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.IContextProperty' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.IContextPropertyActivator' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.IContributeClientContextSink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.IContributeDynamicSink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.IContributeEnvoySink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.IContributeObjectSink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.IContributeServerContextSink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.IDynamicMessageSink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.IDynamicProperty' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Contexts.SynchronizationAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Lifetime.ClientSponsor' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Lifetime.ILease' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Lifetime.ISponsor' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Lifetime.LeaseState' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Lifetime.LifetimeServices' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.AsyncResult' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.CallContext' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.ConstructionCall' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.ConstructionResponse' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.Header' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.HeaderHandler' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.ILogicalThreadAffinative' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.IMessage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.IMessageCtrl' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.IMessageSink' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.IMethodCallMessage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.IMethodMessage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.IMethodReturnMessage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.InternalMessageWrapper' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.IRemotingFormatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.LogicalCallContext' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.MessageSurrogateFilter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.MethodCall' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.MethodCallMessageWrapper' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.MethodResponse' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.MethodReturnMessageWrapper' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.OneWayAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.RemotingSurrogateSelector' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Messaging.ReturnMessage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.SoapAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.SoapFieldAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.SoapMethodAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.SoapOption' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.SoapParameterAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.SoapTypeAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.XmlFieldOrderOption' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.ISoapXsd' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapAnyUri' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapBase64Binary' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapDate' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapDateTime' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapDay' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapDuration' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapEntities' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapEntity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapId' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapIdref' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapIdrefs' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapInteger' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapLanguage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapMonth' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapMonthDay' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapName' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapNcName' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapNegativeInteger' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapNmtoken' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapNmtokens' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapNonNegativeInteger' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapNonPositiveInteger' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapNormalizedString' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapNotation' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapPositiveInteger' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapQName' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapTime' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapToken' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapYear' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Metadata.W3cXsd2001.SoapYearMonth' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Proxies.ProxyAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Proxies.RealProxy' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Services.EnterpriseServicesHelper' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Services.ITrackingHandler' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Remoting.Services.TrackingServices' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.FormatterConverter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.FormatterServices' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.IDeserializationCallback' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.IFormatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.IFormatterConverter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.IObjectReference' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.ISafeSerializationData' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.ISerializable' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.ISerializationSurrogate' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.ISurrogateSelector' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.ObjectIDGenerator' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.ObjectManager' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.OnDeserializedAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.OnDeserializingAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.OnSerializedAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.OnSerializingAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.OptionalFieldAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.SafeSerializationEventArgs' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.SerializationBinder' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.SerializationEntry' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.SerializationException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.SerializationInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.SerializationInfoEnumerator' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.SerializationObjectManager' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.StreamingContext' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.StreamingContextStates' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.SurrogateSelector' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatters.FormatterAssemblyStyle' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatters.FormatterTypeStyle' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatters.IFieldInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatters.InternalRM' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatters.InternalST' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatters.ISoapMessage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatters.ServerFault' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatters.SoapFault' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatters.SoapMessage' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatters.TypeFilterLevel' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Formatters.Binary.BinaryFormatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Versioning.ComponentGuaranteesAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Versioning.ComponentGuaranteesOptions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Versioning.ResourceConsumptionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Versioning.ResourceExposureAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Versioning.ResourceScope' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.Versioning.TargetFrameworkAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.Versioning.VersioningHelper' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.AllowPartiallyTrustedCallersAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.AllowPartiallyTrustedCallersAttribute.PartialTrustVisibilityLevel.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.AllowPartiallyTrustedCallersAttribute.PartialTrustVisibilityLevel.set(System.Security.PartialTrustVisibilityLevel)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.CodeAccessPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.HostProtectionException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.HostSecurityManager' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.HostSecurityManagerOptions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.IEvidenceFactory' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.IPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.ISecurityEncodable' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.ISecurityPolicyEncodable' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.IStackWalk' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.NamedPermissionSet' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.PartialTrustVisibilityLevel' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.PermissionSet' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.PolicyLevelType' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.ReadOnlyPermissionSet' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.SecureString' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.SecurityContext' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.SecurityContextSource' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.SecurityCriticalAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.SecurityCriticalAttribute..ctor(System.Security.SecurityCriticalScope)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityCriticalAttribute.Scope.get()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.SecurityCriticalScope' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.SecurityElement' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.SecurityException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.SecurityException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException..ctor(System.String, System.Object, System.Object, System.Reflection.MethodInfo, System.Object, System.Security.IPermission)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException..ctor(System.String, System.Reflection.AssemblyName, System.Security.PermissionSet, System.Security.PermissionSet, System.Reflection.MethodInfo, System.Security.Permissions.SecurityAction, System.Object, System.Security.IPermission, System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException..ctor(System.String, System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException..ctor(System.String, System.Type, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.Action.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.Action.set(System.Security.Permissions.SecurityAction)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.Demanded.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.Demanded.set(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.DenySetInstance.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.DenySetInstance.set(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.FailedAssemblyInfo.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.FailedAssemblyInfo.set(System.Reflection.AssemblyName)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.FirstPermissionThatFailed.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.FirstPermissionThatFailed.set(System.Security.IPermission)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.GrantedSet.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.GrantedSet.set(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.Method.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.Method.set(System.Reflection.MethodInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.PermissionState.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.PermissionState.set(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.PermissionType.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.PermissionType.set(System.Type)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.PermitOnlySetInstance.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.PermitOnlySetInstance.set(System.Object)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.RefusedSet.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.RefusedSet.set(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.Url.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.Url.set(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.Zone.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.SecurityException.Zone.set(System.Security.SecurityZone)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.SecurityManager' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.SecurityRulesAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.SecurityRuleSet' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.SecuritySafeCriticalAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Security.SecurityState' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.SecurityTransparentAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Security.SecurityTreatAsSafeAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.SecurityZone' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.SuppressUnmanagedCodeSecurityAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.UnverifiableCodeAttribute' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.VerificationException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.VerificationException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.XmlSyntaxException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AccessControlActions' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AccessControlModification' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AccessControlSections' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AccessControlType' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AccessRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AccessRule<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AceEnumerator' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AceFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AceQualifier' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AceType' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AuditFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AuditRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AuditRule<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AuthorizationRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.AuthorizationRuleCollection' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.CommonAce' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.CommonAcl' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.CommonObjectSecurity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.CommonSecurityDescriptor' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.CompoundAce' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.CompoundAceType' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.ControlFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.CryptoKeyAccessRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.CryptoKeyAuditRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.CryptoKeyRights' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.CryptoKeySecurity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.CustomAce' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.DirectoryObjectSecurity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.DirectorySecurity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.DiscretionaryAcl' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.EventWaitHandleAccessRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.EventWaitHandleAuditRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.EventWaitHandleRights' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.EventWaitHandleSecurity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.FileSecurity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.FileSystemAccessRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.FileSystemAuditRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.FileSystemRights' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.FileSystemSecurity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.GenericAce' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.GenericAcl' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.GenericSecurityDescriptor' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.InheritanceFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.KnownAce' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.MutexAccessRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.MutexAuditRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.MutexRights' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.MutexSecurity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.NativeObjectSecurity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.ObjectAccessRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.ObjectAce' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.ObjectAceFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.ObjectAuditRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.ObjectSecurity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.ObjectSecurity<T>' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.PrivilegeNotHeldException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.PropagationFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.QualifiedAce' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.RawAcl' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.RawSecurityDescriptor' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.RegistryAccessRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.RegistryAuditRule' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.RegistrySecurity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.ResourceType' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.SecurityInfos' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.AccessControl.SystemAcl' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Claims.Claim' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Claims.ClaimsIdentity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Claims.ClaimsPrincipal' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Claims.ClaimTypes' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Claims.ClaimValueTypes' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.Aes.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.AsymmetricAlgorithm.Clear()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.AsymmetricAlgorithm.Create()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.AsymmetricAlgorithm.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.AsymmetricAlgorithm.FromXmlString(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.AsymmetricAlgorithm.KeyExchangeAlgorithm.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.AsymmetricAlgorithm.SignatureAlgorithm.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.AsymmetricAlgorithm.ToXmlString(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.AsymmetricKeyExchangeDeformatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.AsymmetricKeyExchangeFormatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.AsymmetricSignatureDeformatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.AsymmetricSignatureFormatter' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.CipherMode System.Security.Cryptography.CipherMode.CFB' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.CipherMode System.Security.Cryptography.CipherMode.OFB' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.CryptoAPITransform' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.CryptoConfig' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.CryptographicException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.CryptographicException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.CryptographicUnexpectedOperationException' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.CryptoStream' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.CryptoStream.Clear()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.CspKeyContainerInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.CspParameters' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.CspProviderFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.DES' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.DESCryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.DSA' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.DSACryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.DSAParameters' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.DSASignatureDeformatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.DSASignatureFormatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.FromBase64Transform' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.FromBase64TransformMode' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.HashAlgorithm' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Byte[] System.Security.Cryptography.HashAlgorithm.HashValue' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Int32 System.Security.Cryptography.HashAlgorithm.HashSizeValue' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Int32 System.Security.Cryptography.HashAlgorithm.State' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HashAlgorithm.CanReuseTransform.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HashAlgorithm.CanTransformMultipleBlocks.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HashAlgorithm.Clear()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HashAlgorithm.Create()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HashAlgorithm.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HashAlgorithm.Hash.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HashAlgorithm.InputBlockSize.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HashAlgorithm.OutputBlockSize.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HashAlgorithm.TransformBlock(System.Byte[], System.Int32, System.Int32, System.Byte[], System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HashAlgorithm.TransformFinalBlock(System.Byte[], System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.HMAC' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HMAC.BlockSizeValue.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HMAC.BlockSizeValue.set(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HMAC.Create()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HMAC.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.HMACMD5' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.HMACRIPEMD160' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.HMACSHA1' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HMACSHA1..ctor(System.Byte[], System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.HMACSHA256' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.HMACSHA384' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HMACSHA384.ProduceLegacyHmacValues.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HMACSHA384.ProduceLegacyHmacValues.set(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.HMACSHA512' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HMACSHA512.ProduceLegacyHmacValues.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.HMACSHA512.ProduceLegacyHmacValues.set(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.ICspAsymmetricAlgorithm' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.KeyedHashAlgorithm' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Byte[] System.Security.Cryptography.KeyedHashAlgorithm.KeyValue' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.KeyedHashAlgorithm.Create()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.KeyedHashAlgorithm.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.KeyNumber' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.MACTripleDES' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.MaskGenerationMethod' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.MD5' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.MD5.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.MD5CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.PaddingMode System.Security.Cryptography.PaddingMode.ANSIX923' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.PaddingMode System.Security.Cryptography.PaddingMode.ISO10126' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.PasswordDeriveBytes' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.PKCS1MaskGenerationMethod' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.RandomNumberGenerator.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.RandomNumberGenerator.GetBytes(System.Byte[], System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.RandomNumberGenerator.GetNonZeroBytes(System.Byte[])' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RC2' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RC2CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.Rfc2898DeriveBytes.CryptDeriveKey(System.String, System.String, System.Int32, System.Byte[])' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.Rijndael' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RijndaelManaged' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RijndaelManagedTransform' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RIPEMD160' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RIPEMD160Managed' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RNGCryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.RSA.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberAbstract : Member 'System.Security.Cryptography.RSA.Decrypt(System.Byte[], System.Security.Cryptography.RSAEncryptionPadding)' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.RSA.DecryptValue(System.Byte[])' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberAbstract : Member 'System.Security.Cryptography.RSA.Encrypt(System.Byte[], System.Security.Cryptography.RSAEncryptionPadding)' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.RSA.EncryptValue(System.Byte[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.RSA.FromXmlString(System.String)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberAbstract : Member 'System.Security.Cryptography.RSA.HashData(System.Byte[], System.Int32, System.Int32, System.Security.Cryptography.HashAlgorithmName)' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberAbstract : Member 'System.Security.Cryptography.RSA.HashData(System.IO.Stream, System.Security.Cryptography.HashAlgorithmName)' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.RSA.KeyExchangeAlgorithm.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.RSA.SignatureAlgorithm.get()' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberAbstract : Member 'System.Security.Cryptography.RSA.SignHash(System.Byte[], System.Security.Cryptography.HashAlgorithmName, System.Security.Cryptography.RSASignaturePadding)' is abstract in the implementation but is not abstract in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.RSA.ToXmlString(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotMakeMemberAbstract : Member 'System.Security.Cryptography.RSA.VerifyHash(System.Byte[], System.Byte[], System.Security.Cryptography.HashAlgorithmName, System.Security.Cryptography.RSASignaturePadding)' is abstract in the implementation but is not abstract in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RSACryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RSAOAEPKeyExchangeDeformatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RSAOAEPKeyExchangeFormatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RSAPKCS1KeyExchangeDeformatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RSAPKCS1KeyExchangeFormatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RSAPKCS1SignatureDeformatter' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.RSAPKCS1SignatureFormatter' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.SHA1' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.SHA1.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SHA1CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SHA1Managed' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.SHA256' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.SHA256.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SHA256Managed' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.SHA384' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.SHA384.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SHA384Managed' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.SHA512' does not implement interface 'System.Security.Cryptography.ICryptoTransform' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.SHA512.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SHA512Managed' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SignatureDescription' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Int32 System.Security.Cryptography.SymmetricAlgorithm.FeedbackSizeValue' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.SymmetricAlgorithm.Clear()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.SymmetricAlgorithm.Create()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.SymmetricAlgorithm.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.SymmetricAlgorithm.FeedbackSize.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.SymmetricAlgorithm.FeedbackSize.set(System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.SymmetricAlgorithm.ValidKeySize(System.Int32)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.ToBase64Transform' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.TripleDES.Create(System.String)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.TripleDESCryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Cryptography.X509Certificates.X509Certificate' does not implement interface 'System.Runtime.Serialization.IDeserializationCallback' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate..ctor(System.Byte[], System.Security.SecureString)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate..ctor(System.Byte[], System.Security.SecureString, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate..ctor(System.Security.Cryptography.X509Certificates.X509Certificate)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate..ctor(System.String, System.Security.SecureString)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate..ctor(System.String, System.Security.SecureString, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.CreateFromCertFile(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.CreateFromSignedFile(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.Export(System.Security.Cryptography.X509Certificates.X509ContentType, System.Security.SecureString)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.FormatDate(System.DateTime)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.GetCertHashString()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.GetEffectiveDateString()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.GetExpirationDateString()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.GetIssuerName()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.GetName()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.GetPublicKeyString()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.GetRawCertData()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.GetRawCertDataString()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.GetSerialNumberString()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.Import(System.Byte[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.Import(System.Byte[], System.Security.SecureString, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.Import(System.Byte[], System.String, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.Import(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.Import(System.String, System.Security.SecureString, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.Import(System.String, System.String, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509Certificate.Reset()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.CodeAccessSecurityAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.EnvironmentPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.EnvironmentPermissionAccess' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.EnvironmentPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.FileDialogPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.FileDialogPermissionAccess' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.FileDialogPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.FileIOPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.FileIOPermissionAccess' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.FileIOPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.GacIdentityPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.GacIdentityPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.HostProtectionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.HostProtectionResource' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.IsolatedStorageContainment' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.IsolatedStorageFilePermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.IsolatedStorageFilePermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.IsolatedStoragePermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.IsolatedStoragePermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.IUnrestrictedPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.KeyContainerPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.KeyContainerPermissionAccessEntry' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.KeyContainerPermissionAccessEntryCollection' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.KeyContainerPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.KeyContainerPermissionFlags' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.PermissionSetAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.PermissionState' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.PrincipalPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.PrincipalPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.PublisherIdentityPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.PublisherIdentityPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.ReflectionPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.ReflectionPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.ReflectionPermissionFlag' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.RegistryPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.RegistryPermissionAccess' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.RegistryPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.SecurityAction' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.SecurityAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.SecurityPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.SecurityPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.SecurityPermissionFlag' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.SiteIdentityPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.SiteIdentityPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.StrongNameIdentityPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.StrongNameIdentityPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.StrongNamePublicKeyBlob' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.UIPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.UIPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.UIPermissionClipboard' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.UIPermissionWindow' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.UrlIdentityPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.UrlIdentityPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.ZoneIdentityPermission' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Permissions.ZoneIdentityPermissionAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.AllMembershipCondition' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.ApplicationDirectory' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.ApplicationDirectoryMembershipCondition' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.ApplicationSecurityInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.ApplicationSecurityManager' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.ApplicationTrust' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.ApplicationTrustCollection' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.ApplicationTrustEnumerator' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.ApplicationVersionMatch' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.CodeConnectAccess' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.CodeGroup' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.Evidence' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.EvidenceBase' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.FileCodeGroup' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.FirstMatchCodeGroup' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.GacInstalled' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.GacMembershipCondition' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.Hash' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.HashMembershipCondition' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.IApplicationTrustManager' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.IIdentityPermissionFactory' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.IMembershipCondition' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.NetCodeGroup' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.PermissionRequestEvidence' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.PolicyException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.PolicyLevel' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.PolicyStatement' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.PolicyStatementAttribute' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.Publisher' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.PublisherMembershipCondition' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.Site' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.SiteMembershipCondition' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.StrongName' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.StrongNameMembershipCondition' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.TrustManagerContext' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.TrustManagerUIContext' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.UnionCodeGroup' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.Url' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.UrlMembershipCondition' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.Zone' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Policy.ZoneMembershipCondition' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.GenericIdentity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.GenericPrincipal' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.IdentityNotMappedException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.IdentityReference' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.IdentityReferenceCollection' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.IIdentity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.IPrincipal' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.NTAccount' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.PrincipalPolicy' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.SecurityIdentifier' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.TokenAccessLevels' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.TokenImpersonationLevel' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.WellKnownSidType' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.WindowsAccountType' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.WindowsBuiltInRole' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.WindowsIdentity' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.WindowsImpersonationContext' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Principal.WindowsPrincipal' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Text.ASCIIEncoding' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Text.Decoder.Convert(System.Byte*, System.Int32, System.Char*, System.Int32, System.Boolean, System.Int32, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Decoder.GetCharCount(System.Byte*, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Decoder.GetChars(System.Byte*, System.Int32, System.Char*, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Text.DecoderExceptionFallbackBuffer' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Text.DecoderFallbackException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Text.DecoderReplacementFallbackBuffer' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoder.Convert(System.Char*, System.Int32, System.Byte*, System.Int32, System.Boolean, System.Int32, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoder.GetByteCount(System.Char*, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoder.GetBytes(System.Char*, System.Int32, System.Byte*, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Text.EncoderExceptionFallbackBuffer' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Text.EncoderFallbackException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Text.EncoderReplacementFallbackBuffer' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Text.Encoding' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Text.Encoding.BodyName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.DecoderFallback.set(System.Text.DecoderFallback)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.Default.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.EncoderFallback.set(System.Text.EncoderFallback)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.GetEncodings()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.HeaderName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.IsAlwaysNormalized()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.IsAlwaysNormalized(System.Text.NormalizationForm)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.IsBrowserDisplay.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.IsBrowserSave.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.IsMailNewsDisplay.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.IsMailNewsSave.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.IsReadOnly.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.Encoding.WindowsCodePage.get()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Text.EncodingInfo' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Text.NormalizationForm' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Text.StringBuilder' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Text.UnicodeEncoding' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Int32 System.Text.UnicodeEncoding.CharSize' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Text.UTF32Encoding' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Text.UTF7Encoding' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Text.UTF8Encoding' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.AbandonedMutexException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.AbandonedMutexException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.ApartmentState' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.AsyncFlowControl' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.AutoResetEvent' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Threading.CompressedStack' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.ContextCallback' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.EventWaitHandle' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.EventWaitHandle..ctor(System.Boolean, System.Threading.EventResetMode, System.String, System.Boolean, System.Security.AccessControl.EventWaitHandleSecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.EventWaitHandle.GetAccessControl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.EventWaitHandle.OpenExisting(System.String, System.Security.AccessControl.EventWaitHandleRights)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.EventWaitHandle.SetAccessControl(System.Security.AccessControl.EventWaitHandleSecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.EventWaitHandle.TryOpenExisting(System.String, System.Security.AccessControl.EventWaitHandleRights, System.Threading.EventWaitHandle)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.ExecutionContext' does not implement interface 'System.IDisposable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.ExecutionContext.CreateCopy()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.ExecutionContext.Dispose()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.ExecutionContext.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.ExecutionContext.IsFlowSuppressed()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.ExecutionContext.RestoreFlow()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.ExecutionContext.SuppressFlow()' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.HostExecutionContext' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.HostExecutionContextManager' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.IOCompletionCallback' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.LockCookie' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.LockRecursionException' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.LockRecursionException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.ManualResetEvent' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.Monitor.Wait(System.Object, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.Monitor.Wait(System.Object, System.TimeSpan, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.Mutex' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.Mutex..ctor(System.Boolean, System.String, System.Boolean, System.Security.AccessControl.MutexSecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.Mutex.GetAccessControl()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.Mutex.OpenExisting(System.String, System.Security.AccessControl.MutexRights)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.Mutex.SetAccessControl(System.Security.AccessControl.MutexSecurity)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.Mutex.TryOpenExisting(System.String, System.Security.AccessControl.MutexRights, System.Threading.Mutex)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.NativeOverlapped' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.Overlapped' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.ParameterizedThreadStart' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.ReaderWriterLock' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.RegisteredWaitHandle' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.SemaphoreFullException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.SemaphoreFullException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.SendOrPostCallback' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.SynchronizationContext.IsWaitNotificationRequired()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.SynchronizationContext.SetWaitNotificationRequired()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.SynchronizationContext.Wait(System.IntPtr[], System.Boolean, System.Int32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.SynchronizationContext.WaitHelper(System.IntPtr[], System.Boolean, System.Int32)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.SynchronizationLockException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.SynchronizationLockException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.Thread' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.ThreadAbortException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.ThreadInterruptedException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.ThreadPool' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.ThreadPriority' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.ThreadStart' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.ThreadStartException' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.ThreadState' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.ThreadStateException' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.Timer' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.Timer..ctor(System.Threading.TimerCallback)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.Timer..ctor(System.Threading.TimerCallback, System.Object, System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.Timer..ctor(System.Threading.TimerCallback, System.Object, System.UInt32, System.UInt32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.Timer.Change(System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.Timer.Change(System.UInt32, System.UInt32)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.Timer.Dispose(System.Threading.WaitHandle)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.TimerCallback' does not implement interface 'System.ICloneable' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Threading.WaitCallback' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.WaitHandle' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.Close()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.Handle.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.Handle.set(System.IntPtr)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.SafeWaitHandle.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.SafeWaitHandle.set(Microsoft.Win32.SafeHandles.SafeWaitHandle)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.SignalAndWait(System.Threading.WaitHandle, System.Threading.WaitHandle)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.SignalAndWait(System.Threading.WaitHandle, System.Threading.WaitHandle, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.SignalAndWait(System.Threading.WaitHandle, System.Threading.WaitHandle, System.TimeSpan, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.WaitAll(System.Threading.WaitHandle[], System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.WaitAll(System.Threading.WaitHandle[], System.TimeSpan, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.WaitAny(System.Threading.WaitHandle[], System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.WaitAny(System.Threading.WaitHandle[], System.TimeSpan, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.WaitOne(System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandle.WaitOne(System.TimeSpan, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.WaitHandleCannotBeOpenedException' does not inherit from base type 'System.ApplicationException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.WaitHandleCannotBeOpenedException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.WaitOrTimerCallback' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.Tasks.Parallel' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.Tasks.ParallelLoopResult' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.Tasks.ParallelLoopState' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Threading.Tasks.ParallelOptions' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.Tasks.Task' does not implement interface 'System.IDisposable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.Tasks.Task.Dispose()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Threading.Tasks.Task.Dispose(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.Tasks.Task<TResult>' does not implement interface 'System.IDisposable' in the implementation but it does in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.Tasks.TaskCanceledException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.Tasks.TaskCanceledException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Threading.Tasks.TaskSchedulerException' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.Threading.Tasks.TaskSchedulerException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+Total Issues: 2707

--- a/src/mscorlib/src/mscorlib.builds
+++ b/src/mscorlib/src/mscorlib.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="mscorlib.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/mscorlib/src/mscorlib.csproj
+++ b/src/mscorlib/src/mscorlib.csproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>mscorlib</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <ContractProject>..\ref\mscorlib.depproj</ContractProject>
+    <UseEcmaKey>true</UseEcmaKey>
+    <GenFacadesArgs>$(GenFacadesArgs) -ignoreMissingTypes</GenFacadesArgs>
+    <BaselineAllAPICompatError>true</BaselineAllAPICompatError>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/mscorlib/src/project.json
+++ b/src/mscorlib/src/project.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "NETStandard.Library": "1.6.0-rc4-24214-03",
+    "Microsoft.Win32.Registry": "4.0.0-rc4-24214-03",
+  },
+  "frameworks": {
+    "netstandard1.5": { }
+  }
+}


### PR DESCRIPTION
Based off .net 4.6 with a substantial baseline, which we'll now start to burn down.
We will likely want to change this to be based off the Xamarin surface area, but this gets the ball rolling.
Does not include any packaging of this mscorlib.dll.
Thanks to WesH.