### PR TITLE
Added support for decoding EnvelopedCms RecipientInfo metadata on Unix

### DIFF
--- a/src/System.Security.Cryptography.Encoding/tests/DerSequenceReaderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerSequenceReaderTests.cs
@@ -94,6 +94,30 @@ namespace System.Security.Cryptography.Encoding.Tests
             Assert.Equal(DateTimeKind.Utc, decodedTime.Kind);
         }
 
+        [Theory]
+        [InlineData("180f31393932303732323133323130305a", 1992, 07, 22, 13, 21, 00)]
+        [InlineData("180f32303138303531383130333731365a", 2018, 05, 18, 10, 37, 16)]
+        public static void ReadGeneralizedTime(string hexString, int year, int month, int day, int hour, int minute, int second)
+        {
+            byte[] payload = hexString.HexToByteArray();
+            DateTime representedTime = new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc);
+            DerSequenceReader reader = DerSequenceReader.CreateForPayload(payload);
+            DateTime decodedTime = reader.ReadGeneralizedTime();
+            Assert.Equal(representedTime, decodedTime);
+            Assert.Equal(DateTimeKind.Utc, decodedTime.Kind);
+        }
+
+        [Theory]
+        [InlineData("030504056e9230", "056e9230")] // With unusedbits
+        [InlineData("030500056e9237", "056e9237")] // Without unusedbits
+        public static void ReadBitString(string hexString, string expected)
+        {
+            byte[] payload = hexString.HexToByteArray();
+            byte[] expectedOctets = expected.HexToByteArray();
+            byte[] decoded = DerSequenceReader.CreateForPayload(payload).ReadBitString();
+            Assert.Equal(expectedOctets, decoded);
+        }
+
         [Fact]
         public static void FalseEncodedLength_MultiByteLength()
         {

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Helpers.cs
@@ -173,7 +173,7 @@ namespace Internal.Cryptography
             return serialBytes.ToUpperHexString();
         }
 
