### PR TITLE
Make UWP Console Color operations not throw

### DIFF
--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -193,6 +193,8 @@ namespace System
 
         public static bool CapsLock { get { return ConsolePal.CapsLock; } }
 
+        internal const ConsoleColor UnknownColor = (ConsoleColor)(-1);
+
         public static ConsoleColor BackgroundColor
         {
             get { return ConsolePal.BackgroundColor; }

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -125,9 +125,8 @@ namespace System
             }
         }
 
-        private const ConsoleColor UnknownColor = (ConsoleColor)(-1);
-        private static ConsoleColor s_trackedForegroundColor = UnknownColor;
-        private static ConsoleColor s_trackedBackgroundColor = UnknownColor;
+        private static ConsoleColor s_trackedForegroundColor = Console.UnknownColor;
+        private static ConsoleColor s_trackedBackgroundColor = Console.UnknownColor;
 
         public static ConsoleColor ForegroundColor
         {
@@ -145,8 +144,8 @@ namespace System
         {
             lock (Console.Out) // synchronize with other writers
             {
-                s_trackedForegroundColor = UnknownColor;
-                s_trackedBackgroundColor = UnknownColor;
+                s_trackedForegroundColor = Console.UnknownColor;
+                s_trackedBackgroundColor = Console.UnknownColor;
                 WriteResetColorString();
             }
         }
@@ -504,7 +503,7 @@ namespace System
         /// </summary>
         private static void RefreshColors(ref ConsoleColor toChange, ConsoleColor value)
         {
-            if (((int)value & ~0xF) != 0 && value != UnknownColor)
+            if (((int)value & ~0xF) != 0 && value != Console.UnknownColor)
             {
                 throw new ArgumentException(SR.Arg_InvalidConsoleColor);
             }
@@ -515,12 +514,12 @@ namespace System
 
                 WriteResetColorString();
 
-                if (s_trackedForegroundColor != UnknownColor)
+                if (s_trackedForegroundColor != Console.UnknownColor)
                 {
                     WriteSetColorString(foreground: true, color: s_trackedForegroundColor);
                 }
 
-                if (s_trackedBackgroundColor != UnknownColor)
+                if (s_trackedBackgroundColor != Console.UnknownColor)
                 {
                     WriteSetColorString(foreground: false, color: s_trackedBackgroundColor);
                 }

--- a/src/System.Console/src/System/ConsolePal.WinRT.cs
+++ b/src/System.Console/src/System/ConsolePal.WinRT.cs
@@ -82,19 +82,27 @@ namespace System
             set { throw new PlatformNotSupportedException(); }
         }
 
+        private const ConsoleColor UnknownColor = (ConsoleColor)(-1);
+        private static ConsoleColor s_trackedForegroundColor = UnknownColor;
+        private static ConsoleColor s_trackedBackgroundColor = UnknownColor;
+
         public static ConsoleColor ForegroundColor
         {
-            get { throw new PlatformNotSupportedException(); }
-            set { throw new PlatformNotSupportedException(); }
+            get { return s_trackedForegroundColor; }
+            set { s_trackedForegroundColor = value; }
         }
 
         public static ConsoleColor BackgroundColor
         {
-            get { throw new PlatformNotSupportedException(); }
-            set { throw new PlatformNotSupportedException(); }
+            get { return s_trackedBackgroundColor; }
+            set { s_trackedBackgroundColor = value; }
         }
 
-        public static void ResetColor() { throw new PlatformNotSupportedException(); }
+        public static void ResetColor()
+        {
+            s_trackedForegroundColor = UnknownColor;
+            s_trackedBackgroundColor = UnknownColor;
+        }
 
         public static bool NumberLock { get { throw new PlatformNotSupportedException(); } }
 

--- a/src/System.Console/src/System/ConsolePal.WinRT.cs
+++ b/src/System.Console/src/System/ConsolePal.WinRT.cs
@@ -82,26 +82,46 @@ namespace System
             set { throw new PlatformNotSupportedException(); }
         }
 
-        private const ConsoleColor UnknownColor = (ConsoleColor)(-1);
-        private static ConsoleColor s_trackedForegroundColor = UnknownColor;
-        private static ConsoleColor s_trackedBackgroundColor = UnknownColor;
+        private static ConsoleColor s_trackedForegroundColor = Console.UnknownColor;
+        private static ConsoleColor s_trackedBackgroundColor = Console.UnknownColor;
 
         public static ConsoleColor ForegroundColor
         {
-            get { return s_trackedForegroundColor; }
-            set { s_trackedForegroundColor = value; }
+            get
+            {
+                return s_trackedForegroundColor;
+            }
+            set
+            {
+                lock (Console.Out) // synchronize with other writers
+                {
+                    s_trackedForegroundColor = value;
+                }
+            }
         }
 
         public static ConsoleColor BackgroundColor
         {
-            get { return s_trackedBackgroundColor; }
-            set { s_trackedBackgroundColor = value; }
+            get
+            {
+                return s_trackedBackgroundColor;
+            }
+            set
+            {
+                lock (Console.Out) // synchronize with other writers
+                {
+                    s_trackedBackgroundColor = value;
+                }
+            }
         }
 
         public static void ResetColor()
         {
-            s_trackedForegroundColor = UnknownColor;
-            s_trackedBackgroundColor = UnknownColor;
+            lock (Console.Out) // synchronize with other writers
+            {
+                s_trackedForegroundColor = Console.UnknownColor;
+                s_trackedBackgroundColor = Console.UnknownColor;
+            }
         }
 
         public static bool NumberLock { get { throw new PlatformNotSupportedException(); } }


### PR DESCRIPTION
Removes the PlatformNotSupportedExceptions thrown in the Console Color operations and adds some very basic logic to allow roundtripping.

resolves #9521

@mattgal @danmosemsft @weshaggard 