### PR TITLE
Add UWP clrcompression build 

### DIFF
--- a/src/Native/Windows/CMakeLists.txt
+++ b/src/Native/Windows/CMakeLists.txt
@@ -5,7 +5,7 @@ SET (CMAKE_C_FLAGS_INIT                     "/W0 /FC")
 SET (CMAKE_C_FLAGS_DEBUG_INIT               "/Od /Zi")
 SET (CMAKE_C_FLAGS_RELEASE_INIT             "/Ox")
 SET (CMAKE_C_FLAGS_RELWITHDEBINFO_INIT      "/O2 /Zi")
-set(CMAKE_ASM_MASM_FLAGS                    "${CMAKE_ASM_MASM_FLAGS} /ZH:SHA_256")
+SET (CMAKE_ASM_MASM_FLAGS                    "${CMAKE_ASM_MASM_FLAGS} /ZH:SHA_256")
 
 # CXX Compiler flags
 SET (CMAKE_CXX_FLAGS                        "-std=c++11")
@@ -18,7 +18,8 @@ SET (CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT    "/O2 /Zi")
 SET (CMAKE_INSTALL_PREFIX                   $ENV{__CMakeBinDir})
 SET (CMAKE_INCLUDE_CURRENT_DIR              ON)
 SET (CMAKE_SHARED_LIBRARY_PREFIX            "")
-  
+SET (__LinkArgs $ENV{__LinkArgs})
+
 # Force an out of source build
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "Binary directory isn't being correctly set before calling Cmake. Tree must be built in separate directory from source.")
@@ -79,6 +80,18 @@ else()
     set(__LinkLibraries "${__LinkLibraries} libvcruntimed.lib")
     set(STATIC_UCRT_LIB "libucrtd.lib")
     set(DYNAMIC_UCRT_LIB "ucrtd.lib")
+endif()
+
+# App-Container builds require a more specific linking to ensure the APIs imported pass WACK
+if ($ENV{__appContainer} STREQUAL true AND UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "RELEASE")
+    set(__LinkCustomCRT true)
+    set(__LinkArgs "${__LinkArgs} /LTCG")
+endif()
+
+if (__LinkCustomCRT STREQUAL "true" AND $ENV{__BuildArch} STREQUAL "arm" )
+    set(__LinkArgs "${__LinkArgs} /DEFAULTLIB:ole32.lib")
+elseif(__LinkCustomCRT STREQUAL "true" AND NOT $ENV{__BuildArch} STREQUAL "arm" )
+    set(__LinkArgs "${__LinkArgs} /NODEFAULTLIB")
 endif()
 
 # Linker flags

--- a/src/Native/Windows/build-native.cmd
+++ b/src/Native/Windows/build-native.cmd
@@ -8,6 +8,7 @@ set __binDir=%~dp0..\..\..\bin
 set __CMakeBinDir=""
 set __IntermediatesDir=""
 set __BuildArch=x64
+set __appContainer=""
 set __VCBuildArch=x86_amd64
 set CMAKE_BUILD_TYPE=Debug
 set "__LinkArgs= "
@@ -30,6 +31,11 @@ if /i [%1] == [/p:Platform]     (
     if /i [%2] == [x64]         ( set __BuildArch=x64&&set __VCBuildArch=x86_amd64&&shift&&shift&goto Arg_Loop)
     if /i [%2] == [amd64]       ( set __BuildArch=x64&&set __VCBuildArch=x86_amd64&&shift&&shift&goto Arg_Loop)
     echo Error: Invalid platform args "%1 and %2"
+    exit /b 1
+)
+if /i [%1] == [/p:TargetGroup]   (
+    if /i [%2] == [netcore50]    ( set "__LinkArgs=%__LinkArgs% /APPCONTAINER"&&set "__appContainer=true"&&shift&&shift&goto Arg_Loop)
+    if /i [%2] == [netcore50aot] ( set "__LinkArgs=%__LinkArgs% /APPCONTAINER"&&set "__appContainer=true"&&shift&&shift&goto Arg_Loop)
     exit /b 1
 )
 if /i [%1] == [-LinkArgument]   ( set "__LinkArgs=%__LinkArgs% %2"&&shift&&shift&goto Arg_Loop)

