### PR TITLE
FileSystem: Expand CanCreateSymlinks test

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -359,19 +359,31 @@ namespace System.IO.Tests
         }
 
         /// <summary>
-        /// Creates a test symlink to determine if symlinks can be successfully created
+        /// In some cases (such as when running without elevated privileges),
+        /// the symbolic link may fail to create. Only run this test if it creates
+        /// links successfully.
         /// </summary>
         protected static bool CanCreateSymbolicLinks
         {
             get
             {
-                var path = Path.GetTempFileName();
-                var linkPath = path + ".link";
-                var ret = CreateSymLink(path, linkPath, isDirectory: false);
-                ret = ret && File.Exists(linkPath);
+                bool success = true;
+
+                // Verify file symlink creation
+                string path = Path.GetTempFileName();
+                string linkPath = path + ".link";
+                success = CreateSymLink(path, linkPath, isDirectory: false);
                 try { File.Delete(path); } catch { }
                 try { File.Delete(linkPath); } catch { }
-                return ret;
+
+                // Verify directory symlink creation
+                path = Path.GetTempFileName();
+                linkPath = path + ".link";
+                success = success && CreateSymLink(path, linkPath, isDirectory: true);
+                try { Directory.Delete(path); } catch { }
+                try { Directory.Delete(linkPath); } catch { }
+
+                return success;
             }
         }
 

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -14,19 +14,32 @@ namespace System.IO.Tests
         protected const PlatformID CaseInsensitivePlatforms = PlatformID.Windows | PlatformID.OSX;
         protected const PlatformID CaseSensitivePlatforms = PlatformID.AnyUnix & ~PlatformID.OSX;
 
-        // In some cases (such as when running without elevated privileges),
-        // the symbolic link may fail to create. Only run this test if it creates
-        // links successfully.
+        /// <summary>
+        /// In some cases (such as when running without elevated privileges),
+        /// the symbolic link may fail to create. Only run this test if it creates
+        /// links successfully.
+        /// </summary>
         protected static bool CanCreateSymbolicLinks
         {
             get
             {
-                var path = Path.GetTempFileName();
-                var linkPath = path + ".link";
-                var ret = MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false);
+                bool success = true;
+
+                // Verify file symlink creation
+                string path = Path.GetTempFileName();
+                string linkPath = path + ".link";
+                success = MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false);
                 try { File.Delete(path); } catch { }
                 try { File.Delete(linkPath); } catch { }
-                return ret;
+
+                // Verify directory symlink creation
+                path = Path.GetTempFileName();
+                linkPath = path + ".link";
+                success = success && MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true);
+                try { Directory.Delete(path); } catch { }
+                try { Directory.Delete(linkPath); } catch { }
+
+                return success;
             }
         }
 


### PR DESCRIPTION
Make it harder to pass the CanCreateSymbolicLinks check so that tests don't fail on some systems where a file symlink can be created but a directory symlink can't be.

Also adds a File.Exists/Directory.Exists check to provide a bit more strengthening to the CanCreateSymbolicLinks check.

likely resolves #9009