### PR TITLE
Flow HttpClient timeouts and cancellation to the response stream

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -83,7 +83,15 @@ namespace System.Net.Http
                 }
             }
 
+#if HTTP_DLL
+            var content = new StreamContent(decompressedStream, state.CancellationToken);
+#else
+            // TODO: Issue https://github.com/dotnet/corefx/issues/9071
+            // We'd like to be able to pass state.CancellationToken into the StreamContent so that its
+            // SerializeToStreamAsync method can use it, but that ctor isn't public, nor is there a
+            // SerializeToStreamAsync override that takes a CancellationToken.
             var content = new StreamContent(decompressedStream);
+#endif
 
             response.Content = content;
             response.RequestMessage = request;

--- a/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
@@ -22,7 +22,6 @@ namespace System.Net.Http.Functional.Tests
             _output = output;
         }
 
-        [ActiveIssue(8663, PlatformID.Windows)]
         [OuterLoop] // includes seconds of delay
         [Theory]
         [InlineData(false, false)]


### PR DESCRIPTION
Basically this is the same as PR #9102.  We reverted that PR when the
internal ToF tests started failing. But it was determined that the
failure was due to infrastructure which is now fixed via
https://github.com/dotnet/coreclr/pull/5695