### PR TITLE
Reduce PLINQ tests outerloop from ~250s to ~85s

### DIFF
--- a/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -30,9 +29,11 @@ namespace System.Linq.Parallel.Tests
             yield return Label("ParallelEnumerable.Range", (start, count, ignore) => ParallelEnumerable.Range(start, count));
             yield return Label("Enumerable.Range", (start, count, ignore) => Enumerable.Range(start, count).AsParallel());
             yield return Label("Array", (start, count, ignore) => Enumerable.Range(start, count).ToArray().AsParallel());
-            yield return Label("Partitioner", (start, count, ignore) => Partitioner.Create(Enumerable.Range(start, count).ToArray()).AsParallel());
             yield return Label("List", (start, count, ignore) => Enumerable.Range(start, count).ToList().AsParallel());
-            yield return Label("ReadOnlyCollection", (start, count, ignore) => new ReadOnlyCollection<int>(Enumerable.Range(start, count).ToList()).AsParallel());
+            yield return Label("Partitioner", (start, count, ignore) => Partitioner.Create(Enumerable.Range(start, count).ToArray()).AsParallel());
+
+            // PLINQ doesn't currently have any special code paths for readonly collections.  If it ever does, this should be uncommented.
+            // yield return Label("ReadOnlyCollection", (start, count, ignore) => new System.Collections.ReadOnlyCollection<int>(Enumerable.Range(start, count).ToList()).AsParallel());
         }
 
         private static IEnumerable<Labeled<Operation>> RangeSources()

