### PR TITLE
Fix on EnvelopedCms.Decode for Unix

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
+++ b/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography
 
             Debug.Assert(data != null, "Data is null");
             Debug.Assert(offset >= 0, "Offset is negative");
-            Debug.Assert(length > 2, "Length is too short");
+            Debug.Assert(length >= 2, "Length is too short");
             Debug.Assert(length <= data.Length - offset, "Array is too short");
 
             _position = offset;
@@ -354,6 +354,10 @@ namespace System.Security.Cryptography
             if (lengthOrLengthLength < 0x80)
             {
                 bytesConsumed = 1;
+
+                if (lengthOrLengthLength > data.Length - offset - 1)
+                    throw new InvalidOperationException(SR.Cryptography_Der_Invalid_Length);
+                
                 return lengthOrLengthLength;
             }
 
@@ -370,6 +374,9 @@ namespace System.Security.Cryptography
                 accum <<= 8;
                 accum += data[i];
             }
+
+            if (accum > data.Length - end)
+                throw new InvalidOperationException(SR.Cryptography_Der_Invalid_Length);
 
             return accum;
         }

--- a/src/System.Security.Cryptography.Encoding/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Encoding/src/Resources/Strings.resx
@@ -120,6 +120,9 @@
   <data name="Cryptography_Der_Invalid_Encoding" xml:space="preserve">
     <value>ASN1 corrupted data.</value>
   </data>
+  <data name="Cryptography_Der_Invalid_Length" xml:space="preserve">
+    <value>ASN1 unexpected end of data.</value>
+  </data>
   <data name="Cryptography_Oid_InvalidValue" xml:space="preserve">
     <value>The OID value is invalid.</value>
   </data>

--- a/src/System.Security.Cryptography.Encoding/tests/DerSequenceReaderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerSequenceReaderTests.cs
@@ -93,5 +93,40 @@ namespace System.Security.Cryptography.Encoding.Tests
             Assert.Equal(representedTime, decodedTime);
             Assert.Equal(DateTimeKind.Utc, decodedTime.Kind);
         }
+
+        [Fact]
+        public static void FalseEncodedLength_MultiByteLength()
+        {
+            // This DER encoding follows the usual style of { tag, length, data }, however the encoding for data length
+            // here specifies that the content is 672 bytes long (0x82 0x02 0xA0) when in reality it holds 671 bytes
+            // that should be encoded as 0x82 0x02 0x9F instead
+            byte[] encodedMessage =
+                 ("308202a006092a864886f70d010703a08202903082028c020100318202583081c5020100302e301a31183016060355040313"
+                + "0f5253414b65795472616e7366657231021031d935fb63e8cfab48a0bf7b397b67c0300d06092a864886f70d010101050004"
+                + "818061b4161da3daff2c6c304b8decb021b09ee2523f5162124a6893b077b22a71327c8ab12a82f80472845e274643bfee33"
+                + "d34caca6b59fffc66f7fdb2279726f58615258bc3787b479fdfeb4856279e85106d5c271b2f5cadcc8b5622f69cb7e7efd90"
+                + "38727c1cb717cb867d2f3e87c3f653cb77837706abb01d40bb22136dac753081c5020100302e301a31183016060355040313"
+                + "0f5253414b65795472616e736665723202102bce9f9ece39f98044f0cd2faa9a14e7300d06092a864886f70d010101050004"
+                + "818077293ebfd59a4cef9161ef60f082eca1fd7b2e52804992ea5421527bbea35d7abf810d4316e07dfe766f90b221ae34aa"
+                + "192e200c26105aba5511c5e168e4cb0bb2996dce730648d5bc8a0005fbb112a80f9a525e266654d4f3de8318abb8f769c387"
+                + "e402889354965f05814dcc4a787de1d5442107ab1bf8dcdbeb432d4d70a73081c5020100302e301a31183016060355040313"
+                + "0f5253414b65795472616e736665723302104497d870785a23aa4432ed0106ef72a6300d06092a864886f70d010101050004"
+                + "81807f2d1e0c34b9c4d8e07cf50107114e10f8c3759eca4bb6385451cf7d3619548b217670e4d9eea0c7a09c513c0e4fc1b1"
+                + "978ee2b2aab4c7b04183031d2685bf5ea32b8b48d8eef34743bdf14ba71cde56c97618d48692e59f529cd5a7922caff4ac02"
+                + "e5a856a5b28db681b0b508b9761b6fa05a5634742c3542986e4073e7932a302b06092a864886f70d010701301406082a8648"
+                + "86f70d030704081ddc958302db22518008d0f4f5bb03b69819").HexToByteArray();
+
+            Assert.Throws<InvalidOperationException>(()=>DerSequenceReader.CreateForPayload(encodedMessage).ReadSequence());
+        }
+
+        [Fact]
+        public static void FalseEncodedLength_SingleByte()
+        {
+            // This is tagged to be an OID (0x06) but data is corrupted and holds a false length and no data. This tests
+            // length sanity check for reading faulty single byte lengths in DER
+            byte[] encodedMessage = ("0601").HexToByteArray();
+
+            Assert.Throws<InvalidOperationException>(() => DerSequenceReader.CreateForPayload(encodedMessage).ReadOid());
+        }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
@@ -123,6 +123,9 @@
   <data name="Cryptography_Der_Invalid_Encoding" xml:space="preserve">
     <value>ASN1 corrupted data.</value>
   </data>
