### PR TITLE
Support filtering to TestTFM

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- Capture OSGroup passed to command line for setting default FilterToOSGroup value below -->
     <_OriginalOSGroup>$(OSGroup)</_OriginalOSGroup>

--- a/dir.targets
+++ b/dir.targets
@@ -17,6 +17,18 @@
   <Target Name="GenerateTestProjectJson" />
   <Target Name="GenerateAllTestProjectJsons" />
 
+  <Target Name="UndefineTestTFM" BeforeTargets="AssignProjectConfiguration">
+    <ItemGroup>
+      <ProjectReference>
+        <!-- 
+        Always undefine TestTFM and FilterToTestTFM for all project reference as not needed for compilation and
+        avoid bin clash tool to fail
+        -->
+        <UndefineProperties>%(ProjectReference.UndefineProperties);TestTFM;FilterToTestTFM</UndefineProperties>
+      </ProjectReference>
+    </ItemGroup>
+  </Target>
+
   <Import Project="$(ToolsDir)/Build.Common.targets" Condition="Exists('$(ToolsDir)/Build.Common.targets')" />
 
   <!-- permit a wrapping build system to contribute targets to this build -->

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -39,7 +39,7 @@
         <UndefineProperties Condition="'%(Project.OSGroup)'==''">%(Project.UndefineProperties);OSGroup</UndefineProperties>
       </Project>
       <Project>
-        <UndefineProperties Condition="'%(Project.Extension)'!='.builds' and '%(Project.Extension)'!='.proj'">%(Project.UndefineProperties);FilterToOSGroup;DefaultBuildAllTarget;SerializeProjects;BuildAllOSGroups</UndefineProperties>
+        <UndefineProperties Condition="'%(Project.Extension)'!='.builds' and '%(Project.Extension)'!='.proj'">%(Project.UndefineProperties);FilterToOSGroup;FilterToTestTFM;DefaultBuildAllTarget;SerializeProjects;BuildAllOSGroups</UndefineProperties>
       </Project>
     </ItemGroup>
 
@@ -101,6 +101,71 @@
 
     <MSBuild Targets="$(DefaultBuildAllTarget)"
              Projects="@(Project)"
