### PR TITLE
Add missing members to System.Console.dll

### DIFF
--- a/src/System.Console/ref/System.Console.cs
+++ b/src/System.Console/ref/System.Console.cs
@@ -36,8 +36,11 @@ namespace System
         public static void MoveBufferArea(int sourceLeft, int sourceTop, int sourceWidth, int sourceHeight, int targetLeft, int targetTop, char sourceChar, ConsoleColor sourceForeColor, ConsoleColor sourceBackColor) { }
         public static bool NumberLock { get { return default(bool); }}
         public static System.IO.Stream OpenStandardError() { return default(System.IO.Stream); }
+        public static System.IO.Stream OpenStandardError(int bufferSize) { return default(System.IO.Stream); }
         public static System.IO.Stream OpenStandardInput() { return default(System.IO.Stream); }
+        public static System.IO.Stream OpenStandardInput(int bufferSize) { return default(System.IO.Stream); }
         public static System.IO.Stream OpenStandardOutput() { return default(System.IO.Stream); }
+        public static System.IO.Stream OpenStandardOutput(int bufferSize) { return default(System.IO.Stream); }
         public static System.IO.TextWriter Out { get { return default(System.IO.TextWriter); } }
         public static System.Text.Encoding OutputEncoding { get { return default(System.Text.Encoding); } set { } }
         public static int Read() { return default(int); }
@@ -97,6 +100,10 @@ namespace System
         public static void WriteLine(uint value) { }
         [System.CLSCompliantAttribute(false)]
         public static void WriteLine(ulong value) { }
+        //[System.CLSCompliantAttribute(false)]
+        //public static void Write(string format, object arg0, object arg1, object arg2, object arg3, __arglist)
+        //[System.CLSCompliantAttribute(false)]
+        //public static void WriteLine(string format, object arg0, object arg1, object arg2, object arg3, __arglist)
     }
     public sealed partial class ConsoleCancelEventArgs : System.EventArgs
     {
@@ -196,6 +203,9 @@ namespace System
         X = 0x58,
         Y = 0x59,
         Z = 0x5A,
+        LeftWindows = 0x5B,
+        RightWindows = 0x5C,
+        Applications = 0x5D,
         Sleep = 0x5F,
         NumPad0 = 0x60,
         NumPad1 = 0x61,
@@ -237,6 +247,24 @@ namespace System
         F22 = 0x85,
         F23 = 0x86,
         F24 = 0x87,
+        BrowserBack = 0xA6,
+        BrowserForward = 0xA7,
+        BrowserRefresh = 0xA8,
+        BrowserStop = 0xA9,
+        BrowserSearch = 0xAA,
+        BrowserFavorites = 0xAB,
+        BrowserHome = 0xAC,
+        VolumeMute = 0xAD,
+        VolumeDown = 0xAE,
+        VolumeUp = 0xAF,
+        MediaNext = 0xB0,
+        MediaPrevious = 0xB1,
+        MediaStop = 0xB2,
+        MediaPlay = 0xB3,
+        LaunchMail = 0xB4,
+        LaunchMediaSelect = 0xB5,
+        LaunchApp1 = 0xB6,
+        LaunchApp2 = 0xB7,
         Oem1 = 0xBA,
         OemPlus = 0xBB,
         OemComma = 0xBC,
@@ -249,6 +277,17 @@ namespace System
         Oem6 = 0xDD,
         Oem7 = 0xDE,
         Oem8 = 0xDF,
+        Oem102 = 0xE2,
+        Process = 0xE5,
+        Packet = 0xE7,
+        Attention = 0xF6,
+        CrSel = 0xF7,
+        ExSel = 0xF8,
+        EraseEndOfFile = 0xF9,
+        Play = 0xFA,
+        Zoom = 0xFB,
+        NoName = 0xFC,
+        Pa1 = 0xFD,
         OemClear = 0xFE,
     }
     [Flags]

--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -414,7 +414,7 @@ namespace System
             {
                 throw new ArgumentOutOfRangeException("bufferSize", SR.ArgumentOutOfRange_NeedNonNegNum);
             }
