### PR TITLE
Fix bug on EnvelopedCms.UnprotectedAttributes.Count (Issue 9252)

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/OpenSslHelpers.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/OpenSslHelpers.cs
@@ -139,19 +139,17 @@ namespace Internal.Cryptography.Pal.OpenSsl
                     DerSequenceReader attributeReader = encodedAttributesReader.ReadSequence();
 
                     Oid attributeOid = attributeReader.ReadOid();
-
-                    // This reads a set of unprotected attributes. If the set is empty then no CryptographicObject will 
-                    // be created. In framework this works differently and is documented on issue 9252. In case this
-                    // behavior wants to be emulated the only thing that would need to be done is create a 
-                    // CryptographicObject with the Oid sorted in attributeOid
+                    AsnEncodedDataCollection attributeCollection = new AsnEncodedDataCollection();
                     DerSequenceReader attributeSetReader = attributeReader.ReadSet();
                     
                     while (attributeSetReader.HasData)
                     {
                         byte[] singleEncodedAttribute = attributeSetReader.ReadNextEncodedValue();
                         AsnEncodedData singleAttribute = Helpers.CreateBestPkcs9AttributeObjectAvailable(attributeOid, singleEncodedAttribute);
-                        unprotectedAttributesCollection.Add(singleAttribute);
+                        attributeCollection.Add(singleAttribute);
                     }
+
+                    unprotectedAttributesCollection.Add(new CryptographicAttributeObject(attributeOid, attributeCollection));
                 }
             }
 

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
@@ -341,13 +341,16 @@ namespace Internal.Cryptography.Pal.Windows
         {
             string oidValue = pCryptAttribute->pszObjId.ToStringAnsi();
             Oid oid = new Oid(oidValue);
+            AsnEncodedDataCollection attributeCollection = new AsnEncodedDataCollection();
 
             for (int i = 0; i < pCryptAttribute->cValue; i++)
             {
                 byte[] encodedAttribute = pCryptAttribute->rgValue[i].ToByteArray();
                 AsnEncodedData attributeObject = Helpers.CreateBestPkcs9AttributeObjectAvailable(oid, encodedAttribute);
-                collection.Add(attributeObject);
+                attributeCollection.Add(attributeObject);
             }
+
+            collection.Add(new CryptographicAttributeObject(oid, attributeCollection));
         }
     }
 }

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
@@ -305,8 +305,28 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
             EnvelopedCms ecms = new EnvelopedCms();
             ecms.Decode(encodedMessage);
-            
+
             Assert.Equal(2, ecms.UnprotectedAttributes.Count);
+            
+            CryptographicAttributeObjectCollection collection = ecms.UnprotectedAttributes;
+
+            int countOfAttr0 = collection[0].Values.Count;
+            int countOfAttr1 = collection[1].Values.Count;
+
+            Assert.True(countOfAttr0 == 0 || countOfAttr0 == 0);
+
+            CryptographicAttributeObject emptyAttributeObj = (countOfAttr0 == 0) ?
+                collection[0] :
+                collection[1];
+
+            CryptographicAttributeObject nonEmptyAttributeObj = (countOfAttr0 != 0) ?
+                collection[0] :
+                collection[1];
+            
+            Assert.Equal(2, nonEmptyAttributeObj.Values.Count);
+
+            Assert.Equal(Oids.DocumentName, emptyAttributeObj.Oid.Value);
+            Assert.Equal(Oids.DocumentDescription, nonEmptyAttributeObj.Oid.Value);
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
@@ -289,10 +289,10 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             // }
             //
             // The important part of this test is that there are 0 attributes of a type that is declared within the encoded message.
-            // On framework, this would return 2 as explained on issue 9252, that is it would create a CryptographicAttributeObjectCollection
-            // with two CryptographicAttributeObjects, the first one holding a list of document description with the two values, the second one
-            // holding an empty list of document name. This makes ecms.UnprotectedAttributes.Count be 2. Core doesn't create the second
-            // list and as such ecms.UnprotectedAttributes.Count returns 1 as documented here.
+            // On framework, this would return 2 as it would create a CryptographicAttributeObjectCollection with two CryptographicAttributeObjects, 
+            // the first one holding a list of document description with the two values, the second one holding an empty list of
+            // document name.
+
             byte[] encodedMessage =
                 ("3082017806092A864886F70D010703A0820169308201650201023181C83081C5020100302E301A311830160603550403"
                 + "130F5253414B65795472616E7366657231021031D935FB63E8CFAB48A0BF7B397B67C0300D06092A864886F70D010101"
@@ -306,7 +306,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             EnvelopedCms ecms = new EnvelopedCms();
             ecms.Decode(encodedMessage);
             
-            Assert.Equal(1, ecms.UnprotectedAttributes.Count);
+            Assert.Equal(2, ecms.UnprotectedAttributes.Count);
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
@@ -289,7 +289,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             // }
             //
             // The important part of this test is that there are 0 attributes of a type that is declared within the encoded message.
-            // On framework, this would return 2 as it would create a CryptographicAttributeObjectCollection with two CryptographicAttributeObjects, 
+            // This should return 2 as it should create a CryptographicAttributeObjectCollection with two CryptographicAttributeObjects, 
             // the first one holding a list of document description with the two values, the second one holding an empty list of
             // document name.
 
@@ -309,24 +309,18 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(2, ecms.UnprotectedAttributes.Count);
             
             CryptographicAttributeObjectCollection collection = ecms.UnprotectedAttributes;
+            string attrObj0Oid = collection[0].Oid.Value;
 
-            int countOfAttr0 = collection[0].Values.Count;
-            int countOfAttr1 = collection[1].Values.Count;
-
-            Assert.True(countOfAttr0 == 0 || countOfAttr0 == 0);
-
-            CryptographicAttributeObject emptyAttributeObj = (countOfAttr0 == 0) ?
+            CryptographicAttributeObject documentDescObj = (attrObj0Oid == Oids.DocumentDescription) ?
                 collection[0] :
                 collection[1];
 
-            CryptographicAttributeObject nonEmptyAttributeObj = (countOfAttr0 != 0) ?
+            CryptographicAttributeObject documentNameObj = (attrObj0Oid == Oids.DocumentName) ?
                 collection[0] :
                 collection[1];
-            
-            Assert.Equal(2, nonEmptyAttributeObj.Values.Count);
 
-            Assert.Equal(Oids.DocumentName, emptyAttributeObj.Oid.Value);
-            Assert.Equal(Oids.DocumentDescription, nonEmptyAttributeObj.Oid.Value);
+            Assert.Equal(0, documentNameObj.Values.Count);
+            Assert.Equal(2, documentDescObj.Values.Count);
         }
 
         [Fact]


### PR DESCRIPTION
Fixed inconsistent behavior between framework and core where EnvelopedCms.UnprotectedAttributes.Count whould return different values
when one of the specified attributes in the encoding only had an oid but
no data. Framework would create an empty object but it wouldn't get
created in core.
Fixes issue #9252 
@bartonjs @weshaggard 