### PR TITLE
Add tests for EnvelopedCms.Encrypt

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/tests/Certificates.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/Certificates.cs
@@ -15,7 +15,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         public static readonly CertLoader RSAKeyTransfer1 = new CertLoaderFromRawData(RawData.s_RSAKeyTransfer1Cer, RawData.s_RSAKeyTransfer1Pfx, "1111");
         public static readonly CertLoader RSAKeyTransfer2 = new CertLoaderFromRawData(RawData.s_RSAKeyTransfer2Cer, RawData.s_RSAKeyTransfer2Pfx, "1111");
         public static readonly CertLoader RSAKeyTransfer3 = new CertLoaderFromRawData(RawData.s_RSAKeyTransfer3Cer, RawData.s_RSAKeyTransfer3Pfx, "1111");
-        public static readonly CertLoader RSAKeyTransfer_ExplicitSkid = new CertLoaderFromRawData(RawData.s_RSAKeyTransferCer_ExplicitSkid, RawData.s_RSAKeyTransferPfx_ExplicitSkid, "1111");
+        public static readonly CertLoader RSAKeyTransfer_ExplicitSki = new CertLoaderFromRawData(RawData.s_RSAKeyTransferCer_ExplicitSki, RawData.s_RSAKeyTransferPfx_ExplicitSki, "1111");
         public static readonly CertLoader RSAKeyTransferCapi1 = new CertLoaderFromRawData(RawData.s_RSAKeyTransferCapi1Cer, RawData.s_RSAKeyTransferCapi1Pfx, "1111");
         public static readonly CertLoader RSASha256KeyTransfer1 = new CertLoaderFromRawData(RawData.s_RSASha256KeyTransfer1Cer, RawData.s_RSASha256KeyTransfer1Pfx, "1111");
         public static readonly CertLoader RSASha384KeyTransfer1 = new CertLoaderFromRawData(RawData.s_RSASha384KeyTransfer1Cer, RawData.s_RSASha384KeyTransfer1Pfx, "1111");
@@ -376,7 +376,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 + "73aef677d25ae8657f81ca1cd5dd50404b70b9373eadcd2d276e263105c00607a86f0c10ab26d1aafd986313a36c70389a4d"
                 + "1a8e88").HexToByteArray();
 
-            public static byte[] s_RSAKeyTransferCer_ExplicitSkid =
+            public static byte[] s_RSAKeyTransferCer_ExplicitSki =
                 ("3082033E30820226A003020102020900B5EFA7E1E80518B4300D06092A864886F70D01010B0500304D310B3009060355"
                 + "04061302515A310D300B060355040813044C616E643111300F060355040713084D7974686963616C311C301A06035504"
                 + "03131353656C662D5369676E6564204578616D706C65301E170D3136303632383030323034355A170D31363037323830"
@@ -397,7 +397,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 + "3188DB9364AAD52D4E28169CC898B621FF84").HexToByteArray();
 
             // password = "1111"
-            public static byte[] s_RSAKeyTransferPfx_ExplicitSkid =
+            public static byte[] s_RSAKeyTransferPfx_ExplicitSki =
                 ("308209810201033082094706092A864886F70D010701A08209380482093430820930308203E706092A864886F70D0107"
                 + "06A08203D8308203D4020100308203CD06092A864886F70D010701301C060A2A864886F70D010C0106300E0408101C5A"
                 + "3E2DBE2A9102020800808203A0F58476F5E4741F8834F50ED49D1A3A5B2FC8C345B54255C30556B1426C1BA1D9EE4440"

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -377,7 +377,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void TestDecryptSimple_ExplicitSki()
         {
-            // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSAKeyTransfer_ExplicitSkid.GetCertificate()
+            // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSAKeyTransfer_ExplicitSki.GetCertificate()
             // and of type SubjectKeyIdentifier. The symmetric algorithm used is Aes256
             byte[] encryptedMessage =
                 ("3082018806092A864886F70D010703A082017930820175020102318201303082012C020102801401952851C"
@@ -393,7 +393,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
             byte[] expectedContent = { 1, 2, 3, 4 };
             ContentInfo expectedContentInfo = new ContentInfo(expectedContent);
-            CertLoader certLoader = Certificates.RSAKeyTransfer_ExplicitSkid;
+            CertLoader certLoader = Certificates.RSAKeyTransfer_ExplicitSki;
 
             VerifySimpleDecrypt(encryptedMessage, certLoader, expectedContentInfo);
         }

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoTests.cs
@@ -123,6 +123,36 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        public static void TestKeyTransRecipientIdValue_ExplicitSki_RoundTrip()
+        {
+            ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
+            EnvelopedCms ecms = new EnvelopedCms(contentInfo);
+            using (X509Certificate2 cert = Certificates.RSAKeyTransfer_ExplicitSki.GetCertificate())
+            {
+                CmsRecipient cmsRecipient = new CmsRecipient(SubjectIdentifierType.SubjectKeyIdentifier, cert);
+                ecms.Encrypt(cmsRecipient);
+            }
+            byte[] encodedMessage = ecms.Encode();
+
+            EnvelopedCms ecms2 = new EnvelopedCms();
+            ecms2.Decode(encodedMessage);
+
+            RecipientInfoCollection recipients = ecms2.RecipientInfos;
+            Assert.Equal(1, recipients.Count);
+            RecipientInfo recipientInfo = recipients[0];
+            Assert.IsType<KeyTransRecipientInfo>(recipientInfo);
+            KeyTransRecipientInfo recipient = (KeyTransRecipientInfo)recipientInfo;
+
+            SubjectIdentifier subjectIdentifier = recipient.RecipientIdentifier;
+            object value = subjectIdentifier.Value;
+            Assert.IsType<string>(value);
+            string ski = (string)value;
+            Assert.Equal("01952851C55DB594B0C6167F5863C5B6B67AEFE6", ski);
+        }
+
+        [Fact]
         public static void TestKeyTransRecipientIdValue_Ski_FixedValue()
         {
             KeyTransRecipientInfo recipient = FixedValueKeyTrans1(SubjectIdentifierType.SubjectKeyIdentifier);
@@ -191,7 +221,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             RecipientInfoCollection recipients = ecms2.RecipientInfos;
             Assert.Equal(1, recipients.Count);
             RecipientInfo recipientInfo = recipients[0];
-            Assert.True(recipientInfo is KeyTransRecipientInfo);
+            Assert.IsType<KeyTransRecipientInfo>(recipientInfo);
             return (KeyTransRecipientInfo)recipientInfo;
         }
 
@@ -218,7 +248,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             RecipientInfoCollection recipients = ecms.RecipientInfos;
             Assert.Equal(1, recipients.Count);
             RecipientInfo recipientInfo = recipients[0];
-            Assert.True(recipientInfo is KeyTransRecipientInfo);
+            Assert.IsType<KeyTransRecipientInfo>(recipientInfo);
             return (KeyTransRecipientInfo)recipientInfo;
         }
 

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
@@ -183,6 +183,25 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal<byte>(expectedContentInfo.Content, actualContentInfo.Content);
         }
 
