### PR TITLE
Remove uses of ThrowsAny in System.Collections test helpers

### DIFF
--- a/src/Common/tests/System/Collections/ICollection.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.Generic.Tests.cs
@@ -53,6 +53,8 @@ namespace System.Collections.Tests
             }
         }
 
+        protected virtual Type ICollection_Generic_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentException);
+
         #endregion
 
         #region IEnumerable<T> Helper Methods
@@ -400,7 +402,7 @@ namespace System.Collections.Tests
             if (!DefaultValueAllowed && !IsReadOnly)
             {
                 if (DefaultValueWhenNotAllowed_Throws)
-                    Assert.ThrowsAny<ArgumentNullException>(() => collection.Contains(default(T)));
+                    Assert.Throws<ArgumentNullException>("item", () => collection.Contains(default(T)));
                 else
                     Assert.False(collection.Contains(default(T)));
             }
@@ -435,7 +437,7 @@ namespace System.Collections.Tests
             ICollection<T> collection = GenericICollectionFactory(count);
             T[] array = new T[count];
             if (count > 0)
-                Assert.Throws<ArgumentException>(() =>collection.CopyTo(array, count));
+                Assert.Throws<ArgumentException>(() => collection.CopyTo(array, count));
             else
                collection.CopyTo(array, count); // does nothing since the array is empty
         }
@@ -446,7 +448,7 @@ namespace System.Collections.Tests
         {
             ICollection<T> collection = GenericICollectionFactory(count);
             T[] array = new T[count];
-            Assert.ThrowsAny<ArgumentException>(() =>collection.CopyTo(array, count + 1)); // some implementations throw ArgumentOutOfRangeException for this scenario
+            Assert.Throws(ICollection_Generic_CopyTo_IndexLargerThanArrayCount_ThrowType, () => collection.CopyTo(array, count + 1));
         }
 
         [Theory]
@@ -457,7 +459,7 @@ namespace System.Collections.Tests
             {
                 ICollection<T> collection = GenericICollectionFactory(count);
                 T[] array = new T[count];
-                Assert.Throws<ArgumentException>(() =>collection.CopyTo(array, 1));
+                Assert.Throws<ArgumentException>(() => collection.CopyTo(array, 1));
             }
         }
 
@@ -609,7 +611,7 @@ namespace System.Collections.Tests
             ICollection<T> collection = GenericICollectionFactory(count);
             Assert.All(InvalidValues, value =>
             {
-                Assert.ThrowsAny<ArgumentException>(() => collection.Remove(value));
+                Assert.Throws<ArgumentException>(() => collection.Remove(value));
             });
             Assert.Equal(count, collection.Count);
         }
@@ -622,7 +624,7 @@ namespace System.Collections.Tests
             if (!DefaultValueAllowed && !IsReadOnly)
             {
                 if (DefaultValueWhenNotAllowed_Throws)
-                    Assert.ThrowsAny<ArgumentNullException>(() => collection.Remove(default(T)));
+                    Assert.Throws<ArgumentNullException>(() => collection.Remove(default(T)));
                 else
                     Assert.False(collection.Remove(default(T)));
             }

--- a/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
@@ -84,6 +84,12 @@ namespace System.Collections.Tests
         /// </summary>
         protected virtual Type ICollection_NonGeneric_SyncRootType => typeof(object);
 
+        /// <summary>
+        /// Used for the ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowsArgumentException tests. Some
+        /// implementations throw a different exception type (e.g. ArgumentOutOfRangeException).
+        /// </summary>
+        protected virtual Type ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentException);
+
         #endregion
 
         #region IEnumerable Helper Methods
@@ -291,7 +297,7 @@ namespace System.Collections.Tests
         {
             ICollection collection = NonGenericICollectionFactory(count);
             object[] array = new object[count];
-            Assert.ThrowsAny<ArgumentException>(() => collection.CopyTo(array, count + 1)); // some implementations throw ArgumentOutOfRangeException for this scenario
+            Assert.Throws(ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowType, () => collection.CopyTo(array, count + 1));
         }
 
         [Theory]

