### PR TITLE
Fix HttpRequestMessage reuse handling in HttpClientHandler on Unix

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -37,6 +37,7 @@ namespace System.Net.Http
             internal readonly CurlResponseMessage _responseMessage;
             internal readonly CancellationToken _cancellationToken;
             internal Stream _requestContentStream;
+            internal long? _requestContentStreamStartingPosition;
 
             internal SafeCurlHandle _easyHandle;
             private SafeCurlSListHandle _requestHeaders;
@@ -134,10 +135,23 @@ namespace System.Net.Http
                 }
             }
 
-            public void FailRequestAndCleanup(Exception error)
+            public void CleanupAndFailRequest(Exception error)
             {
-                FailRequest(error);
-                Cleanup();
+                try
+                {
+                    Cleanup();
+                }
+                catch (Exception exc)
+                {
+                    // This would only happen in an aggregious case, such as a Stream failing to seek when
+                    // it claims to be able to, but in case something goes very wrong, make sure we don't
+                    // lose the exception information.
+                    error = new AggregateException(error, exc);
+                }
+                finally
+                {
+                    FailRequest(error);
+                }
             }
 
             public void FailRequest(Exception error)
@@ -171,12 +185,22 @@ namespace System.Net.Http
 
             public void Cleanup() // not called Dispose because the request may still be in use after it's cleaned up
             {
-                _responseMessage.ResponseStream.SignalComplete(); // No more callbacks so no more data
                 // Don't dispose of the ResponseMessage.ResponseStream as it may still be in use
-                // by code reading data stored in the stream.
+                // by code reading data stored in the stream. Also don't dispose of the request content
+                // stream; that'll be handled by the disposal of the request content by the HttpClient,
+                // and doing it here prevents reuse by an intermediate handler sitting between the client
+                // and this handler.
 
-                // Dispose of the input content stream if there was one.  Nothing should be using it any more.
-                _requestContentStream?.Dispose();
+                // However, if we got an original position for the request stream, we seek back to that position,
+                // for the corner case where the stream does get reused before it's disposed by the HttpClient
+                // (if the same request object is used multiple times from an intermediate handler, we'll be using
+                // ReadAsStreamAsync, which on the same request object will return the same stream object, which
+                // we've already advanced).
+                if (_requestContentStream != null && _requestContentStream.CanSeek)
+                {
+                    Debug.Assert(_requestContentStreamStartingPosition.HasValue, "The stream is seekable, but we don't have a starting position?");
+                    _requestContentStream.Position = _requestContentStreamStartingPosition.GetValueOrDefault();
+                }
 
                 // Dispose of the underlying easy handle.  We're no longer processing it.
                 _easyHandle?.Dispose();
@@ -188,6 +212,7 @@ namespace System.Net.Http
                 // doing any processing that assumes it's valid.
                 _requestHeaders?.Dispose();
 
+                // Dispose native callback resources
                 _callbackHandle?.Dispose();
             }
 
@@ -576,7 +601,6 @@ namespace System.Net.Http
                 {
                     SetChunkedModeForSend(_requestMessage);
 
-                    _requestMessage.Content.Headers.Remove(HttpKnownHeaderNames.ContentLength); // avoid overriding libcurl's handling via INFILESIZE/POSTFIELDSIZE
                     AddRequestHeaders(_requestMessage.Content.Headers, slist);
 
                     if (_requestMessage.Content.Headers.ContentType == null)
@@ -700,6 +724,12 @@ namespace System.Net.Http
             {
                 foreach (KeyValuePair<string, IEnumerable<string>> header in headers)
                 {
+                    if (string.Equals(header.Key, HttpKnownHeaderNames.ContentLength, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // avoid overriding libcurl's handling via INFILESIZE/POSTFIELDSIZE
+                        continue;
+                    }
+
                     string headerValue = headers.GetHeaderString(header.Key);
                     string headerKeyAndValue = string.IsNullOrEmpty(headerValue) ?
                         header.Key + ";" : // semicolon used by libcurl to denote empty value that should be sent

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -473,7 +473,7 @@ namespace System.Net.Http
             }
             catch (Exception exc)
             {
-                easy.FailRequestAndCleanup(exc);
+                easy.CleanupAndFailRequest(exc);
             }
 
             s_diagnosticListener.LogHttpResponse(easy.Task, loggingRequestId);


### PR DESCRIPTION
HttpRequestMessages are meant to be used for a single request.  However, that checking is done by HttpClient rather than by HttpClientHandler.  As a result, if code bypasses HttpClient, e.g. by using HttpMessageInvoker or by using a custom HttpMessageHandler sitting between the HttpClient and the HttpClientHandler, the same HttpRequestMessage can be used multiple times without an exception being thrown warning of the invalid usage.  And on Windows, things happen to work, but with our Unix implementation was never expecting this scenario and doesn't work well with it:
- The handler is explicitly disposing of the request content stream rather than leaving that up to the request content's disposal to handle.
- The handler is removing the Content-Length header from the request message content, as a simple way to avoid overriding the Content-Length header that libcurl itself may send based on previous configuration.
- The handler is using ReadAsStreamAsync to get the request stream to send, but ReadAsStreamAsync caches the returned stream, so if the same request message is reused with the same Content, the stream will have already advanced to the end of the stream, and when the message gets reused, we won't have content to send.

This commit fixes that:
- We now don't dispose the request content stream.  That'll be left up to the request content's disposal.
- We now don't remove the ContentLength header from the request message.  We instead just check as we're writing out the headers whether the header is Content-Length, skipping it if it is.
- We now store the original position of a seekable stream that's provided to us, and at the end of the request, rather than disposing of the stream, we rewind to the original position if it exists.  (If the stream isn't seekable, reusing the request message wouldn't be possible anyway.)

This last point also fixes another theoretical issue.  When libcurl wants to go back to the beginning of the stream (e.g. in a redirect scenario where it needs to rewind), it asks us to seek back to the beginning.  We're currently seeking back to the exact position asked for.  But the stream may have come in to us already advanced beyond 0, in which case we need to seek back to the requested offset plus that original position rather than just the requested offset.

And in doing this, I noticed that we were inadvertently allowing a set of closure/delegate allocations due to inadvertently using some captured state in a place where we were trying to avoid that.  I fixed that as well.

We were also marking everything complete before we'd cleaned up all resources, which meant that any failures from such cleanup would go unnoticed.  I've fixed that to ensure we clean up all state before we officially declare the async operation done.

Fixes #9644 
cc: @ericeil, @davidsh