### PR TITLE
ValueTuple: Lowering framework dependency to netstandard1.0

### DIFF
--- a/src/System.ValueTuple/pkg/System.ValueTuple.pkgproj
+++ b/src/System.ValueTuple/pkg/System.ValueTuple.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\System.ValueTuple.builds">
-      <SupportedFramework>net45;netcore45;netcoreapp1.0;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netcoreapp1.0;wp8;wpa81</SupportedFramework>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -4,10 +4,10 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <ProjectGuid>{4C2655DB-BD9E-4C86-83A6-744ECDDBDF29}</ProjectGuid>
-    <PackageTargetFramework>netstandard1.1</PackageTargetFramework>
+    <PackageTargetFramework>netstandard1.0</PackageTargetFramework>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <UseOpenKey Condition="'$(UseOpenKey)'==''">true</UseOpenKey>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.1</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.ValueTuple/src/project.json
+++ b/src/System.ValueTuple/src/project.json
@@ -9,7 +9,7 @@
   "frameworks": {
     "netstandard1.0": {
       "imports": [
-        "dotnet5.2"
+        "dotnet5.1"
       ]
     }
   }

--- a/src/System.ValueTuple/src/project.json
+++ b/src/System.ValueTuple/src/project.json
@@ -7,7 +7,7 @@
     "System.Runtime": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "netstandard1.0": {
       "imports": [
         "dotnet5.2"
       ]


### PR DESCRIPTION
Tomas pointed out that the dependency on netstandard1.1 is causing him some trouble and it is un-necessary. Changing to 1.0.
Note: I picked this up from `System.Buffers`. You may want to consider a similar change there.

@stephentoub @tmat for review.