### PR TITLE
Port System.Native to be g++ compatible

### DIFF
--- a/src/Native/System.Native/pal_console.cpp
+++ b/src/Native/System.Native/pal_console.cpp
@@ -12,6 +12,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <termios.h>
 #include <unistd.h>
@@ -458,7 +459,10 @@ static bool InitializeSignalHandling()
     }
 
     // Finally, register our signal handlers
-    struct sigaction newAction = { .sa_flags = SA_RESTART | SA_SIGINFO };
+    struct sigaction newAction;
+    memset(&newAction, 0, sizeof(struct sigaction));
+    newAction.sa_flags = SA_RESTART | SA_SIGINFO;
+    
     sigemptyset(&newAction.sa_mask);
     int rv;
 

--- a/src/Native/System.Native/pal_interfaceaddresses.cpp
+++ b/src/Native/System.Native/pal_interfaceaddresses.cpp
@@ -12,6 +12,7 @@
 #include <ifaddrs.h>
 #include <net/if.h>
 #include <netinet/in.h>
+#include <string.h>
 #include <sys/socket.h>
 #if HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
@@ -49,17 +50,19 @@ extern "C" int32_t SystemNative_EnumerateInterfaceAddresses(IPv4AddressFound onI
             if (onIpv4Found != nullptr)
             {
                 // IP Address
-                IpAddressInfo iai = {
-                    .InterfaceIndex = interfaceIndex, .NumAddressBytes = NUM_BYTES_IN_IPV4_ADDRESS,
-                };
+                IpAddressInfo iai;
+                memset(&iai, 0, sizeof(IpAddressInfo));
+                iai.InterfaceIndex = interfaceIndex;
+                iai.NumAddressBytes = NUM_BYTES_IN_IPV4_ADDRESS;
 
                 sockaddr_in* sain = reinterpret_cast<sockaddr_in*>(current->ifa_addr);
                 memcpy(iai.AddressBytes, &sain->sin_addr.s_addr, sizeof(sain->sin_addr.s_addr));
 
                 // Net Mask
-                IpAddressInfo maskInfo = {
-                    .InterfaceIndex = interfaceIndex, .NumAddressBytes = NUM_BYTES_IN_IPV4_ADDRESS,
-                };
+                IpAddressInfo maskInfo;
+                memset(&maskInfo, 0, sizeof(IpAddressInfo));
+                maskInfo.InterfaceIndex = interfaceIndex;
+                maskInfo.NumAddressBytes = NUM_BYTES_IN_IPV4_ADDRESS;
 
                 sockaddr_in* mask_sain = reinterpret_cast<sockaddr_in*>(current->ifa_netmask);
                 memcpy(maskInfo.AddressBytes, &mask_sain->sin_addr.s_addr, sizeof(mask_sain->sin_addr.s_addr));
@@ -71,9 +74,10 @@ extern "C" int32_t SystemNative_EnumerateInterfaceAddresses(IPv4AddressFound onI
         {
             if (onIpv6Found != nullptr)
             {
-                IpAddressInfo iai = {
-                    .InterfaceIndex = interfaceIndex, .NumAddressBytes = NUM_BYTES_IN_IPV6_ADDRESS,
-                };
+                IpAddressInfo iai;
+                memset(&iai, 0, sizeof(IpAddressInfo));
+                iai.InterfaceIndex = interfaceIndex;
+                iai.NumAddressBytes = NUM_BYTES_IN_IPV6_ADDRESS;
 
                 sockaddr_in6* sain6 = reinterpret_cast<sockaddr_in6*>(current->ifa_addr);
                 memcpy(iai.AddressBytes, sain6->sin6_addr.s6_addr, sizeof(sain6->sin6_addr.s6_addr));
@@ -89,11 +93,11 @@ extern "C" int32_t SystemNative_EnumerateInterfaceAddresses(IPv4AddressFound onI
             {
                 sockaddr_ll* sall = reinterpret_cast<sockaddr_ll*>(current->ifa_addr);
 
-                LinkLayerAddressInfo lla = {
-                    .InterfaceIndex = interfaceIndex,
-                    .NumAddressBytes = sall->sll_halen,
-                    .HardwareType = MapHardwareType(sall->sll_hatype),
-                };
+                LinkLayerAddressInfo lla;
+                memset(&lla, 0, sizeof(LinkLayerAddressInfo));
+                lla.InterfaceIndex = interfaceIndex;
+                lla.NumAddressBytes = sall->sll_halen;
+                lla.HardwareType = MapHardwareType(sall->sll_hatype);
 
                 memcpy(&lla.AddressBytes, &sall->sll_addr, sall->sll_halen);
                 onLinkLayerFound(current->ifa_name, &lla);

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -22,6 +22,7 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -247,7 +248,10 @@ SystemNative_IPv6StringToAddress(const uint8_t* address, const uint8_t* port, ui
     assert(scope != nullptr);
     assert(address != nullptr);
 
-    addrinfo hint = { .ai_family = AF_INET6, .ai_flags = AI_NUMERICHOST | AI_NUMERICSERV };
+    addrinfo hint;
+    memset(&hint, 0, sizeof(addrinfo));
+    hint.ai_family = AF_INET6;
+    hint.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
 
     addrinfo* info = nullptr;
     int32_t result = getaddrinfo(reinterpret_cast<const char*>(address), reinterpret_cast<const char*>(port), &hint, &info);
@@ -359,7 +363,10 @@ extern "C" int32_t SystemNative_GetHostEntryForName(const uint8_t* address, Host
     }
 
     // Get all address families and the canonical name
-    addrinfo hint = {.ai_family = AF_UNSPEC, .ai_flags = AI_CANONNAME};
+    addrinfo hint;
+    memset(&hint, 0, sizeof(addrinfo));
+    hint.ai_family = AF_UNSPEC;
+    hint.ai_flags = AI_CANONNAME;
 
     addrinfo* info = nullptr;
     int result = getaddrinfo(reinterpret_cast<const char*>(address), nullptr, &hint, &info);
@@ -1458,7 +1465,10 @@ extern "C" Error SystemNative_SetIPv6MulticastOption(intptr_t socket, int32_t mu
         return PAL_EINVAL;
     }
 
-    ipv6_mreq opt = {.ipv6mr_interface = static_cast<unsigned int>(option->InterfaceIndex)};
+    ipv6_mreq opt;
+    memset(&opt, 0, sizeof(ipv6_mreq));
+    opt.ipv6mr_interface = static_cast<unsigned int>(option->InterfaceIndex);
+    
     ConvertByteArrayToIn6Addr(opt.ipv6mr_multiaddr, &option->Address.Address[0], NUM_BYTES_IN_IPV6_ADDRESS);
 
     int err = setsockopt(fd, IPPROTO_IP, optionName, &opt, sizeof(opt));


### PR DESCRIPTION
This is part of the work that is ongoing to make System.Native build standalone so as to support S.R.IS.RI on mono. @jkotas recommended to PR this change separately.