### PR TITLE
Updating coding standards regarding = and =>

### DIFF
--- a/Documentation/coding-guidelines/coding-style.md
+++ b/Documentation/coding-guidelines/coding-style.md
@@ -27,6 +27,7 @@ The general rule we follow is "use Visual Studio defaults".
 11. We use language keywords instead of BCL types (i.e. `int, string, float` instead of `Int32, String, Single`, etc) for both type references as well as method calls (i.e. `int.Parse` instead of `Int32.Parse`). See issue [391](https://github.com/dotnet/corefx/issues/391) for examples.
 12. We use PascalCasing to name all our constant local variables and fields. The only exception is for interop code where the constant value should exactly match the name and value of the code you are calling via interop.
 13. We use ```nameof(...)``` instead of ```"..."``` whenever possible and relevant.
+14. Avoid mixing `=` and the `=>` (expression bodied property) operator when declaring fields and properties. Place fields first, followed by properties using the `=>` operator.
 
 We have provided a Visual Studio 2013 vssettings file (`corefx.vssettings`) at the root of the corefx repository, enabling C# auto-formatting conforming to the above guidelines. Note that rules 7 and 8 are not covered by the vssettings, since these are not rules currently supported by VS formatting.
 


### PR DESCRIPTION
Nit: Using a mix of = and => when declaring fields and properties can be confusing. I'm proposing that we add the fields first, followed by the properties declared with this operator.

Instead of the following:

```C#
        private static string s_specificUserName = "test";
        private static string DomainJoinedTestServer => TestSettings.Http.DomainJoinedHttpHost;
        private static string s_specificPassword = "Password1";
        private static bool DomainJoinedTestsEnabled => !string.IsNullOrEmpty(DomainJoinedTestServer);
```

write:

```C#
        private static string s_specificUserName = "test";
        private static string s_specificPassword = "Password1";

        private static string DomainJoinedTestServer => TestSettings.Http.DomainJoinedHttpHost;
        private static bool DomainJoinedTestsEnabled => !string.IsNullOrEmpty(DomainJoinedTestServer);
```

@stephentoub @davidsh @weshaggard PTAL