### PR TITLE
Fix octal IP address string parsing on OSX

### DIFF
--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -277,19 +277,17 @@ extern "C" int32_t SystemNative_IPv4StringToAddress(const uint8_t* address, uint
     assert(bufferLength == NUM_BYTES_IN_IPV4_ADDRESS);
     assert(port != nullptr);
 
-    // Call our helper to do the getaddrinfo call for us; once we have the info, copy what we need
-    addrinfo* info;
-    int32_t result = IpStringToAddressHelper(address, nullptr, false, info);
+    in_addr inaddr;
+    int32_t result = inet_aton(reinterpret_cast<const char*>(address), &inaddr);
     if (result == 0)
     {
-        sockaddr_in* addr = reinterpret_cast<sockaddr_in*>(info->ai_addr);
-        ConvertInAddrToByteArray(buffer, bufferLength, addr->sin_addr);
-        *port = addr->sin_port;
-
-        freeaddrinfo(info);
+        return PAL_EAI_NONAME;
     }
 
-    return ConvertGetAddrInfoAndGetNameInfoErrorsToPal(result);
+    ConvertInAddrToByteArray(buffer, bufferLength, inaddr);
+    *port = 0; // callers expect this to always be zero
+
+    return PAL_EAI_SUCCESS;
 }
 
 static void AppendScopeIfNecessary(uint8_t* string, int32_t stringLength, uint32_t scope)

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -153,16 +153,6 @@ constexpr T Max(T left, T right)
     return left > right ? left : right;
 }
 
-static int IpStringToAddressHelper(const uint8_t* address, const uint8_t* port, bool isIPv6, addrinfo*& info)
-{
-    assert(address != nullptr);
-
-    addrinfo hint = {.ai_family = isIPv6 ? AF_INET6 : AF_INET, .ai_flags = AI_NUMERICHOST | AI_NUMERICSERV};
-
-    info = nullptr;
-    return getaddrinfo(reinterpret_cast<const char*>(address), reinterpret_cast<const char*>(port), &hint, &info);
-}
-
 static void ConvertByteArrayToIn6Addr(in6_addr& addr, const uint8_t* buffer, int32_t bufferLength)
 {
 #if HAVE_IN6_U
@@ -255,10 +245,12 @@ SystemNative_IPv6StringToAddress(const uint8_t* address, const uint8_t* port, ui
     assert(buffer != nullptr);
     assert(bufferLength == NUM_BYTES_IN_IPV6_ADDRESS);
     assert(scope != nullptr);
+    assert(address != nullptr);
 
-    // Call our helper to do the getaddrinfo call for us; once we have the info, copy what we need
-    addrinfo* info;
-    int32_t result = IpStringToAddressHelper(address, port, true, info);
+    addrinfo hint = { .ai_family = AF_INET6, .ai_flags = AI_NUMERICHOST | AI_NUMERICSERV };
+
+    addrinfo* info = nullptr;
+    int32_t result = getaddrinfo(reinterpret_cast<const char*>(address), reinterpret_cast<const char*>(port), &hint, &info);
     if (result == 0)
     {
         sockaddr_in6* addr = reinterpret_cast<sockaddr_in6*>(info->ai_addr);
@@ -276,6 +268,7 @@ extern "C" int32_t SystemNative_IPv4StringToAddress(const uint8_t* address, uint
     assert(buffer != nullptr);
     assert(bufferLength == NUM_BYTES_IN_IPV4_ADDRESS);
     assert(port != nullptr);
+    assert(address != nullptr);
 
     in_addr inaddr;
     int32_t result = inet_aton(reinterpret_cast<const char*>(address), &inaddr);

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -44,17 +44,10 @@ namespace System.Net.Primitives.Functional.Tests
         [InlineData("037777777777", "255.255.255.255")]
         [InlineData("023516614433", "157.59.25.27")]
         [InlineData("00000023516614433", "157.59.25.27")]
-        public void ParseIPv4_Octal_Success(string address, string expected)
-        {
-            Assert.Equal(expected, IPAddress.Parse(address).ToString());
-        }
-
-        [Theory]
-        [ActiveIssue(8362, PlatformID.OSX)]
-        [InlineData("000235.000073.0000031.00000033", "157.59.25.27")] // Octal
-        [InlineData("0235.073.031.033", "157.59.25.27")] // Octal
+        [InlineData("000235.000073.0000031.00000033", "157.59.25.27")]
+        [InlineData("0235.073.031.033", "157.59.25.27")]
         [InlineData("157.59.25.033", "157.59.25.27")] // Partial octal
-        public void ParseIPv4_Octal_Success_NonOSX(string address, string expected)
+        public void ParseIPv4_Octal_Success(string address, string expected)
         {
             Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }


### PR DESCRIPTION
On OSX and Linux, IPAddress.Parse uses getaddrinfo to parse the string. This is spec'd to only work for decimal, but seems to do more than that on both platforms. On Linux, I guess it works well for both hex and octal. On OSX, hex seems to work, but octal only sometimes works. After some experimentation, I think what's going on is that getaddrinfo on OSX tries to parse the address as decimal first, and only if that fails does it try to parse it as octal. So an address like "010.010.010.010" will parse as "10.10.10.10," but "0300.0300.0300.0300," since it's not a valid address in decimal, will correctly parse as "192.192.192.192."

With this change, we use inet_aton to parse IPv4 addresses, instead of getaddrinfo.  inet_aton seems to handle octal strings correctly, and is officially documented to do so.

Fixes #8362