### PR TITLE
Fixing DevWorkflow Scripts given that corerun is not present in the tool runtime anymore

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -60,8 +60,8 @@ fi
 echo "Running init-tools.sh"
 $working_tree_root/init-tools.sh
 
-echo -e "\n$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/packages.builds $options $allargs" >> $build_packages_log
-$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/packages.builds $options $allargs
+echo -e "\n$working_tree_root/Tools/dotnetcli/dotnet $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/packages.builds $options $allargs" >> $build_packages_log
+$working_tree_root/Tools/dotnetcli/dotnet $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/packages.builds $options $allargs
 
 
 if [ $? -ne 0 ]; then

--- a/build-tests.sh
+++ b/build-tests.sh
@@ -25,8 +25,8 @@ fi
 echo "Running init-tools.sh"
 $working_tree_root/init-tools.sh
 
-echo -e "\n$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/tests.builds $options $allargs" >> $build_tests_log
-$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/tests.builds $options $allargs
+echo -e "\n$working_tree_root/Tools/dotnetcli/dotnet $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/tests.builds $options $allargs" >> $build_tests_log
+$working_tree_root/Tools/dotnetcli/dotnet $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/tests.builds $options $allargs
 
 
 if [ $? -ne 0 ]; then

--- a/clean.sh
+++ b/clean.sh
@@ -84,8 +84,8 @@ then
     CleanTargetsTrimmed=${CleanTargets:0:${#CleanTargets}-1}
 
     echo "Running MSBuild target(s): $CleanTargetsTrimmed"
-    echo -e "\n$WorkingTreeRoot/Tools/corerun $WorkingTreeRoot/Tools/MSBuild.exe $WorkingTreeRoot/build.proj /t:$CleanTargetsTrimmed $options $unprocessedBuildArgs" >> $CleanLog
-    $WorkingTreeRoot/Tools/corerun $WorkingTreeRoot/Tools/MSBuild.exe $WorkingTreeRoot/build.proj /t:$CleanTargetsTrimmed $options $unprocessedBuildArgs
+    echo -e "\n$WorkingTreeRoot/Tools/dotnetcli/dotnet $WorkingTreeRoot/Tools/MSBuild.exe $WorkingTreeRoot/build.proj /t:$CleanTargetsTrimmed $options $unprocessedBuildArgs" >> $CleanLog
+    $WorkingTreeRoot/Tools/dotnetcli/dotnet $WorkingTreeRoot/Tools/MSBuild.exe $WorkingTreeRoot/build.proj /t:$CleanTargetsTrimmed $options $unprocessedBuildArgs
     check_exit_status
 fi
 

--- a/publish-packages.sh
+++ b/publish-packages.sh
@@ -25,8 +25,8 @@ fi
 echo "Running init-tools.sh"
 $working_tree_root/init-tools.sh
 
-echo -e "\n$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/publish.proj $options $allargs" >> $publish_packages_log
-$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/publish.proj $options $allargs
+echo -e "\n$working_tree_root/Tools/dotnetcli/dotnet $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/publish.proj $options $allargs" >> $publish_packages_log
+$working_tree_root/Tools/dotnetcli/dotnet $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/publish.proj $options $allargs
 
 if [ $? -ne 0 ]; then
     echo -e "\nAn error occurred. Aborting publish-packages.sh ." >> $publish_packages_log

--- a/sync.sh
+++ b/sync.sh
@@ -70,8 +70,8 @@ fi
 
 if [ "$azure_blobs" == true ]; then
     echo "Connecting and downloading packages from Azure BLOB ..."
-    echo -e "\n$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/syncAzure.proj $options $unprocessedBuildArgs" >> $sync_log
-    $working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/syncAzure.proj $options $unprocessedBuildArgs
+    echo -e "\n$working_tree_root/Tools/dotnetcli/dotnet $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/syncAzure.proj $options $unprocessedBuildArgs" >> $sync_log
+    $working_tree_root/Tools/dotnetcli/dotnet $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/syncAzure.proj $options $unprocessedBuildArgs
     if [ $? -ne 0 ]
     then
         echo -e "\nDownload from Azure failed. Aborting sync." >> $sync_log
@@ -83,8 +83,8 @@ fi
 if [ "$sync_packages" == true ]; then
     options="$options /t:BatchRestorePackages /p:RestoreDuringBuild=true"
     echo "Restoring all packages..."
-    echo -e "\n$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/build.proj $options $unprocessedBuildArgs" >> $sync_log
-    $working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/build.proj $options $unprocessedBuildArgs
+    echo -e "\n$working_tree_root/Tools/dotnetcli/dotnet $working_tree_root/Tools/MSBuild.exe $working_tree_root/build.proj $options $unprocessedBuildArgs" >> $sync_log
+    $working_tree_root/Tools/dotnetcli/dotnet $working_tree_root/Tools/MSBuild.exe $working_tree_root/build.proj $options $unprocessedBuildArgs
     if [ $? -ne 0 ]
     then
         echo -e "\nPackage restored failed. Aborting sync." >> $sync_log


### PR DESCRIPTION
cc: @jhendrixMSFT @maririos @weshaggard 

When I changed the tool host I only updated build.sh and forgot the rest of the dev workflow scripts. This PR takes care of that.