### PR TITLE
Disable SocketOptionNameTest.MulticastInterface_Set_AnyInterface_Succeeds on Fedora 23

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -94,7 +94,9 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Fact]
+        private static bool IsNotFedora23 => !PlatformDetection.IsFedora23;
+
+        [ConditionalFact(nameof(IsNotFedora23))] // (#9538) Receive times out
         public void MulticastInterface_Set_AnyInterface_Succeeds()
         {
             // On all platforms, index 0 means "any interface"


### PR DESCRIPTION
Disable `SocketOptionNameTest.MulticastInterface_Set_AnyInterface_Succeeds` on Fedora, while we investigate why this test has been failing (#9538).