-            return ConsolePal.OpenStandardInput();
+            return OpenStandardInput();
         }
 
         public static Stream OpenStandardOutput()
@@ -429,7 +429,7 @@ namespace System
             {
                 throw new ArgumentOutOfRangeException("bufferSize", SR.ArgumentOutOfRange_NeedNonNegNum);
             }
-            return ConsolePal.OpenStandardOutput();
+            return OpenStandardOutput();
         }
 
         public static Stream OpenStandardError()
@@ -444,7 +444,7 @@ namespace System
             {
                 throw new ArgumentOutOfRangeException("bufferSize", SR.ArgumentOutOfRange_NeedNonNegNum);
             }
-            return ConsolePal.OpenStandardError();
+            return OpenStandardError();
         }
 
         public static void SetIn(TextReader newIn)

--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -407,13 +407,43 @@ namespace System
             return ConsolePal.OpenStandardInput();
         }
 
+        public static Stream OpenStandardInput(int bufferSize)
+        {
+            // bufferSize is ignored, other than in argument validation, even in the .NET Framework
+            if (bufferSize < 0)
+            {
+                throw new ArgumentOutOfRangeException("bufferSize", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+            return ConsolePal.OpenStandardInput();
+        }
+
         public static Stream OpenStandardOutput()
         {
             return ConsolePal.OpenStandardOutput();
         }
 
+        public static Stream OpenStandardOutput(int bufferSize)
+        {
+            // bufferSize is ignored, other than in argument validation, even in the .NET Framework
+            if (bufferSize < 0)
+            {
+                throw new ArgumentOutOfRangeException("bufferSize", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+            return ConsolePal.OpenStandardOutput();
+        }
+
         public static Stream OpenStandardError()
         {
+            return ConsolePal.OpenStandardError();
+        }
+
+        public static Stream OpenStandardError(int bufferSize)
+        {
+            // bufferSize is ignored, other than in argument validation, even in the .NET Framework
+            if (bufferSize < 0)
+            {
+                throw new ArgumentOutOfRangeException("bufferSize", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
             return ConsolePal.OpenStandardError();
         }
 
@@ -695,6 +725,32 @@ namespace System
         {
             Out.Write(value);
         }
+
+        // TODO: Uncomment when ArgIterator and friends are available in System.Runtime.dll
+        //
+        //[CLSCompliant(false)]
+        //[MethodImplAttribute(MethodImplOptions.NoInlining)]
+        //public static void WriteLine(string format, object arg0, object arg1, object arg2, object arg3, __arglist)
+        //{
+        //    Out.WriteLine(format, ToObjectArgs(arg0, arg1, arg2, arg3, new ArgIterator(__arglist));
+        //}
+        //
+        //[CLSCompliant(false)]
+        //[MethodImplAttribute(MethodImplOptions.NoInlining)]
+        //public static void Write(string format, object arg0, object arg1, object arg2, object arg3, __arglist)
+        //{
+        //    Out.Write(format, ToObjectArgs(arg0, arg1, arg2, arg3, new ArgIterator(__arglist));
+        //}
+        //
+        //private static object[] ToObjectArgs(object arg0, object arg1, object arg2, object arg3, ArgIterator args)
+        //{
+        //    var objArgs = new object[4 + args.GetRemainingCount()] { arg0, arg1, arg2, arg3 };
+        //    for (int i = 4; i < objArgs.Length; i++)
+        //    {
+        //        objArgs[i] = TypedReference.ToObject(args.GetNextArg());
+        //    }
+        //    return objArgs;
+        //}
 
         private sealed class ControlCDelegateData
         {


### PR DESCRIPTION
Some low hanging fruit.  Adds back missing:
- Values in the ConsoleKey enum
- Console.OpenStandard* overloads that take an Int32
- __arglist-based Console.Write* methods (but these are commented out as ArgIterator and friends aren't yet exposed from System.Runtime)

cc: @KrzysztofCwalina, @danmosemsft, @weshaggard 