### PR TITLE
Reduce System.Threading.Tests from ~650s to ~8s

### DIFF
--- a/src/System.Threading/tests/BarrierTests.cs
+++ b/src/System.Threading/tests/BarrierTests.cs
@@ -362,11 +362,10 @@ namespace System.Threading.Tests
         }
 
         [Fact]
-        [OuterLoop]
         public static void RunBarrierTest10b()
         {
             // Regression test for Barrier race condition
-            for (int j = 0; j < 10000; j++)
+            for (int j = 0; j < 10; j++)
             {
                 Barrier b = new Barrier(2);
                 var t1 = Task.Run(() =>
@@ -384,10 +383,9 @@ namespace System.Threading.Tests
         }
 
         [Fact]
-        [OuterLoop]
         public static void RunBarrierTest10c()
         {
-            for (int j = 0; j < 10000; j++)
+            for (int j = 0; j < 10; j++)
             {
                 Task[] tasks = new Task[2];
                 Barrier b = new Barrier(3);

--- a/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
+++ b/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
@@ -402,7 +402,7 @@ namespace System.Threading.Tests
                             // Add a writer to the wait list for enough time to allow successive readers to enter the wait list while this
                             // writer is waiting
                             beforeTryEnterWriteLock.Set();
-                            if (rwls.TryEnterWriteLock(2000))
+                            if (rwls.TryEnterWriteLock(1000))
                             {
                                 // The typical order of execution is not guaranteed, as sleep times are not guaranteed. For
                                 // instance, before this write lock is added to the wait list, the two new read locks may be
@@ -416,7 +416,7 @@ namespace System.Threading.Tests
                     writeWaiterThread.Start();
                     beforeTryEnterWriteLock.WaitOne();
                 }
-                Thread.Sleep(1000); // wait for TryEnterWriteLock to enter the wait list
+                Thread.Sleep(500); // wait for TryEnterWriteLock to enter the wait list
 
                 // A writer should now be waiting, add readers to the wait list. Since a read lock is still acquired, the writer
                 // should time out waiting, then these readers should enter and exit the lock.

--- a/src/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/System.Threading/tests/SemaphoreSlimTests.cs
@@ -160,27 +160,6 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest7_AvailableWaitHandle(0, 10, SemaphoreSlimActions.Release, true);
         }
 
-        [Fact]
-        [OuterLoop]
-        public static void RunSemaphoreSlimCurrentTests()
-        {
-            RunSemaphoreSlimTest8_ConcWaitAndRelease
-               (5, 1000, 50, 50, 50, 0, 5, 1000);
-            RunSemaphoreSlimTest8_ConcWaitAndRelease
-               (0, 1000, 50, 25, 25, 25, 0, 5000);
-            RunSemaphoreSlimTest8_ConcWaitAndRelease
-              (0, 1000, 50, 0, 0, 50, 0, 100);
-            RunSemaphoreSlimTest8_ConcWaitAsyncAndRelease
-               (5, 1000, 50, 50, 50, 0, 5, 5000);
-            RunSemaphoreSlimTest8_ConcWaitAsyncAndRelease
-               (0, 1000, 50, 25, 25, 25, 0, 5000);
-            RunSemaphoreSlimTest8_ConcWaitAsyncAndRelease
-              (0, 1000, 50, 0, 0, 50, 0, 100);
-            TestConcurrentWaitAndWaitAsync(10, 10);
-            TestConcurrentWaitAndWaitAsync(1, 10);
-            TestConcurrentWaitAndWaitAsync(10, 1);
-        }
-
         /// <summary>
         /// Test SemaphoreSlim constructor
         /// </summary>
@@ -481,7 +460,11 @@ namespace System.Threading.Tests
         /// <param name="failedWait">Number of failed wait threads</param>
         /// <param name="finalCount">The final semaphore count</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
-        private static void RunSemaphoreSlimTest8_ConcWaitAndRelease(int initial, int maximum,
+        [Theory]
+        [InlineData(5, 1000, 50, 50, 50, 0, 5, 1000)]
+        [InlineData(0, 1000, 50, 25, 25, 25, 0, 500)]
+        [InlineData(0, 1000, 50, 0, 0, 50, 0, 100)]
+        public static void RunSemaphoreSlimTest8_ConcWaitAndRelease(int initial, int maximum,
             int waitThreads, int releaseThreads, int succeededWait, int failedWait, int finalCount, int timeout)
         {
             SemaphoreSlim semaphore = new SemaphoreSlim(initial, maximum);
@@ -543,6 +526,10 @@ namespace System.Threading.Tests
         /// <param name="failedWait">Number of failed wait threads</param>
         /// <param name="finalCount">The final semaphore count</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
+        [Theory]
+        [InlineData(5, 1000, 50, 50, 50, 0, 5, 500)]
+        [InlineData(0, 1000, 50, 25, 25, 25, 0, 500)]
+        [InlineData(0, 1000, 50, 0, 0, 50, 0, 100)]
         private static void RunSemaphoreSlimTest8_ConcWaitAsyncAndRelease(int initial, int maximum,
             int waitThreads, int releaseThreads, int succeededWait, int failedWait, int finalCount, int timeout)
         {
@@ -588,7 +575,11 @@ namespace System.Threading.Tests
             Assert.Equal(finalCount, semaphore.CurrentCount);
         }
 
-        private static void TestConcurrentWaitAndWaitAsync(int syncWaiters, int asyncWaiters)
+        [Theory]
+        [InlineData(10, 10)]
+        [InlineData(1, 10)]
+        [InlineData(10, 1)]
+        public static void TestConcurrentWaitAndWaitAsync(int syncWaiters, int asyncWaiters)
         {
             int totalWaiters = syncWaiters + asyncWaiters;
 

--- a/src/System.Threading/tests/SpinLockTests.cs
+++ b/src/System.Threading/tests/SpinLockTests.cs
@@ -41,42 +41,6 @@ namespace System.Threading.Tests
             }
         }
 
-        /// <summary>
-        /// Run all SpinLock tests
-        /// </summary>
-        /// <returns>True if all tests passed, false if at least one test failed</returns>
-        [Fact]
-        [OuterLoop]
-        public static void RunSpinLockTests()
-        {
-            for (int i = 0; i < 2; i++)
-            {
-                bool b;
-                if (i == 0)
-                {
-                    Debug.WriteLine("NO THREAD IDS -- new SpinLock(true)");
-                    b = true;
-                }
-                else
-                {
-                    Debug.WriteLine("WITH THREAD IDS -- new SpinLock(false)");
-                    b = false;
-                }
-
-                RunSpinLockTest0_Enter(2, b);
-                RunSpinLockTest0_Enter(128, b);
-                RunSpinLockTest0_Enter(256, b);
-
-                RunSpinLockTest1_TryEnter(2, b);
-                RunSpinLockTest1_TryEnter(128, b);
-                RunSpinLockTest1_TryEnter(256, b);
-
-                RunSpinLockTest2_TryEnter(2, b);
-                RunSpinLockTest2_TryEnter(128, b);
-                RunSpinLockTest2_TryEnter(256, b);
-            }
-        }
-
         [Fact]
         public static void RunSpinLockTests_NegativeTests()
         {
@@ -105,7 +69,15 @@ namespace System.Threading.Tests
         /// </summary>
         /// <param name="threadsCount">Number of threads that call enter/exit</param>
         /// <returns>True if succeeded, false otherwise</returns>
-        private static void RunSpinLockTest0_Enter(int threadsCount, bool enableThreadIDs)
+        [OuterLoop]
+        [Theory]
+        [InlineData(2, false)]
+        [InlineData(128, false)]
+        [InlineData(256, false)]
+        [InlineData(2, true)]
+        [InlineData(128, true)]
+        [InlineData(256, true)]
+        public static void RunSpinLockTest0_Enter(int threadsCount, bool enableThreadIDs)
         {
             // threads array
             Task[] threads = new Task[threadsCount];
@@ -167,7 +139,15 @@ namespace System.Threading.Tests
         /// </summary>
         /// <param name="threadsCount">Number of threads that call enter/exit</param>
         /// <returns>True if succeeded, false otherwise</returns>
-        private static void RunSpinLockTest1_TryEnter(int threadsCount, bool enableThreadIDs)
+        [OuterLoop]
+        [Theory]
+        [InlineData(2, false)]
+        [InlineData(128, false)]
+        [InlineData(256, false)]
+        [InlineData(2, true)]
+        [InlineData(128, true)]
+        [InlineData(256, true)]
+        public static void RunSpinLockTest1_TryEnter(int threadsCount, bool enableThreadIDs)
         {
             for (int j = 0; j < 2; j++)
             {
@@ -213,7 +193,15 @@ namespace System.Threading.Tests
         /// </summary>
         /// <param name="threadsCount">Number of threads that call enter/exit</param>
         /// <returns>True if succeeded, false otherwise</returns>
-        private static void RunSpinLockTest2_TryEnter(int threadsCount, bool enableThreadIDs)
+        [OuterLoop]
+        [Theory]
+        [InlineData(2, false)]
+        [InlineData(128, false)]
+        [InlineData(256, false)]
+        [InlineData(2, true)]
+        [InlineData(128, true)]
+        [InlineData(256, true)]
+        public static void RunSpinLockTest2_TryEnter(int threadsCount, bool enableThreadIDs)
         {
             for (int j = 0; j < 2; j++)
             {
@@ -244,7 +232,7 @@ namespace System.Threading.Tests
                             // Failed to get the lock within the timeout
                             Interlocked.Increment(ref failed);
                         }
-                    }, i);
+                    }, i, CancellationToken.None, TaskCreationOptions.LongRunning);
                     threads[i].Start(TaskScheduler.Default);
                 }
                 // Wait all threads


### PR DESCRIPTION
As with https://github.com/dotnet/corefx/pull/9466, a few tactical changes to significantly reduce the outerloop running time of the System.Threading.Tests suites (lots of work could be done to further improve/overhaul these tests, but that wasn't my goal):
- Two barrier tests were taking several minutes.  Reduced the number of iterations from 10,000 to 10.  A few iterations helps to verify intended behavior; more than that is a stress test that doesn't belong in the functional suite.
- Reduced explicit timeouts in a ReaderWriterLockSlim test
- Reduced timeouts in some SemaphoreSlim tests.  As part of this I split up a few tests into [Theory]s in order to help identify where the actual problem was.
- SpinLock tests were getting throttled by the ThreadPool; changed them to use new threads rather than pool threads.  As with above, I also split some of these tests into [Theory]s to help identify where exactly the problem was.

cc: @Petermarcu, @mellinoe 