### PR TITLE
Set KeySizeValue instead of doing gymnastics in LegalKeySizes.

### DIFF
--- a/src/Common/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaCng.cs
@@ -13,8 +13,6 @@ namespace System.Security.Cryptography
 #endif
         public sealed partial class ECDsaCng : ECDsa
         {
-            private bool _skipKeySizeCheck;
-
 #if !NETNATIVE
             /// <summary>
             /// Create an ECDsaCng algorithm with a named curve.
@@ -83,32 +81,13 @@ namespace System.Security.Cryptography
                 // it could be outside of the bounds that we currently represent as "legal key sizes".
                 // Since that is our view into the underlying component it can be detached from the
                 // component's understanding.  If it said it has opened a key, and this is the size, trust it.
-                _skipKeySizeCheck = true;
-
-                try
-                {
-                    // Set base.KeySize directly, since we don't want to free the key
-                    // (which we would do if the keysize changed on import)
-                    base.KeySize = newKeySize;
-                }
-                finally
-                {
-                    _skipKeySizeCheck = false;
-                }
+                KeySizeValue = newKeySize;
             }
 
             public override KeySizes[] LegalKeySizes
             {
                 get
                 {
-                    if (_skipKeySizeCheck)
-                    {
-                        // When size limitations are in bypass, accept any positive integer.
-                        // Many of them may not make sense (like 1), but we're just assigning
-                        // the field to whatever value was provided by the native component.
-                        return new[] { new KeySizes(minSize: 1, maxSize: int.MaxValue, skipSize: 1) };
-                    }
-
                     // Return the three sizes that can be explicitly set (for backwards compatibility)
                     return new[] {
                         new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),

--- a/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -20,7 +20,6 @@ namespace System.Security.Cryptography
             internal const string ECDSA_P521_OID_VALUE = "1.3.132.0.35"; // Also called nistP521or secP521r1
 
             private Lazy<SafeEcKeyHandle> _key;
-            private bool _skipKeySizeCheck;
 
             /// <summary>
             /// Create an ECDsaOpenSsl algorithm with a named curve.
@@ -78,37 +77,18 @@ namespace System.Security.Cryptography
                 // it could be outside of the bounds that we currently represent as "legal key sizes".
                 // Since that is our view into the underlying component it can be detached from the
                 // component's understanding.  If it said it has opened a key, and this is the size, trust it.
-                _skipKeySizeCheck = true;
-
-                try
-                {
-                    // Set base.KeySize directly, since we don't want to free the key
-                    // (which we would do if the keysize changed on import)
-                    base.KeySize = newKeySize;
-                }
-                finally
-                {
-                    _skipKeySizeCheck = false;
-                }
+                KeySizeValue = newKeySize;
             }
 
             public override KeySizes[] LegalKeySizes
             {
                 get
                 {
-                    if (_skipKeySizeCheck)
-                    {
-                        // When size limitations are in bypass, accept any positive integer.
-                        // Many of them may not make sense (like 1), but we're just assigning
-                        // the field to whatever value was provided by the native component.
-                        return new[] { new KeySizes(minSize: 1, maxSize: int.MaxValue, skipSize: 1) };
-                    }
-
                     // Return the three sizes that can be explicitly set (for backwards compatibility)
                     return new[] {
-                    new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
-                    new KeySizes(minSize: 521, maxSize: 521, skipSize: 0),
-                };
+                        new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
+                        new KeySizes(minSize: 521, maxSize: 521, skipSize: 0),
+                    };
                 }
             }
 

--- a/src/Common/src/System/Security/Cryptography/RSACng.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.cs
@@ -13,8 +13,6 @@ namespace System.Security.Cryptography
 #endif
     public sealed partial class RSACng : RSA
     {
-        private bool _skipKeySizeCheck;
-
         /// <summary>
         ///     Create an RSACng algorithm with a random 2048 bit key pair.
         /// </summary>
@@ -40,14 +38,6 @@ namespace System.Security.Cryptography
         {
             get
             {
-                if (_skipKeySizeCheck)
-                {
-                    // When size limitations are in bypass, accept any positive integer.
-                    // Many of them may not make sense (like 1), but we're just assigning
-                    // the field to whatever value was provided by the native component.
-                    return new[] { new KeySizes(minSize: 1, maxSize: int.MaxValue, skipSize: 1) };
-                }
-
                 // See https://msdn.microsoft.com/en-us/library/windows/desktop/bb931354(v=vs.85).aspx
                 return new KeySizes[]
                 {
@@ -83,16 +73,7 @@ namespace System.Security.Cryptography
             // create a 384-bit RSA key, which we consider too small to be legal. It can also create
             // a 1032-bit RSA key, which we consider illegal because it doesn't match our 64-bit
             // alignment requirement. (In both cases Windows loads it just fine)
-            _skipKeySizeCheck = true;
-
-            try
-            {
-                KeySize = newKeySize;
-            }
-            finally
-            {
-                _skipKeySizeCheck = false;
-            }
+            KeySizeValue = newKeySize;
         }
     }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS


### PR DESCRIPTION
Now that the field is exposed again as protected member, make {RSA,ECDsa}{Cng,OpenSsl} set it directly.  This makes the code simpler, and removes fields from 4 types, so it saves a smidge of memory, even.

I left ForceSetKeySize as a (quadruple) unique method because it had useful comments that I didn't want to inline to every callsite.  I have faith in the JIT that it'll optimize that away.

Fixes #8601.