### PR TITLE
Add Retain to OSX FileSystemWatcher runloop

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.CoreFoundation.cs
+++ b/src/Common/src/Interop/OSX/Interop.CoreFoundation.cs
@@ -89,6 +89,16 @@ internal static partial class Interop
         }
 
         /// <summary>
+        /// You should retain a Core Foundation object when you receive it from elsewhere
+        /// (that is, you did not create or copy it) and you want it to persist. If you 
+        /// retain a Core Foundation object you are responsible for releasing it
+        /// </summary>
+        /// <param name="ptr">The CFType object to retain. This value must not be NULL</param>
+        /// <returns>The input value</param>
+        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal extern static IntPtr CFRetain(IntPtr ptr);
+
+        /// <summary>
         /// Decrements the reference count on the specified object and, if the ref count hits 0, cleans up the object.
         /// </summary>
         /// <param name="ptr">The pointer on which to decrement the reference count.</param>


### PR DESCRIPTION
The OSX FileSystemWatcher uses the CoreFoundation RunLoop API to watch for events. There is a rule that CF objects received from getter functions are not guaranteed to exist unless explicitly retained. We were not doing this, so there was a very infrequent potential race condition wherein cancellation raced with completion of the thread that owned the runloop. When completion happened first, OSX disposed the unmanaged CoreFoundation RunLoop object that was unique to the thread, and cancellation attempted to call API on that now-invalid object. This commit adds explicit retain/release logic to prevent that race condition.

resolves #8983