### PR TITLE
Update S.D.StackTrace dependencies to use redist versions of dependencies

### DIFF
--- a/src/System.Diagnostics.StackTrace/src/System.Diagnostics.StackTrace.csproj
+++ b/src/System.Diagnostics.StackTrace/src/System.Diagnostics.StackTrace.csproj
@@ -36,15 +36,25 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="System\Diagnostics\StackTraceSymbols.CoreCLR.cs" />
-    <ProjectReference Include="..\..\System.Collections\src\System.Collections.csproj" />
-    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
-      <OSGroup>Windows_NT</OSGroup>
+
+    <!--
+      The following references are only facades that align references for the PCL
+      libraries (Immutable/MetadataReader) this library is referencing. We reference
+      the depproj's with targetgroup netcore50 because we need these to be the older
+      version that matches what we shipped for netcore50. We cannot reference the live
+      csproj's because the version numbers are higher and aren't all supported on netcore50.
+    -->
+    <ProjectReference Include="..\..\System.Collections\src\redist\System.Collections.depproj">
+      <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>
-    <ProjectReference Include="..\..\System.IO\src\System.IO.csproj" />
-    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj">
-      <Aliases>SRE</Aliases>
-      <OSGroup>Windows_NT</OSGroup>
+    <ProjectReference Include="..\..\System.IO\src\redist\System.IO.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Runtime\src\redist\System.Runtime.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Runtime.Extensions\src\redist\System.Runtime.Extensions.depproj">
+      <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'!='netcore50aot'">

--- a/src/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.CoreCLR.cs
+++ b/src/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.CoreCLR.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-extern alias SRE; 
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -9,9 +8,6 @@ using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-
-using Path = SRE::System.IO.Path;  
-using BitConverter = SRE::System.BitConverter;  
 
 namespace System.Diagnostics
 {


### PR DESCRIPTION
System.Diagnostics.StackTrace incorrectly started depending on the live
versions of things like System.Runtime.Extensions which breaks .NET Native
shared library. This change updates the project references for the facades
to be the redist'ed older versions so that the dependencies are correct.

Fixes https://github.com/dotnet/corefx/issues/9649

cc @ericstj @mikem8361 