### PR TITLE
Conform BitArray tests to match corefx behavior.

### DIFF
--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -273,8 +273,8 @@ namespace System.Collections.Tests
         {
             ICollection bitArray = new BitArray(10);
             Assert.Throws<ArgumentNullException>("array", () => bitArray.CopyTo(null, 0));
-            Assert.Throws<ArgumentException>(null, () => bitArray.CopyTo(new long[10], 0));
-            Assert.Throws<ArgumentException>(null, () => bitArray.CopyTo(new int[10, 10], 0));
+            Assert.Throws<ArgumentException>("array", () => bitArray.CopyTo(new long[10], 0));
+            Assert.Throws<ArgumentException>("array", () => bitArray.CopyTo(new int[10, 10], 0));
         }
 
         [Theory]


### PR DESCRIPTION
There are two copies of  `System.Collections.BitArray`  - one in mscorlib, and one in corefx (which is used for AOT). As pointed out in #9581 , the method `CopyTo(...)` supplies parameter names for AOT, and not for mscorlib. This PR just adds the parameter names, to make the version here match the version in corefx.

A few of the remaining  `ArgumentException`s still do not supply parameter names (in both versions), but given the check it's unclear which argument should be "blamed" for the problem (`array` when that's too small altogether, `index` if too far from the end...).

This PR is expected to fail build checks until dotnet/coreclr#6003 is accepted and versions updated.

@tarekgh 