### PR TITLE
Add packaging for System.Composition.* libraries

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -331,6 +331,18 @@
         ]
     },
     {
+        "Name": "System.Composition",
+        "Description": "This packages provides a version of the Managed Extensibility Framework (MEF) that is lightweight and specifically optimized for high throughput scenarios, such as the web.",
+        "CommonTypes": [
+            "System.Composition.ExportAttribute",
+            "System.Composition.ImportAttribute",
+            "System.Composition.Convention.ConventionBuilder",
+            "System.Composition.Hosting.CompositionHost",
+            "System.Composition.CompositionContext",
+            "System.Composition.CompositionContextExtensions",
+        ]
+    },
+    {
         "Name": "System.Composition.AttributedModel",
         "Description": "Provides common attributes used by System.Composition types.",
         "CommonTypes": [

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -331,6 +331,48 @@
         ]
     },
     {
+        "Name": "System.Composition.AttributedModel",
+        "Description": "Provides common attributes used by System.Composition types.",
+        "CommonTypes": [
+            "System.Composition.ExportAttribute",
+            "System.Composition.ImportAttribute",
+            "System.Composition.Convention.AttributedModelProvider"
+        ]
+    },
+    {
+        "Name": "System.Composition.Convention",
+        "Description": "Provides types that support using Managed Extensibility Framework with a convention-based configuration model.",
+        "CommonTypes": [
+            "System.Composition.Convention.ConventionBuilder",
+            "System.Composition.Convention.ExportConventionBuilder",
+            "System.Composition.Convention.ImportConventionBuilder",
+            "System.Composition.Convention.PartConventionBuilder",
+            "System.Composition.Convention.ParameterImportConventionBuilder"
+        ]
+    },
+    {
+        "Name": "System.Composition.Hosting",
+        "Description": "Provides Managed Extensibility Framework types that are useful to developers of extensible applications, or hosts.",
+        "CommonTypes": [
+            "System.Composition.Hosting.CompositionHost"
+        ]
+    },
+    {
+        "Name": "System.Composition.Runtime",
+        "Description": "Contains runtime components of the Managed Extensibility Framework.",
+        "CommonTypes": [
+            "System.Composition.CompositionContext"
+        ]
+    },
+    {
+        "Name": "System.Composition.TypedParts",
+        "Description": "Provides some extension methods for the Managed Extensibility Framework.",
+        "CommonTypes": [
+            "System.Composition.CompositionContextExtensions",
+            "System.Composition.Hosting.ContainerConfiguration"
+        ]
+    },
+    {
         "Name": "System.Console",
         "Description": "Provides the System.Console class, which represents the standard input, output and error streams for console applications.",
         "CommonTypes": [

--- a/src/System.Composition.AttributedModel/pkg/System.Composition.AttributedModel.builds
+++ b/src/System.Composition.AttributedModel/pkg/System.Composition.AttributedModel.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Composition.AttributedModel.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Composition.AttributedModel/pkg/System.Composition.AttributedModel.pkgproj
+++ b/src/System.Composition.AttributedModel/pkg/System.Composition.AttributedModel.pkgproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Composition.AttributedModel.builds">
+      <SupportedFramework>net45;netcore45;netcoreapp1.0;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Composition.AttributedModel/src/System.Composition.AttributedModel.csproj
+++ b/src/System.Composition.AttributedModel/src/System.Composition.AttributedModel.csproj
@@ -6,7 +6,16 @@
     <RootNamespace>System.Composition</RootNamespace>
     <AssemblyName>System.Composition.AttributedModel</AssemblyName>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <AssemblyVersion>1.0.31.0</AssemblyVersion>
   </PropertyGroup>
+  <ItemGroup Condition="'$(PackageTargetFramework)' == ''">
+    <PackageDestination Include="lib/netstandard1.0">
+      <TargetFramework>netstandard1.0</TargetFramework>
+    </PackageDestination>
+    <PackageDestination Include="lib/portable-net45+win8+wp8+wpa81">
+      <TargetFramework>portable-net45+win8+wp8+wpa81</TargetFramework>
+    </PackageDestination>
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>

--- a/src/System.Composition.AttributedModel/src/project.json
+++ b/src/System.Composition.AttributedModel/src/project.json
@@ -1,17 +1,12 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
-    "System.Collections": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.Diagnostics.Tools": "4.0.0",
-    "System.Reflection": "4.0.0",
-    "System.Runtime": "4.0.0"
+    "System.Collections": "4.0.11",
+    "System.Diagnostics.Debug": "4.0.11",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Reflection": "4.1.0"
   },
   "frameworks": {
-    "netstandard1.0": {
-      "imports": [
-        "dotnet5.1"
-      ]
-    }
+    "netstandard1.0": {}
   }
 }

