### PR TITLE
Expand Bit array tests

### DIFF
--- a/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Collections.Tests
 {
-    public class BitArray_CtorTests
+    public static class BitArray_CtorTests
     {
         [Theory]
         [InlineData(0)]
@@ -98,7 +98,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_IntArray_TestData))]
-        public void Ctor_IntArray(int[] array, bool[] expected)
+        public static void Ctor_IntArray(int[] array, bool[] expected)
         {
             BitArray bitArray = new BitArray(array);
             Assert.Equal(expected.Length, bitArray.Length);

--- a/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
@@ -27,12 +27,17 @@ namespace System.Collections.Tests
             ICollection collection = bitArray;
             Assert.Equal(length, collection.Count);
             Assert.False(collection.IsSynchronized);
-
-            Ctor_BitArray(bitArray);
-            Ctor_Int_Bool(length, false);
-            Ctor_Int_Bool(length, true);
         }
 
+        [Theory]
+        [InlineData(0, true)]
+        [InlineData(0, false)]
+        [InlineData(40, true)]
+        [InlineData(40, false)]
+        [InlineData(200, true)]
+        [InlineData(200, false)]
+        [InlineData(65551, true)]
+        [InlineData(65551, false)]
         public static void Ctor_Int_Bool(int length, bool defaultValue)
         {
             BitArray bitArray = new BitArray(length, defaultValue);
@@ -45,8 +50,6 @@ namespace System.Collections.Tests
             ICollection collection = bitArray;
             Assert.Equal(length, collection.Count);
             Assert.False(collection.IsSynchronized);
-
-            Ctor_BitArray(bitArray);
         }
 
         [Fact]
@@ -56,9 +59,22 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentOutOfRangeException>("length", () => new BitArray(-1, false));
         }
 
+        public static IEnumerable<object[]> Ctor_BoolArray_TestData()
+        {
+            yield return new object[] { new bool[0] };
+            yield return new object[] { new bool[] { false } };
+            yield return new object[] { new bool[] { true } };
+            yield return new object[] { new bool[] { false, false, true, false, false, false, true, false, false, true } };
+            yield return new object[] { Enumerable.Repeat(true, 32).ToArray() };
+            yield return new object[] { Enumerable.Repeat(false, 32).ToArray() };
+            yield return new object[] { Enumerable.Range(0, 32).Select(x => x % 2 == 0).ToArray() };
+            yield return new object[] { Enumerable.Repeat(true, 64).ToArray() };
+            yield return new object[] { Enumerable.Repeat(false, 64).ToArray() };
+            yield return new object[] { Enumerable.Range(0, 64).Select(x => x % 2 == 0).ToArray() };
+        }
+
         [Theory]
-        [InlineData(new bool[0])]
-        [InlineData(new bool[] { false, false, true, false, false, false, true, false, false, true })]
+        [MemberData(nameof(Ctor_BoolArray_TestData))]
         public static void Ctor_BoolArray(bool[] values)
         {
             BitArray bitArray = new BitArray(values);
@@ -71,11 +87,30 @@ namespace System.Collections.Tests
             ICollection collection = bitArray;
             Assert.Equal(values.Length, collection.Count);
             Assert.False(collection.IsSynchronized);
-
-            Ctor_BitArray(bitArray);
         }
 
