### PR TITLE
Comments to remind developers not to break VS debugger dependencies

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/AllocFreeConcurrentStack.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/AllocFreeConcurrentStack.cs
@@ -62,6 +62,11 @@ namespace System.Collections.Immutable
 
     internal static class AllocFreeConcurrentStack
     {
+        // The following field is required for interop with the VS Debugger
+        // Prior to making any changes to this field, please reach out to the VS Debugger 
+        // team to make sure that your changes are not going to prevent the debugger
+        // from working.
+
         // Workaround for https://github.com/dotnet/coreclr/issues/2191.
         // When that's fixed, a [ThreadStatic] Stack should be added back to AllocFreeConcurrentStack<T>.
 

--- a/src/System.Collections/src/System/Collections/Generic/Comparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Comparer.cs
@@ -62,6 +62,10 @@ namespace System.Collections.Generic
             return new DefaultComparer<T>();
         }
 
+        // The following field is required for interop with the VS Debugger
+        // Prior to making any changes to this field, please reach out to the VS Debugger 
+        // team to make sure that your changes are not going to prevent the debugger
+        // from working.
         private static Comparer<T> _default;
     }
 

--- a/src/System.Collections/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/EqualityComparer.cs
@@ -82,7 +82,11 @@ namespace System.Collections.Generic
                 return _default;
             }
         }
-
+        
+        // The following field is required for interop with the VS Debugger
+        // Prior to making any changes to this field, please reach out to the VS Debugger 
+        // team to make sure that your changes are not going to prevent the debugger
+        // from working.
         private static volatile EqualityComparer<T> _default;
 
         public abstract bool Equals(T x, T y);


### PR DESCRIPTION
In the previous change, we already have baked in the build system changes. This change is simply adding a bunch of boilerplate comments right next to the fields we care about to remind developers not to change them.