### PR TITLE
Reduce S.R.InteropServices outerloop test time from ~100s to ~0.2s

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/HandleCollectorTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/HandleCollectorTests.cs
@@ -60,7 +60,6 @@ namespace System.Runtime.InteropServices
         }
 
         [Fact]
-        [OuterLoop]
         public static void CountOverflow()
         {
             HandleCollector collector = new HandleCollector("CountOverflow", int.MaxValue);

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/HandleCollectorTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/HandleCollectorTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Reflection;
 using Xunit;
 
 namespace System.Runtime.InteropServices
@@ -63,7 +64,24 @@ namespace System.Runtime.InteropServices
         public static void CountOverflow()
         {
             HandleCollector collector = new HandleCollector("CountOverflow", int.MaxValue);
-            for (int i = 0; i < Int32.MaxValue; i++)
+
+            // We could iterate here 2B times calling Add, but that often takes over 100s
+            // Instead, for testing purposes, we reach into the HandleCollector via reflection
+            // to make it think it's already been called int.MaxValue - 10 times.  We then
+            // only have to call Add 10 times rather than int.MaxValue times, and the test
+            // completes very quickly.  If we ever need to run the test on a platform that
+            // doesn't support such reflection, we can revert to the super-long running test
+            // or find another workaround.
+
+            const int ToAdd = 10; // int.MaxValue
+            {
+                // Jump HandleCollector instance forward until it almost overflows
+                FieldInfo handleCount = typeof(HandleCollector).GetTypeInfo().GetDeclaredField("_handleCount");
+                Assert.NotNull(handleCount);
+                handleCount.SetValue(collector, int.MaxValue - ToAdd);
+            }
+
+            for (int i = 0; i < ToAdd; i++)
             {
                 collector.Add();
             }


### PR DESCRIPTION
Most of the tests in the test library run very quickly.  But one runs for ~100s, calling HandleCollector.Add 2B times to get it to overflow.  As a hack but IMHO a worthwhile hack, this commit uses reflection to jump the HandleCollector forward as if it were already called almost int.MaxValue times.  It then proceeds to do the remaining Adds manually, verifying that still works, and then overflows and verifies the expected failure.  This reduces the overall test execution from over 100 seconds to a few hundred milliseconds.

cc: @mellinoe, @Petermarcu 