### PR TITLE
Fix TestUserCredentialsPropertiesOnWindows outerloop test

### DIFF
--- a/src/System.Diagnostics.Process/tests/Interop.cs
+++ b/src/System.Diagnostics.Process/tests/Interop.cs
@@ -26,7 +26,7 @@ namespace System.Diagnostics.Tests
             public uint PeakPagefileUsage;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         internal struct USER_INFO_1
         {
             public string usri1_name;


### PR DESCRIPTION
Struct was missing CharSet being set to Unicode.
Fixes https://github.com/dotnet/corefx/issues/9678
Replaces https://github.com/dotnet/corefx/pull/9713
cc: @Priya91, @mellinoe 