### PR TITLE
Fix SafeSslHandle<->SafeBioHandle lifetime management

### DIFF
--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeBioHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeBioHandle.Unix.cs
@@ -21,17 +21,20 @@ namespace Microsoft.Win32.SafeHandles
 
         protected override bool ReleaseHandle()
         {
+            IntPtr h = handle;
+            SetHandle(IntPtr.Zero);
+
             if (_parent != null)
             {
-                _parent.DangerousRelease();
+                SafeHandle parent = _parent;
                 _parent = null;
+                parent.DangerousRelease();
+                return true;
             }
             else
             {
-                Interop.Crypto.BioDestroy(handle);
+                return Interop.Crypto.BioDestroy(h);
             }
-            SetHandle(IntPtr.Zero);
-            return true;
         }
 
         public override bool IsInvalid
@@ -47,6 +50,7 @@ namespace Microsoft.Win32.SafeHandles
         internal void TransferOwnershipToParent(SafeHandle parent)
         {
             Debug.Assert(_parent == null, "Expected no existing parent");
+            Debug.Assert(parent != null && !parent.IsInvalid, "Expected new parent to be non-null and valid");
 
             bool addedRef = false;
             parent.DangerousAddRef(ref addedRef);

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeBioHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeBioHandle.Unix.cs
@@ -5,12 +5,15 @@
 using System;
 using System.Security;
 using System.Runtime.InteropServices;
+using System.Diagnostics;
 
 namespace Microsoft.Win32.SafeHandles
 {
     [SecurityCritical]
     internal sealed class SafeBioHandle : SafeHandle
     {
+        private SafeHandle _parent;
+
         private SafeBioHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
@@ -18,14 +21,37 @@ namespace Microsoft.Win32.SafeHandles
 
         protected override bool ReleaseHandle()
         {
-            Interop.Crypto.BioDestroy(handle);
+            if (_parent != null)
+            {
+                _parent.DangerousRelease();
+                _parent = null;
+            }
+            else
+            {
+                Interop.Crypto.BioDestroy(handle);
+            }
             SetHandle(IntPtr.Zero);
             return true;
         }
 
         public override bool IsInvalid
         {
-            get { return handle == IntPtr.Zero; }
+            get
+            {
+                // If handle is 0, we're invalid.
+                // If we have a _parent and they're invalid, we're invalid.
+                return handle == IntPtr.Zero || (_parent != null && _parent.IsInvalid);
+            }
+        }
+
+        internal void TransferOwnershipToParent(SafeHandle parent)
+        {
+            Debug.Assert(_parent == null, "Expected no existing parent");
+
+            bool addedRef = false;
+            parent.DangerousAddRef(ref addedRef);
+
+            _parent = parent;
         }
     }
 }


### PR DESCRIPTION
SafeSslHandles reference two SafeBioHandles, one for reading and one for writing.  The SafeSslHandle represents an underlying SSL structure which via SSL_set_bio has the two BIO pointers represented by those SafeBioHandles stored into it.  Once that happens, the SafeBioHandles no longer "own" the underlying pointers, as instead calling SSL_destroy on the SSL structure will also clean up those BIO handles.  But the lifetime of these handles is not being managed correctly.  The SafeSslHandle is add-ref'ing each of the SafeBioHandles when they're transferred into it; that prevents the SafeBioHandle from closing the underlying handle until the SafeSslHandle is closed, but this is backwards.  We need the SafeBioHandles to keep the SafeSslHandle from being destroyed until the SafeBioHandles are no longer being used.  Otherwise, we can end up in a situation where the SafeBioHandles are passed to some P/Invoke, and while they're being used, the SafeSslHandle is disposed/finalized, destroying the state that the P/Invoke is actively using.

This commit inverts the relationship.  When the SafeBioHandle ownership is transferred to the SafeSslHandle, the SafeBioHandle will no longer attempt to close the underlying handle.  It also add-refs the parent SafeSslHandle, rather than the other way around, so that the SafeSslHandle can't destroy the underlying SSL structure while the SafeBioHandles are being used.

May fix #9574 
cc: @bartonjs, @ericeil 