### PR TITLE
Reduce LINQ outerloop test execution time from 2 minutes to 1.5 seconds

### DIFF
--- a/src/System.Linq/tests/LastOrDefaultTests.cs
+++ b/src/System.Linq/tests/LastOrDefaultTests.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 
-namespace System.Linq.Tests.LegacyTests
+namespace System.Linq.Tests
 {
     public class LastOrDefaultTests : EnumerableTests
     {

--- a/src/System.Linq/tests/SelectManyTests.cs
+++ b/src/System.Linq/tests/SelectManyTests.cs
@@ -7,7 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Xunit;
 
-namespace System.Linq.Tests.LegacyTests
+namespace System.Linq.Tests
 {
     public class SelectManyTests : EnumerableTests
     {
@@ -198,7 +198,7 @@ namespace System.Linq.Tests.LegacyTests
         }
 
         [Fact]
-        [OuterLoop]
+        [ActiveIssue("Valid test but too intensive to enable even in OuterLoop")]
         public void IndexOverflow()
         {
             var selected = new FastInfiniteEnumerator<int>().SelectMany((e, i) => Enumerable.Empty<int>());

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -124,7 +124,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        [OuterLoop]
+        [ActiveIssue("Valid test but too intensive to enable even in OuterLoop")]
         public void Overflow()
         {
             var selected = new FastInfiniteEnumerator<int>().Select((e, i) => e);

--- a/src/System.Linq/tests/ThenByTests.cs
+++ b/src/System.Linq/tests/ThenByTests.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 
-namespace System.Linq.Tests.LegacyTests
+namespace System.Linq.Tests
 {
     public class ThenByTests
     {

--- a/src/System.Linq/tests/WhereTests.cs
+++ b/src/System.Linq/tests/WhereTests.cs
@@ -990,7 +990,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        [OuterLoop]
+        [ActiveIssue("Valid test but too intensive to enable even in OuterLoop")]
         public void IndexOverflows()
         {
             var infiniteWhere = new FastInfiniteEnumerator<int>().Where((e, i) => true);


### PR DESCRIPTION
We have six LINQ tests that are verifying an index overflow condition by iterating through an enumerable with an infinite number of elements, expecting an overflow to occur after we've iterated through 2 billion of them.  We already disabled three of them due to them taking too long; this disables the other three.  I've left them all in but disabled in case we want to have an outer-outerloop in the future where we're ok with individual tests each taking several minutes spinning like these do.

I also renamed a few namespaces which were accidentally still including "Legacy" in their names from the initial test porting effort.

cc: @VSadov, @JonHanna, @Petermarcu