### PR TITLE
Fix MulticastInterface_Set_ValidIndex_Success failures on non-Windows platforms.

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -94,15 +94,26 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        private static bool IsNotOSXOrFedora23()
+        [Fact]
+        public void MulticastInterface_Set_AnyInterface_Succeeds()
         {
-            return !PlatformDetection.IsOSX && !PlatformDetection.IsFedora23;
+            // On all platforms, index 0 means "any interface"
+            MulticastInterface_Set_Helper(0);
         }
 
-        [ConditionalTheory(nameof(IsNotOSXOrFedora23))] // Receive times out on loopback interface
-        [InlineData(0)] // Any
-        [InlineData(1)] // Loopback
-        public void MulticastInterface_Set_ValidIndex_Succeeds(int interfaceIndex)
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // see comment below
+        public void MulticastInterface_Set_Loopback_Succeeds()
+        {
+            // On Windows, we can apparently assume interface 1 is "loopback."  On other platforms, this is not a
+            // valid assumption.  We could maybe use NetworkInterface.LoopbackInterfaceIndex to get the index, but
+            // this would introduce a dependency on System.Net.NetworkInformation, which depends on System.Net.Sockets,
+            // which is what we're testing here....  So for now, we'll just assume "loopback == 1" and run this on
+            // Windows only.
+            MulticastInterface_Set_Helper(1);
+        }
+
+        private void MulticastInterface_Set_Helper(int interfaceIndex)
         {
             IPAddress multicastAddress = IPAddress.Parse("239.1.2.3");
             string message = "hello";
@@ -115,7 +126,11 @@ namespace System.Net.Sockets.Tests
                 receiveSocket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(multicastAddress, interfaceIndex));
 
                 sendSocket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastInterface, IPAddress.HostToNetworkOrder(interfaceIndex));
-                sendSocket.SendTo(Encoding.UTF8.GetBytes(message), new IPEndPoint(multicastAddress, port));
+
+                for (int i = 0; i < Configuration.UDPRedundancy; i++)
+                {
+                    sendSocket.SendTo(Encoding.UTF8.GetBytes(message), new IPEndPoint(multicastAddress, port));
+                }
 
                 var receiveBuffer = new byte[1024];
                 int bytesReceived = receiveSocket.Receive(receiveBuffer);


### PR DESCRIPTION
This test assumed that the "loopback" interface was always at index 1, which is not true on Linux/OSX/etc.  This change makes that assumption explicitly Windows-only, while allowing the "any interface" case to run on all platforms.

I also added a retry loop around the UDP send to harden this a little against the loopback packet loss we've seen on Unix platforms in other tests.

Fixes #8971.

@CIPop @stephentoub 