### PR TITLE
Several managed WebSockets tweaks

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -14,9 +14,9 @@
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
     <!-- // uncomment to use the managed "unix" implementation on Windows
-		<TargetsWindows>false</TargetsWindows>
-		<TargetsUnix>true</TargetsUnix>
-	-->
+      <TargetsWindows>false</TargetsWindows>
+      <TargetsUnix>true</TargetsUnix>
+    -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' and '$(ProjectJson)' == '' ">
     <ProjectJson>unix/project.json</ProjectJson>


### PR DESCRIPTION
- When we fail to connect due to an abort/cancellation, ensure the inner exception of the WebSocketException is an OperationCanceledException rather than an ObjectDisposedException.

- When sending a keep-alive ping, if the send lock is already held, that means we're actively sending something, so there's no value in also sending a keep-alive; we can simply make it a nop.

- Only create the keep-alive timer if asked for.

- Make a field readonly.

cc: @ericeil