+             Condition="'$(SerializeProjects)'!='true'"
+             Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true"
+             BuildInParallel="true"
+             ContinueOnError="ErrorAndContinue" />
+
+    <!-- Given we ErrorAndContinue we need to propagate the error if the overall task failed -->
+    <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
+  </Target>
+
+  <!-- FilterProjectsToTest will filter the project list according to the FilterToTestTFM value -->
+  <Target Name="FilterProjectsToTest"
+          BeforeTargets="TestAllProjects" 
+          Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+
+    <PropertyGroup>
+      <!-- we default FilterToTestTFM to netcoreapp1.0 if it is not explicity defined -->
+      <FilterToTestTFM Condition="'$(FilterToTestTFM)'==''">netcoreapp1.0</FilterToTestTFM>
+    </PropertyGroup>          
+
+    <ItemGroup>
+      <Project>
+        <!-- make sure every defined TestTFM value are surrounded by semicolons for easier search, e.g. ";net46;"" -->
+        <TestTFMs Condition="'%(Project.TestTFMs)' != ''">;%(Project.TestTFMs);</TestTFMs>
+      </Project>
+
+      <!-- for projects not defining TestTFM in .builds files, we assume the TestTFM is the default which is netcoreapp1.0 -->
+      <ProjectsToTest Include="@(Project)" Condition="'%(Project.Extension)'=='.csproj' And '$(FilterToTestTFM)' == 'netcoreapp1.0' And '%(Project.TestTFMs)' == ''" />
+
+      <!-- include the projects have TestTFM value match FilterToTestTFM -->
+      <ProjectsToTest Include="@(Project)" Condition="'%(Project.Extension)'=='.csproj' And $([System.String]::new('%(Project.TestTFMs)').Contains(';$(FilterToTestTFM);'))" /> 
+
+      <!-- For net46 we include projects with TestTFM values net461 and net462 -->
+      <ProjectsToTest Include="@(Project)" Condition="'%(Project.Extension)'=='.csproj' And '$(FilterToTestTFM)' == 'net46' And $([System.String]::new('%(Project.TestTFMs)').Contains(';net461;'))" /> 
+      <ProjectsToTest Include="@(Project)" Condition="'%(Project.Extension)'=='.csproj' And '$(FilterToTestTFM)' == 'net46' And $([System.String]::new('%(Project.TestTFMs)').Contains(';net462;'))" /> 
+      <!-- For net461 we include projects with TestTFM values net462 -->
+      <ProjectsToTest Include="@(Project)" Condition="'%(Project.Extension)'=='.csproj' And '$(FilterToTestTFM)' == 'net461' And $([System.String]::new('%(Project.TestTFMs)').Contains(';net462;'))" /> 
+
+      <ProjectsToTest>
+       <AdditionalProperties Condition="'%(ProjectsToTest.TestTFMs)'!=''">TestTFMs=%(ProjectsToTest.TestTFMs);%(ProjectsToTest.AdditionalProperties)</AdditionalProperties>
+       <AdditionalProperties>TestTFM=$(FilterToTestTFM);%(ProjectsToTest.AdditionalProperties)</AdditionalProperties>
+      </ProjectsToTest>
+      <ProjectsToTest>
+        <FilterToTestTFM>$(FilterToTestTFM)</FilterToTestTFM>
+      </ProjectsToTest>
+      <ProjectsToTest>
+        <AdditionalProperties Condition="'%(ProjectsToTest.FilterToTestTFM)'!=''">FilterToTestTFM=%(ProjectsToTest.FilterToTestTFM);%(ProjectsToTest.AdditionalProperties)</AdditionalProperties>
+      </ProjectsToTest>
+    </ItemGroup>
+  </Target>
+
+  <!-- TestAllProjects will run all tests according to TestTFM value we are filtering with -->
+  <Target Name="TestAllProjects" 
+          AfterTargets="BuildAllProjects" 
+          Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <!-- To Serialize we use msbuild's batching functionality '%' to force it to batch all similar projects with the same identity
+         however since the project names are unique it will essentially force each to run in its own batch -->
+
+    <MSBuild Targets="PrepareForRun;Test"
+             Projects="@(ProjectsToTest)"
+             Condition="'$(SerializeProjects)'=='true' AND '%(Identity)' != ''"
+             Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true"
+             ContinueOnError="ErrorAndContinue" />
+
+    <MSBuild Targets="PrepareForRun;Test"
+             Projects="@(ProjectsToTest)"
              Condition="'$(SerializeProjects)'!='true'"
              Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true"
              BuildInParallel="true"

--- a/src/System.AppContext/tests/System.AppContext.Tests.builds
+++ b/src/System.AppContext/tests/System.AppContext.Tests.builds
@@ -3,6 +3,12 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.AppContext.Tests.csproj" />
+
+    <Project Include="System.AppContext.Tests.csproj">
+      <!-- TestTFMs can have multiple values separated by semicolon -->
+      <TestTFMs>net46</TestTFMs>
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>    
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>


### PR DESCRIPTION
This change is to support filtering according to the TestTFM. e.g. can do
     “build.cmd /p:FilterToTestTFM=net46”
The change here is splitting the Build phase from the Test phase in dir.traversal.targets
so we don’t have to rebuild the test assemblies when passing TestTFM property to run the test.

Now if FilterToTestTFM is not specified, we default running the tests as netcoreapp1.0
so when issuing “build.cmd/sh” Command without passing FilterToTestTFM, it will
filter the tests to netcoreapp1.0 and run those tests.
I have enabled one of the test projects System.AppContext.Tests to support net46
as example, next step will be Enabling the rest of all projects to run against all
platforms (net46, net461, net462, netcore50 and netcore50aot)