### PR TITLE
[release/1.0.1] Redist old build of System.Private.Uri

### DIFF
--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <IsLineupPackage>true</IsLineupPackage>
     <RuntimeFileSource>runtime.json</RuntimeFileSource>
     <SkipValidatePackage>true</SkipValidatePackage>

--- a/src/System.Private.Uri/pkg/win/System.Private.Uri.pkgproj
+++ b/src/System.Private.Uri/pkg/win/System.Private.Uri.pkgproj
@@ -11,7 +11,11 @@
     <ProjectReference Include="..\..\src\System.Private.Uri.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\System.Private.Uri.csproj">
+    <ProjectReference Include="..\..\src\redist\System.Private.Uri.depproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\redist\System.Private.Uri.depproj">
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50aot</TargetGroup>
     </ProjectReference>

--- a/src/System.Private.Uri/pkg/win/System.Private.Uri.pkgproj
+++ b/src/System.Private.Uri/pkg/win/System.Private.Uri.pkgproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
+    <Version>4.0.2</Version>
     <PackageTargetRuntime>win7</PackageTargetRuntime>
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>

--- a/src/System.Private.Uri/src/System.Private.Uri.builds
+++ b/src/System.Private.Uri/src/System.Private.Uri.builds
@@ -8,7 +8,11 @@
     <Project Include="System.Private.Uri.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="System.Private.Uri.csproj">
+    <Project Include="redist\System.Private.Uri.depproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="redist\System.Private.Uri.depproj">
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>

--- a/src/System.Private.Uri/src/redist/System.Private.Uri.depproj
+++ b/src/System.Private.Uri/src/redist/System.Private.Uri.depproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Private.Uri/src/redist/project.json
+++ b/src/System.Private.Uri/src/redist/project.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Targets": "1.0.0",
+    "System.Private.Uri": "4.0.0"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -6,9 +6,10 @@
     <AdditionalProperties>BuildPackageLibraryReferences=false</AdditionalProperties>
     <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(BinDir)pkg/reports/</PackageReportDir>
     <BuildAllOSGroups Condition="'$(FilterToOSGroup)' != ''">false</BuildAllOSGroups>
+    <BuildAllPackages>false</BuildAllPackages>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(BuildAllPackages)' == 'true'" >
     <Project Include="Native\pkg\**\*.builds" Condition="'$(SkipNativePackageBuild)' != 'true'">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
       <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
@@ -17,6 +18,16 @@
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <Project Include="..\pkg\*\*.builds" Condition="'$(SkipManagedPackageBuild)' != 'true'">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipManagedPackageBuild)' != 'true'" >
+    <Project Include="System.Private.Uri\pkg\win\System.Private.Uri.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="..\pkg\Microsoft.NETCore.Targets\Microsoft.NETCore.Targets.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
   </ItemGroup>


### PR DESCRIPTION
System.Private.Uri is part of the shared library and cannot be updated.

Port of https://github.com/dotnet/corefx/commit/5da5eaa790a813a90d76b308f3c40e7b4a5a46a7

/cc @weshaggard @MattWhilden 