### PR TITLE
Bring in Group.Name API from future branch, to be supported for net463 

### DIFF
--- a/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
+++ b/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
@@ -30,6 +30,7 @@ namespace System.Text.RegularExpressions
     {
         internal Group() { }
         public System.Text.RegularExpressions.CaptureCollection Captures { get { return default(System.Text.RegularExpressions.CaptureCollection); } }
+        public string Name { get { return default(string); } }
         public bool Success { get { return default(bool); } }
     }
     public partial class GroupCollection : System.Collections.ICollection, System.Collections.IEnumerable

--- a/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.6</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>

--- a/src/System.Text.RegularExpressions/src/ApiCompatBaseline.net463.txt
+++ b/src/System.Text.RegularExpressions/src/ApiCompatBaseline.net463.txt
@@ -2,3 +2,4 @@ MembersMustExist : Member 'System.Text.RegularExpressions.Regex.Caps.get()' does
 MembersMustExist : Member 'System.Text.RegularExpressions.Regex.Caps.set(System.Collections.IDictionary)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Text.RegularExpressions.Regex.CapNames.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Text.RegularExpressions.Regex.CapNames.set(System.Collections.IDictionary)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Text.RegularExpressions.Group.Name.get()' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}</ProjectGuid>
     <AssemblyName>System.Text.RegularExpressions</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net463'">None</ResourcesSourceOutputDirectory>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.6</PackageTargetFramework>

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroup.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroup.cs
@@ -18,10 +18,10 @@ namespace System.Text.RegularExpressions
         // the empty group object
         internal static Group _emptygroup = new Group(String.Empty, Array.Empty<int>(), 0, string.Empty);
 
-        internal int[] _caps;
+        internal readonly int[] _caps;
         internal int _capcount;
         internal CaptureCollection _capcoll;
-        internal string _name;
+        internal readonly string _name;
 
         internal Group(String text, int[] caps, int capcount, string name)
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroup.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroup.cs
@@ -16,19 +16,21 @@ namespace System.Text.RegularExpressions
     public class Group : Capture
     {
         // the empty group object
-        internal static Group _emptygroup = new Group(String.Empty, Array.Empty<int>(), 0);
+        internal static Group _emptygroup = new Group(String.Empty, Array.Empty<int>(), 0, string.Empty);
 
         internal int[] _caps;
         internal int _capcount;
         internal CaptureCollection _capcoll;
+        internal string _name;
 
-        internal Group(String text, int[] caps, int capcount)
+        internal Group(String text, int[] caps, int capcount, string name)
 
         : base(text, capcount == 0 ? 0 : caps[(capcount - 1) * 2],
                capcount == 0 ? 0 : caps[(capcount * 2) - 1])
         {
             _caps = caps;
             _capcount = capcount;
+            _name = name;
         }
 
         /// <summary>
@@ -39,6 +41,14 @@ namespace System.Text.RegularExpressions
             get
             {
                 return _capcount != 0;
+            }
+        }
+
+        public string Name
+        {
+            get
+            {
+                return _name;
             }
         }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -94,7 +94,8 @@ namespace System.Text.RegularExpressions
                 _groups = new Group[_match._matchcount.Length - 1];
                 for (int i = 0; i < _groups.Length; i++)
                 {
-                    _groups[i] = new Group(_match._text, _match._matches[i + 1], _match._matchcount[i + 1]);
+                    string groupname = _match._regex.GroupNameFromNumber(i + 1);
+                    _groups[i] = new Group(_match._text, _match._matches[i + 1], _match._matchcount[i + 1], groupname);
                 }
             }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatch.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatch.cs
@@ -64,8 +64,7 @@ namespace System.Text.RegularExpressions
         }
 
         internal Match(Regex regex, int capcount, String text, int begpos, int len, int startpos)
-
-        : base(text, new int[2], 0)
+            : base(text, new int[2], 0, "0")
         {
             _regex = regex;
             _matchcount = new int[capcount];

--- a/src/System.Text.RegularExpressions/tests/RegexGroupNameTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexGroupNameTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Text.RegularExpressions;
+using System.Collections;
+
+namespace System.Text.RegularExpressionsTests
+{
+    /// <summary>
+    /// Tests the Name property on the Group class.
+    /// </summary>
+    public class RegexGroupNameTests
+    {
+        [Fact]
+        public static void NameTests()
+        {
+            string pattern = @"\b(?<FirstWord>\w+)\s?((\w+)\s)*(?<LastWord>\w+)?(?<Punctuation>\p{Po})";
+            string input = "The cow jumped over the moon.";
+            Regex regex = new Regex(pattern);
+            Match match = regex.Match(input);
+            if (match.Success)
+            {
+                string[] names = regex.GetGroupNames();
+                for (int i = 0; i < names.Length; i++)
+                {
+                    Assert.Equal(names[i], match.Groups[i].Name);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexGroupNameTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexGroupNameTests.cs
@@ -20,13 +20,12 @@ namespace System.Text.RegularExpressionsTests
             string input = "The cow jumped over the moon.";
             Regex regex = new Regex(pattern);
             Match match = regex.Match(input);
-            if (match.Success)
+            Assert.True(match.Success);
+
+            string[] names = regex.GetGroupNames();
+            for (int i = 0; i < names.Length; i++)
             {
-                string[] names = regex.GetGroupNames();
-                for (int i = 0; i < names.Length; i++)
-                {
-                    Assert.Equal(names[i], match.Groups[i].Name);
-                }
+                Assert.Equal(names[i], match.Groups[i].Name);
             }
         }
     }

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="GroupCollectionTests.cs" />
     <Compile Include="MatchCollectionTests.cs" />
     <Compile Include="PrecompiledRegexScenarioTest.cs" />
+    <Compile Include="RegexGroupNameTests.cs" />
     <Compile Include="Regex.EscapeUnescape.Tests.cs" />
     <Compile Include="Regex.GetGroupNames.Tests.cs" />
     <Compile Include="Regex.Ctor.Tests.cs" />


### PR DESCRIPTION
Going to be adding new APIs that shipped in 4.1.0, and the one from future to desktop 463, hence merging to master. Also bumped up the contract version to 4.2.0.

cc @joshfree @ericstj 