### PR TITLE
Allow the HTTP2 protocol test to pass with untrusted chains on Debian.

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -21,6 +21,7 @@ namespace System
 
         public static int WindowsVersion { get; } = GetWindowsVersion();
 
+        public static bool IsDebian8 { get; } = IsDistroAndVersion("debian", "8");
         public static bool IsUbuntu1510 { get; } = IsDistroAndVersion("ubuntu", "15.10");
         public static bool IsUbuntu1604 { get; } = IsDistroAndVersion("ubuntu", "16.04");
         public static bool IsFedora23 { get; } = IsDistroAndVersion("fedora", "23");


### PR DESCRIPTION
The TLS context is set up to make this chain:
  CN=http2.akamai.com, O=Akamai Technologies Inc., L=Santa Clara, S=CA, C=US
  CN=Verizon Akamai SureServer CA G14-SHA2, OU=Cybertrust, O=Verizon Enterprise Solutions, L=Amsterdam, C=NL
  CN=Baltimore CyberTrust Root, OU=CyberTrust, O=Baltimore, C=IE
  CN=GTE CyberTrust Global Root, OU="GTE CyberTrust Solutions, Inc.", O=GTE Corporation, C=US

making use of the cross-signed Baltimore CyberTrust Root certificate.
Unfortunately, that chain is not trusted on Debian 8.4 (GTE CyberTrust Global Root was removed), and a combination of data and installed software results in the valid chain using the self-signed Baltimore root is never built.

To prevent this situation from making the tests show as a failure, selectively allow Debian 8 to succeed on an incomplete chain.