-        public static void Ctor_BitArray(BitArray bits)
+        public static IEnumerable<object[]> Ctor_BitArray_TestData()
+        {
+            foreach (int size in new[] { 0, 1, 8, 32, 64 })
+            {
+                yield return new object[] { "length", new BitArray(size) };
+                yield return new object[] { "length|default(true)", new BitArray(size, true) };
+                yield return new object[] { "length|default(false)", new BitArray(size, false) };
+                yield return new object[] { "bool[](all)", new BitArray(Enumerable.Repeat(true, size).ToArray()) };
+                yield return new object[] { "bool[](none)", new BitArray(Enumerable.Repeat(false, size).ToArray()) };
+                yield return new object[] { "bool[](alternating)", new BitArray(Enumerable.Range(0, size).Select(x => x % 2 == 0).ToArray()) };
+                yield return new object[] { "byte[](all)", new BitArray(Enumerable.Repeat((byte)255, size / 8).ToArray()) };
+                yield return new object[] { "byte[](none)", new BitArray(Enumerable.Repeat((byte)0, size / 8).ToArray()) };
+                yield return new object[] { "byte[](alternating)", new BitArray(Enumerable.Repeat((byte)0xaa, size / 8).ToArray()) };
+                yield return new object[] { "int[](all)", new BitArray(Enumerable.Repeat(unchecked((int)0xffffffff), size / 32).ToArray()) };
+                yield return new object[] { "int[](none)", new BitArray(Enumerable.Repeat(0, size / 32).ToArray()) };
+                yield return new object[] { "int[](alternating)", new BitArray(Enumerable.Repeat(unchecked((int)0xaaaaaaaa), size / 32).ToArray()) };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Ctor_BitArray_TestData))]
+        public static void Ctor_BitArray(string label, BitArray bits)
         {
             BitArray bitArray = new BitArray(bits);
             Assert.Equal(bits.Length, bitArray.Length);
@@ -91,6 +126,7 @@ namespace System.Collections.Tests
 
         public static IEnumerable<object[]> Ctor_IntArray_TestData()
         {
+            yield return new object[] { new int[0], new bool[0] };
             yield return new object[] { Enumerable.Repeat(unchecked((int)0xffffffff), 10).ToArray(), Enumerable.Repeat(true, 320).ToArray() };
             yield return new object[] { Enumerable.Repeat(0, 10).ToArray(), Enumerable.Repeat(false, 320).ToArray() };
             yield return new object[] { Enumerable.Repeat(unchecked((int)0xaaaaaaaa), 10).ToArray(), Enumerable.Range(0, 320).Select(i => i % 2 == 1).ToArray() };
@@ -117,7 +153,7 @@ namespace System.Collections.Tests
         {
             Assert.Throws<ArgumentNullException>("bits", () => new BitArray((BitArray)null));
         }
-        
+
         [Fact]
         public static void Ctor_BoolArray_Null_ThrowsArgumentNullException()
         {
@@ -132,8 +168,15 @@ namespace System.Collections.Tests
 
         public static IEnumerable<object[]> Ctor_ByteArray_TestData()
         {
+            yield return new object[] { new byte[0], new bool[0] };
             yield return new object[] { new byte[] { 255, 255 }, Enumerable.Repeat(true, 16).ToArray() };
             yield return new object[] { new byte[] { 0, 0 }, Enumerable.Repeat(false, 16).ToArray() };
+            yield return new object[] { new byte[] { 255, 255, 255, 255 }, Enumerable.Repeat(true, 32).ToArray() };
+            yield return new object[] { new byte[] { 0, 0, 0, 0 }, Enumerable.Repeat(false, 32).ToArray() };
+            yield return new object[] { Enumerable.Repeat((byte)0xaa, 4).ToArray(), Enumerable.Range(0, 32).Select(i => i % 2 == 1).ToArray() };
+            yield return new object[] { new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, Enumerable.Repeat(true, 64).ToArray() };
+            yield return new object[] { new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, Enumerable.Repeat(false, 64).ToArray() };
+            yield return new object[] { Enumerable.Repeat((byte)0xaa, 8).ToArray(), Enumerable.Range(0, 64).Select(i => i % 2 == 1).ToArray() };
         }
 
         [Theory]

--- a/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
@@ -10,8 +10,8 @@ namespace System.Collections.Tests
 {
     public static class BitArray_CtorTests
     {
-        public const int BitsPerByte = 8;
-        public const int BitsPerInt32 = 32;
+        private const int BitsPerByte = 8;
+        private const int BitsPerInt32 = 32;
 
         [Theory]
         [InlineData(0)]

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -10,8 +10,8 @@ namespace System.Collections.Tests
 {
     public static class BitArray_GetSetTests
     {
-        private const int BitsPerByte = 8;
-        private const int BitsPerInt32 = 32;
+        private const int BitsPerByte = BitArray_CtorTests.BitsPerByte;
+        private const int BitsPerInt32 = BitArray_CtorTests.BitsPerInt32;
 
         public static IEnumerable<object[]> Get_Set_Data()
         {

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Collections.Tests
 {
-    public class BitArray_GetSetTests
+    public static class BitArray_GetSetTests
     {
         private static BitArray s_allTrue = new BitArray(320, true);
         private static BitArray s_allFalse = new BitArray(320, false);
@@ -175,7 +175,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(CopyTo_IntArray_TestData))]
-        public void CopyTo(BitArray bitArray, Array array, int index, Array expected, Type arrayType)
+        public static void CopyTo(BitArray bitArray, Array array, int index, Array expected, Type arrayType)
         {
             object defaultValue = Activator.CreateInstance(arrayType);
             ICollection collection = bitArray;
@@ -195,7 +195,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public void CopyTo_Invalid()
+        public static void CopyTo_Invalid()
         {
             ICollection bitArray = new BitArray(10);
             // Invalid array
@@ -210,7 +210,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public void SyncRoot()
+        public static void SyncRoot()
         {
             ICollection bitArray = new BitArray(10);
             Assert.Same(bitArray.SyncRoot, bitArray.SyncRoot);

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -206,8 +206,12 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => bitArray.Length = -1);
         }
 
-        public static IEnumerable<object[]> CopyTo_IntArray_TestData()
+        public static IEnumerable<object[]> CopyTo_Array_TestData()
         {
+            yield return new object[] { new BitArray(0), 0, 0, new bool[0], default(bool) };
+            yield return new object[] { new BitArray(0), 0, 0, new byte[0], default(byte) };
+            yield return new object[] { new BitArray(0), 0, 0, new int[0], default(int) };
+
             foreach (int bitArraySize in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
             {
                 BitArray allTrue = new BitArray(Enumerable.Repeat(true, bitArraySize).ToArray());
@@ -244,7 +248,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData(nameof(CopyTo_IntArray_TestData))]
+        [MemberData(nameof(CopyTo_Array_TestData))]
         public static void CopyTo<T>(BitArray bitArray, int length, int index, T[] expected, T def)
         {
             T[] array = (T[])Array.CreateInstance(typeof(T), length);

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -254,18 +254,35 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void CopyTo_Invalid()
+        public static void CopyTo_Type_Invalid()
         {
             ICollection bitArray = new BitArray(10);
-            // Invalid array
             Assert.Throws<ArgumentNullException>("array", () => bitArray.CopyTo(null, 0));
             Assert.Throws<ArgumentException>(null, () => bitArray.CopyTo(new long[10], 0));
             Assert.Throws<ArgumentException>(null, () => bitArray.CopyTo(new int[10, 10], 0));
+        }
 
-            // Invalid index
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => bitArray.CopyTo(new byte[10], -1));
-            Assert.Throws<ArgumentException>(null, () => bitArray.CopyTo(new byte[1], 2));
-            Assert.Throws<ArgumentException>(null, () => bitArray.CopyTo(new bool[10], 2));
+        [Theory]
+        [InlineData(default(bool), 1, 0, 0)]
+        [InlineData(default(bool), 1, 1, 1)]
+        [InlineData(default(bool), BitsPerByte, BitsPerByte - 1, 0)]
+        [InlineData(default(bool), BitsPerByte, BitsPerByte, 1)]
+        [InlineData(default(bool), BitsPerInt32, BitsPerInt32 - 1, 0)]
+        [InlineData(default(bool), BitsPerInt32, BitsPerInt32, 1)]
+        [InlineData(default(byte), BitsPerByte, 0, 0)]
+        [InlineData(default(byte), BitsPerByte, 1, 1)]
+        [InlineData(default(byte), BitsPerByte * 4, 4 - 1, 0)]
+        [InlineData(default(byte), BitsPerByte * 4, 4, 1)]
+        [InlineData(default(int), BitsPerInt32, 0, 0)]
+        [InlineData(default(int), BitsPerInt32, 1, 1)]
+        [InlineData(default(int), BitsPerInt32 * 4, 4 - 1, 0)]
+        [InlineData(default(int), BitsPerInt32 * 4, 4, 1)]
+        public static void CopyTo_Size_Invalid<T>(T def, int bits, int arraySize, int index)
+        {
+            ICollection bitArray = new BitArray(bits);
+            T[] array = (T[])Array.CreateInstance(typeof(T), arraySize);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => bitArray.CopyTo(array, -1));
+            Assert.Throws<ArgumentException>(def is int ? string.Empty : null, () => bitArray.CopyTo(array, index));
         }
 
         [Fact]

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -10,8 +10,8 @@ namespace System.Collections.Tests
 {
     public static class BitArray_GetSetTests
     {
-        private const int BitsPerByte = BitArray_CtorTests.BitsPerByte;
-        private const int BitsPerInt32 = BitArray_CtorTests.BitsPerInt32;
+        private const int BitsPerByte = 8;
+        private const int BitsPerInt32 = 32;
 
         public static IEnumerable<object[]> Get_Set_Data()
         {

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -10,9 +10,8 @@ namespace System.Collections.Tests
 {
     public static class BitArray_GetSetTests
     {
-        private static BitArray s_allTrue = new BitArray(320, true);
-        private static BitArray s_allFalse = new BitArray(320, false);
-        private static BitArray s_alternating = new BitArray(Enumerable.Repeat(unchecked((int)0xaaaaaaaa), 10).ToArray());
+        private const int BitsPerByte = 8;
+        private const int BitsPerInt32 = 32;
 
         [Theory]
         [InlineData(new bool[] { true })]
@@ -52,12 +51,21 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [InlineData(6, true)]
-        [InlineData(6, false)]
-        [InlineData(0x1000F, true)]
+        [InlineData(0, true)]
+        [InlineData(0, false)]
+        [InlineData(1, true)]
+        [InlineData(1, false)]
+        [InlineData(BitsPerByte, true)]
+        [InlineData(BitsPerByte, false)]
+        [InlineData(+1, true)]
+        [InlineData(+1, false)]
+        [InlineData(BitsPerInt32, true)]
+        [InlineData(BitsPerInt32, false)]
+        [InlineData(BitsPerInt32 + 1, true)]
+        [InlineData(BitsPerInt32 + 1, false)]
         public static void SetAll(int size, bool defaultValue)
         {
-            BitArray bitArray = new BitArray(6, defaultValue);
+            BitArray bitArray = new BitArray(size, defaultValue);
             bitArray.SetAll(!defaultValue);
             for (int i = 0; i < bitArray.Length; i++)
             {
@@ -72,10 +80,20 @@ namespace System.Collections.Tests
                 Assert.Equal(defaultValue, bitArray.Get(i));
             }
         }
-            
+
+        public static IEnumerable<object[]> GetEnumerator_Data()
+        {
+            foreach (int size in new[] { 0, 1, BitsPerByte, +1, BitsPerInt32, BitsPerInt32 + 1 })
+            {
+                foreach (bool lead in new[] { true, false })
+                {
+                    yield return new object[] { Enumerable.Range(0, size).Select(i => lead ^ (i % 2 == 0)).ToArray() };
+                }
+            }
+        }
+
         [Theory]
-        [InlineData(new bool[0])]
-        [InlineData(new bool[] { true, false, true, false, true, false, true, false, true, false })]
+        [MemberData(nameof(GetEnumerator_Data))]
         public static void GetEnumerator(bool[] values)
         {
             BitArray bitArray = new BitArray(values);
@@ -94,10 +112,16 @@ namespace System.Collections.Tests
             }
         }
 
-        [Fact]
-        public static void GetEnumerator_Invalid()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(BitsPerByte)]
+        [InlineData(+1)]
+        [InlineData(BitsPerInt32)]
+        [InlineData(BitsPerInt32 + 1)]
+        public static void GetEnumerator_Invalid(int size)
         {
-            BitArray bitArray = new BitArray(10, true);
+            BitArray bitArray = new BitArray(size, true);
             IEnumerator enumerator = bitArray.GetEnumerator();
 
             // Has not started enumerating
@@ -112,18 +136,30 @@ namespace System.Collections.Tests
             Assert.Throws<InvalidOperationException>(() => enumerator.Current);
 
             // Has modified underlying collection
-            enumerator.MoveNext();
-            bitArray[0] = false;
-            Assert.True((bool)enumerator.Current);
-            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
-            Assert.Throws<InvalidOperationException>(() => enumerator.Reset());
+            if (size > 0)
+            {
+                enumerator.MoveNext();
+                bitArray[0] = false;
+                Assert.True((bool)enumerator.Current);
+                Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
+                Assert.Throws<InvalidOperationException>(() => enumerator.Reset());
+            }
+        }
+
+        public static IEnumerable<object[]> Length_Set_Data()
+        {
+            int[] sizes = { 1, BitsPerByte, +1, BitsPerInt32, BitsPerInt32 + 1 };
+            foreach (int original in sizes.Concat(new[] { 16384 }))
+            {
+                foreach (int n in sizes)
+                {
+                    yield return new object[] { original, n };
+                }
+            }
         }
 
         [Theory]
-        [InlineData(16, 48)]
-        [InlineData(48, 24)]
-        [InlineData(16384, 256)]
-        [InlineData(48, 48)]
+        [MemberData(nameof(Length_Set_Data))]
         public static void Length_Set(int originalSize, int newSize)
         {
             BitArray bitArray = new BitArray(originalSize, true);
@@ -148,6 +184,7 @@ namespace System.Collections.Tests
 
             bitArray.Length = newSize;
             Assert.Equal(newSize, bitArray.Length);
+            Assert.False(bitArray.Get(0));
             Assert.False(bitArray.Get(newSize - 1));
         }
 
@@ -160,37 +197,59 @@ namespace System.Collections.Tests
 
         public static IEnumerable<object[]> CopyTo_IntArray_TestData()
         {
-            yield return new object[] { s_allTrue, new int[10], 0, Enumerable.Repeat(unchecked((int)0xffffffff), 10).ToArray(), typeof(int) };
-            yield return new object[] { s_allFalse, new int[11], 1, Enumerable.Repeat(0, 10).ToArray(), typeof(int) };
-            yield return new object[] { s_alternating, new int[12], 1, Enumerable.Repeat(unchecked((int)0xaaaaaaaa), 10).ToArray(), typeof(int) };
+            foreach (int bitArraySize in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
+            {
+                BitArray allTrue = new BitArray(Enumerable.Repeat(true, bitArraySize).ToArray());
+                BitArray allFalse = new BitArray(Enumerable.Repeat(false, bitArraySize).ToArray());
+                BitArray alternating = new BitArray(Enumerable.Range(0, bitArraySize).Select(i => i % 2 == 1).ToArray());
 
-            yield return new object[] { s_allTrue, new bool[320], 0, Enumerable.Repeat(true, 320).ToArray(), typeof(bool) };
-            yield return new object[] { s_allFalse, new bool[321], 1, Enumerable.Repeat(false, 320).ToArray(), typeof(bool) };
-            yield return new object[] { s_alternating, new bool[322], 1, Enumerable.Range(0, 320).Select(i => i % 2 == 1).ToArray(), typeof(bool) };
+                foreach (var d in new[] { Tuple.Create(bitArraySize, 0),
+                    Tuple.Create(bitArraySize * 2 + 1, 0),
+                    Tuple.Create(bitArraySize * 2 + 1, bitArraySize + 1),
+                    Tuple.Create(bitArraySize * 2 + 1, bitArraySize / 2 + 1) })
+                {
+                    int arraySize = d.Item1;
+                    int index = d.Item2;
 
-            yield return new object[] { s_allTrue, new byte[40], 0, Enumerable.Repeat((byte)255, 40).ToArray(), typeof(byte) };
-            yield return new object[] { s_allFalse, new byte[41], 1, Enumerable.Repeat((byte)0, 40).ToArray(), typeof(byte) };
-            yield return new object[] { s_alternating, new byte[42], 1, Enumerable.Repeat((byte)170, 40).ToArray(), typeof(byte) };
+                    yield return new object[] { allTrue, arraySize, index, Enumerable.Repeat(true, bitArraySize).ToArray(), default(bool) };
+                    yield return new object[] { allFalse, arraySize, index, Enumerable.Repeat(false, bitArraySize).ToArray(), default(bool) };
+                    yield return new object[] { alternating, arraySize, index, Enumerable.Range(0, bitArraySize).Select(i => i % 2 == 1).ToArray(), default(bool) };
+
+                    if (bitArraySize >= BitsPerByte)
+                    {
+                        yield return new object[] { allTrue, arraySize / BitsPerByte, index / BitsPerByte, Enumerable.Repeat((byte)0xff, bitArraySize / BitsPerByte).ToArray(), default(byte) };
+                        yield return new object[] { allFalse, arraySize / BitsPerByte, index / BitsPerByte, Enumerable.Repeat((byte)0x00, bitArraySize / BitsPerByte).ToArray(), default(byte) };
+                        yield return new object[] { alternating, arraySize / BitsPerByte, index / BitsPerByte, Enumerable.Repeat((byte)0xaa, bitArraySize / BitsPerByte).ToArray(), default(byte) };
+                    }
+
+                    if (bitArraySize >= BitsPerInt32)
+                    {
+                        yield return new object[] { allTrue, arraySize / BitsPerInt32, index / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xffffffff), bitArraySize / BitsPerInt32).ToArray(), default(int) };
+                        yield return new object[] { allFalse, arraySize / BitsPerInt32, index / BitsPerInt32, Enumerable.Repeat(0x00000000, bitArraySize / BitsPerInt32).ToArray(), default(int) };
+                        yield return new object[] { alternating, arraySize / BitsPerInt32, index / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xaaaaaaaa), bitArraySize / BitsPerInt32).ToArray(), default(int) };
+                    }
+                }
+            }
         }
 
         [Theory]
         [MemberData(nameof(CopyTo_IntArray_TestData))]
-        public static void CopyTo(BitArray bitArray, Array array, int index, Array expected, Type arrayType)
+        public static void CopyTo<T>(BitArray bitArray, int length, int index, T[] expected, T def)
         {
-            object defaultValue = Activator.CreateInstance(arrayType);
+            T[] array = (T[])Array.CreateInstance(typeof(T), length);
             ICollection collection = bitArray;
             collection.CopyTo(array, index);
             for (int i = 0; i < index; i++)
             {
-                Assert.Equal(defaultValue, array.GetValue(i));
+                Assert.Equal(def, array[i]);
             }
             for (int i = 0; i < expected.Length; i++)
             {
-                Assert.Equal(expected.GetValue(i), array.GetValue(i + index));
+                Assert.Equal(expected[i], array[i + index]);
             }
             for (int i = index + expected.Length; i < array.Length; i++)
             {
-                Assert.Equal(defaultValue, array.GetValue(i));
+                Assert.Equal(def, array[i]);
             }
         }
 

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -13,13 +13,24 @@ namespace System.Collections.Tests
         private const int BitsPerByte = 8;
         private const int BitsPerInt32 = 32;
 
-        [Theory]
-        [InlineData(new bool[] { true })]
-        [InlineData(new bool[] { false })]
-        [InlineData(new bool[] { true, false, true, true, false, true })]
-        public static void Get_Set(bool[] newValues)
+        public static IEnumerable<object[]> Get_Set_Data()
         {
-            BitArray bitArray = new BitArray(newValues.Length, false);
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
+            {
+                foreach (bool def in new[] { true, false })
+                {
+                    yield return new object[] { def, Enumerable.Repeat(true, size).ToArray() };
+                    yield return new object[] { def, Enumerable.Repeat(false, size).ToArray() };
+                    yield return new object[] { def, Enumerable.Range(0, size).Select(i => i % 2 == 1).ToArray() };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Set_Data))]
+        public static void Get_Set(bool def, bool[] newValues)
+        {
+            BitArray bitArray = new BitArray(newValues.Length, def);
             for (int i = 0; i < newValues.Length; i++)
             {
                 bitArray.Set(i, newValues[i]);
@@ -57,8 +68,8 @@ namespace System.Collections.Tests
         [InlineData(1, false)]
         [InlineData(BitsPerByte, true)]
         [InlineData(BitsPerByte, false)]
-        [InlineData(+1, true)]
-        [InlineData(+1, false)]
+        [InlineData(BitsPerByte + 1, true)]
+        [InlineData(BitsPerByte + 1, false)]
         [InlineData(BitsPerInt32, true)]
         [InlineData(BitsPerInt32, false)]
         [InlineData(BitsPerInt32 + 1, true)]
@@ -83,7 +94,7 @@ namespace System.Collections.Tests
 
         public static IEnumerable<object[]> GetEnumerator_Data()
         {
-            foreach (int size in new[] { 0, 1, BitsPerByte, +1, BitsPerInt32, BitsPerInt32 + 1 })
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte + 1, BitsPerInt32, BitsPerInt32 + 1 })
             {
                 foreach (bool lead in new[] { true, false })
                 {
@@ -116,7 +127,7 @@ namespace System.Collections.Tests
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(BitsPerByte)]
-        [InlineData(+1)]
+        [InlineData(BitsPerByte + 1)]
         [InlineData(BitsPerInt32)]
         [InlineData(BitsPerInt32 + 1)]
         public static void GetEnumerator_Invalid(int size)
@@ -148,7 +159,7 @@ namespace System.Collections.Tests
 
         public static IEnumerable<object[]> Length_Set_Data()
         {
-            int[] sizes = { 1, BitsPerByte, +1, BitsPerInt32, BitsPerInt32 + 1 };
+            int[] sizes = { 1, BitsPerByte, BitsPerByte + 1, BitsPerInt32, BitsPerInt32 + 1 };
             foreach (int original in sizes.Concat(new[] { 16384 }))
             {
                 foreach (int n in sizes)
@@ -290,6 +301,7 @@ namespace System.Collections.Tests
         {
             ICollection bitArray = new BitArray(10);
             Assert.Same(bitArray.SyncRoot, bitArray.SyncRoot);
+            Assert.NotSame(bitArray.SyncRoot, ((ICollection)new BitArray(10)).SyncRoot);
         }
     }
 }

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -7,8 +7,8 @@ using Xunit;
 namespace System.Collections.Tests
 {
     public enum Operator { Xor, Or, And };
-    
-    public class BitArray_OperatorsTests
+
+    public static class BitArray_OperatorsTests
     {
         [Fact]
         public static void And_EmptyArray()

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -162,7 +162,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void BitArray_XorTest_Negative()
+        public static void Xor_Invalid()
         {
             BitArray bitArray1 = new BitArray(11, false);
             BitArray bitArray2 = new BitArray(6, false);

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -10,8 +10,8 @@ namespace System.Collections.Tests
 {
     public static class BitArray_OperatorsTests
     {
-        private const int BitsPerByte = BitArray_CtorTests.BitsPerByte;
-        private const int BitsPerInt32 = BitArray_CtorTests.BitsPerInt32;
+        private const int BitsPerByte = 8;
+        private const int BitsPerInt32 = 32;
 
         public static IEnumerable<object[]> Not_Operator_Data()
         {

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -41,7 +41,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> And_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
+            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();
@@ -77,7 +77,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> Or_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
+            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();
@@ -113,7 +113,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> Xor_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
+            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -8,8 +8,6 @@ using Xunit;
 
 namespace System.Collections.Tests
 {
-    public enum Operator { Xor, Or, And };
-
     public static class BitArray_OperatorsTests
     {
         private const int BitsPerByte = BitArray_CtorTests.BitsPerByte;
@@ -40,101 +38,115 @@ namespace System.Collections.Tests
             }
         }
 
-        [Fact]
-        public static void And_EmptyArray()
+        public static IEnumerable<object[]> And_Operator_Data()
         {
-            BitArray bitArray1 = new BitArray(0);
-            BitArray bitArray2 = new BitArray(0);
-
-            Assert.Equal(0, bitArray1.And(bitArray2).Length);
+            yield return new object[] { new bool[0], new bool[0], new bool[0] };
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
+            {
+                bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
+                bool[] allFalse = Enumerable.Repeat(false, size).ToArray();
+                bool[] alternating = Enumerable.Range(0, size).Select(i => i % 2 == 1).ToArray();
+                yield return new object[] { allTrue, allTrue, allTrue };
+                yield return new object[] { allTrue, allFalse, allFalse };
+                yield return new object[] { allFalse, allTrue, allFalse };
+                yield return new object[] { allFalse, allFalse, allFalse };
+                yield return new object[] { allTrue, alternating, alternating };
+                yield return new object[] { alternating, allTrue, alternating };
+                yield return new object[] { allFalse, alternating, allFalse };
+                yield return new object[] { alternating, allFalse, allFalse };
+            }
         }
 
         [Theory]
-        [InlineData(Operator.And)]
-        [InlineData(Operator.Or)]
-        [InlineData(Operator.Xor)]
-        public static void OperatorTest(Operator op)
+        [MemberData(nameof(And_Operator_Data))]
+        public static void And_Operator(bool[] l, bool[] r, bool[] expected)
         {
-            BitArray bitArray1 = new BitArray(6, false);
-            BitArray bitArray2 = new BitArray(6, false);
-            BitArray result;
+            BitArray left = new BitArray(l);
+            BitArray right = new BitArray(r);
 
-            bitArray1.Set(0, true);
-            bitArray1.Set(1, true);
+            BitArray actual = left.And(right);
+            Assert.Same(left, actual);
+            Assert.Equal(actual.Length, expected.Length);
 
-            bitArray2.Set(1, true);
-            bitArray2.Set(2, true);
-
-            switch (op)
+            for (int i = 0; i < expected.Length; i++)
             {
-                case Operator.Xor:
-                    result = bitArray1.Xor(bitArray2);
-                    Assert.Same(bitArray1, result);
-                    Assert.True(result.Get(0));
-                    Assert.False(result.Get(1));
-                    Assert.True(result.Get(2));
-                    Assert.False(result.Get(4));
-                    break;
-
-                case Operator.And:
-                    result = bitArray1.And(bitArray2);
-                    Assert.Same(bitArray1, result);
-                    Assert.False(result.Get(0));
-                    Assert.True(result.Get(1));
-                    Assert.False(result.Get(2));
-                    Assert.False(result.Get(4));
-                    break;
-
-                case Operator.Or:
-                    result = bitArray1.Or(bitArray2);
-                    Assert.Same(bitArray1, result);
-                    Assert.True(result.Get(0));
-                    Assert.True(result.Get(1));
-                    Assert.True(result.Get(2));
-                    Assert.False(result.Get(4));
-                    break;
-            }
-            
-            // Size stress cases.
-            bitArray1 = new BitArray(0x1000F, false);
-            bitArray2 = new BitArray(0x1000F, false);
-
-            bitArray1.Set(0x10000, true); // The bit for 1 (2^0).
-            bitArray1.Set(0x10001, true); // The bit for 2 (2^1).
-
-            bitArray2.Set(0x10001, true); // The bit for 2 (2^1).
-
-            switch (op)
-            {
-                case Operator.Xor:
-                    result = bitArray1.Xor(bitArray2);
-                    Assert.Same(bitArray1, result);
-                    Assert.True(result.Get(0x10000));
-                    Assert.False(result.Get(0x10001));
-                    Assert.False(result.Get(0x10002));
-                    Assert.False(result.Get(0x10004));
-                    break;
-
-                case Operator.And:
-                    result = bitArray1.And(bitArray2);
-                    Assert.Same(bitArray1, result);
-                    Assert.False(result.Get(0x10000));
-                    Assert.True(result.Get(0x10001));
-                    Assert.False(result.Get(0x10002));
-                    Assert.False(result.Get(0x10004));
-                    break;
-
-                case Operator.Or:
-                    result = bitArray1.Or(bitArray2);
-                    Assert.Same(bitArray1, result);
-                    Assert.True(result.Get(0x10000));
-                    Assert.True(result.Get(0x10001));
-                    Assert.False(result.Get(0x10002));
-                    Assert.False(result.Get(0x10004));
-                    break;
+                Assert.Equal(expected[i], actual[i]);
             }
         }
-        
+
+        public static IEnumerable<object[]> Or_Operator_Data()
+        {
+            yield return new object[] { new bool[0], new bool[0], new bool[0] };
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
+            {
+                bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
+                bool[] allFalse = Enumerable.Repeat(false, size).ToArray();
+                bool[] alternating = Enumerable.Range(0, size).Select(i => i % 2 == 1).ToArray();
+                yield return new object[] { allTrue, allTrue, allTrue };
+                yield return new object[] { allTrue, allFalse, allTrue };
+                yield return new object[] { allFalse, allTrue, allTrue };
+                yield return new object[] { allFalse, allFalse, allFalse };
+                yield return new object[] { allTrue, alternating, allTrue };
+                yield return new object[] { alternating, allTrue, allTrue };
+                yield return new object[] { allFalse, alternating, alternating };
+                yield return new object[] { alternating, allFalse, alternating };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Or_Operator_Data))]
+        public static void Or_Operator(bool[] l, bool[] r, bool[] expected)
+        {
+            BitArray left = new BitArray(l);
+            BitArray right = new BitArray(r);
+
+            BitArray actual = left.Or(right);
+            Assert.Same(left, actual);
+            Assert.Equal(actual.Length, expected.Length);
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i], actual[i]);
+            }
+        }
+
+        public static IEnumerable<object[]> Xor_Operator_Data()
+        {
+            yield return new object[] { new bool[0], new bool[0], new bool[0] };
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
+            {
+                bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
+                bool[] allFalse = Enumerable.Repeat(false, size).ToArray();
+                bool[] alternating = Enumerable.Range(0, size).Select(i => i % 2 == 1).ToArray();
+                bool[] inverse = Enumerable.Range(0, size).Select(i => i % 2 == 0).ToArray();
+                yield return new object[] { allTrue, allTrue, allFalse };
+                yield return new object[] { allTrue, allFalse, allTrue };
+                yield return new object[] { allFalse, allTrue, allTrue };
+                yield return new object[] { allFalse, allFalse, allFalse };
+                yield return new object[] { allTrue, alternating, inverse };
+                yield return new object[] { alternating, allTrue, inverse };
+                yield return new object[] { allFalse, alternating, alternating };
+                yield return new object[] { alternating, allFalse, alternating };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Xor_Operator_Data))]
+        public static void Xor_Operator(bool[] l, bool[] r, bool[] expected)
+        {
+            BitArray left = new BitArray(l);
+            BitArray right = new BitArray(r);
+
+            BitArray actual = left.Xor(right);
+            Assert.Same(left, actual);
+            Assert.Equal(actual.Length, expected.Length);
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i], actual[i]);
+            }
+        }
+
         [Fact]
         public static void And_Invalid()
         {
@@ -147,7 +159,7 @@ namespace System.Collections.Tests
 
             Assert.Throws<ArgumentNullException>("value", () => bitArray1.And(null));
         }
-        
+
         [Fact]
         public static void Or_Invalid()
         {

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.Collections.Tests
@@ -10,46 +12,43 @@ namespace System.Collections.Tests
 
     public static class BitArray_OperatorsTests
     {
-        [Fact]
-        public static void And_EmptyArray()
+        private const int BitsPerByte = BitArray_CtorTests.BitsPerByte;
+        private const int BitsPerInt32 = BitArray_CtorTests.BitsPerInt32;
+
+        public static IEnumerable<object[]> Not_Operator_Data()
         {
-            BitArray bitArray1 = new BitArray(0);
-            BitArray bitArray2 = new BitArray(0);
-            
-            Assert.Equal(0, bitArray1.And(bitArray2).Length);
-        }
-        
-        [Theory]
-        [InlineData(0)]
-        [InlineData(6)]
-        [InlineData(0x1000F)]
-        public static void Not(int length)
-        {
-            BitArray bitArray = new BitArray(length, false);
-            if (length > 0)
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
             {
-                bitArray[0] = true;
-                bitArray[1] = true;
-                bitArray[length - 2] = true;
-                bitArray[length - 1] = true;
+                yield return new object[] { Enumerable.Repeat(true, size).ToArray() };
+                yield return new object[] { Enumerable.Repeat(false, size).ToArray() };
+                yield return new object[] { Enumerable.Range(0, size).Select(i => i % 2 == 1).ToArray() };
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(Not_Operator_Data))]
+        public static void Not(bool[] data)
+        {
+            BitArray bitArray = new BitArray(data);
 
             BitArray bitArrayNot = bitArray.Not();
             Assert.Equal(bitArray.Length, bitArrayNot.Length);
             Assert.Same(bitArray, bitArrayNot);
             for (int i = 0; i < bitArray.Length; i++)
             {
-                if (i <= 1 || i >= length - 2)
-                {
-                    Assert.False(bitArrayNot[i]);
-                }
-                else
-                {
-                    Assert.True(bitArrayNot[i]);
-                }
+                Assert.Equal(!data[i], bitArrayNot[i]);
             }
         }
-        
+
+        [Fact]
+        public static void And_EmptyArray()
+        {
+            BitArray bitArray1 = new BitArray(0);
+            BitArray bitArray2 = new BitArray(0);
+
+            Assert.Equal(0, bitArray1.And(bitArray2).Length);
+        }
+
         [Theory]
         [InlineData(Operator.And)]
         [InlineData(Operator.Or)]

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -15,7 +15,7 @@ namespace System.Collections.Tests
 
         public static IEnumerable<object[]> Not_Operator_Data()
         {
-            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
             {
                 yield return new object[] { Enumerable.Repeat(true, size).ToArray() };
                 yield return new object[] { Enumerable.Repeat(false, size).ToArray() };
@@ -41,7 +41,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> And_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();
@@ -77,7 +77,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> Or_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();
@@ -113,7 +113,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> Xor_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -127,6 +127,8 @@ namespace System.Collections.Tests
                 yield return new object[] { alternating, allTrue, inverse };
                 yield return new object[] { allFalse, alternating, alternating };
                 yield return new object[] { alternating, allFalse, alternating };
+                yield return new object[] { alternating, inverse, allTrue };
+                yield return new object[] { inverse, alternating, allTrue };
             }
         }
 


### PR DESCRIPTION
Expand most of the BitArray tests, especially for greybox testing (knowing it stores things in an `int` array underneath).

Tests will pass against the version of `BitArray` in mscorlib (in coreclr), but not against the AOT version here in corefx; this is pre-existing behavior, not something related to my changes.

Interesting:
 - The tests for invalid length/index in `CopyTo` have different results for `int` arrays than for either `bool` or `byte` arrays, due the use of `Array.Copy` underneath (and I'm assuming it's a symptom of how that's forwarded to a runtime implementation) - the parameter name is blank, not null.