--- a/src/Native/Windows/clrcompression/CMakeLists.txt
+++ b/src/Native/Windows/clrcompression/CMakeLists.txt
@@ -8,53 +8,48 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include (GenerateExportHeader)
 
 if($ENV{__BuildArch} STREQUAL x86 OR $ENV{__BuildArch} STREQUAL x64)
-set(NATIVECOMPRESSION_SOURCES
-    clrcompression.def
-    zlib-intel/adler32.c
-    zlib-intel/crc_folding.c
-    zlib-intel/crc32.c
-    zlib-intel/deflate_quick.c
-    zlib-intel/deflate.c
-    zlib-intel/fill_window_sse.c
-    zlib-intel/match.c
-    zlib-intel/trees.c
-    zlib-intel/x86.c
-    zlib-intel/zutil.c
-    zlib/compress.c 
-    zlib/inffast.c
-    zlib/inflate.c
-    zlib/inftrees.c
-    #zlib/gzclose.c
-    #zlib/gzlib.c
-    #zlib/gzread.c
-    #zlib/gzwrite.c
-    #zlib/uncompr.c
-    #zlib/infback.c
-    #zlib/uncompr.c
+    set(NATIVECOMPRESSION_SOURCES
+        clrcompression.def
+        zlib-intel/adler32.c
+        zlib-intel/crc_folding.c
+        zlib-intel/crc32.c
+        zlib-intel/deflate_quick.c
+        zlib-intel/deflate.c
+        zlib-intel/fill_window_sse.c
+        zlib-intel/match.c
+        zlib-intel/trees.c
+        zlib-intel/x86.c
+        zlib-intel/zutil.c
+        zlib/compress.c 
+        zlib/inffast.c
+        zlib/inflate.c
+        zlib/inftrees.c
 )
-endif()
-
-if($ENV{__BuildArch} STREQUAL arm)
-set(NATIVECOMPRESSION_SOURCES
-    clrcompression.def
-    zlib/adler32.c
-    zlib/compress.c
-    zlib/crc32.c
-    zlib/deflate.c
-    zlib/inffast.c
-    zlib/inflate.c
-    zlib/inftrees.c
-    zlib/trees.c
-    zlib/zutil.c
-    #zlib/gzio.c
-    #zlib/infback.c
-    #zlib/uncompr.c
-)
+elseif($ENV{__BuildArch} STREQUAL arm)
+    set(NATIVECOMPRESSION_SOURCES
+        clrcompression.def
+        zlib/adler32.c
+        zlib/compress.c
+        zlib/crc32.c
+        zlib/deflate.c
+        zlib/inffast.c
+        zlib/inflate.c
+        zlib/inftrees.c
+        zlib/trees.c
+        zlib/zutil.c
+    )
 endif()
 
 if ($ENV{__VSVersion} STREQUAL vs2015)
     add_definitions(-DHAVE_VSNPRINTF)
 endif ()
+
+if(__LinkCustomCRT STREQUAL true)
+    set(NATIVECOMPRESSION_SOURCES
+        ${NATIVECOMPRESSION_SOURCES}
+        crt.cpp
+    )
+endif()
 
 # Include 'bin/obj' dir since it contains _version.h
 include_directories("${CMAKE_BINARY_DIR}/../../")

--- a/src/Native/Windows/clrcompression/crt.cpp
+++ b/src/Native/Windows/clrcompression/crt.cpp
@@ -1,0 +1,231 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <windows.h>
+
+#if defined(_M_IX86)
+#include <winnt.h>
+#endif
+
+extern "C" void __cdecl __security_init_cookie(void);
+
+extern "C" BOOL WINAPI _DllMainCRTStartup(HANDLE hDllHandle, DWORD dwReason, LPVOID lpreserved)
+{
+    if (dwReason == DLL_PROCESS_ATTACH)
+    {
+        __security_init_cookie();
+        DisableThreadLibraryCalls((HMODULE)hDllHandle);
+    }
+
+    return TRUE;
+}
+
+extern "C" void* __cdecl malloc(size_t size)
+{
+    return CoTaskMemAlloc(size);
+}
+
+extern "C" void __cdecl free(PVOID block)
+{
+    CoTaskMemFree(block);
+}
+
+extern "C" __declspec(noreturn) void __cdecl __report_rangecheckfailure(void)
+{
+    __fastfail(FAST_FAIL_RANGE_CHECK_FAILURE);
+}
+
+#if defined(_M_IX86)
+extern "C" __declspec(noreturn) void __cdecl __report_gsfailure(void)
+#else
+extern "C" __declspec(noreturn) void __cdecl __report_gsfailure(uintptr_t StackCookie)
+#endif
+{
+    __fastfail(FAST_FAIL_STACK_COOKIE_CHECK_FAILURE);
+}
+
+/*
+ * Union to facilitate converting from FILETIME to unsigned __int64
+ */
+typedef union {
+    unsigned __int64 ft_scalar;
+    FILETIME ft_struct;
+} FT;
+
+/*
+ * Default value used for the global /GS security cookie, defined here and
+ * in gs_support.c (since standalone SDK build can't use CRT's internal.h).
+ */
+
+#ifdef  _WIN64
+#define DEFAULT_SECURITY_COOKIE 0x00002B992DDFA232
+#else
+#define DEFAULT_SECURITY_COOKIE 0xBB40E64E
+#endif
+
+/*
+ * The global security cookie.  This name is known to the compiler.
+ * Initialize to a garbage non-zero value just in case we have a buffer overrun
+ * in any code that gets run before __security_init_cookie() has a chance to
+ * initialize the cookie to the final value.
+ */
+
+extern "C" DECLSPEC_SELECTANY UINT_PTR __security_cookie = DEFAULT_SECURITY_COOKIE;
+
+extern "C" DECLSPEC_SELECTANY UINT_PTR __security_cookie_complement = ~(DEFAULT_SECURITY_COOKIE);
+
+/***
+*__security_init_cookie(cookie) - init buffer overrun security cookie.
+*
+*Purpose:
+*       Initialize the global buffer overrun security cookie which is used by
+*       the /GS compile switch to detect overwrites to local array variables
+*       the potentially corrupt the return address.  This routine is called
+*       at EXE/DLL startup.
+*
+*Entry:
+*
+*Exit:
+*
+*Exceptions:
+*
+*******************************************************************************/
+
+//
+// We don't want define any local variables inside __security_init_cookie
+// because doing so make the compiler generate cookie checking on __security_init_cookie
+// which for sure will fail because __security_init_cookie will change the cookie 
+// value
+// 
+    UINT_PTR cookie;
+    FT systime={0};
+    LARGE_INTEGER perfctr;
+#if defined(CHECK_FOR_LATE_COOKIE_INIT)
+    PEXCEPTION_REGISTRATION_RECORD ehrec;
+#endif
+
+extern "C" void __cdecl __security_init_cookie(void)
+{
+    /*
+     * Do nothing if the global cookie has already been initialized.  On x86,
+     * reinitialize the cookie if it has been previously initialized to a
+     * value with the high word 0x0000.  Some versions of Windows will init
+     * the cookie in the loader, but using an older mechanism which forced the
+     * high word to zero.
+     */
+
+    if (__security_cookie != DEFAULT_SECURITY_COOKIE
+#if defined(_M_IX86)
+        && (__security_cookie & 0xFFFF0000) != 0
+#endif
+       )
+    {
+        __security_cookie_complement = ~__security_cookie;
+        return;
+    }
+
+#if defined(CHECK_FOR_LATE_COOKIE_INIT)
+    /*
+     * The security cookie is used to ensure the integrity of exception
+     * handling.  That means the cookie must be initialized in an image before
+     * that image registers an exception handler that will use the cookie.  We
+     * attempt to detect this situation by checking if the calling thread has
+     * already registered SEH handler _except_handler4.
+     */
+
+    for (ehrec = (PEXCEPTION_REGISTRATION_RECORD)(UINT_PTR)
+                    __readfsdword(FIELD_OFFSET(NT_TIB, ExceptionList));
+         ehrec != EXCEPTION_CHAIN_END;
+         ehrec = ehrec->Next)
+    {
+        if (ehrec->Handler == &_except_handler4)
+        {
+            /*
+             * We've detected __except_handler4, alert the user by issuing
+             * error R6035 and terminate the process.  We use FatalAppExitW
+             * instead of _NMSG_WRITE because the loader lock may be held now,
+             * and _NMSG_WRITE may do GetLibrary("user32.dll") for MessageBox,
+             * which is unsafe under the loader lock.
+             */
+            FatalAppExitW(0, _RT_COOKIE_INIT_TXT);
+        }
+
+        if (ehrec >= ehrec->Next)
+        {
+            /*
+             * Nodes in the exception record linked list are supposed to appear
+             * at increasing addresses within the thread's stack.  If the next
+             * node is at a lower address, then the exception list is corrupted,
+             * and we stop our check to avoid hitting a cycle in the list.
+             */
+
+            break;
+        }
+    }
+
+#endif
+
+    /*
+     * Initialize the global cookie with an unpredictable value which is
+     * different for each module in a process.  Combine a number of sources
+     * of randomness.
+     */
+
+    GetSystemTimeAsFileTime(&systime.ft_struct);
+#if defined(_WIN64)
+    cookie = systime.ft_scalar;
+#else
+    cookie = systime.ft_struct.dwLowDateTime;
+    cookie ^= systime.ft_struct.dwHighDateTime;
+#endif
+
+    cookie ^= GetCurrentThreadId();
+
+#if defined(_WIN64)
+    cookie ^= (((UINT_PTR) GetTickCount64()) << 24);
+#endif
+    cookie ^= (UINT_PTR) GetTickCount64();
+
+    QueryPerformanceCounter(&perfctr);
+#if defined(_WIN64)
+    cookie ^= (((UINT_PTR)perfctr.LowPart << 32) ^ perfctr.QuadPart);
+#else
+    cookie ^= perfctr.LowPart;
+    cookie ^= perfctr.HighPart;
+#endif
+
+    /*
+     * Increase entropy using ASLR relocation
+     */
+    cookie ^= (UINT_PTR)&cookie;
+
+#if defined(_WIN64)
+    /*
+     * On Win64, generate a cookie with the most significant word set to zero,
+     * as a defense against buffer overruns involving null-terminated strings.
+     * Don't do so on Win32, as it's more important to keep 32 bits of cookie.
+     */
+    cookie &= 0x0000FFFFffffFFFFi64;
+#endif
+
+    /*
+     * Make sure the cookie is initialized to a value that will prevent us from
+     * reinitializing it if this routine is ever called twice.
+     */
+
+    if (cookie == DEFAULT_SECURITY_COOKIE)
+    {
+        cookie = DEFAULT_SECURITY_COOKIE + 1;
+    }
+#if defined(_M_IX86)
+    else if ((cookie & 0xFFFF0000) == 0)
+    {
+        cookie |= ( (cookie|0x4711) << 16);
+    }
+#endif
+
+    __security_cookie = cookie;
+    __security_cookie_complement = ~cookie;
+
+}

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -43,6 +43,21 @@
       <OSGroup>Windows_NT</OSGroup>
       <Platform>arm</Platform>
     </Project>
+    <Project Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>x86</Platform>
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+    <Project Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>amd64</Platform>
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+    <Project Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>arm</Platform>
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -9,18 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-  <RuntimeDependency Include="runtime.win10-amd64-aot.runtime.native.System.IO.Compression">
-      <TargetRuntime>win10-amd64-aot</TargetRuntime>
-      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
-    </RuntimeDependency>
-    <RuntimeDependency Include="runtime.win10-arm-aot.runtime.native.System.IO.Compression">
-      <TargetRuntime>win10-arm-aot</TargetRuntime>
-      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
-    </RuntimeDependency>
-    <RuntimeDependency Include="runtime.win10-x86-aot.runtime.native.System.IO.Compression">
-      <TargetRuntime>win10-x86-aot</TargetRuntime>
-      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
-    </RuntimeDependency>
     <!-- make this package installable and noop in a packages.config-based project -->
     <File Include="$(PlaceHolderFile)">
       <TargetPath>lib/netstandard1.0</TargetPath>
@@ -53,6 +41,15 @@
       <Platform>amd64</Platform>
     </ProjectReference>
     <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>arm</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>x86</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win10\runtime.native.System.IO.Compression.pkgproj">
       <Platform>arm</Platform>
     </ProjectReference>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win10/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win10/runtime.native.System.IO.Compression.pkgproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <NativeFile Include="$(WinNativePath)..\..\NetCoreForCoreCLR\native\clrcompression.dll">
-      <TargetPath>runtimes/win10-$(PackagePlatform)-aot/lib/netcore50</TargetPath>
+    <NativeFile Include="$(WinNativePath)\clrcompression.dll">
+      <TargetPath>runtimes/win10-$(PackagePlatform)-aot/native</TargetPath>
     </NativeFile>
   </ItemGroup>
 


### PR DESCRIPTION
The AOT netcore50 clrcompression (formerly represented by win10) is currently the only one that still needs to be built in TFS. This commit resolves that requirement by adding AppContainer support to the Open Windows native build. It also ports some custom CRT code to circumvent undefined API errors and make it WACK-friendly.

- The result of this is that a clrcompression built with /p:TargetGroup=netcore50 will have the APPCONTAINER bit set.
- When building in netcore50 Release, the imports of the clrcompression will be a limited set of the usual (i.e. non-UWP) imports - this makes the dll pass the WACK supported API check.
- The import methods of the Release netcore50 clrcompression are identical to the corresponding clrcompression shipped out of TFS, though the latter imports "api-ms-win-core*" whereas the former imports "kernel32" and "ole32".
- This commit will need to be merged alongside a TFS commit to remove clrcompression entirely from the "PackagesToPublish" group.
- We will also need a commit to the build pipeline to add netcore50 configs to the "pipelines.corefx.json" file for the "CoreFx-Windows-Product-Native-Trusted" builds.

imports of this dll:
```
KERNEL32.dll
         180009000 Import Address Table
         18000CF30 Import Name Table
                 0 time date stamp
                 0 Index of first forwarder reference

                     214 GetCurrentThreadId
                     2FA GetTickCount64
                     117 DisableThreadLibraryCalls
                     2DD GetSystemTimeAsFileTime
                     430 QueryPerformanceCounter

ole32.dll
         180009030 Import Address Table
         18000CF60 Import Name Table
                 0 time date stamp
                 0 Index of first forwarder reference

                      7F CoTaskMemFree
                      7E CoTaskMemAlloc
```

imports of the dll from TFS:
```
 api-ms-win-core-profile-l1-1-0.dll
          180008038 Import Address Table
          18000C188 Import Name Table
                  0 time date stamp
                  0 Index of first forwarder reference

                        0 QueryPerformanceCounter

 api-ms-win-core-processthreads-l1-1-0.dll
          180008028 Import Address Table
          18000C178 Import Name Table
                  0 time date stamp
                  0 Index of first forwarder reference

                        D GetCurrentThreadId

 api-ms-win-core-sysinfo-l1-1-0.dll
          180008048 Import Address Table
          18000C198 Import Name Table
                  0 time date stamp
                  0 Index of first forwarder reference

                        A GetSystemTimeAsFileTime
                        E GetTickCount64

 api-ms-win-core-libraryloader-l1-1-0.dll
          180008018 Import Address Table
          18000C168 Import Name Table
                  0 time date stamp
                  0 Index of first forwarder reference

                        0 DisableThreadLibraryCalls

 api-ms-win-core-com-l1-1-0.dll
          180008000 Import Address Table
          18000C150 Import Name Table
                  0 time date stamp
                  0 Index of first forwarder reference

                       3E CoTaskMemFree
                       3D CoTaskMemAlloc
```

This also has the added benefit of upgrading the version of ZLib used in UWP to Zlib-Intel.