### PR TITLE
Uri supports unknown schemes wrt. RFC3986-5.4.2

### DIFF
--- a/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
@@ -136,6 +136,16 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        public void Uri_Relative_SimplePartialPathWithUnknownScheme_Unicode_ReturnsPartialPathWithScheme()
+        {
+            string schemeAndRelative = "scheme:\u011E";
+            Uri resolved = new Uri(schemeAndRelative, UriKind.RelativeOrAbsolute);
+
+            String expectedResult = schemeAndRelative;
+            Assert.Equal(expectedResult, resolved.ToString());
+        }
+
+        [Fact]
         public void Uri_Relative_SimplePartialPathWithScheme_Unicode_ReturnsPartialPathWithScheme()
         {
             string schemeAndRelative = "http:\u00C7";


### PR DESCRIPTION
Unicode relative paths with unknown schemes without "//" characters are parsed correctly.

Fix #9596