### PR TITLE
Allow override of __DOTNET_PKG used for Tools init

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -14,32 +14,39 @@ __PROJECT_JSON_PATH=$__TOOLRUNTIME_DIR/$__BUILD_TOOLS_PACKAGE_VERSION
 __PROJECT_JSON_FILE=$__PROJECT_JSON_PATH/project.json
 __PROJECT_JSON_CONTENTS="{ \"dependencies\": { \"Microsoft.DotNet.BuildTools\": \"$__BUILD_TOOLS_PACKAGE_VERSION\" }, \"frameworks\": { \"netcoreapp1.0\": { } } }"
 
+if [ -z "$__DOTNET_PKG" ]; then
 OSName=$(uname -s)
-case $OSName in
-    Darwin)
-        OS=OSX
-        __DOTNET_PKG=dotnet-dev-osx-x64
-        ulimit -n 2048
-        ;;
+    case $OSName in
+        Darwin)
+            OS=OSX
+            __DOTNET_PKG=dotnet-dev-osx-x64
+            ulimit -n 2048
+            ;;
 
-    Linux)
-        OS=Linux
-        if [ ! -e /etc/os-release ]; then
-            echo "Cannot determine Linux distribution, asuming Ubuntu 14.04."
-            __DOTNET_PKG=dotnet-dev-ubuntu.14.04-x64
-        else
-            source /etc/os-release
-            __DOTNET_PKG="dotnet-dev-$ID.$VERSION_ID-x64"
-        fi
-        ;;
+        Linux)
+            OS=Linux
+            if [ ! -e /etc/os-release ]; then
+                echo "Cannot determine Linux distribution, asuming Ubuntu 14.04."
+                __DOTNET_PKG=dotnet-dev-ubuntu.14.04-x64
+            else
+                source /etc/os-release
+                if [[ "$ID" == "ubuntu" && "$VERSION_ID" != "14.04" && "$VERSION_ID" != "16.04" ]]; then
+                    echo "Unsupported Ubuntu version, falling back to Ubuntu 14.04."
+                    __DOTNET_PKG=dotnet-dev-ubuntu.14.04-x64
+                else
+                    __DOTNET_PKG="dotnet-dev-$ID.$VERSION_ID-x64"
+                fi
+            fi
+            ;;
 
-    *)
-        echo "Unsupported OS '$OSName' detected. Downloading ubuntu-x64 tools."
-        OS=Linux
-        __DOTNET_PKG=dotnet-dev-ubuntu-x64
-        ;;
-esac
-
+        *)
+            echo "Unsupported OS '$OSName' detected. Downloading ubuntu-x64 tools."
+            OS=Linux
+            __DOTNET_PKG=dotnet-dev-ubuntu-x64
+            ;;
+  esac
+fi
+   
 if [ ! -e $__PROJECT_JSON_FILE ]; then
     if [ -e $__TOOLRUNTIME_DIR ]; then rm -rf -- $__TOOLRUNTIME_DIR; fi
     echo "Running: $__scriptpath/init-tools.sh" > $__init_tools_log


### PR DESCRIPTION
* Also, fall back to Ubuntu 14.04 if using an unsupported version.

I've been doing all of my developing on Ubuntu 15.04, and until recently the tool initialization would automatically fall back to Ubuntu 14.04. I've added back that fallback, and also allowed you to explicitly override which package gets downloaded.

There is also a similar change in buildtools that needs to happen to make other parts of init-tools.sh work.

@ellismg , @joperezr 