### PR TITLE
Fixing NegotiateStream Windows Interop. Adding NTLM and Kerberos remote tests.

### DIFF
--- a/src/Common/src/Interop/Windows/sspicli/Interop.SSPI.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.SSPI.cs
@@ -514,7 +514,7 @@ internal static partial class Interop
         internal unsafe static extern SecurityStatus SspiFreeAuthIdentity(
             [In] IntPtr authData);
 
-        [DllImport(Interop.Libraries.Sspi, ExactSpelling = true, SetLastError = true)]
+        [DllImport(Interop.Libraries.Sspi, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
         internal unsafe static extern SecurityStatus SspiEncodeStringsAsAuthIdentity(
             [In] string userName,
             [In] string domainName,

--- a/src/Common/tests/System/Net/Capability.Security.cs
+++ b/src/Common/tests/System/Net/Capability.Security.cs
@@ -22,6 +22,16 @@ namespace System.Net.Test.Common
             return s_trustedCertificateSupport.Value;
         }
 
+        public static bool IsDomainAvailable()
+        {
+            return !string.IsNullOrWhiteSpace(Configuration.ActiveDirectoryName);
+        }
+
+        public static bool IsNegotiateServerAvailable()
+        {
+            return !(Configuration.NegotiateServer == null);
+        }
+
         private static bool InitializeTrustedRootCertificateCapability()
         {
             using (var store = new X509Store(StoreName.Root, StoreLocation.CurrentUser))

--- a/src/Common/tests/System/Net/Configuration.Security.cs
+++ b/src/Common/tests/System/Net/Configuration.Security.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace System.Net.Test.Common
+{
+    public static partial class Configuration
+    {
+        public static string ActiveDirectoryName => GetValue("COREFX_NET_AD_DOMAINNAME");
+
+        public static string ActiveDirectoryUserName => GetValue("COREFX_NET_AD_USERNAME");
+
+        public static string ActiveDirectoryUserPassword => GetValue("COREFX_NET_AD_PASSWORD");
+
+        public static Uri NegotiateServer => GetUriValue("COREFX_NET_NEGO_SERVER");
+    }
+}

--- a/src/Common/tests/System/Net/Configuration.cs
+++ b/src/Common/tests/System/Net/Configuration.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+namespace System.Net.Test.Common
+{
+    public static partial class Configuration
+    {
+        private static string GetValue(string envName, string defaultValue=null)
+        {
+            string envValue = Environment.GetEnvironmentVariable(envName);
+
+            if (string.IsNullOrWhiteSpace(envValue))
+            {
+                return defaultValue;
+            }
+
+            return Environment.ExpandEnvironmentVariables(envValue);
+        }
+
+        private static Uri GetUriValue(string envName, Uri defaultValue=null)
+        {
+            string envValue = GetValue(envName, null);
+
+            if (envValue == null)
+            {
+                return defaultValue;
+            }
+
+            return new Uri(envValue);
+        }
+    }
+}

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
@@ -1,0 +1,144 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Net.Test.Common;
+using System.Security.Authentication;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Security.Tests
+{
+    public class NegotiateStreamKerberosTest
+    {
+        public static bool IsServerAndDomainAvailable => 
+            Capability.IsDomainAvailable() && Capability.IsNegotiateServerAvailable();
+        
+        public static IEnumerable<object[]> GoodCredentialsData
+        {
+            get
+            {
+                yield return new object[] { CredentialCache.DefaultNetworkCredentials };
+                yield return new object[] { new NetworkCredential(
+                    Configuration.ActiveDirectoryUserName,
+                    Configuration.ActiveDirectoryUserPassword,
+                    Configuration.ActiveDirectoryName) };
+                
+                // Anonymous (with domain name).
+                yield return new object[] { new NetworkCredential(
+                    Configuration.ActiveDirectoryUserName,
+                    null,
+                    Configuration.ActiveDirectoryName) };
+                
+                // Anonymous (without domain).
+                yield return new object[] { new NetworkCredential(
+                    Configuration.ActiveDirectoryUserName,
+                    null,
+                    null) };
+            }
+        }
+
+        public static IEnumerable<object[]> BadCredentialsData
+        {
+            get
+            {
+                yield return new object[] { new NetworkCredential(null, null, Configuration.ActiveDirectoryName) };
+                yield return new object[] { new NetworkCredential(null, null, null) };
+                yield return new object[] { new NetworkCredential(
+                    "baduser", 
+                    null, 
+                    Configuration.ActiveDirectoryName) };
+                yield return new object[] { new NetworkCredential(
+                    "baduser", 
+                    "badpassword", 
+                    Configuration.ActiveDirectoryName) };
+            }
+        }
+
+        [OuterLoop]
+        [ConditionalTheory(nameof(IsServerAndDomainAvailable))]
+        [MemberData(nameof(GoodCredentialsData))]
+        public async Task NegotiateStream_AuthenticationRemote_Success(object credentialObject)
+        {
+            var credential = (NetworkCredential)credentialObject;
+            await VerifyAuthentication(credential);
+        }
+
+        [OuterLoop]
+        [ConditionalTheory(nameof(IsServerAndDomainAvailable))]
+        [MemberData(nameof(BadCredentialsData))]
+        public async Task NegotiateStream_AuthenticationRemote_Fails(object credentialObject)
+        {
+            var credential = (NetworkCredential)credentialObject;
+            await Assert.ThrowsAsync<AuthenticationException>(() => VerifyAuthentication(credential));
+        }
+
+        private async Task VerifyAuthentication(NetworkCredential credential)
+        {
+            string serverName = Configuration.NegotiateServer.Host;
+            int port = Configuration.NegotiateServer.Port;
+            string serverSPN = "HOST/" + serverName;
+            bool isLocalhost = await IsLocalHost(serverName);
+            
+            string expectedAuthenticationType = "Kerberos";
+            bool mutualAuthenitcated = true;
+
+            if (credential == CredentialCache.DefaultNetworkCredentials && isLocalhost)
+            {
+                expectedAuthenticationType = "NTLM";
+            }
+            else if (credential != CredentialCache.DefaultNetworkCredentials && 
+                (string.IsNullOrEmpty(credential.UserName) || string.IsNullOrEmpty(credential.Password)))
+            {
+                // Anonymous authentication.
+                expectedAuthenticationType = "NTLM";
+                mutualAuthenitcated = false;
+            }
+
+            using (var client = new TcpClient())
+            {
+                await client.ConnectAsync(serverName, port);
+
+                NetworkStream clientStream = client.GetStream();
+                using (var auth = new NegotiateStream(clientStream, leaveInnerStreamOpen:false))
+                {
+                    await auth.AuthenticateAsClientAsync(
+                        credential,
+                        serverSPN,
+                        ProtectionLevel.EncryptAndSign,
+                        System.Security.Principal.TokenImpersonationLevel.Identification);
+
+                    Assert.Equal(expectedAuthenticationType, auth.RemoteIdentity.AuthenticationType);
+                    Assert.Equal(serverSPN, auth.RemoteIdentity.Name);
+
+                    Assert.Equal(true, auth.IsAuthenticated);
+                    Assert.Equal(true, auth.IsEncrypted);
+                    Assert.Equal(mutualAuthenitcated, auth.IsMutuallyAuthenticated);
+                    Assert.Equal(true, auth.IsSigned);
+
+                    // Send a message to the server. Encode the test data into a byte array.
+                    byte[] message = Encoding.UTF8.GetBytes("Hello from the client.");
+                    await auth.WriteAsync(message, 0, message.Length);
+                }
+            }
+        }
+
+        private async static Task<bool> IsLocalHost(string hostname)
+        {
+            IPAddress[] hostAddresses = await Dns.GetHostAddressesAsync(hostname);
+            IPAddress[] localHostAddresses = await Dns.GetHostAddressesAsync(Dns.GetHostName());
+
+            // Note: This returns 127.0.0.1 and ::1 but 127.0.0.0/8 which most systems consider localhost.
+            IPAddress[] loopbackAddresses = await Dns.GetHostAddressesAsync("localhost");
+            int isLocalHost = hostAddresses.Intersect(localHostAddresses).Count();
+            int isLoopback = hostAddresses.Intersect(loopbackAddresses).Count();
+
+            return isLocalHost + isLoopback > 0;
+        }
+    }
+}

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -52,6 +52,7 @@
     <!-- NegotiateStream Tests -->
     <Compile Include="NegotiateStreamStreamToStreamTest.cs" />
     <Compile Include="ServiceNameCollectionTest.cs" />
+    <Compile Include="NegotiateStreamKerberosTest.cs" />
 
     <!-- Common test files -->
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
@@ -62,6 +63,12 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
       <Link>Common\System\Net\Capability.Security.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+      <Link>Common\System\Net\Configuration.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Security.cs">
+      <Link>Common\System\Net\Configuration.Security.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\SchSendAuxRecordTestServer.cs">
       <Link>Common\System\Net\SchSendAuxRecordTestServer.cs</Link>

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -9,6 +9,7 @@
     "System.Globalization.Extensions": "4.0.1-rc4-24215-01",
     "System.IO.FileSystem": "4.0.1-rc4-24215-01",
     "System.Linq.Expressions": "4.1.0-rc4-24215-01",
+    "System.Net.NameResolution": "4.0.0-rc4-24215-01",
     "System.Net.Primitives": "4.0.11-rc4-24215-01",
     "System.Net.Security": "4.0.0-rc4-24215-01",
     "System.Net.Sockets": "4.1.0-rc4-24215-01",

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -6,6 +6,7 @@
     "System.Diagnostics.Tracing": "4.1.0-rc4-24215-01",
     "System.IO.FileSystem": "4.0.1-rc4-24215-01",
     "System.Linq.Expressions": "4.1.0-rc4-24215-01",
+    "System.Net.NameResolution": "4.0.0-rc4-24215-01",
     "System.Net.Primitives": "4.0.11-rc4-24215-01",
     "System.Net.Sockets": "4.1.0-rc4-24215-01",
     "System.Net.TestData": "1.0.0-prerelease",


### PR DESCRIPTION
Fixing Windows SSPI Interop.
Adding a common Configuration and Capabilities infrastructure for System.Net in preparation for multi-machine testing.

Fixes #9160.

@davidsh @stephentoub PTAL