--- a/src/System.Composition.Convention/pkg/System.Composition.Convention.builds
+++ b/src/System.Composition.Convention/pkg/System.Composition.Convention.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Composition.Convention.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Composition.Convention/pkg/System.Composition.Convention.pkgproj
+++ b/src/System.Composition.Convention/pkg/System.Composition.Convention.pkgproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Composition.Convention.builds">
+      <SupportedFramework>net45;netcore45;netcoreapp1.0;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Composition.Convention/src/System.Composition.Convention.csproj
+++ b/src/System.Composition.Convention/src/System.Composition.Convention.csproj
@@ -6,7 +6,16 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Composition.Convention</AssemblyName>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <AssemblyVersion>1.0.31.0</AssemblyVersion>
   </PropertyGroup>
+  <ItemGroup Condition="'$(PackageTargetFramework)' == ''">
+    <PackageDestination Include="lib/netstandard1.0">
+      <TargetFramework>netstandard1.0</TargetFramework>
+    </PackageDestination>
+    <PackageDestination Include="lib/portable-net45+win8+wp8+wpa81">
+      <TargetFramework>portable-net45+win8+wp8+wpa81</TargetFramework>
+    </PackageDestination>
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>

--- a/src/System.Composition.Convention/src/project.json
+++ b/src/System.Composition.Convention/src/project.json
@@ -1,23 +1,19 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
-    "System.Collections": "4.0.0",
-    "System.Globalization": "4.0.0",
-    "System.Diagnostics.Contracts": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.Diagnostics.Tools": "4.0.0",
-    "System.Linq": "4.0.0",
-    "System.Linq.Expressions": "4.0.0",
-    "System.Reflection": "4.0.0",
-    "System.Reflection.Extensions": "4.0.0",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Threading": "4.0.0"
+    "System.Collections": "4.0.11",
+    "System.Diagnostics.Contracts": "4.0.1",
+    "System.Diagnostics.Debug": "4.0.11",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Globalization": "4.0.11",
+    "System.Linq": "4.1.0",
+    "System.Linq.Expressions": "4.1.0",
+    "System.Reflection": "4.1.0",
+    "System.Reflection.Extensions": "4.0.1",
+    "System.Resources.ResourceManager": "4.0.1",
+    "System.Threading": "4.0.11"
   },
   "frameworks": {
-    "netstandard1.0": {
-      "imports": [
-        "dotnet5.1"
-      ]
-    }
+    "netstandard1.0": {}
   }
 }

--- a/src/System.Composition.Hosting/pkg/System.Composition.Hosting.builds
+++ b/src/System.Composition.Hosting/pkg/System.Composition.Hosting.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Composition.Hosting.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Composition.Hosting/pkg/System.Composition.Hosting.pkgproj
+++ b/src/System.Composition.Hosting/pkg/System.Composition.Hosting.pkgproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Composition.Hosting.builds">
+      <SupportedFramework>net45;netcore45;netcoreapp1.0;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Composition.Hosting/src/System.Composition.Hosting.csproj
+++ b/src/System.Composition.Hosting/src/System.Composition.Hosting.csproj
@@ -5,7 +5,16 @@
     <ProjectGuid>{2B8FECC6-34A1-48FE-BA75-99572D2D6DB2}</ProjectGuid>
     <AssemblyName>System.Composition.Hosting</AssemblyName>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <AssemblyVersion>1.0.31.0</AssemblyVersion>
   </PropertyGroup>