--- a/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
@@ -913,7 +913,7 @@ namespace System.Collections.Tests
             if (!DefaultValueAllowed && !IsReadOnly)
             {
                 if (DefaultValueWhenNotAllowed_Throws)
-                    Assert.ThrowsAny<ArgumentNullException>(() => collection.Contains(default(KeyValuePair<TKey, TValue>)));
+                    Assert.Throws<ArgumentNullException>(() => collection.Contains(default(KeyValuePair<TKey, TValue>)));
                 else
                     Assert.False(collection.Remove(default(KeyValuePair<TKey, TValue>)));
             }

--- a/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
+++ b/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
@@ -19,11 +19,17 @@ namespace System.Collections.Tests
     {
         #region IGenericSharedAPI<T> Helper methods
 
-        protected virtual bool DuplicateValuesAllowed { get { return true; } }
-        protected virtual bool DefaultValueWhenNotAllowed_Throws { get { return true; } }
-        protected virtual bool IsReadOnly { get { return false; } }
-        protected virtual bool DefaultValueAllowed { get { return true; } }
-        protected virtual IEnumerable<T> InvalidValues { get { return Array.Empty<T>(); } }
+        protected virtual bool DuplicateValuesAllowed => true;
+        protected virtual bool DefaultValueWhenNotAllowed_Throws => true;
+        protected virtual bool IsReadOnly => false;
+        protected virtual bool DefaultValueAllowed => true;
+        protected virtual IEnumerable<T> InvalidValues => Array.Empty<T>();
+
+        /// <summary>
+        /// Used for the IGenericSharedAPI_CopyTo_IndexLargerThanArrayCount_ThrowsArgumentException tests. Some
+        /// implementations throw a different exception type (e.g. ArgumentOutOfRangeException).
+        /// </summary>
+        protected virtual Type IGenericSharedAPI_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentException);
 
         protected virtual void AddToCollection(IEnumerable<T> collection, int numberOfItemsToAdd)
         {
@@ -355,7 +361,7 @@ namespace System.Collections.Tests
             if (!DefaultValueAllowed && !IsReadOnly)
             {
                 if (DefaultValueWhenNotAllowed_Throws)
-                    Assert.ThrowsAny<ArgumentNullException>(() => Contains(collection, default(T)));
+                    Assert.Throws<ArgumentNullException>(() => Contains(collection, default(T)));
                 else
                     Assert.False(Contains(collection, default(T)));
             }
@@ -401,7 +407,7 @@ namespace System.Collections.Tests
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
             T[] array = new T[count];
-            Assert.ThrowsAny<ArgumentException>(() => CopyTo(collection, array, count + 1)); // some implementations throw ArgumentOutOfRangeException for this scenario
+            Assert.Throws(IGenericSharedAPI_CopyTo_IndexLargerThanArrayCount_ThrowType, () => CopyTo(collection, array, count + 1));
         }
 
         [Theory]

