### PR TITLE
Redist old build of System.Private.Uri

### DIFF
--- a/src/System.Private.Uri/pkg/win/System.Private.Uri.pkgproj
+++ b/src/System.Private.Uri/pkg/win/System.Private.Uri.pkgproj
@@ -11,7 +11,11 @@
     <ProjectReference Include="..\..\src\System.Private.Uri.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\System.Private.Uri.csproj">
+    <ProjectReference Include="..\..\src\redist\System.Private.Uri.depproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\redist\System.Private.Uri.depproj">
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50aot</TargetGroup>
     </ProjectReference>

--- a/src/System.Private.Uri/src/System.Private.Uri.builds
+++ b/src/System.Private.Uri/src/System.Private.Uri.builds
@@ -8,7 +8,11 @@
     <Project Include="System.Private.Uri.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="System.Private.Uri.csproj">
+    <Project Include="redist\System.Private.Uri.depproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="redist\System.Private.Uri.depproj">
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>

--- a/src/System.Private.Uri/src/redist/System.Private.Uri.depproj
+++ b/src/System.Private.Uri/src/redist/System.Private.Uri.depproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Private.Uri/src/redist/project.json
+++ b/src/System.Private.Uri/src/redist/project.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Targets": "1.0.0",
+    "System.Private.Uri": "4.0.0"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}


### PR DESCRIPTION
System.Private.Uri is part of the shared library and cannot be updated.

/cc @weshaggard @MattWhilden 

Fixes https://github.com/dotnet/corefx/issues/9711