-        private static string ToUpperHexString(this byte[] ba)
+        public static string ToUpperHexString(this byte[] ba)
         {
             StringBuilder sb = new StringBuilder(ba.Length * 2);
             foreach (byte b in ba)

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/DecryptorPalOpenSsl.DecodeRecipients.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/DecryptorPalOpenSsl.DecodeRecipients.cs
@@ -1,0 +1,297 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+
+namespace Internal.Cryptography.Pal.OpenSsl
+{
+    internal sealed partial class DecryptorPalOpenSsl : DecryptorPal
+    {
+        private static RecipientInfoCollection ReadRecipientInfos(DerSequenceReader encodedCms)
+        {
+            DerSequenceReader recipientSet = encodedCms.ReadSet();
+            List<RecipientInfo> recipientInfoStack = new List<RecipientInfo>();
+
+            // RecipientInfo objects are defined as (in RFC 2630) 
+            //
+            // RecipientInfo ::= CHOICE {
+            //      ktri KeyTransRecipientInfo
+            //      kari [1] KeyAgreementRecipientInfo
+            //      kekri [2] KEKRecipientInfo }
+            //
+            // New types have been added but we don't support them
+
+            const byte ConstructedSequence = (byte)DerSequenceReader.DerTag.Sequence | DerSequenceReader.ConstructedFlag;
+            const byte ContextSpecific1 = DerSequenceReader.ConstructedFlag | DerSequenceReader.ContextSpecificTagFlag | 0x01;
+
+            while (recipientSet.HasData)
+            {
+                byte tag = recipientSet.PeekTag();
+                
+                switch (tag)
+                {
+                    case ConstructedSequence:
+                        KeyTransRecipientInfo ktri = ReadKeyTrans(recipientSet);
+                        recipientInfoStack.Add(ktri);
+                        break;
+                    case ContextSpecific1:
+                        ReadAndAddKeyAgrees(recipientSet, recipientInfoStack);
+                        break;
+                    default:
+                        // If the tag is another context specific, it corresponds to a recipient
+                        // type we don't support. A PlatformNotSupportedException seems more fit for this,
+                        // but for compat reasons with the Windows implementation this is the exception thrown. 
+                        throw new CryptographicException(SR.Cryptography_Err_Not_Impl);
+                }
+            }
+
+            return new RecipientInfoCollection(recipientInfoStack);
+        }
+
+        private static void ReadAndAddKeyAgrees(DerSequenceReader recipientSet, List<RecipientInfo> recipientInfoStack)
+        {
+            // KeyAgreeRecipientInfo::= SEQUENCE {
+            //      version CMSVersion,  --always set to 3
+            //      originator[0] EXPLICIT OriginatorIdentifierOrKey,
+            //      ukm[1] EXPLICIT UserKeyingMaterial OPTIONAL,
+            //      keyEncryptionAlgorithm KeyEncryptionAlgorithmIdentifier,
+            //      recipientEncryptedKeys RecipientEncryptedKeys }
+
+            DerSequenceReader encodedKeyAgreement = recipientSet.ReadSequence();
+            int version = encodedKeyAgreement.ReadInteger();
+
+            // OriginatorIdentifierOrKey::= CHOICE {
+            //      issuerAndSerialNumber IssuerAndSerialNumber,
+            //      subjectKeyIdentifier[0] SubjectKeyIdentifier,
+            //      originatorKey[1] OriginatorPublicKey }
+
+            const byte ConstructedSequence = (byte)DerSequenceReader.DerTag.Sequence | DerSequenceReader.ConstructedFlag;
+            const byte ContextSpecific1 = DerSequenceReader.ConstructedFlag | DerSequenceReader.ContextSpecificTagFlag | 0x01;
+
+            DerSequenceReader originator = encodedKeyAgreement.ReadSequence();
+            byte tag = originator.PeekTag();
+
+            SubjectIdentifierOrKey originatorIdentifierOrKey;
+
+            switch (tag)
+            {
+                case ConstructedSequence:
+                    X509IssuerSerial issuerSerial = ReadIssuerSerial(originator);
+
+                    originatorIdentifierOrKey =
+                        new SubjectIdentifierOrKey(SubjectIdentifierOrKeyType.IssuerAndSerialNumber, issuerSerial);
+
+                    break;
+
+                case DerSequenceReader.ContextSpecificTagFlag:
+                    string skid = ReadSubjectKeyId(originator);
+
+                    originatorIdentifierOrKey =
+                        new SubjectIdentifierOrKey(SubjectIdentifierOrKeyType.SubjectKeyIdentifier, skid);
+
+                    break;
+
+                case ContextSpecific1:
+                    PublicKeyInfo publicKeyInfo = ReadOriginatorPublicKey(originator);
+
+                    originatorIdentifierOrKey =
+                        new SubjectIdentifierOrKey(SubjectIdentifierOrKeyType.PublicKeyInfo, publicKeyInfo);
+
+                    break;
+
+                default:
+                    throw new CryptographicException(SR.Format(SR.Cryptography_Cms_Invalid_Originator_Identifier_Choice, tag));
+            }
+
+            if (encodedKeyAgreement.PeekTag() == ContextSpecific1)
+            {
+                // Skip extra keying material; this one isn't exposed in the API and Framework does
+                // nothing with it.
+                encodedKeyAgreement.SkipValue();
+            }
+
+            AlgorithmIdentifier keyEncryptionAlgo = encodedKeyAgreement.ReadAlgoIdentifier();
+
+            // As there might be more than one element in RecipientEncryptedKeys, we have to create one KeyAgreeRecipientInfo for each
+            // one of the elements hold all the previously read values as common elements. We delegate this to ReadRecipientEncryptedKeys
+            ReadRecipientEncryptedKeys(encodedKeyAgreement, version, originatorIdentifierOrKey, keyEncryptionAlgo, recipientInfoStack);            
+        }
+
+        private static PublicKeyInfo ReadOriginatorPublicKey(DerSequenceReader encodedKeyAgreement)
+        {
+            // OriginatorPublicKey::= SEQUENCE {
+            //      algorithm AlgorithmIdentifier,
+            //      publicKey BIT STRING }
+            DerSequenceReader publicKeyReader = encodedKeyAgreement.ReadSequence();
+
+            AlgorithmIdentifier publicKeyAlgorithm = publicKeyReader.ReadAlgoIdentifier();
+            byte[] publicKey = publicKeyReader.ReadBitString();
+
+            return new PublicKeyInfo(publicKeyAlgorithm, publicKey);
+        }
+
+        private static KeyTransRecipientInfo ReadKeyTrans(DerSequenceReader recipientSet)
+        {
+
+            // KeyTransRecipientInfo are defined in RFC 2630 as
+            //
+            // KeyTransRecipientInfo::= SEQUENCE {
+            //      version CMSVersion,  --always set to 0 or 2
+            //      rid RecipientIdentifier,
+            //      keyEncryptionAlgorithm KeyEncryptionAlgorithmIdentifier,
+            //      encryptedKey EncryptedKey }
+            //
+            // EncryptedKey::= OCTET STRING
+
+            DerSequenceReader encodedKeyTransport = recipientSet.ReadSequence();
+            int version = encodedKeyTransport.ReadInteger();
+
+            // RecipientIdentifier is either SubjectKeyIdentifier or IssuerAndSerialNumber
+            //
+            // RecipientIdentifier ::= CHOICE {
+            //      issuerAndSerialNumber IssuerAndSerialNumber,
+            //      subjectKeyIdentifier[0] SubjectKeyIdentifier }
+
+            byte tag = encodedKeyTransport.PeekTag();
+            const byte ConstructedSequence = (byte)DerSequenceReader.DerTag.Sequence | DerSequenceReader.ConstructedFlag;
+
+            SubjectIdentifier subject;
+            switch (tag)
+            {
+                case ConstructedSequence:
+                    subject = new SubjectIdentifier(SubjectIdentifierType.IssuerAndSerialNumber, ReadIssuerSerial(encodedKeyTransport));
+                    break;
+                case DerSequenceReader.ContextSpecificTagFlag:
+                    subject = new SubjectIdentifier(SubjectIdentifierType.SubjectKeyIdentifier, ReadSubjectKeyId(encodedKeyTransport));
+                    break;
+                default:
+                    throw new CryptographicException(SR.Format(SR.Cryptography_Cms_Invalid_Subject_Identifier_Type, tag));
+            }
+
+            AlgorithmIdentifier kekAlgoId = encodedKeyTransport.ReadAlgoIdentifier();
+            byte[] encryptedKey = encodedKeyTransport.ReadOctetString();
+
+            KeyTransRecipientInfoPalOpenSsl ktriObj =
+                new KeyTransRecipientInfoPalOpenSsl(version, subject, kekAlgoId, encryptedKey);
+            return new KeyTransRecipientInfo(ktriObj);
+        }
+
+        private static string ReadSubjectKeyId(DerSequenceReader recipientSet)
+        {
+            return recipientSet.ReadOctetString().ToSkiString();
+        }
+
+        private static X509IssuerSerial ReadIssuerSerial(DerSequenceReader recipientSet)
+        {
+            // According to RFC 2630:
+            //
+            // IssuerAndSerialNumber::= SEQUENCE {
+            //    issuer Name,
+            //    serialNumber CertificateSerialNumber }
+
+            DerSequenceReader issuerAndSerial = recipientSet.ReadSequence();
+
+            byte[] issuerNameEncoded = issuerAndSerial.ReadNextEncodedValue();
+            string issuer = new X500DistinguishedName(issuerNameEncoded).Name;
+
+            // CertificateSerialNumber ::= INTEGER
+            //
+            // Getting bytes as it can be a big integer. Order of the bytes in the reader is big endian so use
+            // ToUpperHexString without reversing it.
+            
+            byte[] serial = issuerAndSerial.ReadIntegerBytes();
+            return new X509IssuerSerial(issuer, serial.ToUpperHexString());
+        }
+
+        private static void ReadRecipientEncryptedKeys(
+            DerSequenceReader keyAgreement,
+            int version,
+            SubjectIdentifierOrKey originatorId,
+            AlgorithmIdentifier keyEncryptAlgo,
+            List<RecipientInfo> recipientStack)
+        {
+            // RecipientEncryptedKeys::= SEQUENCE OF RecipientEncryptedKey
+            
+            DerSequenceReader recipientEncryptedKeySequence = keyAgreement.ReadSequence();
+
+            const byte ContextConstructed0 = DerSequenceReader.ContextSpecificTagFlag | DerSequenceReader.ConstructedFlag;
+            const byte ConstructedSequence = (byte)DerSequenceReader.DerTag.Sequence | DerSequenceReader.ConstructedFlag;
+
+            while (recipientEncryptedKeySequence.HasData)
+            {   
+                // This is to match the default behavior from Framework in case the values are not set as they are
+                // optional in the encoding
+                DateTime date = DateTime.FromFileTimeUtc(0);
+                CryptographicAttributeObject otherKeyMaterial = null;
+
+                // RecipientEncryptedKey::= SEQUENCE {
+                //      rid KeyAgreeRecipientIdentifier,
+                //      encryptedKey EncryptedKey }
+
+                DerSequenceReader recipientEncryptedKey = recipientEncryptedKeySequence.ReadSequence();
+                SubjectIdentifier recipientId;
+                byte tag = recipientEncryptedKey.PeekTag();
+                
+                // KeyAgreeRecipientIdentifier::= CHOICE {
+                //    issuerAndSerialNumber IssuerAndSerialNumber,
+                //    rKeyId[0] IMPLICIT RecipientKeyIdentifier }
+
+                switch (tag)
+                { 
+                    case ContextConstructed0:
+                        // RecipientKeyIdentifier::= SEQUENCE {
+                        //      subjectKeyIdentifier SubjectKeyIdentifier,
+                        //      date GeneralizedTime OPTIONAL,
+                        //      other OtherKeyAttribute OPTIONAL }
+                        DerSequenceReader recipientKeyIdentifier = recipientEncryptedKey.ReadSequence();
+                        recipientId
+                            = new SubjectIdentifier(SubjectIdentifierType.SubjectKeyIdentifier, ReadSubjectKeyId(recipientKeyIdentifier));
+
+                        if (recipientKeyIdentifier.PeekTag() == (byte)DerSequenceReader.DerTag.GeneralizedTime)
+                        {
+                            date = recipientKeyIdentifier.ReadGeneralizedTime();
+                        }
+
+                        if (recipientKeyIdentifier.PeekTag() == ConstructedSequence)
+                        {
+                            // OtherKeyAttribute::= SEQUENCE {
+                            //      keyAttrId OBJECT IDENTIFIER,
+                            //      keyAttr ANY DEFINED BY keyAttrId OPTIONAL }
+
+                            DerSequenceReader otherKeyAttribute = recipientKeyIdentifier.ReadSequence();
+                            Oid oid = otherKeyAttribute.ReadOid();
+                            byte[] payload = otherKeyAttribute.ReadNextEncodedValue();
+                            AsnEncodedData attr = Helpers.CreateBestPkcs9AttributeObjectAvailable(oid, payload);
+                            otherKeyMaterial = new CryptographicAttributeObject(oid, new AsnEncodedDataCollection(attr));
+                        }
+                        break;
+
+                    case ConstructedSequence:
+                        recipientId = new SubjectIdentifier(SubjectIdentifierType.IssuerAndSerialNumber, ReadIssuerSerial(recipientEncryptedKey));
+                        break;
+
+                    default:
+                        throw new CryptographicException(SR.Format(SR.Cryptography_Cms_Invalid_Subject_Identifier_Type, tag));
+                }
+
+                byte[] encryptionKey = recipientEncryptedKey.ReadOctetString();
+
+                KeyAgreeRecipientInfoPalOpenSsl kari = new KeyAgreeRecipientInfoPalOpenSsl(
+                        version,
+                        recipientId,
+                        originatorId,
+                        otherKeyMaterial,
+                        keyEncryptAlgo,
+                        encryptionKey,
+                        date);
+                recipientStack.Add(new KeyAgreeRecipientInfo(kari));
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/KeyAgreeRecipientInfoPalOpenSsl.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/KeyAgreeRecipientInfoPalOpenSsl.cs
@@ -10,11 +10,40 @@ namespace Internal.Cryptography.Pal.OpenSsl
 {
     internal sealed class KeyAgreeRecipientInfoPalOpenSsl : KeyAgreeRecipientInfoPal
     {
+        private readonly DateTime _date;
+        private readonly byte[] _encryptedKey;
+        private readonly AlgorithmIdentifier _keyEncryptionAlgorithm;
+        private readonly SubjectIdentifierOrKey _originatorIdentifierOrKey;
+        private readonly CryptographicAttributeObject _otherKeyAttribute;
+        private readonly SubjectIdentifier _recipientIdentifier;
+        private readonly int _version;
+
+        public KeyAgreeRecipientInfoPalOpenSsl(
+            int version,
+            SubjectIdentifier recipientIdentifier,
+            SubjectIdentifierOrKey originatorIdentifierOrKey,
+            CryptographicAttributeObject otherKeyAttribute,
+            AlgorithmIdentifier keyEncryptionAlgorithm,
+            byte[] encryptedKey,
+            DateTime date)
+        {
+            _version = version;
+            _encryptedKey = encryptedKey;
+            _keyEncryptionAlgorithm = keyEncryptionAlgorithm;
+            _originatorIdentifierOrKey = originatorIdentifierOrKey;
+            _otherKeyAttribute = otherKeyAttribute;
+            _recipientIdentifier = recipientIdentifier;
+            _date = date;
+        }
+
         public override DateTime Date
         {
             get
             {
-                throw new NotImplementedException();
+                if (_recipientIdentifier.Type != SubjectIdentifierType.SubjectKeyIdentifier)
+                    throw new InvalidOperationException(SR.Cryptography_Cms_Key_Agree_Date_Not_Available);
+
+                return _date;
             }
         }
 
@@ -22,7 +51,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
         {
             get
             {
-                throw new NotImplementedException();
+                return _encryptedKey;
             }
         }
 
@@ -30,7 +59,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
         {
             get
             {
-                throw new NotImplementedException();
+                return _keyEncryptionAlgorithm;
             }
         }
 
@@ -38,7 +67,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
         {
             get
             {
-                throw new NotImplementedException();
+                return _originatorIdentifierOrKey;
             }
         }
 
@@ -46,7 +75,10 @@ namespace Internal.Cryptography.Pal.OpenSsl
         {
             get
             {
-                throw new NotImplementedException();
+                if (_recipientIdentifier.Type != SubjectIdentifierType.SubjectKeyIdentifier)
+                    throw new InvalidOperationException(SR.Cryptography_Cms_Key_Agree_Date_Not_Available);
+
+                return _otherKeyAttribute;
             }
         }
 
@@ -54,7 +86,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
         {
             get
             {
-                throw new NotImplementedException();
+                return _recipientIdentifier;
             }
         }
 
@@ -62,7 +94,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
         {
             get
             {
-                throw new NotImplementedException();
+                return _version;
             }
         }
     }

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/KeyTransRecipientInfoPalOpenSsl.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/KeyTransRecipientInfoPalOpenSsl.cs
@@ -11,19 +11,28 @@ namespace Internal.Cryptography.Pal.OpenSsl
 {
     internal sealed class KeyTransRecipientInfoPalOpenSsl : KeyTransRecipientInfoPal
     {
-        private readonly SafeSharedCmsRecipientInfoHandle _recipientHandle;
+        private readonly int _version;
+        private readonly AlgorithmIdentifier _keyEncryptionAlgorithm;
+        private readonly SubjectIdentifier _recipientIdentifier;
+        private readonly byte[] _encryptedKey;
 
-        internal KeyTransRecipientInfoPalOpenSsl(SafeSharedCmsRecipientInfoHandle recipient)
+        internal KeyTransRecipientInfoPalOpenSsl(
+            int version,
+            SubjectIdentifier recipientIdentifier,
+            AlgorithmIdentifier keyEncryptionAlgorithm,
+            byte[] encrypted)
         {
-            _recipientHandle = recipient;
-            // TODO(3334): Design decision, how to deal with opaqued fields for CMS_RecipientInfo
+            _version = version;
+            _keyEncryptionAlgorithm = keyEncryptionAlgorithm;
+            _recipientIdentifier = recipientIdentifier;
+            _encryptedKey = encrypted;
         }
 
         public override byte[] EncryptedKey
         {
             get
             {
-                throw new NotImplementedException();
+                return _encryptedKey;
             }
         }
 
@@ -31,7 +40,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
         {
             get
             {
-                throw new NotImplementedException();
+                return _keyEncryptionAlgorithm;
             }
         }
 
@@ -39,7 +48,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
         {
             get
             {
-                throw new NotImplementedException();
+                return _recipientIdentifier;
             }
         }
 
@@ -47,7 +56,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
         {
             get
             {
-                throw new NotImplementedException();
+                return _version;
             }
         }
     }

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -159,6 +159,9 @@
   <data name="Cryptography_Cms_UnknownKeySpec" xml:space="preserve">
     <value>Unable to determine the type of key handle from this keyspec {0}.</value>
   </data>
+  <data name="Cryptography_Err_Not_Impl" xml:space="preserve">
+    <value>Not implemented</value>
+  </data>
   <data name="Cryptography_Der_Invalid_Encoding" xml:space="preserve">
     <value>ASN1 corrupted data.</value>
   </data>

--- a/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -186,6 +186,7 @@
   <ItemGroup Condition="'$(TargetsUnix)' == 'true' AND '$(IsPartialFacadeAssembly)' != 'true' AND '$(GeneratePlatformNotSupportedAssembly)' != 'true'">
     <Compile Include="Internal\Cryptography\Pal\Unix\DecryptorPalOpenSsl.cs" />
     <Compile Include="Internal\Cryptography\Pal\Unix\DecryptorPalOpenSsl.Decode.cs" />
+    <Compile Include="Internal\Cryptography\Pal\Unix\DecryptorPalOpenSsl.DecodeRecipients.cs" />
     <Compile Include="Internal\Cryptography\Pal\Unix\OpenSslHelpers.cs" />
     <Compile Include="Internal\Cryptography\Pal\Unix\KeyAgreeRecipientInfoPalOpenSsl.cs" />
     <Compile Include="Internal\Cryptography\Pal\Unix\KeyTransRecipientInfoPalOpenSsl.cs" />

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
@@ -22,7 +22,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeVersion_FixedValue()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1();
@@ -38,7 +37,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeType_FixedValue()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1();
@@ -55,7 +53,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeRecipientIdType_FixedValue()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1();
@@ -77,7 +74,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeRecipientIdValue_FixedValue()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1();
@@ -99,7 +95,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeRecipientIdType_Ski_FixedValue()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1(SubjectIdentifierType.SubjectKeyIdentifier);
@@ -120,7 +115,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeRecipientIdValue_Ski_FixedValue()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1(SubjectIdentifierType.SubjectKeyIdentifier);
@@ -142,7 +136,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeKeyEncryptionAlgorithm_FixedValue()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1();
@@ -161,7 +154,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeEncryptedKey_FixedValue()
         {
             byte[] expectedEncryptedKey = "c39323a9f5113c1465bf27b558ffeda656d606e08f8dc37e67cb8cbf7fb04d71dbe20071eaaa20db".HexToByteArray();
@@ -189,7 +181,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeOriginatorIdentifierOrKey_FixedValue()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1();
@@ -219,7 +210,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeDate_FixedValue()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1();
@@ -239,7 +229,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeDate_FixedValue_Ski()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1(SubjectIdentifierType.SubjectKeyIdentifier);
@@ -260,7 +249,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeOtherKeyAttribute_FixedValue()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1();
@@ -269,7 +257,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeOtherKeyAttribute_FixedValue_Ski()
         {
             //
@@ -295,6 +282,66 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             AsnEncodedData asnData = attribute.Values[0];
             byte[] expectedAsnData = "0403424d58".HexToByteArray();
             Assert.Equal<byte>(expectedAsnData, asnData.RawData);
+        }
+
+        [Fact]
+        public static void TestMultipleKeyAgree_ShortNotation()
+        {
+            // KeyAgreement recipients are defined in RFC 2630 as
+            //
+            // KeyAgreeRecipientInfo::= SEQUENCE {
+            //      version CMSVersion,  --always set to 3
+            //      originator[0] EXPLICIT OriginatorIdentifierOrKey,
+            //      ukm[1] EXPLICIT UserKeyingMaterial OPTIONAL,
+            //      keyEncryptionAlgorithm KeyEncryptionAlgorithmIdentifier,
+            //      recipientEncryptedKeys RecipientEncryptedKeys }
+            //
+            // RecipientEncryptedKeys::= SEQUENCE OF RecipientEncryptedKey
+            //
+            // RecipientEncryptedKey::= SEQUENCE {
+            //      rid KeyAgreeRecipientIdentifier,
+            //      encryptedKey EncryptedKey }
+            //
+            // When RecipientEncryptedKeys has more than one sequence in it, then different KeyAgreement recipients are created, where each
+            // recipient hold the information from one RecipientEncryptedKey. This message has one KeyAgreeRecipientInfo object that has two
+            // RecipientEncryptedKeys so it needs to have two recipients in the end.   
+
+            byte[] encodedMessage =
+                ("3082019206092A864886F70D010703A08201833082017F0201023182014BA1820147020103A08196A18193300906072A"
+                + "8648CE3E02010381850002818100AC89002E19D3A7DC35DAFBF083413483EF14691FC00A465B957496CA860BA4918182"
+                + "1CAFB50EB25330952BB11A71A44B44691CF9779999F1115497CD1CE238B452CA95622AF968E39F06E165D2EBE1991493"
+                + "70334D925AA47273751AC63A0EF80CDCF6331ED3324CD689BFFC90E61E9CC921C88EF5FB92B863053C4C1FABFE15301E"
+                + "060B2A864886F70D0109100305300F060B2A864886F70D010910030605003081883042A016041410DA1370316788112E"
+                + "B8594C864C2420AE7FBA420428DFBDC19AD44063478A0C125641BE274113441AD5891C78F925097F06A3DF57F3F1E6D1"
+                + "160F8D3C223042A016041411DA1370316788112EB8594C864C2420AE7FBA420428DFBDC19AD44063478A0C125641BE27"
+                + "4113441AD5891C78F925097F06A3DF57F3F1E6D1160F8D3C22302B06092A864886F70D010701301406082A864886F70D"
+                + "030704088AADC286F258F6D78008FC304F518A653F83").HexToByteArray();
+
+            EnvelopedCms ecms = new EnvelopedCms();
+            ecms.Decode(encodedMessage);
+
+            RecipientInfoCollection recipients = ecms.RecipientInfos;
+            Assert.Equal(2, recipients.Count);
+            RecipientInfo recipient0 = recipients[0];
+            RecipientInfo recipient1 = recipients[1];
+
+            Assert.IsType<KeyAgreeRecipientInfo>(recipient0);
+            Assert.IsType<KeyAgreeRecipientInfo>(recipient1);
+
+            KeyAgreeRecipientInfo recipient0Cast = recipient0 as KeyAgreeRecipientInfo;
+            KeyAgreeRecipientInfo recipient1Cast = recipient1 as KeyAgreeRecipientInfo;
+
+            Assert.Equal(3, recipient0.Version);
+            Assert.Equal(3, recipient1.Version);
+
+            Assert.Equal(SubjectIdentifierOrKeyType.PublicKeyInfo, recipient0Cast.OriginatorIdentifierOrKey.Type);
+            Assert.Equal(SubjectIdentifierOrKeyType.PublicKeyInfo, recipient1Cast.OriginatorIdentifierOrKey.Type);
+
+            Assert.Equal(SubjectIdentifierType.SubjectKeyIdentifier, recipient0Cast.RecipientIdentifier.Type);
+            Assert.Equal(SubjectIdentifierType.SubjectKeyIdentifier, recipient1Cast.RecipientIdentifier.Type);
+
+            Assert.Equal("10DA1370316788112EB8594C864C2420AE7FBA42", recipient0Cast.RecipientIdentifier.Value);
+            Assert.Equal("11DA1370316788112EB8594C864C2420AE7FBA42", recipient1Cast.RecipientIdentifier.Value);
         }
 
         private static KeyAgreeRecipientInfo EncodeKeyAgreel(SubjectIdentifierType type = SubjectIdentifierType.IssuerAndSerialNumber)

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoTests.cs
@@ -30,7 +30,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransVersion_FixedValue()
         {
             KeyTransRecipientInfo recipient = FixedValueKeyTrans1();
@@ -46,7 +45,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransType_FixedValue()
         {
             KeyTransRecipientInfo recipient = FixedValueKeyTrans1();
@@ -63,7 +61,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransRecipientIdType_FixedValue()
         {
             KeyTransRecipientInfo recipient = FixedValueKeyTrans1();
@@ -85,7 +82,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransRecipientIdValue_FixedValue()
         {
             KeyTransRecipientInfo recipient = FixedValueKeyTrans1();
@@ -107,7 +103,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransRecipientIdType_Ski_FixedValue()
         {
             KeyTransRecipientInfo recipient = FixedValueKeyTrans1(SubjectIdentifierType.SubjectKeyIdentifier);
@@ -128,7 +123,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransRecipientIdValue_Ski_FixedValue()
         {
             KeyTransRecipientInfo recipient = FixedValueKeyTrans1(SubjectIdentifierType.SubjectKeyIdentifier);
@@ -150,7 +144,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransKeyEncryptionAlgorithm_FixedValue()
         {
             KeyTransRecipientInfo recipient = FixedValueKeyTrans1();
@@ -169,7 +162,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransEncryptedKey_FixedValue()
         {
             byte[] expectedEncryptedKey =


### PR DESCRIPTION
+ Added support to decode RecipientInfo on Enveloped CMS for Unix. It
included support for both KeyTransportRecipientInfo and
KeyAgreeRecipientInfo.

+ Added support for decoding bitstring and generalized times on
DerSequenceReader and added appropriate tests on
System.Security.Cryptography.Encoding.Tests.

+ Enabled tests for KeyAgreeRecipientInfo and KeyTransRecipientInfo as
well as added some new tests.

@bartonjs @weshaggard 