### PR TITLE
Convert CredentialCache perf tests to xunit.performance

### DIFF
--- a/src/System.Net.Primitives/tests/PerformanceTests/System.Net.Primitives.Performance.Tests.csproj
+++ b/src/System.Net.Primitives/tests/PerformanceTests/System.Net.Primitives.Performance.Tests.csproj
@@ -9,6 +9,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{86256B36-4C78-4A71-A80A-CCA35C4AE758}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />

--- a/src/System.Net.Primitives/tests/PerformanceTests/project.json
+++ b/src/System.Net.Primitives/tests/PerformanceTests/project.json
@@ -9,7 +9,8 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00508-01"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00508-01",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {
     "netstandard1.3": {}


### PR DESCRIPTION
These tests were running for a long time, and then ignoring the result.  These tests run for ~2 minutes in our functional test passes, even though we're not getting useful data out of them.

This change converts the tests to use xunit.performance.  This will greatly reduce their runtime when not running as performance tests (we just run one iteration in that case).  It will also enable them to produce useful results in our perf lab, where we *do* have the infrastructure to find regressions in both throughput and GC counts for xunit.performance-based tests.

@stephentoub @davidsh @CIPop @justinvp @brianrob 