--- a/src/Common/tests/System/Collections/IList.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IList.NonGeneric.Tests.cs
@@ -949,7 +949,7 @@ namespace System.Collections.Tests
                 IList collection = NonGenericIListFactory(count);
                 Assert.All(InvalidValues, value =>
                 {
-                    Assert.ThrowsAny<ArgumentException>(() => collection.Remove(value));
+                    Assert.Throws<ArgumentException>(() => collection.Remove(value));
                 });
                 Assert.Equal(count, collection.Count);
             }

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
@@ -10,10 +10,10 @@ namespace System.Collections.Tests
 {
     public class Dictionary_Generic_Tests_Keys : ICollection_Generic_Tests<string>
     {
-        protected override bool DefaultValueAllowed { get { return false; } }
-        protected override bool DuplicateValuesAllowed { get { return false; } }
-        protected override bool IsReadOnly { get { return true; } }
-        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
+        protected override bool DefaultValueAllowed => false;
+        protected override bool DuplicateValuesAllowed => false;
+        protected override bool IsReadOnly => true;
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
         protected override ICollection<string> GenericICollectionFactory()
         {
             return new Dictionary<string, string>().Keys;
@@ -37,6 +37,8 @@ namespace System.Collections.Tests
             return Convert.ToBase64String(bytes);
         }
 
+        protected override Type ICollection_Generic_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
+
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_KeyCollection_Constructor_NullDictionary(int count)
@@ -58,11 +60,13 @@ namespace System.Collections.Tests
 
     public class Dictionary_Generic_Tests_Keys_AsICollection : ICollection_NonGeneric_Tests
     {
-        protected override bool NullAllowed { get { return false; } }
-        protected override bool DuplicateValuesAllowed { get { return false; } }
-        protected override bool IsReadOnly { get { return true; } }
-        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
+        protected override bool NullAllowed => false;
+        protected override bool DuplicateValuesAllowed => false;
+        protected override bool IsReadOnly => true;
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
+
+        protected override Type ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
 
         protected override ICollection NonGenericICollectionFactory()
         {
@@ -92,7 +96,7 @@ namespace System.Collections.Tests
             Debug.Assert(false);
         }
 
-        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
@@ -10,10 +10,10 @@ namespace System.Collections.Tests
 {
     public class Dictionary_Generic_Tests_Values : ICollection_Generic_Tests<string>
     {
-        protected override bool DefaultValueAllowed { get { return true; } }
-        protected override bool DuplicateValuesAllowed { get { return true; } }
-        protected override bool IsReadOnly { get { return true; } }
-        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
+        protected override bool DefaultValueAllowed => true;
+        protected override bool DuplicateValuesAllowed => true;
+        protected override bool IsReadOnly => true;
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         protected override ICollection<string> GenericICollectionFactory()
         {
@@ -38,6 +38,8 @@ namespace System.Collections.Tests
             return Convert.ToBase64String(bytes);
         }
 
+        protected override Type ICollection_Generic_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
+
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_ValueCollection_Constructor_NullDictionary(int count)
@@ -59,15 +61,18 @@ namespace System.Collections.Tests
 
     public class Dictionary_Generic_Tests_Values_AsICollection : ICollection_NonGeneric_Tests
     {
-        protected override bool NullAllowed { get { return true; } }
-        protected override bool DuplicateValuesAllowed { get { return true; } }
-        protected override bool IsReadOnly { get { return true; } }
-        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
+        protected override bool NullAllowed => true;
+        protected override bool DuplicateValuesAllowed => true;
+        protected override bool IsReadOnly => true;
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
-        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
+
+        protected override Type ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
+
         protected override ICollection NonGenericICollectionFactory()
         {
-            return (ICollection)(new Dictionary<string, string>().Values);
+            return new Dictionary<string, string>().Values;
         }
 
         protected override ICollection NonGenericICollectionFactory(int count)
@@ -76,7 +81,7 @@ namespace System.Collections.Tests
             int seed = 13453;
             for (int i = 0; i < count; i++)
                 list.Add(CreateT(seed++), CreateT(seed++));
-            return (ICollection)(list.Values);
+            return list.Values;
         }
 
         private string CreateT(int seed)

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.cs
@@ -21,6 +21,8 @@ namespace System.Collections.Tests
             return new Dictionary<TKey, TValue>();
         }
 
+        protected override Type ICollection_Generic_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
+
         #endregion
 
         #region Constructors

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.cs
@@ -23,15 +23,12 @@ namespace System.Collections.Tests
             return Convert.ToBase64String(bytes1);
         }
 
-        protected override string CreateTValue(int seed)
-        {
-            return CreateTKey(seed);
-        }
+        protected override string CreateTValue(int seed) => CreateTKey(seed);
     }
 
     public class Dictionary_Generic_Tests_int_int : Dictionary_Generic_Tests<int, int>
     {
-        protected override bool DefaultValueAllowed { get { return true; } }
+        protected override bool DefaultValueAllowed => true;
 
         protected override KeyValuePair<int, int> CreateT(int seed)
         {
@@ -45,10 +42,7 @@ namespace System.Collections.Tests
             return rand.Next();
         }
 
-        protected override int CreateTValue(int seed)
-        {
-            return CreateTKey(seed);
-        }
+        protected override int CreateTValue(int seed) => CreateTKey(seed);
     }
 
     public class Dictionary_Generic_Tests_SimpleInt_int_With_Comparer_WrapStructural_SimpleInt : Dictionary_Generic_Tests<SimpleInt, int>

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
@@ -33,10 +33,9 @@ namespace System.Collections.Tests
         /// Creates an object that is dependent on the seed given. The object may be either
         /// a value type or a reference type, chosen based on the value of the seed.
         /// </summary>
-        protected override object CreateTValue(int seed)
-        {
-            return CreateTKey(seed);
-        }
+        protected override object CreateTValue(int seed) => CreateTKey(seed);
+
+        protected override Type ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
 
         #region IDictionary tests
 

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.AsNonGenericIEnumerable.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.AsNonGenericIEnumerable.cs
@@ -17,7 +17,7 @@ namespace System.Collections.Tests
             return set;
         }
 
-        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
 
         /// <summary>
         /// Returns a set of ModifyEnumerable delegates that modify the enumerable passed to them.

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -15,13 +15,7 @@ namespace System.Collections.Tests
     {
         #region ISet<T> Helper Methods
 
-        protected override bool ResetImplemented
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool ResetImplemented => true;
 
         protected override ISet<T> GenericISetFactory()
         {

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.cs
@@ -27,7 +27,7 @@ namespace System.Collections.Tests
             return rand.Next();
         }
 
-        protected override bool DefaultValueAllowed { get { return true; } }
+        protected override bool DefaultValueAllowed => true;
     }
 
     public class HashSet_Generic_Tests_int_With_Comparer_WrapStructural_Int : HashSet_Generic_Tests<int>

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AddLast.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AddLast.cs
@@ -12,7 +12,6 @@ namespace System.Collections.Tests
     /// </summary>
     public abstract partial class LinkedList_Generic_Tests<T> : ICollection_Generic_Tests<T>
     {
-
         [Fact]
         public void AddLast_T_Tests()
         {

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AsNonGenericICollection.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AsNonGenericICollection.cs
@@ -23,7 +23,7 @@ namespace System.Collections.Tests
             return new LinkedList<string>();
         }
 
-        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
 
         /// <summary>
         /// Returns a set of ModifyEnumerable delegates that modify the enumerable passed to them.

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.cs
@@ -19,6 +19,8 @@ namespace System.Collections.Tests
             return GenericLinkedListFactory();
         }
 
+        protected override Type ICollection_Generic_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
+
         #endregion
 
         #region LinkedList<T> Helper Methods

--- a/src/System.Collections/tests/Generic/List/List.Generic.Tests.AsNonGenericIList.cs
+++ b/src/System.Collections/tests/Generic/List/List.Generic.Tests.AsNonGenericIList.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using Xunit;
 
 namespace System.Collections.Tests
 {
@@ -17,7 +13,7 @@ namespace System.Collections.Tests
     {
         #region IList_Generic_Tests
 
-        protected override bool NullAllowed { get { return true; } }
+        protected override bool NullAllowed => true;
 
         protected override IList NonGenericIListFactory()
         {

--- a/src/System.Collections/tests/Generic/List/List.Generic.Tests.Find.cs
+++ b/src/System.Collections/tests/Generic/List/List.Generic.Tests.Find.cs
@@ -14,8 +14,8 @@ namespace System.Collections.Tests
     public abstract partial class List_Generic_Tests<T> : IList_Generic_Tests<T>
     {
         private readonly Predicate<T> EqualsDefaultDelegate = (T item) => { return default(T) == null ? item == null : default(T).Equals(item);};
-        private readonly Predicate<T> AlwaysTrueDelegate = (T item) => { return true; };
-        private readonly Predicate<T> AlwaysFalseDelegate = (T item) => { return false; };
+        private readonly Predicate<T> AlwaysTrueDelegate = (T item) => true;
+        private readonly Predicate<T> AlwaysFalseDelegate = (T item) => false;
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]

--- a/src/System.Collections/tests/Generic/List/List.Generic.cs
+++ b/src/System.Collections/tests/Generic/List/List.Generic.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using Xunit;
 
 namespace System.Collections.Tests
 {
@@ -42,13 +38,7 @@ namespace System.Collections.Tests
             return Convert.ToBase64String(bytes);
         }
 
-        protected override bool IsReadOnly
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool IsReadOnly => true;
 
         protected override IList<string> GenericIListFactory(int setLength)
         {
@@ -60,7 +50,7 @@ namespace System.Collections.Tests
             return GenericListFactory().AsReadOnly();
         }
 
-        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
     }
 
     public class List_Generic_Tests_int_ReadOnly : List_Generic_Tests<int>
@@ -71,13 +61,7 @@ namespace System.Collections.Tests
             return rand.Next();
         }
 
-        protected override bool IsReadOnly
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool IsReadOnly => true;
 
         protected override IList<int> GenericIListFactory(int setLength)
         {
@@ -88,6 +72,6 @@ namespace System.Collections.Tests
         {
             return GenericListFactory().AsReadOnly();
         }
-        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
     }
 }

--- a/src/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
@@ -44,13 +44,15 @@ namespace System.Collections.Tests
             return GenericQueueFactory(count);
         }
 