+  <ItemGroup Condition="'$(PackageTargetFramework)' == ''">
+    <PackageDestination Include="lib/netstandard1.0">
+      <TargetFramework>netstandard1.0</TargetFramework>
+    </PackageDestination>
+    <PackageDestination Include="lib/portable-net45+win8+wp8+wpa81">
+      <TargetFramework>portable-net45+win8+wp8+wpa81</TargetFramework>
+    </PackageDestination>
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>

--- a/src/System.Composition.Hosting/src/project.json
+++ b/src/System.Composition.Hosting/src/project.json
@@ -1,24 +1,20 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
-    "System.Collections": "4.0.0",
-    "System.Diagnostics.Contracts": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.Diagnostics.Tools": "4.0.0",
-    "System.Globalization": "4.0.0",
-    "System.Linq": "4.0.0",
-    "System.Linq.Expressions": "4.0.0",
-    "System.ObjectModel": "4.0.0",
-    "System.Reflection": "4.0.0",
-    "System.Reflection.Extensions": "4.0.0",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Threading": "4.0.0"
+    "System.Collections": "4.0.11",
+    "System.Diagnostics.Contracts": "4.0.1",
+    "System.Diagnostics.Debug": "4.0.11",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Globalization": "4.0.11",
+    "System.Linq": "4.1.0",
+    "System.Linq.Expressions": "4.1.0",
+    "System.ObjectModel": "4.0.12",
+    "System.Reflection": "4.1.0",
+    "System.Reflection.Extensions": "4.0.1",
+    "System.Resources.ResourceManager": "4.0.1",
+    "System.Threading": "4.0.11",
   },
   "frameworks": {
-    "netstandard1.0": {
-      "imports": [
-        "dotnet5.1"
-      ]
-    }
+    "netstandard1.0": {}
   }
 }

--- a/src/System.Composition.Runtime/pkg/System.Composition.Runtime.builds
+++ b/src/System.Composition.Runtime/pkg/System.Composition.Runtime.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Composition.Runtime.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Composition.Runtime/pkg/System.Composition.Runtime.pkgproj
+++ b/src/System.Composition.Runtime/pkg/System.Composition.Runtime.pkgproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Composition.Runtime.builds">
+      <SupportedFramework>net45;netcore45;netcoreapp1.0;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Composition.Runtime/src/System.Composition.Runtime.csproj
+++ b/src/System.Composition.Runtime/src/System.Composition.Runtime.csproj
@@ -6,7 +6,16 @@
     <RootNamespace>System.Composition</RootNamespace>
     <AssemblyName>System.Composition.Runtime</AssemblyName>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <AssemblyVersion>1.0.31.0</AssemblyVersion>
   </PropertyGroup>
+  <ItemGroup Condition="'$(PackageTargetFramework)' == ''">
+    <PackageDestination Include="lib/netstandard1.0">
+      <TargetFramework>netstandard1.0</TargetFramework>
+    </PackageDestination>
+    <PackageDestination Include="lib/portable-net45+win8+wp8+wpa81">
+      <TargetFramework>portable-net45+win8+wp8+wpa81</TargetFramework>
+    </PackageDestination>
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>

--- a/src/System.Composition.Runtime/src/project.json
+++ b/src/System.Composition.Runtime/src/project.json
@@ -1,19 +1,15 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
-    "System.Collections": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.Diagnostics.Tools": "4.0.0",
-    "System.Globalization": "4.0.0",
-    "System.Linq": "4.0.0",
-    "System.Reflection": "4.0.0",
-    "System.Resources.ResourceManager": "4.0.0"
+    "System.Collections": "4.0.11",
+    "System.Diagnostics.Debug": "4.0.11",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Globalization": "4.0.11",
+    "System.Linq": "4.1.0",
+    "System.Reflection": "4.1.0",
+    "System.Resources.ResourceManager": "4.0.1",
   },
   "frameworks": {
-    "netstandard1.0": {
-      "imports": [
-        "dotnet5.1"
-      ]
-    }
+    "netstandard1.0": {}
   }
 }

