### PR TITLE
Upgrade TFS dependencies and prime packages

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -86,7 +86,7 @@
 
     <CoreFxExpectedPrerelease>rc4-24215-01</CoreFxExpectedPrerelease>
     <CoreClrExpectedPrerelease>rc4-24215-01</CoreClrExpectedPrerelease>
-    <ExternalExpectedPrerelease>rc4-24215-00</ExternalExpectedPrerelease>
+    <ExternalExpectedPrerelease>beta-24215-00</ExternalExpectedPrerelease>
 
     <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore\.Targets)|(Microsoft\.NETCore\.Platforms)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)$</CoreFxVersionsIdentityRegex>
   </PropertyGroup>

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -3,16 +3,16 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <!-- TODO: Get this from the file version -->
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
   <ItemGroup>
     <Dependency Include="runtime.win7-x64.runtime.native.System.Data.SqlClient.sni">
-      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
+      <Version>4.0.2-$(ExternalExpectedPrerelease)</Version>
     </Dependency>
     <Dependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
-      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
+      <Version>4.0.2-$(ExternalExpectedPrerelease)</Version>
     </Dependency>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Diagnostics.Contracts/src/netcore50aot/project.json
+++ b/src/System.Diagnostics.Contracts/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     }
   }

--- a/src/System.Diagnostics.Debug.SymbolReader/src/project.json
+++ b/src/System.Diagnostics.Debug.SymbolReader/src/project.json
@@ -13,7 +13,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.Debug/src/project.json
+++ b/src/System.Diagnostics.Debug/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.StackTrace/src/project.json
+++ b/src/System.Diagnostics.StackTrace/src/project.json
@@ -13,7 +13,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.Tools/src/project.json
+++ b/src/System.Diagnostics.Tools/src/project.json
@@ -15,7 +15,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     }
   }

--- a/src/System.Globalization.Calendars/src/netcore50aot/project.json
+++ b/src/System.Globalization.Calendars/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     }
   }

--- a/src/System.Globalization/src/netcore50aot/project.json
+++ b/src/System.Globalization/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     }
   }

--- a/src/System.IO.FileSystem/src/netcore50/project.json
+++ b/src/System.IO.FileSystem/src/netcore50/project.json
@@ -23,7 +23,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Globalization": "4.0.10",
         "System.Reflection": "4.0.10",

--- a/src/System.IO.IsolatedStorage/src/project.json
+++ b/src/System.IO.IsolatedStorage/src/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.NETCore.Targets": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Collections": "4.0.0",
         "System.Diagnostics.Contracts": "4.0.0",

--- a/src/System.IO/src/project.json
+++ b/src/System.IO/src/project.json
@@ -12,7 +12,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
@@ -34,7 +34,7 @@
       ],
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",

--- a/src/System.Linq.Expressions/src/netcore50/project.json
+++ b/src/System.Linq.Expressions/src/netcore50/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
-    "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+    "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Private.DataContractSerialization/src/netcore50aot/project.json
+++ b/src/System.Private.DataContractSerialization/src/netcore50aot/project.json
@@ -3,7 +3,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "System.Collections": "4.0.10",
         "System.Collections.Concurrent": "4.0.10",
         "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Private.Uri/src/project.json
+++ b/src/System.Private.Uri/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     },
     "netstandard1.3": {
@@ -18,7 +18,7 @@
         "netcore50"
       ],
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     }
   }

--- a/src/System.Reflection.DispatchProxy/src/project.json
+++ b/src/System.Reflection.DispatchProxy/src/project.json
@@ -21,7 +21,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "System.Runtime": "4.0.20"
       }
     }

--- a/src/System.Reflection.Extensions/src/project.json
+++ b/src/System.Reflection.Extensions/src/project.json
@@ -12,7 +12,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.IO": "4.0.10",

--- a/src/System.Reflection.TypeExtensions/src/project.json
+++ b/src/System.Reflection.TypeExtensions/src/project.json
@@ -13,7 +13,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "System.Collections": "4.0.0",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Linq": "4.0.0",

--- a/src/System.Reflection/src/netcore50aot/project.json
+++ b/src/System.Reflection/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     }
   }

--- a/src/System.Resources.ResourceManager/src/netcore50aot/project.json
+++ b/src/System.Resources.ResourceManager/src/netcore50aot/project.json
@@ -3,7 +3,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Diagnostics.Debug": "4.0.0",
         "System.Diagnostics.Tools": "4.0.0",

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -15,7 +15,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1"
       }
     },
@@ -24,7 +24,7 @@
         "netcore50"
       ],
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     }
   }

--- a/src/System.Runtime.Handles/src/project.json
+++ b/src/System.Runtime.Handles/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     },
     "net46": {

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "System.Runtime": "4.0.20"
       }
     },

--- a/src/System.Runtime.InteropServices/src/project.json
+++ b/src/System.Runtime.InteropServices/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     },
     "net462": {

--- a/src/System.Runtime.WindowsRuntime/src/netcore50aot/project.json
+++ b/src/System.Runtime.WindowsRuntime/src/netcore50aot/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.NETCore.Targets": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Collections": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Runtime/src/project.json
+++ b/src/System.Runtime/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     },
     "net462": {

--- a/src/System.Text.Encoding.Extensions/src/netcore50aot/project.json
+++ b/src/System.Text.Encoding.Extensions/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     }
   }

--- a/src/System.Text.Encoding/src/netcore50aot/project.json
+++ b/src/System.Text.Encoding/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     }
   }

--- a/src/System.Threading.Tasks/src/project.json
+++ b/src/System.Threading.Tasks/src/project.json
@@ -15,7 +15,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00"
       }
     }
   }

--- a/src/System.Threading.Timer/src/netcore50aot/project.json
+++ b/src/System.Threading.Timer/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "System.Runtime": "4.0.20"
       }
     }

--- a/src/System.Threading/src/project.json
+++ b/src/System.Threading/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc4-24215-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24215-00",
         "System.Runtime": "4.0.20"
       }
     },


### PR DESCRIPTION
This ensures that the first build out of CoreFx won't have any dangling
dependencies.

I repacked everything from the current TFS baseline with new versions and published to myget.

/cc @weshaggard @stephentoub 