-        protected override int Count(IEnumerable<T> enumerable) { return ((Queue<T>)enumerable).Count; }
-        protected override void Add(IEnumerable<T> enumerable, T value) { ((Queue<T>)enumerable).Enqueue(value); }
-        protected override void Clear(IEnumerable<T> enumerable) { ((Queue<T>)enumerable).Clear(); }
-        protected override bool Contains(IEnumerable<T> enumerable, T value) { return ((Queue<T>)enumerable).Contains(value); }
-        protected override void CopyTo(IEnumerable<T> enumerable, T[] array, int index) { ((Queue<T>)enumerable).CopyTo(array, index); }
+        protected override int Count(IEnumerable<T> enumerable) => ((Queue<T>)enumerable).Count;
+        protected override void Add(IEnumerable<T> enumerable, T value) => ((Queue<T>)enumerable).Enqueue(value);
+        protected override void Clear(IEnumerable<T> enumerable) => ((Queue<T>)enumerable).Clear();
+        protected override bool Contains(IEnumerable<T> enumerable, T value) => ((Queue<T>)enumerable).Contains(value);
+        protected override void CopyTo(IEnumerable<T> enumerable, T[] array, int index) => ((Queue<T>)enumerable).CopyTo(array, index);
         protected override bool Remove(IEnumerable<T> enumerable) { ((Queue<T>)enumerable).Dequeue(); return true; }
