### PR TITLE
Add static tests for EnvelopedCms.Decrypt

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -200,6 +200,29 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         [Fact]
         [ActiveIssue(3334, PlatformID.AnyUnix)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void TestDecryptSimpleAes192_IssuerAndSerial()
+        {
+            // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSAKeyTransfer1.GetCertificate()
+            // and of type IssuerAndSerialNumber. The symmetric algorithm used is Aes192
+            byte[] encryptedMessage =
+                ("3082011F06092A864886F70D010703A08201103082010C0201003181C83081C5020100302E301A311830160"
+                + "603550403130F5253414B65795472616E7366657231021031D935FB63E8CFAB48A0BF7B397B67C0300D0609"
+                + "2A864886F70D010107300004818029B82454B4C301F277D7872A14695A41ED24FD37AC4C9942F9EE96774E0"
+                + "C6ACC18E756993A38AB215E5702CD34F244E52402DA432E8B79DF748405135E8A6D8CB78D88D9E4C142565C"
+                + "06F9FAFB32F5A9A4074E10FCCB0758A708CA758C12A17A4961969FCB3B2A6E6C9EB49F5E688D107E1B1DF3D"
+                + "531BC684B944FCE6BD4550C303C06092A864886F70D010701301D06096086480165030401160410FD7CBBF5"
+                + "6101854387E584C1B6EF3B08801034BD11C68228CB683E0A43AB5D27A8A4").HexToByteArray();
+
+            byte[] expectedContent = { 1, 2, 3, 4 };
+            ContentInfo expectedContentInfo = new ContentInfo(expectedContent);
+            CertLoader certLoader = Certificates.RSAKeyTransfer1;
+
+            VerifySimpleDecrypt(encryptedMessage, certLoader, expectedContentInfo);
+        }
+
+        [Fact]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void TestDecryptSimpleAes256_IssuerAndSerial()
         {
             // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSAKeyTransfer1.GetCertificate()

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -174,6 +174,190 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal<byte>(content, contentInfo.Content);
         }
 
+        [Fact]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void TestDecryptSimpleAes128_IssuerAndSerial()
+        {
+            // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSAKeyTransfer1.GetCertificate()
+            // and of type IssuerAndSerialNumber. The symmetric algorithm is Aes128
+            byte[] encryptedMessage =
+                ("3082011F06092A864886F70D010703A08201103082010C0201003181C83081C5020100302E301A311830160"
+                + "603550403130F5253414B65795472616E7366657231021031D935FB63E8CFAB48A0BF7B397B67C0300D0609"
+                + "2A864886F70D0101073000048180862175CD3B2932235A67C6A025F75CDA1A43B53E785370895BA9AC8D0DD"
+                + "318EB36DFAE275B16ABD497FEBBFCF2D4B3F38C75B91DC40941A2CC1F7F47E701EEA2D5A770C485565F8726"
+                + "DC0D59DDE17AA6DB0F9384C919FC8BC6CB561A980A9AE6095486FDF9F52249FB466B3676E4AEFE4035C15DC"
+                + "EE769F25E4660D4BE664E7F303C06092A864886F70D010701301D060960864801650304010204100A068EE9"
+                + "03E085EA5A03D1D8B4B73DD88010740E5DE9B798AA062B449F104D0F5D35").HexToByteArray();
+
+            byte[] expectedContent = { 1, 2, 3, 4 };
+            ContentInfo expectedContentInfo = new ContentInfo(expectedContent);
+            CertLoader certLoader = Certificates.RSAKeyTransfer1;
+
+            VerifySimpleDecrypt(encryptedMessage, certLoader, expectedContentInfo);
+        }
+
+        [Fact]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void TestDecryptSimpleAes256_IssuerAndSerial()
+        {
+            // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSAKeyTransfer1.GetCertificate()
+            // and of type IssuerAndSerialNumber. The symmetric algorithm used is Aes256
+            byte[] encryptedMessage =
+                ("3082011F06092A864886F70D010703A08201103082010C0201003181C83081C5020100302E301A311830160"
+                + "603550403130F5253414B65795472616E7366657231021031D935FB63E8CFAB48A0BF7B397B67C0300D0609"
+                + "2A864886F70D01010730000481800215BF7505BCD5D083F8EFDA01A4F91D61DE3967779B2F5E4360593D4CB"
+                + "96474E36198531A5E20E417B04C5C7E3263C3301DF8FA888FFBECC796500D382858379059C986285AFD605C"
+                + "B5DE125487CCA658DF261C836720E2E14440DA60E2F12D6D5E3992A0DB59973929DF6FC23D8E891F97CA956"
+                + "2A7AD160B502FA3C10477AA303C06092A864886F70D010701301D060960864801650304012A04101287FE80"
+                + "93F3C517AE86AFB95E599D7E80101823D88F47191857BE0743C4C730E39E").HexToByteArray();
+
+            byte[] expectedContent = { 1, 2, 3, 4 };
+            ContentInfo expectedContentInfo = new ContentInfo(expectedContent);
+            CertLoader certLoader = Certificates.RSAKeyTransfer1;
+
+            VerifySimpleDecrypt(encryptedMessage, certLoader, expectedContentInfo);
+        }
+
+        [Fact]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void TestDecryptSimpleTripleDes_IssuerAndSerial()
+        {
+            // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSAKeyTransfer1.GetCertificate()
+            // and of type IssuerAndSerialNumber. The symmetric algorithm used is 3DES-CBC
+            byte[] encryptedMessage =
+                ("3082010C06092A864886F70D010703A081FE3081FB0201003181C83081C5020100302E301A3118301606035"
+                + "50403130F5253414B65795472616E7366657231021031D935FB63E8CFAB48A0BF7B397B67C0300D06092A86"
+                + "4886F70D0101010500048180062F6F16637C8F35B73924AD85BA47D99DBB4800CB8F0C4094F6896050B7C1F"
+                + "11CE79BEE55A638EAAE70F2C32C01FC24B8D09D9D574CB7373788C8BC3A4748124154338C74B644A2A11750"
+                + "9E97D1B3535FAE70E4E7C8F2F866232CBFC6448E89CF9D72B948EDCF9C9FC9C153BCC7104680282A4BBBC1E"
+                + "E367F094F627EE45FCD302B06092A864886F70D010701301406082A864886F70D030704081E3F12D42E4041"
+                + "58800877A4A100165DD0F2").HexToByteArray();
+
+            byte[] expectedContent = { 1, 2, 3, 4 };
+            ContentInfo expectedContentInfo = new ContentInfo(expectedContent);
+            CertLoader certLoader = Certificates.RSAKeyTransfer1;
+
+            VerifySimpleDecrypt(encryptedMessage, certLoader, expectedContentInfo);
+        }
+
+        [Fact]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void TestDecryptSimpleAes256_Ski()
+        {
+            // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSAKeyTransfer1.GetCertificate()
+            // and of type SubjectKeyIdentifier. The symmetric algorithm used is Aes256
+            byte[] encryptedMessage =
+                ("3082010306092A864886F70D010703A081F53081F20201023181AE3081AB0201028014F2008AA9FA3742E83"
+                + "70CB1674CE1D1582921DCC3300D06092A864886F70D010101050004818055F258073615B95426A7021E1B30"
+                + "9CFE8DD135B58D29F174B9FE19AE80CFC84621BCE3DBD63A5422AF30A6FAA3E2DFC05CB1AB5AB4FBA6C84EB"
+                + "1C2E17D5BE5C4959DBE8F96BF1A9701F55B697843032EEC7AFEC58A36815168F017DCFD70C74AD05C48B5E4"
+                + "D9DDEE409FDC9DC3326B6C5BA9F433A9E031FF9B09473176637F50303C06092A864886F70D010701301D060"
+                + "960864801650304012A0410314DA87435ED110DFE4F52FA70CEF7B080104DDA6C617338DEBDD10913A9141B"
+                + "EE52").HexToByteArray();
+
+            byte[] expectedContent = { 1, 2, 3, 4 };
+            ContentInfo expectedContentInfo = new ContentInfo(expectedContent);
+            CertLoader certLoader = Certificates.RSAKeyTransfer1;
+
+            VerifySimpleDecrypt(encryptedMessage, certLoader, expectedContentInfo);
+        }
+
+        [Fact]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void TestDecryptSimpleAes256_RsaTransferCapi()
+        {
+            // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSAKeyTransferCapi1.GetCertificate()
+            // and of type IssuerAndSerialNumber. The symmetric algorithm used is Aes256
+            byte[] encryptedMessage =
+                ("3082012306092A864886F70D010703A0820114308201100201003181CC3081C90201003032301E311C301A0"
+                + "60355040313135253414B65795472616E73666572436170693102105D2FFFF863BABC9B4D3C80AB178A4CCA"
+                + "300D06092A864886F70D01010730000481804F3F4A6707B329AB9A7343C62F20D5C1EAF4E74ECBB2DC66D1C"
+                + "642FC4AA3E40FC4C13547C6C9F73D525EE2FE4147B2043B8FEBF8604C0E4091C657B48DFD83A322F0879580"
+                + "FA002C9B27AD1FCF9B8AF24EDDA927BB6728D11530B3F96EBFC859ED6B9F7B009F992171FACB587A7D05E8B"
+                + "467B3A1DACC08B2F3341413A7E96576303C06092A864886F70D010701301D060960864801650304012A0410"
+                + "6F911E14D9D991DAB93C0B7738D1EC208010044264D201501735F73052FFCA4B2A95").HexToByteArray();
+
+            byte[] expectedContent = { 1, 2, 3, 4 };
+            ContentInfo expectedContentInfo = new ContentInfo(expectedContent);
+            CertLoader certLoader = Certificates.RSAKeyTransferCapi1;
+
+            VerifySimpleDecrypt(encryptedMessage, certLoader, expectedContentInfo);
+        }
+
+        [Fact]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void TestDecryptSimpleAes256_RsaSha256()
+        {
+            // Message encrypted on framework for a recipient using the certificate returned by 
+            // Certificates.RSASha256KeyTransfer1.GetCertificate() and of type IssuerAndSerialNumber. The symmetric algorithm used is Aes256
+            byte[] encryptedMessage =
+                ("3082012506092A864886F70D010703A0820116308201120201003181CE3081CB02010030343020311E301C0"
+                + "60355040313155253415368613235364B65795472616E7366657231021072C6C7734916468C4D608253DA01"
+                + "7676300D06092A864886F70D01010730000481805C32FA32EBDCFFC3595166EEDACFC9E9D60842105B581E1"
+                + "8B85DE1409F4C999995637153480438530955EE4481A3B27B866FF4E106A525CDFFC6941BDD01EFECCC6CCC"
+                + "82A3D7F743F7543AB20A61A7831FE4DFB24A1652B072B3758FE4B2588D3B94A29575B6422DC5EF52E432565"
+                + "36CA25A11BB92817D61FEAFBDDDEC6EE331303C06092A864886F70D010701301D060960864801650304012A"
+                + "041021D59FDB89C13A3EC3766EF32FB333D080105AE8DEB71DF50DD85F66FEA63C8113F4").HexToByteArray();
+
+            byte[] expectedContent = { 1, 2, 3, 4 };
+            ContentInfo expectedContentInfo = new ContentInfo(expectedContent);
+            CertLoader certLoader = Certificates.RSASha256KeyTransfer1;
+
+            VerifySimpleDecrypt(encryptedMessage, certLoader, expectedContentInfo);
+        }
+
+        [Fact]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void TestDecryptSimpleAes256_RsaSha384()
+        {
+            // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSASha384KeyTransfer1.GetCertificate()
+            // and of type IssuerAndSerialNumber. The symmetric algorithm used is Aes256
+            byte[] encryptedMessage =
+                ("3082012506092A864886F70D010703A0820116308201120201003181CE3081CB02010030343020311E301C0"
+                + "60355040313155253415368613338344B65795472616E736665723102103C724FB7A0159A9345CAAC9E3DF5"
+                + "F136300D06092A864886F70D010107300004818011C1B85914331C005EA89E30D00364821B29BC0C459A22D"
+                + "917494A1092CDBDA2022792E46C5E88BAD0EE3FD4927B856722311F9B17934FB29CAB8FE595C2AB2B20096B"
+                + "9E2FC6F9D7B92125F571CBFC945C892EE4764D9B63369350FD2DAEFE455B367F48E100CB461F112808E792A"
+                + "8AA49B66C79E511508A877530BBAA896696303C06092A864886F70D010701301D060960864801650304012A"
+                + "0410D653E25E06BFF2EEB0BED4A90D00FE2680106B7EF143912ABA5C24F5E2C151E59D7D").HexToByteArray();
+
+            byte[] expectedContent = { 1, 2, 3, 4 };
+            ContentInfo expectedContentInfo = new ContentInfo(expectedContent);
+            CertLoader certLoader = Certificates.RSASha384KeyTransfer1;
+
+            VerifySimpleDecrypt(encryptedMessage, certLoader, expectedContentInfo);
+        }
+
+        [Fact]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void TestDecryptSimpleAes256_RsaSha512()
+        {
+            // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSASha512KeyTransfer1.GetCertificate()
+            // and of type IssuerAndSerialNumber. The symmetric algorithm used is Aes256
+            byte[] encryptedMessage =
+                ("3082012506092A864886F70D010703A0820116308201120201003181CE3081CB02010030343020311E301C0"
+                + "60355040313155253415368613531324B65795472616E736665723102102F5D9D58A5F41B844650AA233E68"
+                + "F105300D06092A864886F70D01010730000481802156D42FF5ED2F0338302E7298EF79BA1D04E20E68B079D"
+                + "B3239120E1FC03FEDA8B544F59142AACAFBC5E58205E8A0D124AAD17B5DCAA39BFC6BA634E820DE623BFDB6"
+                + "582BC48AF1B3DEF6849A57D2033586AF01079D67C9AB3AA9F6B51754BCC479A19581D4045EBE23145370219"
+                + "98ECB6F5E1BCF8D6BED6A75FE957A40077D303C06092A864886F70D010701301D060960864801650304012A"
+                + "04100B696608E489E7C35914D0A3DB9EB27F80103D362181B54721FB2CB7CE461CB31030").HexToByteArray();
+
+            byte[] expectedContent = { 1, 2, 3, 4 };
+            ContentInfo expectedContentInfo = new ContentInfo(expectedContent);
+            CertLoader certLoader = Certificates.RSASha512KeyTransfer1;
+
+            VerifySimpleDecrypt(encryptedMessage, certLoader, expectedContentInfo);
+        }
+
         private static void TestSimpleDecrypt_RoundTrip(CertLoader certLoader, ContentInfo contentInfo, string algorithmOidValue, SubjectIdentifierType type)
         {
             // Deep-copy the contentInfo since the real ContentInfo doesn't do this. This defends against a bad implementation changing


### PR DESCRIPTION
Added tests to verify compatibility of decrypt with messages encrypted on
framework with different symmetric algorithms and to test decrypt independently of encrypt.

@bartonjs @weshaggard 