### PR TITLE
Fix test break in SqlClient.ManualTests

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/ADO/BaseProviderAsyncTest/BaseProviderAsyncTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/ADO/BaseProviderAsyncTest/BaseProviderAsyncTest.cs
@@ -11,7 +11,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public static class BaseProviderAsyncTest
     {
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TestDbConnection()
         {
             MockConnection connection = new MockConnection();
@@ -45,7 +45,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             DataTestUtility.AssertEqualsWithDescription(ConnectionState.Closed, connection.State, "Connection state should have been marked as Closed");
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TestDbCommand()
         {
             MockCommand command = new MockCommand()
@@ -127,7 +127,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             Assert.True(result.IsFaulted, "Task result should be faulted");
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TestDbDataReader()
         {
             var query = Enumerable.Range(1, 2).Select((x) => new object[] { x, x.ToString(), DBNull.Value });

--- a/src/System.Data.SqlClient/tests/ManualTests/ADO/ParametersTest/ParametersTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/ADO/ParametersTest/ParametersTest.cs
@@ -12,7 +12,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     {
         private static string s_connString = DataTestUtility.TcpConnStr;
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void CodeCoverageSqlClient()
         {
             SqlParameterCollection opc = new SqlCommand().Parameters;
@@ -96,11 +96,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             DataTestUtility.AssertThrowsWrapper<ArgumentException>(() => new SqlCommand().Parameters.Remove(new SqlParameter()), "Attempted to remove an SqlParameter that is not contained by this SqlParameterCollection.");
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void Test_WithEnumValue_ShouldInferToUnderlyingType()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (var conn = new SqlConnection(s_connString))
             {
                 conn.Open();
@@ -111,11 +109,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void Test_WithOutputEnumParameter_ShouldReturnEnum()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (var conn = new SqlConnection(s_connString))
             {
                 conn.Open();
@@ -134,11 +130,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void Test_WithDecimalValue_ShouldReturnDecimal()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (var conn = new SqlConnection(s_connString))
             {
                 conn.Open();
@@ -149,11 +143,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void Test_WithGuidValue_ShouldReturnGuid()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (var conn = new SqlConnection(s_connString))
             {
                 conn.Open();

--- a/src/System.Data.SqlClient/tests/ManualTests/ADO/ParametersTest/ParametersTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/ADO/ParametersTest/ParametersTest.cs
@@ -99,6 +99,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void Test_WithEnumValue_ShouldInferToUnderlyingType()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (var conn = new SqlConnection(s_connString))
             {
                 conn.Open();
@@ -112,6 +114,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void Test_WithOutputEnumParameter_ShouldReturnEnum()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (var conn = new SqlConnection(s_connString))
             {
                 conn.Open();
@@ -133,6 +137,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void Test_WithDecimalValue_ShouldReturnDecimal()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (var conn = new SqlConnection(s_connString))
             {
                 conn.Open();
@@ -146,6 +152,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void Test_WithGuidValue_ShouldReturnGuid()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (var conn = new SqlConnection(s_connString))
             {
                 conn.Open();

--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDAsyncTest/DDAsyncTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDAsyncTest/DDAsyncTest.cs
@@ -13,6 +13,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void OpenConnection_WithAsyncTrue_ThrowsNotSupportedException()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             var asyncConnectionString = DataTestUtility.TcpConnStr + ";async=true";
             Assert.Throws<NotSupportedException>(() => { new SqlConnection(asyncConnectionString); });
         }
@@ -21,6 +23,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void ExecuteCommand_WithNewConnection_ShouldPerformAsyncByDefault()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             var executedProcessList = new List<string>();
 
             var task1 = ExecuteCommandWithNewConnectionAsync("A", "SELECT top 10 * FROM Orders", executedProcessList);
@@ -66,6 +70,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void ExecuteCommand_WithSharedConnection_ShouldPerformAsyncByDefault()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             var executedProcessList = new List<string>();
 
             //for shared connection we need to add MARS capabilities

--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDAsyncTest/DDAsyncTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDAsyncTest/DDAsyncTest.cs
@@ -10,21 +10,17 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public static class DDAsyncTest
     {
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void OpenConnection_WithAsyncTrue_ThrowsNotSupportedException()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             var asyncConnectionString = DataTestUtility.TcpConnStr + ";async=true";
             Assert.Throws<NotSupportedException>(() => { new SqlConnection(asyncConnectionString); });
         }
 
         #region <<ExecuteCommand_WithNewConnection>>
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void ExecuteCommand_WithNewConnection_ShouldPerformAsyncByDefault()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             var executedProcessList = new List<string>();
 
             var task1 = ExecuteCommandWithNewConnectionAsync("A", "SELECT top 10 * FROM Orders", executedProcessList);
@@ -67,11 +63,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         #endregion
 
         #region <<ExecuteCommand_WithSharedConnection>>
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void ExecuteCommand_WithSharedConnection_ShouldPerformAsyncByDefault()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             var executedProcessList = new List<string>();
 
             //for shared connection we need to add MARS capabilities

--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDDataTypesTest/DDDataTypesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDDataTypesTest/DDDataTypesTest.cs
@@ -10,11 +10,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public static class DDDataTypesTest
     {
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void XmlTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             string tempTable = "xml_" + Guid.NewGuid().ToString().Replace('-', '_');
             string initStr = "create table " + tempTable + " (xml_col XML)";
             string insertNormStr = "INSERT " + tempTable + " VALUES('<doc>Hello World</doc>')";
@@ -73,11 +71,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MaxTypesTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             string tempTable = "max_" + Guid.NewGuid().ToString().Replace('-', '_');
             string initStr = "create table " + tempTable + " (col1 varchar(max), col2 nvarchar(max), col3 varbinary(max))";
 

--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDDataTypesTest/DDDataTypesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDDataTypesTest/DDDataTypesTest.cs
@@ -13,7 +13,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void XmlTest()
         {
-            string connStr = DataTestUtility.TcpConnStr;
+            if (!DataTestUtility.AreConnStringsValid()) return;
 
             string tempTable = "xml_" + Guid.NewGuid().ToString().Replace('-', '_');
             string initStr = "create table " + tempTable + " (xml_col XML)";
@@ -21,7 +21,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             string insertParamStr = "INSERT " + tempTable + " VALUES(@x)";
             string queryStr = "select * from " + tempTable;
 
-            using (SqlConnection conn = new SqlConnection(connStr))
+            using (SqlConnection conn = new SqlConnection(DataTestUtility.TcpConnStr))
             {
                 conn.Open();
 
@@ -76,7 +76,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MaxTypesTest()
         {
-            string connStr = DataTestUtility.TcpConnStr;
+            if (!DataTestUtility.AreConnStringsValid()) return;
 
             string tempTable = "max_" + Guid.NewGuid().ToString().Replace('-', '_');
             string initStr = "create table " + tempTable + " (col1 varchar(max), col2 nvarchar(max), col3 varbinary(max))";
@@ -88,7 +88,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             string insertParamStr = "INSERT " + tempTable + " VALUES(@x, @y, @z)";
             string queryStr = "select * from " + tempTable;
 
-            using (SqlConnection conn = new SqlConnection(connStr))
+            using (SqlConnection conn = new SqlConnection(DataTestUtility.TcpConnStr))
             {
                 conn.Open();
 

--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDMARSTest/DDMARSTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDMARSTest/DDMARSTest.cs
@@ -8,11 +8,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public static class DDMARSTest
     {
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TestMain()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             string connstr = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { MultipleActiveResultSets = true }).ConnectionString;
             string cmdText1 = "select * from Orders; select count(*) from Customers";
             string cmdText2 = "select * from Customers; select count(*) from Orders";

--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDMARSTest/DDMARSTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDMARSTest/DDMARSTest.cs
@@ -11,6 +11,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void TestMain()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             string connstr = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { MultipleActiveResultSets = true }).ConnectionString;
             string cmdText1 = "select * from Orders; select count(*) from Customers";
             string cmdText2 = "select * from Customers; select count(*) from Orders";

--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/CheckConnStrSetupFactAttribute.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/CheckConnStrSetupFactAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Data.SqlClient.ManualTesting.Tests
+{
+    public class CheckConnStrSetupFactAttribute : FactAttribute
+    {
+        public CheckConnStrSetupFactAttribute()
+        {
+            if(!DataTestUtility.AreConnStringsSetup())
+            {
+                Skip = "Connection Strings Not Setup";
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -18,11 +18,15 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             NpConnStr = Environment.GetEnvironmentVariable("TEST_NP_CONN_STR");
             TcpConnStr = Environment.GetEnvironmentVariable("TEST_TCP_CONN_STR");
 
-            if (string.IsNullOrEmpty(NpConnStr) || string.IsNullOrEmpty(TcpConnStr))
+            if (!AreConnStringsValid())
             {
-                Console.WriteLine("WARNING: Test connection strings not defined! Tests cannot be run. ***");
-                Environment.Exit(0);
+                Console.WriteLine("WARNING: Test connection strings not defined! Tests cannot be run.");
             }
+        }
+
+        public static bool AreConnStringsValid()
+        {
+            return !string.IsNullOrEmpty(NpConnStr) && !string.IsNullOrEmpty(TcpConnStr);
         }
 
         // the name length will be no more then (16 + prefix.Length + escapeLeft.Length + escapeRight.Length)

--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -18,13 +18,13 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             NpConnStr = Environment.GetEnvironmentVariable("TEST_NP_CONN_STR");
             TcpConnStr = Environment.GetEnvironmentVariable("TEST_TCP_CONN_STR");
 
-            if (!AreConnStringsValid())
+            if (!AreConnStringsSetup())
             {
                 Console.WriteLine("WARNING: Test connection strings not defined! Tests cannot be run.");
             }
         }
 
-        public static bool AreConnStringsValid()
+        public static bool AreConnStringsSetup()
         {
             return !string.IsNullOrEmpty(NpConnStr) && !string.IsNullOrEmpty(TcpConnStr);
         }

--- a/src/System.Data.SqlClient/tests/ManualTests/ProviderAgnostic/MultipleResultsTest/MultipleResultsTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/ProviderAgnostic/MultipleResultsTest/MultipleResultsTest.cs
@@ -17,11 +17,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private StringBuilder _outputBuilder;
         private string[] _outputFilter;
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public void TestMain()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             Assert.True(RunTestCoreAndCompareWithBaseline());
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/ProviderAgnostic/MultipleResultsTest/MultipleResultsTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/ProviderAgnostic/MultipleResultsTest/MultipleResultsTest.cs
@@ -20,6 +20,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public void TestMain()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             Assert.True(RunTestCoreAndCompareWithBaseline());
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
@@ -11,10 +11,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public static class ReaderTest
     {
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TestMain()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
             string connectionString = DataTestUtility.TcpConnStr;
 
             string tempTable = DataTestUtility.GetUniqueName("T", "[", "]");

--- a/src/System.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
@@ -14,6 +14,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void TestMain()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
             string connectionString = DataTestUtility.TcpConnStr;
 
             string tempTable = DataTestUtility.GetUniqueName("T", "[", "]");

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncTest.cs
@@ -14,9 +14,10 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void ExecuteTest()
         {
-            string connStr = DataTestUtility.TcpConnStr;
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             SqlCommand com = new SqlCommand("select * from Orders");
-            SqlConnection con = new SqlConnection(connStr);
+            SqlConnection con = new SqlConnection(DataTestUtility.TcpConnStr);
 
             com.Connection = con;
 
@@ -40,12 +41,13 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void FailureTest()
         {
-            string connStr = DataTestUtility.TcpConnStr;
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             bool failure = false;
             bool taskCompleted = false;
 
             SqlCommand com = new SqlCommand("select * from Orders");
-            SqlConnection con = new SqlConnection(connStr + ";pooling=false");
+            SqlConnection con = new SqlConnection((new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { Pooling = false }).ConnectionString);
             com.Connection = con;
             con.Open();
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncTest.cs
@@ -11,11 +11,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     {
         private const int TaskTimeout = 5000;
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void ExecuteTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             SqlCommand com = new SqlCommand("select * from Orders");
             SqlConnection con = new SqlConnection(DataTestUtility.TcpConnStr);
 
@@ -38,11 +36,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             con.Close();
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void FailureTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             bool failure = false;
             bool taskCompleted = false;
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
@@ -12,35 +12,27 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         // Shrink the packet size - this should make timeouts more likely
         private static readonly string s_connStr = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { PacketSize = 512 }).ConnectionString;
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MultiThreadedCancel_NonAsync()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             MultiThreadedCancel(s_connStr, false);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TimeoutCancel()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             TimeoutCancel(s_connStr);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void CancelAndDisposePreparedCommand()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             CancelAndDisposePreparedCommand(s_connStr);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TimeOutDuringRead()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             TimeOutDuringRead(s_connStr);
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
@@ -15,24 +15,32 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MultiThreadedCancel_NonAsync()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             MultiThreadedCancel(s_connStr, false);
         }
 
         [Fact]
         public static void TimeoutCancel()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             TimeoutCancel(s_connStr);
         }
 
         [Fact]
         public static void CancelAndDisposePreparedCommand()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             CancelAndDisposePreparedCommand(s_connStr);
         }
 
         [Fact]
         public static void TimeOutDuringRead()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             TimeOutDuringRead(s_connStr);
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -14,19 +14,15 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private static readonly string _tcpConnStr = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { MultipleActiveResultSets = false }).ConnectionString;
         private static readonly string _tcpMarsConnStr = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { MultipleActiveResultSets = true }).ConnectionString;
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void ConnectionPool_NonMars()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             RunDataTestForSingleConnString(_tcpConnStr);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void ConnectionPool_Mars()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             RunDataTestForSingleConnString(_tcpMarsConnStr);
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -17,12 +17,16 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void ConnectionPool_NonMars()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             RunDataTestForSingleConnString(_tcpConnStr);
         }
 
         [Fact]
         public static void ConnectionPool_Mars()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             RunDataTestForSingleConnString(_tcpMarsConnStr);
         }
 
@@ -133,7 +137,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         /// <param name="connectionString"></param>
         private static void ReclaimEmancipatedOnOpenTest(string connectionString)
         {
-            string newConnectionString = connectionString + ";Max Pool Size=1";
+            string newConnectionString = (new SqlConnectionStringBuilder(connectionString) { MaxPoolSize = 1 }).ConnectionString;
             SqlConnection.ClearAllPools();
 
             InternalConnectionWrapper internalConnection = CreateEmancipatedConnection(newConnectionString);

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -18,6 +18,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void RunAllTestsForSingleServer_NP()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 DataTestUtility.AssertThrowsWrapper<PlatformNotSupportedException>(() => RunAllTestsForSingleServer(DataTestUtility.NpConnStr, true));
@@ -31,6 +33,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void RunAllTestsForSingleServer_TCP()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             RunAllTestsForSingleServer(DataTestUtility.TcpConnStr);
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -15,11 +15,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public static class DataStreamTest
     {
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void RunAllTestsForSingleServer_NP()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 DataTestUtility.AssertThrowsWrapper<PlatformNotSupportedException>(() => RunAllTestsForSingleServer(DataTestUtility.NpConnStr, true));
@@ -30,11 +28,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void RunAllTestsForSingleServer_TCP()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             RunAllTestsForSingleServer(DataTestUtility.TcpConnStr);
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DateTimeTest/DateTimeTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DateTimeTest/DateTimeTest.cs
@@ -9,7 +9,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public static class DateTimeTest
     {
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void SQLBU503165Test()
         {
             SqlParameter p = new SqlParameter();
@@ -21,7 +21,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             Assert.True(p.SqlValue.Equals(expectedValue), "FAILED: SqlValue did not match expected DateTime value");
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void SQLBU527900Test()
         {
             object chs = new char[] { 'a', 'b', 'c' };
@@ -35,11 +35,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             Assert.True(parameter.Value is char[], "FAILED: Expected parameter value to be char[]");
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void SQLBU503290Test()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (SqlConnection conn = new SqlConnection(DataTestUtility.TcpConnStr))
             {
                 conn.Open();
@@ -54,11 +52,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void ReaderParameterTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             string tempTable = "#t_" + Guid.NewGuid().ToString().Replace('-', '_');
             string tempProc = "#p_" + Guid.NewGuid().ToString().Replace('-', '_');
             string tempProcN = "#pn_" + Guid.NewGuid().ToString().Replace('-', '_');
@@ -314,11 +310,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TypeVersionKnobTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             string tempTable = "#t_" + Guid.NewGuid().ToString().Replace('-', '_');
             string prepTable1 = "CREATE TABLE " + tempTable + " (ci int, c0 dateTime, c1 date, c2 time(7), c3 datetime2(3), c4 datetimeoffset)";
             string prepTable2 = "INSERT INTO " + tempTable + " VALUES (0, " +

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DateTimeTest/DateTimeTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DateTimeTest/DateTimeTest.cs
@@ -38,6 +38,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void SQLBU503290Test()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (SqlConnection conn = new SqlConnection(DataTestUtility.TcpConnStr))
             {
                 conn.Open();
@@ -55,6 +57,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void ReaderParameterTest()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             string tempTable = "#t_" + Guid.NewGuid().ToString().Replace('-', '_');
             string tempProc = "#p_" + Guid.NewGuid().ToString().Replace('-', '_');
             string tempProcN = "#pn_" + Guid.NewGuid().ToString().Replace('-', '_');
@@ -313,6 +317,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void TypeVersionKnobTest()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             string tempTable = "#t_" + Guid.NewGuid().ToString().Replace('-', '_');
             string prepTable1 = "CREATE TABLE " + tempTable + " (ci int, c0 dateTime, c1 date, c2 time(7), c3 datetime2(3), c4 datetimeoffset)";
             string prepTable2 = "INSERT INTO " + tempTable + " VALUES (0, " +

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
@@ -23,6 +23,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void NonWindowsIntAuthFailureTest()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             string connectionString = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { IntegratedSecurity = true }).ConnectionString;
             Assert.Throws<NotSupportedException>(() => new SqlConnection(connectionString).Open());
 
@@ -35,7 +37,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void WarningTest()
         {
-            string connectionString = DataTestUtility.TcpConnStr;
+            if (!DataTestUtility.AreConnStringsValid()) return;
 
             Action<object, SqlInfoMessageEventArgs> warningCallback =
                 (object sender, SqlInfoMessageEventArgs imevent) =>
@@ -47,7 +49,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 };
 
             SqlInfoMessageEventHandler handler = new SqlInfoMessageEventHandler(warningCallback);
-            using (SqlConnection sqlConnection = new SqlConnection(connectionString + ";pooling=false;"))
+            using (SqlConnection sqlConnection = new SqlConnection((new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { Pooling = false }).ConnectionString))
             {
                 sqlConnection.InfoMessage += handler;
                 sqlConnection.Open();
@@ -63,7 +65,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void WarningsBeforeRowsTest()
         {
-            string connectionString = DataTestUtility.TcpConnStr;
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             bool hitWarnings = false;
 
             int iteration = 0;
@@ -78,7 +81,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 };
 
             SqlInfoMessageEventHandler handler = new SqlInfoMessageEventHandler(warningCallback);
-            SqlConnection sqlConnection = new SqlConnection(connectionString);
+            SqlConnection sqlConnection = new SqlConnection(DataTestUtility.TcpConnStr);
             sqlConnection.InfoMessage += handler;
             sqlConnection.Open();
             foreach (string orderClause in new string[] { "", " order by FirstName" })
@@ -149,8 +152,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void ExceptionTests()
         {
-            string connectionString = DataTestUtility.TcpConnStr;
-            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
 
             // tests improper server name thrown from constructor of tdsparser
             SqlConnectionStringBuilder badBuilder = new SqlConnectionStringBuilder(builder.ConnectionString) { DataSource = badServer, ConnectTimeout = 1 };
@@ -179,9 +183,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void VariousExceptionTests()
         {
-            string connectionString = DataTestUtility.TcpConnStr;
+            if (!DataTestUtility.AreConnStringsValid()) return;
 
-            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
 
 
             // Test 1 - A
@@ -207,9 +211,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void IndependentConnectionExceptionTest()
         {
-            string connectionString = DataTestUtility.TcpConnStr;
+            if (!DataTestUtility.AreConnStringsValid()) return;
 
-            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
 
             SqlConnectionStringBuilder badBuilder = new SqlConnectionStringBuilder(builder.ConnectionString) { DataSource = badServer, ConnectTimeout = 1 };
             using (var sqlConnection = new SqlConnection(badBuilder.ConnectionString))

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
@@ -20,11 +20,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private const string orderIdQuery = "select orderid from orders where orderid < 10250";
 
 #if MANAGED_SNI
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void NonWindowsIntAuthFailureTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             string connectionString = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { IntegratedSecurity = true }).ConnectionString;
             Assert.Throws<NotSupportedException>(() => new SqlConnection(connectionString).Open());
 
@@ -34,11 +32,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         }
 #endif
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void WarningTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             Action<object, SqlInfoMessageEventArgs> warningCallback =
                 (object sender, SqlInfoMessageEventArgs imevent) =>
                 {
@@ -62,11 +58,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void WarningsBeforeRowsTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             bool hitWarnings = false;
 
             int iteration = 0;
@@ -149,11 +143,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             return true;
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void ExceptionTests()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
 
             // tests improper server name thrown from constructor of tdsparser
@@ -180,11 +172,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             VerifyConnectionFailure<SqlException>(() => GenerateConnectionException(badBuilder.ConnectionString), errorMessage, (ex) => VerifyException(ex, 1, 18456, 1, 14));
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void VariousExceptionTests()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
 
 
@@ -208,11 +198,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void IndependentConnectionExceptionTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
 
             SqlConnectionStringBuilder badBuilder = new SqlConnectionStringBuilder(builder.ConnectionString) { DataSource = badServer, ConnectTimeout = 1 };

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSSessionPoolingTest/MARSSessionPoolingTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSSessionPoolingTest/MARSSessionPoolingTest.cs
@@ -29,58 +29,46 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 MultipleActiveResultSets = true
             }).ConnectionString;
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MarsExecuteScalar_AllFlavors()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             TestMARSSessionPooling("Case: Text, ExecuteScalar", _testConnString, CommandType.Text, ExecuteType.ExecuteScalar, ReaderTestType.ReaderClose, GCType.Wait);
             TestMARSSessionPooling("Case: RPC,  ExecuteScalar", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteScalar, ReaderTestType.ReaderClose, GCType.Wait);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MarsExecuteNonQuery_AllFlavors()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             TestMARSSessionPooling("Case: Text, ExecuteNonQuery", _testConnString, CommandType.Text, ExecuteType.ExecuteNonQuery, ReaderTestType.ReaderClose, GCType.Wait);
             TestMARSSessionPooling("Case: RPC,  ExecuteNonQuery", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteNonQuery, ReaderTestType.ReaderClose, GCType.Wait);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MarsExecuteReader_Text_NoGC()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             TestMARSSessionPooling("Case: Text, ExecuteReader, ReaderClose", _testConnString, CommandType.Text, ExecuteType.ExecuteReader, ReaderTestType.ReaderClose, GCType.Wait);
             TestMARSSessionPooling("Case: Text, ExecuteReader, ReaderDispose", _testConnString, CommandType.Text, ExecuteType.ExecuteReader, ReaderTestType.ReaderDispose, GCType.Wait);
             TestMARSSessionPooling("Case: Text, ExecuteReader, ConnectionClose", _testConnString, CommandType.Text, ExecuteType.ExecuteReader, ReaderTestType.ConnectionClose, GCType.Wait);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MarsExecuteReader_RPC_NoGC()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             TestMARSSessionPooling("Case: RPC,  ExecuteReader, ReaderClose", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteReader, ReaderTestType.ReaderClose, GCType.Wait);
             TestMARSSessionPooling("Case: RPC,  ExecuteReader, ReaderDispose", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteReader, ReaderTestType.ReaderDispose, GCType.Wait);
             TestMARSSessionPooling("Case: RPC,  ExecuteReader, ConnectionClose", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteReader, ReaderTestType.ConnectionClose, GCType.Wait);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MarsExecuteReader_Text_WithGC()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             TestMARSSessionPooling("Case: Text, ExecuteReader, GC-Wait", _testConnString, CommandType.Text, ExecuteType.ExecuteReader, ReaderTestType.ReaderGC, GCType.Wait);
             TestMARSSessionPooling("Case: Text, ExecuteReader, GC-NoWait", _testConnString, CommandType.Text, ExecuteType.ExecuteReader, ReaderTestType.ReaderGC, GCType.NoWait);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MarsExecuteReader_StoredProcedure_WithGC()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             TestMARSSessionPooling("Case: RPC,  ExecuteReader, GC-Wait", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteReader, ReaderTestType.ReaderGC, GCType.Wait);
             TestMARSSessionPooling("Case: RPC,  ExecuteReader, GC-NoWait", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteReader, ReaderTestType.ReaderGC, GCType.NoWait);
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSSessionPoolingTest/MARSSessionPoolingTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSSessionPoolingTest/MARSSessionPoolingTest.cs
@@ -32,6 +32,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MarsExecuteScalar_AllFlavors()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             TestMARSSessionPooling("Case: Text, ExecuteScalar", _testConnString, CommandType.Text, ExecuteType.ExecuteScalar, ReaderTestType.ReaderClose, GCType.Wait);
             TestMARSSessionPooling("Case: RPC,  ExecuteScalar", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteScalar, ReaderTestType.ReaderClose, GCType.Wait);
         }
@@ -39,6 +41,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MarsExecuteNonQuery_AllFlavors()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             TestMARSSessionPooling("Case: Text, ExecuteNonQuery", _testConnString, CommandType.Text, ExecuteType.ExecuteNonQuery, ReaderTestType.ReaderClose, GCType.Wait);
             TestMARSSessionPooling("Case: RPC,  ExecuteNonQuery", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteNonQuery, ReaderTestType.ReaderClose, GCType.Wait);
         }
@@ -46,6 +50,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MarsExecuteReader_Text_NoGC()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             TestMARSSessionPooling("Case: Text, ExecuteReader, ReaderClose", _testConnString, CommandType.Text, ExecuteType.ExecuteReader, ReaderTestType.ReaderClose, GCType.Wait);
             TestMARSSessionPooling("Case: Text, ExecuteReader, ReaderDispose", _testConnString, CommandType.Text, ExecuteType.ExecuteReader, ReaderTestType.ReaderDispose, GCType.Wait);
             TestMARSSessionPooling("Case: Text, ExecuteReader, ConnectionClose", _testConnString, CommandType.Text, ExecuteType.ExecuteReader, ReaderTestType.ConnectionClose, GCType.Wait);
@@ -54,6 +60,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MarsExecuteReader_RPC_NoGC()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             TestMARSSessionPooling("Case: RPC,  ExecuteReader, ReaderClose", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteReader, ReaderTestType.ReaderClose, GCType.Wait);
             TestMARSSessionPooling("Case: RPC,  ExecuteReader, ReaderDispose", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteReader, ReaderTestType.ReaderDispose, GCType.Wait);
             TestMARSSessionPooling("Case: RPC,  ExecuteReader, ConnectionClose", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteReader, ReaderTestType.ConnectionClose, GCType.Wait);
@@ -62,6 +70,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MarsExecuteReader_Text_WithGC()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             TestMARSSessionPooling("Case: Text, ExecuteReader, GC-Wait", _testConnString, CommandType.Text, ExecuteType.ExecuteReader, ReaderTestType.ReaderGC, GCType.Wait);
             TestMARSSessionPooling("Case: Text, ExecuteReader, GC-NoWait", _testConnString, CommandType.Text, ExecuteType.ExecuteReader, ReaderTestType.ReaderGC, GCType.NoWait);
         }
@@ -69,6 +79,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MarsExecuteReader_StoredProcedure_WithGC()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             TestMARSSessionPooling("Case: RPC,  ExecuteReader, GC-Wait", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteReader, ReaderTestType.ReaderGC, GCType.Wait);
             TestMARSSessionPooling("Case: RPC,  ExecuteReader, GC-NoWait", _testConnString, CommandType.StoredProcedure, ExecuteType.ExecuteReader, ReaderTestType.ReaderGC, GCType.NoWait);
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/MARSTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/MARSTest.cs
@@ -14,11 +14,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private static readonly string _connStr = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { MultipleActiveResultSets = true }).ConnectionString;
 
 #if DEBUG
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MARSAsyncTimeoutTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (SqlConnection connection = new SqlConnection(_connStr))
             {
                 connection.Open();
@@ -56,11 +54,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MARSSyncTimeoutTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (SqlConnection connection = new SqlConnection(_connStr))
             {
                 connection.Open();
@@ -112,11 +108,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         }
 #endif
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MARSSyncBusyReaderTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();
@@ -158,11 +152,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MARSSyncExecuteNonQueryTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();
@@ -182,11 +174,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MARSSyncExecuteReaderTest1()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();
@@ -236,11 +226,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         }
 
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MARSSyncExecuteReaderTest2()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();
@@ -261,11 +249,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MARSSyncExecuteReaderTest3()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();
@@ -298,11 +284,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MARSSyncExecuteReaderTest4()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/MARSTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/MARSTest.cs
@@ -17,6 +17,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MARSAsyncTimeoutTest()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (SqlConnection connection = new SqlConnection(_connStr))
             {
                 connection.Open();
@@ -57,6 +59,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MARSSyncTimeoutTest()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (SqlConnection connection = new SqlConnection(_connStr))
             {
                 connection.Open();
@@ -111,6 +115,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MARSSyncBusyReaderTest()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();
@@ -155,6 +161,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MARSSyncExecuteNonQueryTest()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();
@@ -177,6 +185,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MARSSyncExecuteReaderTest1()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();
@@ -229,6 +239,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MARSSyncExecuteReaderTest2()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();
@@ -252,6 +264,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MARSSyncExecuteReaderTest3()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();
@@ -287,6 +301,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MARSSyncExecuteReaderTest4()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             using (SqlConnection conn = new SqlConnection(_connStr))
             {
                 conn.Open();

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ParallelTransactionsTest/ParallelTransactionsTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ParallelTransactionsTest/ParallelTransactionsTest.cs
@@ -9,19 +9,15 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     public static class ParallelTransactionsTest
     {
         #region <<Basic Parallel Test>>
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void BasicParallelTest_ShouldThrowsUnsupported_Yukon()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             BasicParallelTest_shouldThrowsUnsupported(DataTestUtility.TcpConnStr);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void BasicParallelTest_ShouldThrowsUnsupported_Katmai()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             BasicParallelTest_shouldThrowsUnsupported(DataTestUtility.TcpConnStr);
         }
 
@@ -79,19 +75,15 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         #endregion
 
         #region <<MultipleExecutesInSameTransactionTest>>
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MultipleExecutesInSameTransactionTest_ShouldThrowsUnsupported_Yukon()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             MultipleExecutesInSameTransactionTest_shouldThrowsUnsupported(DataTestUtility.TcpConnStr);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void MultipleExecutesInSameTransactionTest_ShouldThrowsUnsupported_Katmai()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             MultipleExecutesInSameTransactionTest_shouldThrowsUnsupported(DataTestUtility.TcpConnStr);
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ParallelTransactionsTest/ParallelTransactionsTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ParallelTransactionsTest/ParallelTransactionsTest.cs
@@ -12,12 +12,16 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void BasicParallelTest_ShouldThrowsUnsupported_Yukon()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             BasicParallelTest_shouldThrowsUnsupported(DataTestUtility.TcpConnStr);
         }
 
         [Fact]
         public static void BasicParallelTest_ShouldThrowsUnsupported_Katmai()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             BasicParallelTest_shouldThrowsUnsupported(DataTestUtility.TcpConnStr);
         }
 
@@ -78,12 +82,16 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void MultipleExecutesInSameTransactionTest_ShouldThrowsUnsupported_Yukon()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             MultipleExecutesInSameTransactionTest_shouldThrowsUnsupported(DataTestUtility.TcpConnStr);
         }
 
         [Fact]
         public static void MultipleExecutesInSameTransactionTest_ShouldThrowsUnsupported_Katmai()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             MultipleExecutesInSameTransactionTest_shouldThrowsUnsupported(DataTestUtility.TcpConnStr);
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
@@ -38,6 +38,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public void TestMain()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             _operationCanceledErrorMessage = SystemDataResourceManager.Instance.SQL_OperationCancelled;
             _severeErrorMessage = SystemDataResourceManager.Instance.SQL_SevereError;
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
@@ -35,11 +35,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private long _totalTicks;
         private RandomizerPool _randPool;
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public void TestMain()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             _operationCanceledErrorMessage = SystemDataResourceManager.Instance.SQL_OperationCancelled;
             _severeErrorMessage = SystemDataResourceManager.Instance.SQL_SevereError;
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
@@ -12,6 +12,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void ValidConnStringTest()
         {
+            if (string.IsNullOrEmpty(DataTestUtility.NpConnStr)) return;
+
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.NpConnStr);
             builder.ConnectTimeout = 5;
 
@@ -35,6 +37,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void InvalidConnStringTest()
         {
+            if (string.IsNullOrEmpty(DataTestUtility.NpConnStr)) return;
+
             const string invalidConnStringError = "A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: Named Pipes Provider, error: 25 - Connection string is not valid)";
 
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.NpConnStr);

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
@@ -12,7 +12,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void ValidConnStringTest()
         {
-            if (string.IsNullOrEmpty(DataTestUtility.NpConnStr)) return;
+            if (!DataTestUtility.AreConnStringsValid()) return;
 
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.NpConnStr);
             builder.ConnectTimeout = 5;
@@ -37,7 +37,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void InvalidConnStringTest()
         {
-            if (string.IsNullOrEmpty(DataTestUtility.NpConnStr)) return;
+            if (!DataTestUtility.AreConnStringsValid()) return;
 
             const string invalidConnStringError = "A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: Named Pipes Provider, error: 25 - Connection string is not valid)";
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
@@ -9,11 +9,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public static class SqlNamedPipesTest
     {
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void ValidConnStringTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.NpConnStr);
             builder.ConnectTimeout = 5;
 
@@ -34,11 +32,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         }
 
 #if MANAGED_SNI
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void InvalidConnStringTest()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             const string invalidConnStringError = "A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: Named Pipes Provider, error: 25 - Connection string is not valid)";
 
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.NpConnStr);

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlTypeTest/SqlTypeTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlTypeTest/SqlTypeTest.cs
@@ -74,7 +74,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             0x0409   // English - United States
         };
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void SqlStringValidComparisonTest()
         {
             for (int j = 0; j < s_cultureInfo.Length; ++j)
@@ -88,7 +88,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void SqlStringNullComparisonTest()
         {
             SqlString nullSqlString = new SqlString(null);

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionTest.cs
@@ -9,14 +9,10 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     public static class TransactionTest
     {
         [Fact]
-        public static void TestYukon()
+        public static void TestMain()
         {
-            new TransactionTestWorker((new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { MultipleActiveResultSets = true }).ConnectionString).StartTest();
-        }
+            if (!DataTestUtility.AreConnStringsValid()) return;
 
-        [Fact]
-        public static void TestKatmai()
-        {
             new TransactionTestWorker((new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { MultipleActiveResultSets = true }).ConnectionString).StartTest();
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionTest.cs
@@ -8,11 +8,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public static class TransactionTest
     {
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TestMain()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             new TransactionTestWorker((new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { MultipleActiveResultSets = true }).ConnectionString).StartTest();
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs
@@ -43,6 +43,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void TestReaderNonMars()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             string connString =
                 (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) 
                 {
@@ -72,6 +74,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void TestTransactionSingle()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             string connString =
                 (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) 
                 {

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs
@@ -40,11 +40,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             TransactionGCConnectionClose,
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TestReaderNonMars()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             string connString =
                 (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) 
                 {
@@ -71,11 +69,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             TestReaderNonMarsCase("Case 15: ExecuteReader, GC, Connection Close, BeginTransaction.", connString, ReaderTestType.ReaderGCConnectionClose, ReaderVerificationType.BeginTransaction);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TestTransactionSingle()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             string connString =
                 (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) 
                 {

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/WeakRefTestYukonSpecific/WeakRefTestYukonSpecific.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/WeakRefTestYukonSpecific/WeakRefTestYukonSpecific.cs
@@ -15,11 +15,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private const string DATABASE_NAME = "master";
         private const int CONCURRENT_COMMANDS = 5;
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TestReaderMars()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             string connectionString =
                 (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) 
                 {
@@ -46,11 +44,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             TestReaderMarsCase("Case 14: ExecuteReader*5 GC, Connection Close, BeginTransaction.", connectionString, ReaderTestType.ReaderGCConnectionClose, ReaderVerificationType.BeginTransaction);
         }
 
-        [Fact]
+        [CheckConnStrSetupFact]
         public static void TestTransactionSingle()
         {
-            if (!DataTestUtility.AreConnStringsValid()) return;
-
             string connectionString =
                 (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) 
                 {

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/WeakRefTestYukonSpecific/WeakRefTestYukonSpecific.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/WeakRefTestYukonSpecific/WeakRefTestYukonSpecific.cs
@@ -18,6 +18,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void TestReaderMars()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             string connectionString =
                 (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) 
                 {
@@ -47,6 +49,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void TestTransactionSingle()
         {
+            if (!DataTestUtility.AreConnStringsValid()) return;
+
             string connectionString =
                 (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) 
                 {

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -20,6 +20,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DataCommon\CheckConnStrSetupFactAttribute.cs" />
     <Compile Include="SQL\Common\AsyncDebugScope.cs" />
     <Compile Include="SQL\Common\ConnectionPoolWrapper.cs" />
     <Compile Include="SQL\Common\InternalConnectionWrapper.cs" />

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Data.SqlClient.csproj">
       <Name>System.Data.SqlClient</Name>
-      <OSGroup>$(OSGroup)</OSGroup>
+      <OSGroup>$(InputOSGroup)</OSGroup>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Calling Environment.Exit(0) in ManualTests during pipeline tests causes the test to be marked as failed, since Helix expects a results.xml file afterwards. This change removes the generic process exit in conn string setup in favor of conn string validity checking in each test Fact.