-        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+
+        protected override Type IGenericSharedAPI_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
 
         #endregion
 

--- a/src/System.Collections/tests/Generic/Queue/Queue.Tests.cs
+++ b/src/System.Collections/tests/Generic/Queue/Queue.Tests.cs
@@ -27,7 +27,9 @@ namespace System.Collections.Tests
             return new Queue<string>();
         }
 
-        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+
+        protected override Type ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
 
         /// <summary>
         /// Returns a set of ModifyEnumerable delegates that modify the enumerable passed to them.

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Keys.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Keys.cs
@@ -10,11 +10,11 @@ namespace System.Collections.Tests
 {
     public class SortedList_Generic_Tests_Keys : IList_Generic_Tests<string>
     {
-        protected override bool DefaultValueAllowed { get { return false; } }
-        protected override bool DuplicateValuesAllowed { get { return false; } }
-        protected override bool IsReadOnly { get { return true; } }
-        protected override bool DefaultValueWhenNotAllowed_Throws { get { return true; } }
-        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
+        protected override bool DefaultValueAllowed => false;
+        protected override bool DuplicateValuesAllowed => false;
+        protected override bool IsReadOnly => true;
+        protected override bool DefaultValueWhenNotAllowed_Throws => true;
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         protected override IList<string> GenericIListFactory()
         {
@@ -91,6 +91,6 @@ namespace System.Collections.Tests
             Debug.Assert(false);
         }
 
-        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
     }
 }

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Values.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Values.cs
@@ -10,10 +10,10 @@ namespace System.Collections.Tests
 {
     public class SortedList_Generic_Tests_Values : IList_Generic_Tests<string>
     {
-        protected override bool DefaultValueAllowed { get { return true; } }
-        protected override bool DuplicateValuesAllowed { get { return true; } }
-        protected override bool IsReadOnly { get { return true; } }
-        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
+        protected override bool DefaultValueAllowed => true;
+        protected override bool DuplicateValuesAllowed => true;
+        protected override bool IsReadOnly => true;
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         protected override IList<string> GenericIListFactory()
         {
@@ -90,6 +90,6 @@ namespace System.Collections.Tests
             Debug.Assert(false);
         }
 
-        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
     }
 }

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.cs
@@ -33,7 +33,9 @@ namespace System.Collections.Tests
             if (count > 0)
                 Assert.True(enumerator.MoveNext());
         }