+  <data name="Cryptography_Der_Invalid_Length" xml:space="preserve">
+    <value>ASN1 unexpected end of data.</value>
+  </data>
   <data name="Cryptography_Invalid_IA5String" xml:space="preserve">
     <value>The string contains a character not in the 7 bit ASCII character set.</value>
   </data>

--- a/src/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
@@ -153,4 +153,7 @@
   <data name="Cryptography_Der_Invalid_Encoding" xml:space="preserve">
     <value>ASN1 corrupted data.</value>
   </data>
+  <data name="Cryptography_Der_Invalid_Length" xml:space="preserve">
+    <value>ASN1 unexpected end of data.</value>
+  </data>
 </root>

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/DecryptorPalOpenSsl.Decode.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/DecryptorPalOpenSsl.Decode.cs
@@ -103,8 +103,8 @@ namespace Internal.Cryptography.Pal.OpenSsl
 
             // Skip recipientInfos as these are retrieved with OpenSSL
             const byte constructedSequence = (byte)DerSequenceReader.DerTag.Set | DerSequenceReader.ConstructedFlag;
-            Debug.Assert(encodedCms.PeekTag() == constructedSequence);
-            encodedCms.SkipValue();
+            Debug.Assert(innerSequenceReader.PeekTag() == constructedSequence);
+            innerSequenceReader.SkipValue();
 
             contentEncryptionAlgorithm = innerSequenceReader.ReadEncryptionAlgorithm();
             unprotectedAttributes = innerSequenceReader.ReadUnprotectedAttributes();

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/OpenSslHelpers.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/OpenSslHelpers.cs
@@ -156,7 +156,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
 
             if (encodedCms.HasData && encodedCms.PeekTag() == contextImplicit1)
             {
-                DerSequenceReader encodedAttributesReader = encodedCms.ReadSequence();
+                DerSequenceReader encodedAttributesReader = encodedCms.ReadSet();
                 while (encodedAttributesReader.HasData)
                 {
                     DerSequenceReader attributeReader = encodedAttributesReader.ReadSequence();

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -162,6 +162,9 @@
   <data name="Cryptography_Der_Invalid_Encoding" xml:space="preserve">
     <value>ASN1 corrupted data.</value>
   </data>
+  <data name="Cryptography_Der_Invalid_Length" xml:space="preserve">
+    <value>ASN1 unexpected end of data.</value>
+  </data>
   <data name="Cryptography_Invalid_IA5String" xml:space="preserve">
     <value>The string contains a character not in the 7 bit ASCII character set.</value>
   </data>

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -159,6 +159,9 @@
   <data name="Cryptography_Der_Invalid_Encoding" xml:space="preserve">
     <value>ASN1 corrupted data.</value>
   </data>
+  <data name="Cryptography_Der_Invalid_Length" xml:space="preserve">
+    <value>ASN1 unexpected end of data.</value>
+  </data>
   <data name="Cryptography_InvalidContextHandle" xml:space="preserve">
     <value>The chain context handle is invalid.</value>
   </data>


### PR DESCRIPTION
+Fixed bugs introduced by the refactoring of EnvelopedCms.Decode
refactoring.
+Added sanity check on encoded lengths for DerSequenceReader and added
corresponding test cases.

@bartonjs @weshaggard 