### PR TITLE
Improve performance of DCJS serializing DateTime objects

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonWriterDelegator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonWriterDelegator.cs
@@ -177,11 +177,26 @@ namespace System.Runtime.Serialization.Json
             // This will break round-tripping of these dates (see 
             if (value.Kind != DateTimeKind.Utc)
             {
-                //long tickCount = value.Ticks - TimeZone.CurrentTimeZone.GetUtcOffset(value).Ticks;
-                long tickCount = value.Ticks - TimeZoneInfo.Local.GetUtcOffset(value).Ticks;
-                if ((tickCount > DateTime.MaxValue.Ticks) || (tickCount < DateTime.MinValue.Ticks))
+                // Fetching the UtcOffset is expensive so we need to avoid it if possible. We can do a fast
+                // bounds check to decide if the more expensive bounds check is needed. The result from 
+                // TimeZoneInfo.Local.GetUtcOffset(value) is bounded to +/- 24 hours. If 
+                // (DateTime.MinValue + 24 hours) < value < (DateTime.MaxValue – 24 hours), then we don't need
+                // to check using the the real UtcOffset as it doesn't matter what the offset is, it can't cause
+                // an overflow/underflow condition.
+                
+                // Pre-calculated value of DateTime.MinValue.AddDays(1.0).Ticks;
+                long lowBound = 0xC92A69C000;
+                // Pre-calculated value of DateTime.MaxValue.AddDays(-1.0).Ticks;
+                long highBound = 0x2BCA27ACC9CD7FFF;
+
+                long tickCount = value.Ticks;
+                if (lowBound > tickCount || highBound < tickCount) // We could potentially under/over flow
                 {
-                    throw XmlObjectSerializer.CreateSerializationException(SR.JsonDateTimeOutOfRange, new ArgumentOutOfRangeException(nameof(value)));
+                    tickCount = tickCount - TimeZoneInfo.Local.GetUtcOffset(value).Ticks;
+                    if ((tickCount > DateTime.MaxValue.Ticks) || (tickCount < DateTime.MinValue.Ticks))
+                    {
+                        throw XmlObjectSerializer.CreateSerializationException(SR.JsonDateTimeOutOfRange, new ArgumentOutOfRangeException(nameof(value)));
+                    }
                 }
             }
 
@@ -195,18 +210,7 @@ namespace System.Runtime.Serialization.Json
                     // +"zzzz";
                     //TimeSpan ts = TimeZone.CurrentTimeZone.GetUtcOffset(value.ToLocalTime());
                     TimeSpan ts = TimeZoneInfo.Local.GetUtcOffset(value.ToLocalTime());
-                    if (ts.Ticks < 0)
-                    {
-                        writer.WriteString("-");
-                    }
-                    else
-                    {
-                        writer.WriteString("+");
-                    }
-                    int hours = Math.Abs(ts.Hours);
-                    writer.WriteString((hours < 10) ? "0" + hours : hours.ToString(CultureInfo.InvariantCulture));
-                    int minutes = Math.Abs(ts.Minutes);
-                    writer.WriteString((minutes < 10) ? "0" + minutes : minutes.ToString(CultureInfo.InvariantCulture));
+                    writer.WriteString(string.Format(CultureInfo.InvariantCulture, "{0:+00;-00}{1:00;00}", ts.Hours, ts.Minutes));
                     break;
                 case DateTimeKind.Utc:
                     break;

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/PerformanceTestsCommon.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/PerformanceTestsCommon.cs
@@ -21,7 +21,8 @@ namespace System.Runtime.Serialization
         ListOfInt,
         String,
         ByteArray,
-        XmlElement
+        XmlElement,
+        DateTimeArray
     }
 
     public interface IPerfTestSerializer
@@ -78,6 +79,7 @@ namespace System.Runtime.Serialization
             yield return new PerfTestConfig(1, TestType.SimpleType, 15);
             yield return new PerfTestConfig(10000, TestType.ISerializable, -1);
             yield return new PerfTestConfig(10000, TestType.XmlElement, -1);
+            yield return new PerfTestConfig(100, TestType.DateTimeArray, 1024);
         }
 
         public static IEnumerable<object[]> PerformanceMemberData()
@@ -146,6 +148,22 @@ namespace System.Runtime.Serialization
             return Enumerable.Range(0, count).ToList();
         }
 
+        public static DateTime[] CreateDateTimeArray(int count)
+        {
+            DateTime[] arr = new DateTime[count];
+            int kind = (int)DateTimeKind.Unspecified;
+            int maxDateTimeKind = (int) DateTimeKind.Local;
+            DateTime val = DateTime.Now.AddHours(count/2);
+            for (int i = 0; i < count; i++)
+            {
+                arr[i] = DateTime.SpecifyKind(val, (DateTimeKind)kind);
+                val = val.AddHours(1);
+                kind = (kind + 1)%maxDateTimeKind;
+            }
+
+            return arr;
+        }
+
         public static object GetSerializationObject(TestType testType, int testSize)
         {
             Object obj = null;
@@ -175,6 +193,9 @@ namespace System.Runtime.Serialization
                     XmlElement xmlElement = xmlDoc.CreateElement("Element");
                     xmlElement.InnerText = "Element innertext";
                     obj = xmlElement;
+                    break;
+                case TestType.DateTimeArray:
+                    obj = CreateDateTimeArray(testSize);
                     break;
                 default:
                     throw new ArgumentException();


### PR DESCRIPTION
Fixes #9342 

This has a larger effect on Linux than Windows because Linux has a lot more timezone rules which are checked when fetching the offset. Results on my Linux VM are without the fix average test time is 169ms, with the fix, 122ms. This is a 28% performance improvement.