### PR TITLE
Add NERR_UserNotFound code to check on netuserdel.

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -393,7 +393,8 @@ namespace System.Diagnostics.Tests
             }
             finally
             {
-                Assert.Equal((uint)0, Interop.NetUserDel(null, username));
+                IEnumerable<uint> collection = new uint[] { 0 /* NERR_Success */, 2221 /* NERR_UserNotFound */ };
+                Assert.Contains<uint>(Interop.NetUserDel(null, username), collection);
 
                 if (handle != null)
                     handle.Dispose();


### PR DESCRIPTION
The outerloop windows runs are run concurrently if necessary, so one run may have deleted the user. Check if user exists before attempting to delete. 

fixes #8984 
cc @stephentoub 