### PR TITLE
Update EventSource tests to dispose EventListeners

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
@@ -2745,9 +2745,15 @@ namespace BasicEventSourceTests
 
                 // Run tests for ETW
 #if USE_ETW // TODO: Enable when TraceEvent is available on CoreCLR. GitHub issue #4864.
-                EventTestHarness.RunTests(tests, new EtwListener(), logger);
+                using (var listener = new EtwListener())
+                {
+                    EventTestHarness.RunTests(tests, listener, logger);
+                }
 #endif // USE_ETW
-                EventTestHarness.RunTests(tests, new EventListenerListener(), logger);
+                using (var listener = new EventListenerListener())
+                {
+                    EventTestHarness.RunTests(tests, listener, logger);
+                }
             }
         }
     }

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
@@ -263,7 +263,7 @@ namespace BasicEventSourceTests
         {
             add
             {
-                if(this.m_listener != null)
+                if (this.m_listener != null)
                 {
                     this.m_listener.EventSourceCreated += value;
                 }
@@ -319,7 +319,7 @@ namespace BasicEventSourceTests
 #if false // TODO: enable when we ship the events. GitHub issue #4865
         private void mListenerEventSourceCreated(object sender, EventSourceCreatedEventArgs eventSource)
         {
-            if(_onEventSourceCreated != null)
+            if (_onEventSourceCreated != null)
             {
                 _onEventSourceCreated(eventSource.EventSource);
             }

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
@@ -46,13 +46,19 @@ namespace BasicEventSourceTests
         [Fact]
         public void Test_Write_Metric_EventListener()
         {
-            Test_Write_Metric(new EventListenerListener());
+            using (var listener = new EventListenerListener())
+            {
+                Test_Write_Metric(listener);
+            }
         }
 
         [Fact]
         public void Test_Write_Metric_ETW()
         {
-            Test_Write_Metric(new EtwListener());
+            using (var listener = new EtwListener())
+            {
+                Test_Write_Metric(listener);
+            }
         }
 
         private void Test_Write_Metric(Listener listener)

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.cs
@@ -22,7 +22,7 @@ namespace BasicEventSourceTests
     public class TestsManifestGeneration
     {
         /// <summary>
-        /// Visual Studio Online bug #125529, EventSource would fail when an EventSource was named "EventSource".
+        /// EventSource would fail when an EventSource was named "EventSource".
         /// </summary>
         [Fact]
         public void Test_EventSource_NamedEventSource()

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
@@ -28,7 +28,10 @@ namespace BasicEventSourceTests
         [Fact]
         public void Test_WriteEvent_Manifest_ETW()
         {
-            Test_WriteEvent(new EtwListener(), false);
+            using (var listener = new EtwListener())
+            {
+                Test_WriteEvent(listener, false);
+            }
         }
 #endif // USE_ETW
         /// <summary>
@@ -38,7 +41,10 @@ namespace BasicEventSourceTests
         [Fact]
         public void Test_WriteEvent_Manifest_EventListener()
         {
-            Test_WriteEvent(new EventListenerListener(), false);
+            using (var listener = new EventListenerListener())
+            {
+                Test_WriteEvent(listener, false);
+            }
         }
 
         /// <summary>
@@ -58,7 +64,10 @@ namespace BasicEventSourceTests
         [Fact]
         public void Test_WriteEvent_SelfDescribing_ETW()
         {
-            Test_WriteEvent(new EtwListener(), true);
+            using (var listener = new EtwListener())
+            {
+                Test_WriteEvent(listener, true);
+            }
         }
 #endif
         /// <summary>
@@ -68,7 +77,10 @@ namespace BasicEventSourceTests
         [Fact]
         public void Test_WriteEvent_SelfDescribing_EventListener()
         {
-            Test_WriteEvent(new EventListenerListener(), true);
+            using (var listener = new EventListenerListener())
+            {
+                Test_WriteEvent(listener, true);
+            }
         }
 
         /// <summary>
@@ -404,7 +416,10 @@ namespace BasicEventSourceTests
         [Fact]
         public void Test_WriteEvent_ComplexData_SelfDescribing_EventListener()
         {
-            Test_WriteEvent_ComplexData_SelfDescribing(new EventListenerListener());
+            using (var listener = new EventListenerListener())
+            {
+                Test_WriteEvent_ComplexData_SelfDescribing(listener);
+            }
         }
 
 #if USE_ETW // TODO: Enable when TraceEvent is available on CoreCLR. GitHub issue #4864.
@@ -415,7 +430,10 @@ namespace BasicEventSourceTests
         [Fact]
         public void Test_WriteEvent_ComplexData_SelfDescribing_ETW()
         {
-            Test_WriteEvent_ComplexData_SelfDescribing(new EtwListener());
+            using (var listener = new EtwListener())
+            {
+                Test_WriteEvent_ComplexData_SelfDescribing(listener);
+            }
         }
 #endif // USE_ETW
 
@@ -475,7 +493,10 @@ namespace BasicEventSourceTests
         [Fact]
         public void Test_WriteEvent_ByteArray_Manifest_EventListener()
         {
-            Test_WriteEvent_ByteArray(false, new EventListenerListener());
+            using (var listener = new EventListenerListener())
+            {
+                Test_WriteEvent_ByteArray(false, listener);
+            }
         }
 
         /// <summary>
@@ -499,7 +520,10 @@ namespace BasicEventSourceTests
         [Fact]
         public void Test_WriteEvent_ByteArray_Manifest_ETW()
         {
-            Test_WriteEvent_ByteArray(false, new EtwListener());
+            using (var listener = new EtwListener())
+            {
+                Test_WriteEvent_ByteArray(false, listener);
+            }
         }
 #endif // USE_ETW
 
@@ -511,7 +535,10 @@ namespace BasicEventSourceTests
         [Fact]
         public void Test_WriteEvent_ByteArray_SelfDescribing_EventListener()
         {
-            Test_WriteEvent_ByteArray(true, new EventListenerListener());
+            using (var listener = new EventListenerListener())
+            {
+                Test_WriteEvent_ByteArray(true, listener);
+            }
         }
 
 #if USE_ETW // TODO: Enable when TraceEvent is available on CoreCLR. GitHub issue #4864.
@@ -523,7 +550,10 @@ namespace BasicEventSourceTests
         [Fact]
         public void Test_WriteEvent_ByteArray_SelfDescribing_ETW()
         {
-            Test_WriteEvent_ByteArray(true, new EtwListener());
+            using (var listener = new EtwListener())
+            {
+                Test_WriteEvent_ByteArray(true, listener);
+            }
         }
 #endif // USE_ETW
 

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
@@ -366,26 +366,28 @@ namespace BasicEventSourceTests
                 log = new EventSource(esName);
                 log2 = new EventSource(esName2);
 
-                el = new EventListenerListener();
-
-                List<EventSource> eventSourceNotificationsReceived = new List<EventSource>();
-                el.EventSourceCreated += (s, a) =>
+                
+                using (var listener = new EventListenerListener())
                 {
-                    if (a.EventSource.Name.Equals(esName))
+                    List<EventSource> eventSourceNotificationsReceived = new List<EventSource>();
+                    listener.EventSourceCreated += (s, a) =>
                     {
-                        esNameHit = true;
-                    }
+                        if (a.EventSource.Name.Equals(esName))
+                        {
+                            esNameHit = true;
+                        }
 
-                    if (a.EventSource.Name.Equals(esName2))
-                    {
-                        esName2Hit = true;
-                    }
-                };
+                        if (a.EventSource.Name.Equals(esName2))
+                        {
+                            esName2Hit = true;
+                        }
+                    };
 
-                Thread.Sleep(1000);
+                    Thread.Sleep(1000);
 
-                Assert.Equal(true, esNameHit);
-                Assert.Equal(true, esName2Hit);
+                    Assert.Equal(true, esNameHit);
+                    Assert.Equal(true, esName2Hit);
+                }
             }
             finally
             {
@@ -419,34 +421,35 @@ namespace BasicEventSourceTests
 
             try
             {
-                el = new EventListenerListener();
-
-                string esName = "EventSourceName_HopefullyUnique";
-                string esName2 = "EventSourceName_HopefullyUnique2";
-                bool esNameHit = false;
-                bool esName2Hit = false;
-
-                List<EventSource> eventSourceNotificationsReceived = new List<EventSource>();
-                el.EventSourceCreated += (s, a) =>
+                using (var listener = new EventListenerListener())
                 {
-                    if(a.EventSource.Name.Equals(esName))
+                    string esName = "EventSourceName_HopefullyUnique";
+                    string esName2 = "EventSourceName_HopefullyUnique2";
+                    bool esNameHit = false;
+                    bool esName2Hit = false;
+
+                    List<EventSource> eventSourceNotificationsReceived = new List<EventSource>();
+                    listener.EventSourceCreated += (s, a) =>
                     {
-                        esNameHit = true;
-                    }
+                        if (a.EventSource.Name.Equals(esName))
+                        {
+                            esNameHit = true;
+                        }
 
-                    if (a.EventSource.Name.Equals(esName2))
-                    {
-                        esName2Hit = true;
-                    }
-                };
+                        if (a.EventSource.Name.Equals(esName2))
+                        {
+                            esName2Hit = true;
+                        }
+                    };
 
-                log = new EventSource(esName);
-                log2 = new EventSource(esName2);
+                    log = new EventSource(esName);
+                    log2 = new EventSource(esName2);
 
-                Thread.Sleep(1000);
+                    Thread.Sleep(1000);
 
-                Assert.Equal(true, esNameHit);
-                Assert.Equal(true, esName2Hit);
+                    Assert.Equal(true, esNameHit);
+                    Assert.Equal(true, esName2Hit);
+                }
             }
             finally
             {


### PR DESCRIPTION
We were not previously disposing EventListeners. When you create an EventListener, a reference is kept in EventSource internals and it doesn't ever go away until disposed.