### PR TITLE
Reduce System.Threading.Tasks.Tests from ~140s to ~10s

### DIFF
--- a/src/Common/tests/System/Threading/ThreadPoolHelpers.cs
+++ b/src/Common/tests/System/Threading/ThreadPoolHelpers.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+namespace System.Threading
+{
+    internal static class ThreadPoolHelpers
+    {
+        internal static void EnsureMinThreadsAtLeast(int minWorkerThreads)
+        {
+            // Until ThreadPool.Get/SetMinThreads are exposed, we try to access them via reflection. 
+
+            Type threadPool = typeof(object).GetTypeInfo().Assembly.GetType("System.Threading.ThreadPool");
+            MethodInfo getMinThreads = threadPool?.GetTypeInfo().GetMethod("GetMinThreads");
+            MethodInfo setMinThreads = threadPool?.GetTypeInfo().GetMethod("SetMinThreads");
+            if (getMinThreads != null && setMinThreads != null)
+            {
+                var threadCounts = new object[2];
+                getMinThreads.Invoke(null, threadCounts);
+
+
+                int workerThreads = (int)threadCounts[0];
+                if (workerThreads < minWorkerThreads)
+                {
+                    threadCounts[0] = minWorkerThreads;
+                    setMinThreads.Invoke(null, threadCounts);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
+++ b/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
@@ -36,6 +36,9 @@
     <Compile Include="RangePartitionerThreadSafetyTests.cs" />
     <Compile Include="RespectParentCancellationTest.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
+    <Compile Include="$(CommonTestPath)\System\Threading\ThreadPoolHelpers.cs">
+      <Link>CommonTest\System\Threading\ThreadPoolHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Threading.Tasks.Parallel.pkgproj">

--- a/src/System.Threading.Tasks/tests/MethodCoverage.cs
+++ b/src/System.Threading.Tasks/tests/MethodCoverage.cs
@@ -15,10 +15,9 @@ namespace TaskCoverage
     {
         // Regression test: Validates that tasks can wait on int.MaxValue without assertion.
         [Fact]
-        [OuterLoop]
         public static void TaskWait_MaxInt32()
         {
-            Task t = Task.Delay(10000);
+            Task t = Task.Delay(1);
             Debug.WriteLine("Wait with int.Maxvalue");
             Task.WaitAll(new Task[] { t }, int.MaxValue);
         }

--- a/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/TaskAwaiterTests.cs
+++ b/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/TaskAwaiterTests.cs
@@ -151,7 +151,7 @@ namespace System.Threading.Tasks.Tests
                 Task.Run(() => tcs.Task.ConfigureAwait(false).GetAwaiter().GetResult()),
                 Task.Run(() => ((Task)tcs.Task).ConfigureAwait(false).GetAwaiter().GetResult())
             };
-            Assert.False(Task.WaitAll(tasks, 4000), "Tasks should not have completed");
+            Assert.Equal(-1, Task.WaitAny(tasks, 100)); // "Tasks should not have completed"
 
             // Now complete the tasks, after which all the tasks should complete successfully.
             tcs.SetResult(true);

--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -56,6 +56,9 @@
     <Compile Include="System.Runtime.CompilerServices\TaskAwaiterTests.cs" />
     <Compile Include="System.Runtime.CompilerServices\YieldAwaitableTests.cs" />
     <Compile Include="System.Runtime.CompilerServices\AsyncTaskMethodBuilderTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Threading\ThreadPoolHelpers.cs">
+      <Link>CommonTest\System\Threading\ThreadPoolHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Threading.Tasks/tests/Task/TaskAPMTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskAPMTest.cs
@@ -80,9 +80,10 @@ namespace System.Threading.Tasks.Tests
                 longTask = new LongTask(LongTaskMilliseconds);
 
             IAsyncResult asyncResult = longTask.BeginDoTask(null, null);
+            var mres = new ManualResetEventSlim();
             while (!asyncResult.IsCompleted)
             {
-                Task.Delay(300).Wait();
+                mres.Wait(1);
             }
 
             AssertTaskCompleted(asyncResult);

--- a/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTest.cs
@@ -28,7 +28,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
 
         private TaskInfo _taskTree;                     // the _taskTree to track child task cancellation option
 
-        private static readonly int s_delatTimeOut = 100;
+        private static readonly int s_deltaTimeOut = 10;
 
         private bool _taskCompleted;                    // result to record the Wait(timeout) return value
         private AggregateException _caughtException;    // exception thrown during wait
@@ -100,12 +100,12 @@ namespace System.Threading.Tasks.Tests.CancelWait
 
             if (_waitTimeout != -1)
             {
-                long delta = sw.ElapsedMilliseconds - ((long)_waitTimeout + s_delatTimeOut);
+                long delta = sw.ElapsedMilliseconds - ((long)_waitTimeout + s_deltaTimeOut);
 
                 if (delta > 0)
                 {
                     Debug.WriteLine("ElapsedMilliseconds way more than requested Timeout.");
-                    Debug.WriteLine("WaitTime= {0} ms, ElapsedTime= {1} ms, Allowed Descrepancy = {2} ms", _waitTimeout, sw.ElapsedMilliseconds, s_delatTimeOut);
+                    Debug.WriteLine("WaitTime= {0} ms, ElapsedTime= {1} ms, Allowed Descrepancy = {2} ms", _waitTimeout, sw.ElapsedMilliseconds, s_deltaTimeOut);
                     Debug.WriteLine("Delta= {0} ms", delta);
                 }
                 else
@@ -677,11 +677,11 @@ namespace System.Threading.Tasks.Tests.CancelWait
     {
         Exceptional = -2,
         Cancelled = -1,
-        VeryLight = 1000,     // the number is the N input to the ZetaSequence workload
-        Light = 5000,
-        Medium = 100000,
-        Heavy = 500000,
-        VeryHeavy = 1000000,
+        VeryLight = 100,     // the number is the N input to the ZetaSequence workload
+        Light = 200,
+        Medium = 400,
+        Heavy = 800,
+        VeryHeavy = 1600,
     }
 
     #endregion

--- a/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTests.cs
@@ -1309,7 +1309,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             node_2.AddChildren(new[] { node_2_1, node_2_2, });
 
             node.AddChildren(new[] { node_1, node_2, });
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
@@ -1324,7 +1324,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskInfo node_1 = new TaskInfo(node, "node_1", WorkloadType.VeryHeavy, "None");
 
             node.AddChildren(new[] { node_1, });
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
@@ -1351,7 +1351,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskInfo node_7 = new TaskInfo(node, "node_7", WorkloadType.VeryLight, "LongRunning, RespectParentCancellation");
 
             node.AddChildren(new[] { node_1, node_2, node_3, node_4, node_5, node_6, node_7, });
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
@@ -1374,7 +1374,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             node_2.AddChildren(new[] { node_2_1, node_2_2, });
 
             node.AddChildren(new[] { node_1, node_2, });
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
@@ -1398,7 +1398,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             node_3.AddChildren(new[] { node_3_1, node_3_2, });
 
             node.AddChildren(new[] { node_1, node_2, node_3, });
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
@@ -1425,7 +1425,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskInfo node_7 = new TaskInfo(node, "node_7", WorkloadType.VeryLight, "LongRunning, AttachedToParent");
 
             node.AddChildren(new[] { node_1, node_2, node_3, node_4, node_5, node_6, node_7, });
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
@@ -1442,7 +1442,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskInfo node_2 = new TaskInfo(node, "node_2", WorkloadType.Light, "AttachedToParent");
 
             node.AddChildren(new[] { node_1, node_2, });
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
@@ -1459,7 +1459,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskInfo node_2 = new TaskInfo(node, "node_2", WorkloadType.Light, "RespectParentCancellation");
 
             node.AddChildren(new[] { node_1, node_2, });
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
@@ -1471,7 +1471,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.VeryHeavy, "RespectParentCancellation");
 
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
@@ -1495,7 +1495,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             node_3.AddChildren(new[] { node_3_1, node_3_2, });
 
             node.AddChildren(new[] { node_1, node_2, node_3, });
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
@@ -1518,7 +1518,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             node_2.AddChildren(new[] { node_2_1, node_2_2, });
 
             node.AddChildren(new[] { node_1, node_2, });
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
@@ -1542,7 +1542,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             node_3.AddChildren(new[] { node_3_1, node_3_2, });
 
             node.AddChildren(new[] { node_1, node_2, node_3, });
-            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 197);
+            TestParameters parameters = new TestParameters(node, API.Wait, WaitBy.Millisecond, 97);
 
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();

--- a/src/System.Threading.Tasks/tests/Task/TaskContinueWithAllAnyTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskContinueWithAllAnyTests.cs
@@ -752,11 +752,11 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
     {
         Exceptional = -2,
         Cancelled = -1,
-        VeryLight = 1000,     // the number is the N input to the ZetaSequence workload
-        Light = 10000,
-        Medium = 1000000,
-        Heavy = 100000000,
-        VeryHeavy = 1000000000,
+        VeryLight = 100,     // the number is the N input to the ZetaSequence workload
+        Light = 200,
+        Medium = 400,
+        Heavy = 800,
+        VeryHeavy = 1600,
     }
 
     /// <summary>

--- a/src/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
@@ -407,6 +407,13 @@ namespace System.Threading.Tasks.Tests
 
     public class TaskRunSyncTests
     {
+        static TaskRunSyncTests()
+        {
+            // Tests that create tasks which need to run concurrently require us to bump up the number
+            // of threads in the pool, or else we need to wait for it to grow dynamically to the desired number
+            ThreadPoolHelpers.EnsureMinThreadsAtLeast(10);
+        }
+
         #region Test methods
 
         [Fact]

--- a/src/System.Threading.Tasks/tests/Task/TaskStatusTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskStatusTest.cs
@@ -159,7 +159,7 @@ namespace System.Threading.Tasks.Tests.Status
                         // without Detached options and current status of the child isn't RanToCompletion or Faulted yet
                         //
 
-                        Task.Delay(100).Wait();
+                        Task.Delay(1).Wait();
 
                         if (_createChildTask &&
                             _childTask != null &&
@@ -372,9 +372,9 @@ namespace System.Threading.Tasks.Tests.Status
             }
 
             //
-            // Sleep for 5 sec to simulate long running child task
+            // Sleep for a few milliseconds to simulate a child task executing
             //
-            Task t = Task.Delay(5000);
+            Task t = Task.Delay(1);
             t.Wait();
 
             if (_childTaskToken.IsCancellationRequested)

--- a/src/System.Threading.Tasks/tests/Task/TaskWaitAllAnyTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskWaitAllAnyTest.cs
@@ -53,11 +53,11 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
     {
         Exceptional = -2,
         Cancelled = -1,
-        VeryLight = 1000,     // the number is the N input to the ZetaSequence workload
-        Light = 10000,
-        Medium = 1000000,
-        Heavy = 100000000,
-        VeryHeavy = 1000000000,
+        VeryLight = 100,     // the number is the N input to the ZetaSequence workload
+        Light = 200,
+        Medium = 400,
+        Heavy = 800,
+        VeryHeavy = 1600,
     }
 
     public class TestParameters_WaitAllAny

--- a/src/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
+++ b/src/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
@@ -18,6 +18,7 @@ namespace System.Threading.Tasks.Tests
     public static class TaskSchedulerTests
     {
         // Just ensure we eventually complete when many blocked tasks are created.
+        [OuterLoop]
         [Fact]
         public static void RunBlockedInjectionTest()
         {


### PR DESCRIPTION
As with https://github.com/dotnet/corefx/pull/9468 and https://github.com/dotnet/corefx/pull/9466, this commit focuses on reducing the total, outerloop running time of our worst-offending test suites.  This one is on the System.Threading.Tasks tests.  Some of the tests are not in good shape, e.g. it's not clear to me that the TaskCancelWaitTests are actually verifying everything they should, even though they're spending a lot of time doing it.

Changes:
- Reduced artificially long wait times in TaskAwaiter, IAsyncResult, TaskCancelWaitTests, TaskStatusTests, CESchedulerPairTests, and Coverage tests
- Reduced size of workload in TaskCancelWaitTests, TaskContinueWithAllAnyTests, and TaskWaitAllAnyTests
- Ensured that the ThreadPool was ramped up to serve several tests expecting more threads available
- Removed some unnecessary spinning

cc: @mellinoe, @Petermarcu 