### PR TITLE
Make X509 CollectionsTests run without modifying system state

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -860,15 +860,18 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        // This test can cause an intermediate certificate to be written to disk,
-        // but creating that intermediate store directory can fail on Fedora23 CI due to an unsupported filesystem (#9293)
-        private static bool IsReliableInCI { get; } = !PlatformDetection.IsFedora23;
-        [ConditionalFact(nameof(IsReliableInCI))]
         public static void X509ChainElementCollection_CopyTo_NonZeroLowerBound_ThrowsIndexOutOfRangeException()
         {
-            using (X509Certificate2 microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
+            using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
+            using (var microsoftDotComIssuer = new X509Certificate2(TestData.MicrosoftDotComIssuerBytes))
+            using (var microsoftDotComRoot = new X509Certificate2(TestData.MicrosoftDotComRootBytes))
             using (X509Chain chain = new X509Chain())
             {
+                chain.ChainPolicy.ExtraStore.Add(microsoftDotComRoot);
+                chain.ChainPolicy.ExtraStore.Add(microsoftDotComIssuer);
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllFlags;
+
                 chain.Build(microsoftDotCom);
                 ICollection collection = chain.ChainElements;
                 Array array = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });


### PR DESCRIPTION
X509ChainElementCollection_CopyTo_NonZeroLowerBound_ThrowsIndexOutOfRangeException naively builds a cert chain, but since the issuer isn't part of the ca-certificates bundle it gets downloaded as part of the test (and then cached to the hard drive).

Since the network-enabled and caching parts are not explicitly needed for this test, provide it enough information to work fully-standalone.

This undoes a partial suppression related to issue #9293, making it such that the situation doesn't apply.