### PR TITLE
Fix Console.In.Peek and friends

### DIFF
--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -162,7 +162,7 @@
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And '$(TargetGroup)' != 'net46'">
     <Compile Include="System\ConsolePal.Unix.cs" />
     <Compile Include="System\TermInfo.cs" />
-    <Compile Include="System\IO\StdInStreamReader.cs" />
+    <Compile Include="System\IO\StdInReader.cs" />
     <Compile Include="System\IO\SyncTextReader.Unix.cs" />
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs</Link>

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -57,8 +57,7 @@ namespace System
                     Console.EnsureInitialized(
                         ref s_stdInReader,
                         () => SyncTextReader.GetSynchronizedTextReader(
-                            new StdInStreamReader(
-                                stream: OpenStandardInput(),
+                            new StdInReader(
                                 encoding: new ConsoleEncoding(Console.InputEncoding), // This ensures no prefix is written to the stream.
                                 bufferSize: DefaultBufferSize)));
             }
@@ -353,7 +352,7 @@ namespace System
                     // Read the response.  There's a race condition here if the user is typing,
                     // or if other threads are accessing the console; there's relatively little
                     // we can do about that, but we try not to lose any data.
-                    StdInStreamReader r = StdInReader.Inner;
+                    StdInReader r = StdInReader.Inner;
                     const int BufferSize = 1024;
                     byte* bytes = stackalloc byte[BufferSize];
 
@@ -406,7 +405,7 @@ namespace System
         /// <summary>Reads from the stdin reader, unbuffered, until the specified condition is met.</summary>
         /// <returns>true if the condition was met; otherwise, false.</returns>
         private static unsafe bool ReadStdinUntil(
-            StdInStreamReader reader, 
+            StdInReader reader, 
             byte* buffer, int bufferSize, 
             ref int bytesRead, ref int pos, 
             Func<byte, bool> condition)

--- a/src/System.Console/src/System/IO/SyncTextReader.Unix.cs
+++ b/src/System.Console/src/System/IO/SyncTextReader.Unix.cs
@@ -11,11 +11,11 @@ namespace System.IO
      */
     internal sealed partial class SyncTextReader : TextReader
     {
-        internal StdInStreamReader Inner
+        internal StdInReader Inner
         {
             get
             {
-                var inner = _in as StdInStreamReader;
+                var inner = _in as StdInReader;
                 Debug.Assert(inner != null);
                 return inner;
             }
@@ -35,7 +35,7 @@ namespace System.IO
             {
                 lock (this)
                 {
-                    StdInStreamReader r = Inner;
+                    StdInReader r = Inner;
                     return !r.IsUnprocessedBufferEmpty() || r.StdinReady;
                 }
             }


### PR DESCRIPTION
The StdInStreamReader used on Unix as the TextReader used in Console.In derives from StreamReader and is passed the ConsoleStream for stdin.  This is both unnecessary and problematic.  It's unnecessary because all of the reading is done via special functions exposed from System.Native.so.  It's problematic because the base StreamReader does its own buffering based on the ConsoleStream and not all of the functions have been overridden by the StdInStreamReader.  As a result, for example, calling Read(char[], int, int) ends up bypassing previously cached data.

This commit does two main things:
- Renames StdInStreamReader to StdInReader and changes it from deriving from StreamReader to deriving from the base TextReader.  The only functions that must be overridden on TextReader to enable the behaviorally enable the rest are Read and Peek.
- Adds an override of Peek.  Read is already overridden.

Fixes https://github.com/dotnet/corefx/issues/9767
cc: @ianhays, @ellismg, @swgillespie 