-        
+
+        protected override Type ICollection_Generic_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
+
         #endregion
 
         #region Constructor_IComparer

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.cs
@@ -23,15 +23,12 @@ namespace System.Collections.Tests
             return Convert.ToBase64String(bytes1);
         }
 
-        protected override string CreateTValue(int seed)
-        {
-            return CreateTKey(seed);
-        }
+        protected override string CreateTValue(int seed) => CreateTKey(seed);
     }
 
     public class SortedList_Generic_Tests_int_int : SortedList_Generic_Tests<int, int>
     {
-        protected override bool DefaultValueAllowed { get { return true; } }
+        protected override bool DefaultValueAllowed => true;
         protected override KeyValuePair<int, int> CreateT(int seed)
         {
             Random rand = new Random(seed);
@@ -44,10 +41,7 @@ namespace System.Collections.Tests
             return rand.Next();
         }
 
-        protected override int CreateTValue(int seed)
-        {
-            return CreateTKey(seed);
-        }
+        protected override int CreateTValue(int seed) => CreateTKey(seed);
     }
 
     [OuterLoop]

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
@@ -25,10 +25,9 @@ namespace System.Collections.Tests
             return Convert.ToBase64String(bytes);
         }
 
-        protected override object CreateTValue(int seed)
-        {
-            return CreateTKey(seed);
-        }
+        protected override object CreateTValue(int seed) => CreateTKey(seed);
+
+        protected override Type ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
 
         #endregion
 

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
@@ -27,13 +27,7 @@ namespace System.Collections.Tests
             return rand.Next();
         }
 
-        protected override bool DefaultValueAllowed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool DefaultValueAllowed => true;
     }
 
     [OuterLoop]

--- a/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
@@ -32,6 +32,8 @@ namespace System.Collections.Tests
             return stack;
         }
 
+        protected override Type IGenericSharedAPI_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
+
         #endregion
 
         protected override IEnumerable<T> GenericIEnumerableFactory()
@@ -44,13 +46,13 @@ namespace System.Collections.Tests
             return GenericStackFactory(count);
         }
 
-        protected override int Count(IEnumerable<T> enumerable) { return ((Stack<T>)enumerable).Count; }
-        protected override void Add(IEnumerable<T> enumerable, T value) { ((Stack<T>)enumerable).Push(value); }
-        protected override void Clear(IEnumerable<T> enumerable) { ((Stack<T>)enumerable).Clear(); }
-        protected override bool Contains(IEnumerable<T> enumerable, T value) { return ((Stack<T>)enumerable).Contains(value); }
-        protected override void CopyTo(IEnumerable<T> enumerable, T[] array, int index) { ((Stack<T>)enumerable).CopyTo(array, index); }
+        protected override int Count(IEnumerable<T> enumerable) => ((Stack<T>)enumerable).Count;
+        protected override void Add(IEnumerable<T> enumerable, T value) => ((Stack<T>)enumerable).Push(value);
+        protected override void Clear(IEnumerable<T> enumerable) => ((Stack<T>)enumerable).Clear();
+        protected override bool Contains(IEnumerable<T> enumerable, T value) => ((Stack<T>)enumerable).Contains(value);
+        protected override void CopyTo(IEnumerable<T> enumerable, T[] array, int index) => ((Stack<T>)enumerable).CopyTo(array, index);
         protected override bool Remove(IEnumerable<T> enumerable) { ((Stack<T>)enumerable).Pop(); return true; }
-        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
 
         #endregion
 

--- a/src/System.Collections/tests/Generic/Stack/Stack.Tests.cs
+++ b/src/System.Collections/tests/Generic/Stack/Stack.Tests.cs
@@ -24,7 +24,9 @@ namespace System.Collections.Tests
             return new Stack<string>();
         }
 
-        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+
+        protected override Type ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
 
         /// <summary>
         /// Returns a set of ModifyEnumerable delegates that modify the enumerable passed to them.


### PR DESCRIPTION
Add customization points instead
Also uses expression bodied members to enhance readability

I'm getting tens of thousands of build errors running `msbuild /T:BuildAndTest` on System.Collections.NonGeneric and System.Collections.Concurrent (e.g. cannot find System.Object), so the CI may fail. I will fix those if/when they come up.

/cc @ianhays