### PR TITLE
Several more WebSocket tweaks

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Unix.cs
@@ -749,9 +749,9 @@ namespace System.Net.WebSockets
                 }
                 catch (Exception exc)
                 {
-                    throw _state == WebSocketState.Aborted ?
+                    return Task.FromException(_state == WebSocketState.Aborted ?
                         CreateOperationCanceledException(exc) :
-                        new WebSocketException(WebSocketError.ConnectionClosedPrematurely, exc);
+                        new WebSocketException(WebSocketError.ConnectionClosedPrematurely, exc));
                 }
                 finally
                 {


### PR DESCRIPTION
- Refactor out of the ReceiveAsyncPrivate method the portions responsibility for handling the close, ping, and pong messages; this slightly increases allocations for handling those, but helps with the send/receive cases.
- Ensure we capture an exception into the task returned from SendAsync rather than throwing it out synchronously
- Properly handle a few more "bad message" cases. We're now passing 100% of the autobahn WebSockets tests (other than the "unimplemented" compression ones).

cc: @ericeil