+        [Fact]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void PostEncrypt_Certs()
+        {
+            ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
+            EnvelopedCms ecms = new EnvelopedCms(expectedContentInfo);
+            ecms.Certificates.Add(Certificates.RSAKeyTransfer2.GetCertificate());
+            ecms.Certificates.Add(Certificates.RSAKeyTransfer3.GetCertificate());
+
+            using (X509Certificate2 cert = Certificates.RSAKeyTransfer1.GetCertificate())
+            {
+                ecms.Encrypt(new CmsRecipient(cert));
+            }
+
+            Assert.Equal(Certificates.RSAKeyTransfer2.GetCertificate(), ecms.Certificates[0]);
+            Assert.Equal(Certificates.RSAKeyTransfer3.GetCertificate(), ecms.Certificates[1]);
+        }
+
         //
         // State 3: Called Decode()
         //
@@ -350,6 +369,30 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
                 // after a successful Decrypt() throws a CryptographicException saying "Already decrypted."
                 Assert.ThrowsAny<CryptographicException>(() => ecms.Decrypt(r[1], extraStore));
             }
+        }
+
+        [Fact]
+        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        public static void PostEncode_DifferentData()
+        {
+            // This ensures that the decoding and encoding output different values to make sure Encrypt changes the state of the data.
+            byte[] encoded =
+                ("3082010206092A864886F70D010703A081F43081F10201003181C83081C5020100302E301A311830160603550403130F"
+                + "5253414B65795472616E7366657231021031D935FB63E8CFAB48A0BF7B397B67C0300D06092A864886F70D0101010500"
+                + "04818009C16B674495C2C3D4763189C3274CF7A9142FBEEC8902ABDC9CE29910D541DF910E029A31443DC9A9F3B05F02"
+                + "DA1C38478C400261C734D6789C4197C20143C4312CEAA99ECB1849718326D4FC3B7FBB2D1D23281E31584A63E99F2C17"
+                + "132BCD8EDDB632967125CD0A4BAA1EFA8CE4C855F7C093339211BDF990CEF5CCE6CD74302106092A864886F70D010701"
+                + "301406082A864886F70D03070408779B3DE045826B18").HexToByteArray();
+            EnvelopedCms ecms = new EnvelopedCms();
+            ecms.Decode(encoded);
+            using (X509Certificate2 cert = Certificates.RSAKeyTransfer1.GetCertificate())
+            {
+                ecms.Encrypt(new CmsRecipient(cert));
+            }
+
+            byte[] encrypted = ecms.Encode();
+
+            Assert.NotEqual<byte>(encoded, encrypted);
         }
 
         private static void AssertEncryptedContentEqual(byte[] expected, byte[] actual)


### PR DESCRIPTION
+ Added test with multiple RecipientInfos with different
SubjectIdentifierTypes.

+ Added tests to check metadata integrity after encryption.

+ Added sanity check to ensure calling decrypt and re-encrypting the
message will yield a different outcome.

+ Test encryption with certificates explicitly containing a
SubjectKeyIdentifier.

@bartonjs @weshaggard 