### PR TITLE
Guard file reads in /sys/class/net/<iface> directories

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -90,13 +90,17 @@ namespace System.Net.NetworkInformation
 
             if (File.Exists(path))
             {
-                Interop.LinuxNetDeviceFlags flags = (Interop.LinuxNetDeviceFlags)StringParsingHelpers.ParseRawHexFileAsInt(path);
-                return (flags & Interop.LinuxNetDeviceFlags.IFF_MULTICAST) == Interop.LinuxNetDeviceFlags.IFF_MULTICAST;
+                try
+                {
+                    Interop.LinuxNetDeviceFlags flags = (Interop.LinuxNetDeviceFlags)StringParsingHelpers.ParseRawHexFileAsInt(path);
+                    return (flags & Interop.LinuxNetDeviceFlags.IFF_MULTICAST) == Interop.LinuxNetDeviceFlags.IFF_MULTICAST;
+                }
+                catch (FileNotFoundException)
+                {
+                }
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
 
         public override IPInterfaceProperties GetIPProperties()
@@ -147,13 +151,17 @@ namespace System.Net.NetworkInformation
             string path = Path.Combine(NetworkFiles.SysClassNetFolder, name, NetworkFiles.OperstateFileName);
             if (File.Exists(path))
             {
-                string state = File.ReadAllText(path).Trim();
-                return MapState(state);
+                try
+                {
+                    string state = File.ReadAllText(path).Trim();
+                    return MapState(state);
+                }
+                catch (FileNotFoundException)
+                {
+                }
             }
-            else
-            {
-                return OperationalStatus.Unknown;
-            }
+
+            return OperationalStatus.Unknown;
         }
 
         // Maps values from /sys/class/net/<interface>/operstate to OperationStatus values.

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -14,7 +14,7 @@ namespace System.Net.NetworkInformation
     internal class LinuxNetworkInterface : UnixNetworkInterface
     {
         private readonly OperationalStatus _operationalStatus;
-        private readonly bool _supportsMulticast;
+        private readonly bool? _supportsMulticast;
         private readonly long? _speed;
         private readonly LinuxIPInterfaceProperties _ipProperties;
 
@@ -68,15 +68,35 @@ namespace System.Net.NetworkInformation
             return lni;
         }
 
-        public override bool SupportsMulticast { get { return _supportsMulticast; } }
+        public override bool SupportsMulticast
+        {
+            get
+            {
+                if (_supportsMulticast.HasValue)
+                {
+                    return _supportsMulticast.Value;
+                }
+                else
+                {
+                    throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+                }
+            }
+        }
 
-        private static bool GetSupportsMulticast(string name)
+        private static bool? GetSupportsMulticast(string name)
         {
             // /sys/class/net/<interface_name>/flags
             string path = Path.Combine(NetworkFiles.SysClassNetFolder, name, NetworkFiles.FlagsFileName);
-            Interop.LinuxNetDeviceFlags flags = (Interop.LinuxNetDeviceFlags)StringParsingHelpers.ParseRawHexFileAsInt(path);
 
-            return (flags & Interop.LinuxNetDeviceFlags.IFF_MULTICAST) == Interop.LinuxNetDeviceFlags.IFF_MULTICAST;
+            if (File.Exists(path))
+            {
+                Interop.LinuxNetDeviceFlags flags = (Interop.LinuxNetDeviceFlags)StringParsingHelpers.ParseRawHexFileAsInt(path);
+                return (flags & Interop.LinuxNetDeviceFlags.IFF_MULTICAST) == Interop.LinuxNetDeviceFlags.IFF_MULTICAST;
+            }
+            else
+            {
+                return null;
+            }
         }
 
         public override IPInterfaceProperties GetIPProperties()
@@ -125,8 +145,15 @@ namespace System.Net.NetworkInformation
         {
             // /sys/class/net/<name>/operstate
             string path = Path.Combine(NetworkFiles.SysClassNetFolder, name, NetworkFiles.OperstateFileName);
-            string state = File.ReadAllText(path).Trim();
-            return MapState(state);
+            if (File.Exists(path))
+            {
+                string state = File.ReadAllText(path).Trim();
+                return MapState(state);
+            }
+            else
+            {
+                return OperationalStatus.Unknown;
+            }
         }
 
         // Maps values from /sys/class/net/<interface>/operstate to OperationStatus values.


### PR DESCRIPTION
Some systems may not have the expected files present in these directories. If such a situation is encountered, try still to return a reasonable value, or throw a PlatformNotSupportedException instead of a FileNotFoundException if we shouldn't "guess" a value.

@stephentoub , @davidsh 

I think I will take a look at all of the file access in the library and consider guarding additional places. As long as there are obscure cases where some systems do not have the information we expect, we should try to throw a `PlatformNotSupportedException` instead of a less-obvious `FileNotFoundException`.

For this PR, I've only guarded accesses made to files in the /sys/class/net directory, as it seems avahi-daemon maintains files there that do not conform to what we expect.

Addresses #9761 