### PR TITLE
Fix logic with setting response body receive timeout

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -862,13 +862,13 @@ namespace System.Net.Http
 
                 state.CancellationToken.ThrowIfCancellationRequested();
 
-                responseMessage = WinHttpResponseParser.CreateResponseMessage(state, _doManualDecompressionCheck);
-
                 // Since the headers have been read, set the "receive" timeout to be based on each read
                 // call of the response body data. WINHTTP_OPTION_RECEIVE_TIMEOUT sets a timeout on each
                 // lower layer winsock read.
                 uint optionData = (uint)_receiveDataTimeout.TotalMilliseconds;
                 SetWinHttpOption(state.RequestHandle, Interop.WinHttp.WINHTTP_OPTION_RECEIVE_TIMEOUT, ref optionData);
+
+                responseMessage = WinHttpResponseParser.CreateResponseMessage(state, _doManualDecompressionCheck);
             }
             catch (Exception ex)
             {
@@ -1183,6 +1183,7 @@ namespace System.Net.Http
 
         private void SetWinHttpOption(SafeWinHttpHandle handle, uint option, ref uint optionData)
         {
+            Debug.Assert(handle != null);
             if (!Interop.WinHttp.WinHttpSetOption(
                 handle,
                 option,
@@ -1194,6 +1195,7 @@ namespace System.Net.Http
 
         private void SetWinHttpOption(SafeWinHttpHandle handle, uint option, string optionData)
         {
+            Debug.Assert(handle != null);
             if (!Interop.WinHttp.WinHttpSetOption(
                 handle,
                 option,
@@ -1210,6 +1212,7 @@ namespace System.Net.Http
             IntPtr optionData,
             uint optionSize)
         {
+            Debug.Assert(handle != null);
             if (!Interop.WinHttp.WinHttpSetOption(
                 handle,
                 option,


### PR DESCRIPTION
Due to code moving around with PR #8996, the `state.RequestHandle` was
already null when trying to set the receive timeout for the response
body. This generated an exception which was caught internally.

This fix moves the setting of the receive timeout so that it has a valid
`state.RequestHandle` to use.

Fixes #9578