### PR TITLE
Fix MulticastInterface_Set_Helper in Fedora Outerloop runs

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -122,6 +122,11 @@ namespace System.Net.Sockets.Tests
             using (Socket receiveSocket = CreateBoundUdpSocket(out port),
                           sendSocket    = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
+                // Make sure the sending socket is bound to the same interface as the receive socket, to avoid
+                // routing issues in the test environment.
+                IPEndPoint receiveEndpoint = (IPEndPoint)receiveSocket.LocalEndPoint;
+                sendSocket.Bind(new IPEndPoint(receiveEndpoint.Address, 0));
+
                 receiveSocket.ReceiveTimeout = 1000;
                 receiveSocket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(multicastAddress, interfaceIndex));
 


### PR DESCRIPTION
Attempt to work around routing issues in the test environment by manually sending from the same interface we'll receive on.

Fixes #9538.