--- a/src/System.Composition.TypedParts/pkg/System.Composition.TypedParts.builds
+++ b/src/System.Composition.TypedParts/pkg/System.Composition.TypedParts.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Composition.TypedParts.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Composition.TypedParts/pkg/System.Composition.TypedParts.pkgproj
+++ b/src/System.Composition.TypedParts/pkg/System.Composition.TypedParts.pkgproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Composition.TypedParts.builds">
+      <SupportedFramework>net45;netcore45;netcoreapp1.0;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Composition.TypedParts/src/System.Composition.TypedParts.csproj
+++ b/src/System.Composition.TypedParts/src/System.Composition.TypedParts.csproj
@@ -6,7 +6,16 @@
     <RootNamespace>System.Composition</RootNamespace>
     <AssemblyName>System.Composition.TypedParts</AssemblyName>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <AssemblyVersion>1.0.31.0</AssemblyVersion>
   </PropertyGroup>
+  <ItemGroup Condition="'$(PackageTargetFramework)' == ''">
+    <PackageDestination Include="lib/netstandard1.0">
+      <TargetFramework>netstandard1.0</TargetFramework>
+    </PackageDestination>
+    <PackageDestination Include="lib/portable-net45+win8+wp8+wpa81">
+      <TargetFramework>portable-net45+win8+wp8+wpa81</TargetFramework>
+    </PackageDestination>
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup>

--- a/src/System.Composition.TypedParts/src/project.json
+++ b/src/System.Composition.TypedParts/src/project.json
@@ -1,22 +1,19 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
-    "System.Collections": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.Diagnostics.Tools": "4.0.0",
-    "System.Globalization": "4.0.0",
-    "System.Linq": "4.0.0",
-    "System.Linq.Expressions": "4.0.0",
-    "System.Reflection": "4.0.0",
-    "System.Reflection.Extensions": "4.0.0",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Runtime.Extensions": "4.0.0"
+    "System.Collections": "4.0.11",
+    "System.Diagnostics.Debug": "4.0.11",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Globalization": "4.0.11",
+    "System.Linq": "4.1.0",
+    "System.Linq.Expressions": "4.1.0",
+    "System.Reflection": "4.1.0",
+    "System.Reflection.Extensions": "4.0.1",
+    "System.Resources.ResourceManager": "4.0.1",
+    "System.Threading": "4.0.11",
+    "System.Runtime.Extensions": "4.1.0",
   },
   "frameworks": {
-    "netstandard1.0": {
-      "imports": [
-        "dotnet5.1"
-      ]
-    }
+    "netstandard1.0": {}
   }
 }

--- a/src/System.Composition/pkg/System.Composition.builds
+++ b/src/System.Composition/pkg/System.Composition.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Composition.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Composition/pkg/System.Composition.pkgproj
+++ b/src/System.Composition/pkg/System.Composition.pkgproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <Version>1.0.31</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\System.Composition.AttributedModel\pkg\System.Composition.AttributedModel.pkgproj" />
+    <ProjectReference Include="..\..\System.Composition.Convention\pkg\System.Composition.Convention.pkgproj" />
+    <ProjectReference Include="..\..\System.Composition.Hosting\pkg\System.Composition.Hosting.pkgproj" />
+    <ProjectReference Include="..\..\System.Composition.Runtime\pkg\System.Composition.Runtime.pkgproj" />
+    <ProjectReference Include="..\..\System.Composition.TypedParts\pkg\System.Composition.TypedParts.pkgproj" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
This adds standard, individual packaging for each of the System.Composition.* libraries. Previously, we shipped all of this as one NuGet package, Microsoft.Composition. We may also consider adding a "System.Composition" meta-package which references these individual components for ease of consumption.

I've bumped each assembly's patch version from the version we used in the old package.