### PR TITLE
Reduce FileSystem outerloop test time

### DIFF
--- a/src/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
@@ -61,24 +61,11 @@ namespace System.IO.Tests
         public void ReadFileOver2GB()
         {
             string path = GetTestFilePath();
-            int split = 10;
-            string toWrite = new string('a', Int32.MaxValue / split);
-            using (var writer = new StreamWriter(File.Create(path)))
+            using (FileStream fs = File.Create(path))
             {
-                for (int i = 0; i < (split + 1); i++)
-                {
-                    try
-                    {
-                        writer.Write(toWrite);
-                        writer.Flush();
-                    }
-                    catch (OutOfMemoryException)
-                    {
-                        split /= 2;
-                        toWrite = new string('a', Int32.MaxValue / split);
-                    }
-                }
+                fs.SetLength(int.MaxValue + 1L);
             }
+
             // File is too large for ReadAllBytes at once
             Assert.Throws<IOException>(() => File.ReadAllBytes(path));
         }

--- a/src/System.IO.FileSystem/tests/FileStream/ReadAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ReadAsync.cs
@@ -319,7 +319,7 @@ namespace System.IO.Tests
         [Fact, OuterLoop]
         public async Task ReadAsyncMiniStress()
         {
-            TimeSpan testRunTime = TimeSpan.FromSeconds(30);
+            TimeSpan testRunTime = TimeSpan.FromSeconds(10);
             const int MaximumReadSize = 16 * 1024;
             const int NormalReadSize = 4 * 1024;
 

--- a/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -459,7 +459,7 @@ namespace System.IO.Tests
         [Fact, OuterLoop]
         public async Task WriteAsyncMiniStress()
         {
-            TimeSpan testRunTime = TimeSpan.FromSeconds(30);
+            TimeSpan testRunTime = TimeSpan.FromSeconds(10);
             const int MaximumWriteSize = 16 * 1024;
             const int NormalWriteSize = 4 * 1024;
 


### PR DESCRIPTION
Changes:
- An outerloop test verifying that we would throw when trying to use File.ReadAllBytes to read a > 2GB file was first writing out 2GB worth of data to disk.  We can instead just create a FileStream and explicitly change its length.  On my machine, this changes the execution time of that test from ~25s to just a few milliseconds.
- Two "mini stress" tests are enabled in outerloop and are explicitly coded to run for 30 seconds doing lots of reading and writing.  I've changed these to be 10 seconds.

On my machine this reduces outerloop execution time from ~70s to ~45s.

cc: @ianhays, @Petermarcu 