--- a/src/System.Linq.Parallel/tests/Helpers/IntegerRangeSet.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/IntegerRangeSet.cs
@@ -10,28 +10,35 @@ using Xunit;
 namespace System.Linq.Parallel.Tests
 {
     // Dummy psuedo-set for verifying we've seen all of a range of integers, and only once.
-    internal class IntegerRangeSet : IEnumerable<KeyValuePair<int, bool>>
+    internal sealed class IntegerRangeSet : IEnumerable<KeyValuePair<int, bool>>
     {
-        private BitArray _seen;
+        private readonly BitArray _seen;
         private int _start;
-        private object _locker;
+        private SpinLock _lock = new SpinLock(enableThreadOwnerTracking: false);
 
         public IntegerRangeSet(int start, int count)
         {
             _start = start;
             _seen = new BitArray(count);
-            _locker = new object();
         }
 
         public bool Add(int entry)
         {
             Assert.InRange(entry, _start, _start + _seen.Length - 1);
 
-            lock (_locker)
-            {
-                Assert.False(_seen[entry - _start]);
-                return _seen[entry - _start] = true;
-            }
+            bool seen;
+
+            bool lockTaken = false;
+            _lock.Enter(ref lockTaken);
+
+            int pos = entry - _start;
+            seen = _seen[pos];
+            _seen[pos] = true;
+
+            _lock.Exit(useMemoryBarrier: false);
+
+            Assert.False(seen);
+            return true;
         }
 
         public void AssertComplete()
@@ -49,10 +56,10 @@ namespace System.Linq.Parallel.Tests
             return GetEnumerator();
         }
 
-        private class BitArrayEnumerator : IEnumerator<KeyValuePair<int, bool>>
+        private sealed class BitArrayEnumerator : IEnumerator<KeyValuePair<int, bool>>
         {
             private int _start;
-            private BitArray _values;
+            private readonly BitArray _values;
 
             private int _current = -1;
 
@@ -96,9 +103,9 @@ namespace System.Linq.Parallel.Tests
     }
 
     // Simple class for counting the number of times an integer in a range has occurred.
-    internal class IntegerRangeCounter : IEnumerable<KeyValuePair<int, int>>
+    internal sealed class IntegerRangeCounter : IEnumerable<KeyValuePair<int, int>>
     {
-        private int[] _seen;
+        private readonly int[] _seen;
         private int _start;
 
         public IntegerRangeCounter(int start, int count)

--- a/src/System.Linq.Parallel/tests/Helpers/Sources.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Sources.cs
@@ -8,8 +8,9 @@ namespace System.Linq.Parallel.Tests
 {
     internal static class Sources
     {
-        // For outerloop, it's more important to saturate the processors/consumers and fill up buffers.
-        public static readonly int OuterLoopCount = 64 * 1024 * Environment.ProcessorCount;
+        // For outerloop, we use a large count that makes it more likely we'll fill buffers and saturate
+        // producers/consumers, while at the same time being cognizant of total test execution time.
+        public static readonly int OuterLoopCount = 16 * 1024 * Environment.ProcessorCount;
 
         private static readonly IEnumerable<int> OuterLoopCounts = new[] { OuterLoopCount };
 

--- a/src/System.Linq.Parallel/tests/Helpers/UnorderedSources.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/UnorderedSources.cs
@@ -238,7 +238,9 @@ namespace System.Linq.Parallel.Tests
             IList<int> rangeList = rangeArray.ToList();
             yield return Labeled.Label("List", rangeList.AsParallel());
             yield return Labeled.Label("Partitioner", Partitioner.Create(rangeArray).AsParallel());
-            yield return Labeled.Label("ReadOnlyCollection", new ReadOnlyCollection<int>(rangeList).AsParallel());
+
+            // PLINQ doesn't currently have any special code paths for readonly collections.  If it ever does, this should be uncommented.
+            // yield return Labeled.Label("ReadOnlyCollection", new ReadOnlyCollection<int>(rangeList).AsParallel());
         }
     }
 }

--- a/src/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
@@ -13,6 +13,7 @@ namespace System.Linq.Parallel.Tests
     {
         private const int KeyFactor = 4;
         private const int GroupFactor = 8;
+        private const int LongRunningCount = 16 * 1024;
 
         // Get ranges from 0 to each count.  The data is random, seeded from the size of the range.
         public static IEnumerable<object[]> OrderByRandomData(int[] counts)
@@ -80,9 +81,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy(labeled, count);
@@ -107,9 +108,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_Reversed(labeled, count);
@@ -134,9 +135,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending(labeled, count);
@@ -161,9 +162,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_Reversed(labeled, count);
@@ -183,9 +184,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_NotPipelined(labeled, count);
@@ -205,9 +206,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_Reversed_NotPipelined(labeled, count);
@@ -227,9 +228,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_NotPipelined(labeled, count);
@@ -249,9 +250,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_Reversed_NotPipelined(labeled, count);
@@ -276,9 +277,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_CustomComparer(labeled, count);
@@ -303,9 +304,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_CustomComparer(labeled, count);
@@ -325,9 +326,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_NotPipelined_CustomComparer(labeled, count);
@@ -347,9 +348,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_NotPipelined_CustomComparer(labeled, count);
@@ -554,9 +555,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy(labeled, count);
@@ -588,9 +589,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_Reversed(labeled, count);
@@ -622,9 +623,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending(labeled, count);
@@ -656,9 +657,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_Reversed(labeled, count);
@@ -691,9 +692,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_NotPipelined(labeled, count);
@@ -726,9 +727,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_Reversed_NotPipelined(labeled, count);
@@ -761,9 +762,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_NotPipelined(labeled, count);
@@ -796,9 +797,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_Reversed_NotPipelined(labeled, count);
@@ -830,9 +831,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_CustomComparer(labeled, count);
@@ -864,9 +865,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_CustomComparer(labeled, count);
@@ -899,9 +900,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_NotPipelined_CustomComparer(labeled, count);
@@ -934,9 +935,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_NotPipelined_CustomComparer(labeled, count);
@@ -1014,9 +1015,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_ThenBy_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_ThenBy(labeled, count);
@@ -1042,9 +1043,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_ThenByDescending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_ThenByDescending(labeled, count);
@@ -1071,9 +1072,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_ThenBy_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_ThenBy_NotPipelined(labeled, count);
@@ -1100,9 +1101,9 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { LongRunningCount })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_ThenByDescending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_ThenByDescending_NotPipelined(labeled, count);
@@ -1227,8 +1228,8 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void StableSort_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort(labeled, count);
@@ -1258,8 +1259,8 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void StableSort_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort_NotPipelined(labeled, count);
@@ -1289,8 +1290,8 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void StableSort_Descending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort_Descending(labeled, count);
@@ -1320,8 +1321,8 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { LongRunningCount }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { LongRunningCount }, MemberType = typeof(UnorderedSources))]
         public static void StableSort_Descending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort_Descending_NotPipelined(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/SelectSelectManyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SelectSelectManyTests.cs
@@ -266,7 +266,6 @@ namespace System.Linq.Parallel.Tests
         {
             yield return Labeled.Label("Array", (Func<int, int, IEnumerable<int>>)((start, count) => Enumerable.Range(start * count, count).ToArray()));
             yield return Labeled.Label("Enumerable.Range", (Func<int, int, IEnumerable<int>>)((start, count) => Enumerable.Range(start * count, count)));
-            yield return Labeled.Label("ParallelEnumerable.Range", (Func<int, int, IEnumerable<int>>)((start, count) => ParallelEnumerable.Range(start * count, count).AsOrdered().Select(x => x)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -25,6 +25,9 @@
     <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Threading\ThreadPoolHelpers.cs">
+      <Link>CommonTest\System\Threading\ThreadPoolHelpers.cs</Link>
+    </Compile>
     <Compile Include="Combinatorial\CancellationParallelQueryCombinationTests.cs" />
     <Compile Include="Combinatorial\FailingParallelQueryCombinationTests.cs" />
     <Compile Include="Combinatorial\ParallelQueryCombinationTests.cs" />


### PR DESCRIPTION
The tests have been overhauled and are in fairly decent shape, thanks to the efforts of @Clockwork-Muse, so there wasn't as much low-hanging fruit as in some of the other test libraries (https://github.com/dotnet/corefx/pull/9479, https://github.com/dotnet/corefx/pull/9468, https://github.com/dotnet/corefx/pull/9466), but there are still a few notable places we can make improvements and others we can cut back without losing quality of coverage.

Changes:
- Even though some care had been taken to avoid it, at least one DegreeOfParallelismTests was taking an extra ~25s on my machine waiting for the thread pool to ramp up.  Fixed via the same helper used in other test libs.
- Removed ReadOnlyCollection as a source.  There are special PLINQ code paths for arrays, lists, ParallelEnumerable.Range, and custom partitioners, but not for other collection types, so I've commented out that source until such time as we do have such special cases.  This removes ~1/6th of the test cases and an equivalent amount of execution time.
- Improved throughput of the IntegerRangeSet helper, which is used in lots of tests and was a source of significant contention due to a lock used in the main Add method.  Replacing it with a SpinLock reduced execution time by ~10%.
- Removed ParallelEnumerable.Range as an "expander" in the SelectSelectManyTests.  The delegate is returning an IEnumerable, so subsequent operations performed on the expander aren't continuing the PLINQ execution and are instead starting a new one, making this essentially equivalent to (but more expensive than and duplicative of) the Enumerable.Range expander that already exists.
- Lowered outerloop default iteration count from 64K*ProcCount to 16K*ProcCount
- Lowered OrderByThenByTest outerloop iteration count from 32K to 16K, and removed the additional 1K iteration count being performed.

cc: @Petermarcu, @Clockwork-Muse, @AlfredoMS, @mellinoe 