### PR TITLE
Pass --build-id=sha1 to linker explicitly

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -102,6 +102,8 @@ endif ()
 
 if (CMAKE_SYSTEM_NAME STREQUAL Linux)
    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,--noexecstack")
+   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--build-id=sha1")
+   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id=sha1")
 endif ()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)


### PR DESCRIPTION
On some platforms, a build-id was not being added to native artifacts
and we would like it to be present. Explicitly pass --build-id=sha1 to
the linker.

Related: dotnet/coreclr#5796