### PR TITLE
Add Reflection Based (De-)Serialization Support for DCJS

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -148,6 +148,8 @@
     <Compile Include="$(JsonSources)\JsonEncodingStreamWrapper.cs" />
     <Compile Include="$(JsonSources)\JsonFormatGeneratorStatics.cs" Condition="!$(NetNative)" />
     <Compile Include="System\Runtime\Serialization\AccessorBuilder.cs" />
+    <Compile Include="System\Runtime\Serialization\Json\ReflectionJsonFormatReader.cs" />
+    <Compile Include="System\Runtime\Serialization\ReflectionReader.cs" />
     <Compile Include="System\Runtime\Serialization\ReflectionXmlFormatReader.cs" />
     <Compile Include="System\Runtime\Serialization\ReflectionXmlFormatWriter.cs" />
     <Compile Include="System\Runtime\Serialization\SerializationOption.cs" />

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -151,6 +151,7 @@
     <Compile Include="System\Runtime\Serialization\Json\ReflectionJsonFormatReader.cs" />
     <Compile Include="System\Runtime\Serialization\Json\ReflectionJsonFormatWriter.cs" />
     <Compile Include="System\Runtime\Serialization\ReflectionReader.cs" />
+    <Compile Include="System\Runtime\Serialization\ReflectionClassWriter.cs" />
     <Compile Include="System\Runtime\Serialization\ReflectionXmlFormatReader.cs" />
     <Compile Include="System\Runtime\Serialization\ReflectionXmlFormatWriter.cs" />
     <Compile Include="System\Runtime\Serialization\SerializationOption.cs" />

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -149,6 +149,7 @@
     <Compile Include="$(JsonSources)\JsonFormatGeneratorStatics.cs" Condition="!$(NetNative)" />
     <Compile Include="System\Runtime\Serialization\AccessorBuilder.cs" />
     <Compile Include="System\Runtime\Serialization\Json\ReflectionJsonFormatReader.cs" />
+    <Compile Include="System\Runtime\Serialization\Json\ReflectionJsonFormatWriter.cs" />
     <Compile Include="System\Runtime\Serialization\ReflectionReader.cs" />
     <Compile Include="System\Runtime\Serialization\ReflectionXmlFormatReader.cs" />
     <Compile Include="System\Runtime\Serialization\ReflectionXmlFormatWriter.cs" />

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -1001,7 +1001,6 @@ namespace System.Runtime.Serialization
                 IEnumerator enumerator = ((IEnumerable)obj).GetEnumerator();
                 if (Kind == CollectionKind.GenericDictionary)
                 {
-
                     if (_createGenericDictionaryEnumeratorDelegate == null)
                     {
                         var keyValueTypes = ItemType.GetGenericArguments();

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -107,12 +107,11 @@ namespace System.Runtime.Serialization
 #endif
         }
 
-#if !NET_NATIVE
         internal MethodInfo ParseMethod
         {
             get { return _helper.ParseMethod; }
         }
-#endif
+
         internal static DataContract GetDataContract(Type type)
         {
             return GetDataContract(type.TypeHandle, type);
@@ -545,10 +544,8 @@ namespace System.Runtime.Serialization
             private XmlDictionaryString _name;
             private XmlDictionaryString _ns;
 
-#if !NET_NATIVE
             private MethodInfo _parseMethod;
             private bool _parseMethodSet;
-#endif
 
             /// <SecurityNote>
             /// Critical - in deserialization, we initialize an object instance passing this Type to GetUninitializedObject method
@@ -1187,7 +1184,6 @@ namespace System.Runtime.Serialization
                 get { return false; }
             }
 
-#if !NET_NATIVE
             internal MethodInfo ParseMethod
             {
                 get
@@ -1206,7 +1202,6 @@ namespace System.Runtime.Serialization
                     return _parseMethod;
                 }
             }
-#endif
 
             internal virtual void WriteRootElement(XmlWriterDelegator writer, XmlDictionaryString name, XmlDictionaryString ns)
             {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -1101,9 +1101,7 @@ namespace System.Runtime.Serialization
         public const string KeyLocalName = "Key";
         public const string ValueLocalName = "Value";
         public const string MscorlibAssemblyName = "0";
-#if !NET_NATIVE
         public const string ParseMethodName = "Parse";
-#endif
         public const string SafeSerializationManagerName = "SafeSerializationManager";
         public const string SafeSerializationManagerNamespace = "http://schemas.datacontract.org/2004/07/System.Runtime.Serialization";
         public const string ISerializableFactoryTypeLocalName = "FactoryType";

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
@@ -37,7 +37,7 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatClassReaderDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = new ReflectionJsonFormatReader(TraditionalClassDataContract).ReflectionReadClass;
+                                tempDelegate = new ReflectionJsonClassReader(TraditionalClassDataContract).ReflectionReadClass;
                             }
                             else
                             {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
@@ -68,7 +68,17 @@ namespace System.Runtime.Serialization.Json
                         if (_helper.JsonFormatWriterDelegate == null)
                         {
 #if !NET_NATIVE
-                            JsonFormatClassWriterDelegate tempDelegate = new JsonFormatWriterGenerator().GenerateClassWriter(TraditionalClassDataContract);
+                            JsonFormatClassWriterDelegate tempDelegate;
+
+                            if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
+                            {
+                                tempDelegate = new ReflectionJsonFormatWriter().ReflectionWriteClass;
+                            }
+                            else
+                            {
+                                tempDelegate = new JsonFormatWriterGenerator().GenerateClassWriter(TraditionalClassDataContract);
+                            }
+
                             Interlocked.MemoryBarrier();
 #else
                             JsonFormatClassWriterDelegate tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalClassDataContract).ClassWriterDelegate;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
@@ -34,7 +34,16 @@ namespace System.Runtime.Serialization.Json
                         if (_helper.JsonFormatReaderDelegate == null)
                         {
 #if !NET_NATIVE
-                            JsonFormatClassReaderDelegate tempDelegate = new JsonFormatReaderGenerator().GenerateClassReader(TraditionalClassDataContract);
+                            JsonFormatClassReaderDelegate tempDelegate;
+                            if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
+                            {
+                                tempDelegate = new ReflectionJsonFormatReader(TraditionalClassDataContract).ReflectionReadClass;
+                            }
+                            else
+                            {
+                                tempDelegate = new JsonFormatReaderGenerator().GenerateClassReader(TraditionalClassDataContract);
+                            }
+
                             Interlocked.MemoryBarrier();
 #else
                             JsonFormatClassReaderDelegate tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalClassDataContract).ClassReaderDelegate;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
@@ -36,7 +36,7 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatCollectionReaderDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = new ReflectionJsonFormatReader(TraditionalCollectionDataContract).ReflectionReadCollection;
+                                tempDelegate = new ReflectionJsonCollectionReader().ReflectionReadCollection;
                             }
                             else
                             {
@@ -74,7 +74,7 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatGetOnlyCollectionReaderDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = new ReflectionJsonFormatReader(TraditionalCollectionDataContract).ReflectionReadGetOnlyCollection;
+                                tempDelegate = new ReflectionJsonCollectionReader().ReflectionReadGetOnlyCollection;
                             }
                             else
                             {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
@@ -32,20 +32,31 @@ namespace System.Runtime.Serialization.Json
                     {
                         if (_helper.JsonFormatReaderDelegate == null)
                         {
-#if !NET_NATIVE
                             JsonFormatCollectionReaderDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
                                 tempDelegate = new ReflectionJsonCollectionReader().ReflectionReadCollection;
                             }
-                            else
+#if NET_NATIVE
+                            else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                             {
-                                tempDelegate = new JsonFormatReaderGenerator().GenerateCollectionReader(TraditionalCollectionDataContract);
+                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).CollectionReaderDelegate;
+                                tempDelegate = tempDelegate ?? new ReflectionJsonCollectionReader().ReflectionReadCollection;
+
+                                if (tempDelegate == null)
+                                    throw new InvalidDataContractException(SR.Format(SR.SerializationCodeIsMissingForType, TraditionalCollectionDataContract.UnderlyingType.ToString()));
                             }
-                            Interlocked.MemoryBarrier();
-#else
-                            JsonFormatCollectionReaderDelegate tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).CollectionReaderDelegate;
 #endif
+                            else 
+                            {
+#if NET_NATIVE
+                                tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).CollectionReaderDelegate;
+#else   
+                                tempDelegate = new JsonFormatReaderGenerator().GenerateCollectionReader(TraditionalCollectionDataContract);
+#endif
+                            }
+
+                            Interlocked.MemoryBarrier();
                             _helper.JsonFormatReaderDelegate = tempDelegate;
                         }
                     }
@@ -70,21 +81,32 @@ namespace System.Runtime.Serialization.Json
                             {
                                 throw new InvalidDataContractException(SR.Format(SR.GetOnlyCollectionMustHaveAddMethod, DataContract.GetClrTypeFullName(this.TraditionalDataContract.UnderlyingType)));
                             }
-#if !NET_NATIVE
+
                             JsonFormatGetOnlyCollectionReaderDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
                                 tempDelegate = new ReflectionJsonCollectionReader().ReflectionReadGetOnlyCollection;
                             }
+#if NET_NATIVE
+                            else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
+                            {
+                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).GetOnlyCollectionReaderDelegate;
+                                tempDelegate = tempDelegate ?? new ReflectionJsonCollectionReader().ReflectionReadGetOnlyCollection;
+
+                                if (tempDelegate == null)
+                                    throw new InvalidDataContractException(SR.Format(SR.SerializationCodeIsMissingForType, TraditionalCollectionDataContract.UnderlyingType.ToString()));
+                            }
+#endif
                             else
                             {
+#if NET_NATIVE
+                                tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).GetOnlyCollectionReaderDelegate;
+#else   
                                 tempDelegate = new JsonFormatReaderGenerator().GenerateGetOnlyCollectionReader(TraditionalCollectionDataContract);
+#endif
                             }
 
                             Interlocked.MemoryBarrier();
-#else
-                            JsonFormatGetOnlyCollectionReaderDelegate tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).GetOnlyCollectionReaderDelegate;
-#endif
                             _helper.JsonFormatGetOnlyReaderDelegate = tempDelegate;
                         }
                     }
@@ -104,20 +126,31 @@ namespace System.Runtime.Serialization.Json
                     {
                         if (_helper.JsonFormatWriterDelegate == null)
                         {
-#if !NET_NATIVE
                             JsonFormatCollectionWriterDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
                                 tempDelegate = new ReflectionJsonFormatWriter().ReflectionWriteCollection;
                             }
+#if NET_NATIVE
+                            else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
+                            {
+                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).CollectionWriterDelegate;
+                                tempDelegate = tempDelegate ?? new ReflectionJsonFormatWriter().ReflectionWriteCollection;
+
+                                if (tempDelegate == null)
+                                    throw new InvalidDataContractException(SR.Format(SR.SerializationCodeIsMissingForType, TraditionalCollectionDataContract.UnderlyingType.ToString()));
+                            }
+#endif
                             else
                             {
+#if NET_NATIVE
+                                tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).CollectionWriterDelegate;
+#else   
                                 tempDelegate = new JsonFormatWriterGenerator().GenerateCollectionWriter(TraditionalCollectionDataContract);
-                            }
-                            Interlocked.MemoryBarrier();
-#else
-                            JsonFormatCollectionWriterDelegate tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).CollectionWriterDelegate;
 #endif
+                            }
+
+                            Interlocked.MemoryBarrier();
                             _helper.JsonFormatWriterDelegate = tempDelegate;
                         }
                     }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
@@ -105,7 +105,15 @@ namespace System.Runtime.Serialization.Json
                         if (_helper.JsonFormatWriterDelegate == null)
                         {
 #if !NET_NATIVE
-                            JsonFormatCollectionWriterDelegate tempDelegate = new JsonFormatWriterGenerator().GenerateCollectionWriter(TraditionalCollectionDataContract);
+                            JsonFormatCollectionWriterDelegate tempDelegate;
+                            if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
+                            {
+                                tempDelegate = new ReflectionJsonFormatWriter().ReflectionWriteCollection;
+                            }
+                            else
+                            {
+                                tempDelegate = new JsonFormatWriterGenerator().GenerateCollectionWriter(TraditionalCollectionDataContract);
+                            }
                             Interlocked.MemoryBarrier();
 #else
                             JsonFormatCollectionWriterDelegate tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).CollectionWriterDelegate;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
@@ -33,7 +33,15 @@ namespace System.Runtime.Serialization.Json
                         if (_helper.JsonFormatReaderDelegate == null)
                         {
 #if !NET_NATIVE
-                            JsonFormatCollectionReaderDelegate tempDelegate = new JsonFormatReaderGenerator().GenerateCollectionReader(TraditionalCollectionDataContract);
+                            JsonFormatCollectionReaderDelegate tempDelegate;
+                            if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
+                            {
+                                tempDelegate = new ReflectionJsonFormatReader(TraditionalCollectionDataContract).ReflectionReadCollection;
+                            }
+                            else
+                            {
+                                tempDelegate = new JsonFormatReaderGenerator().GenerateCollectionReader(TraditionalCollectionDataContract);
+                            }
                             Interlocked.MemoryBarrier();
 #else
                             JsonFormatCollectionReaderDelegate tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).CollectionReaderDelegate;
@@ -63,7 +71,16 @@ namespace System.Runtime.Serialization.Json
                                 throw new InvalidDataContractException(SR.Format(SR.GetOnlyCollectionMustHaveAddMethod, DataContract.GetClrTypeFullName(this.TraditionalDataContract.UnderlyingType)));
                             }
 #if !NET_NATIVE
-                            JsonFormatGetOnlyCollectionReaderDelegate tempDelegate = new JsonFormatReaderGenerator().GenerateGetOnlyCollectionReader(TraditionalCollectionDataContract);
+                            JsonFormatGetOnlyCollectionReaderDelegate tempDelegate;
+                            if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
+                            {
+                                tempDelegate = new ReflectionJsonFormatReader(TraditionalCollectionDataContract).ReflectionReadGetOnlyCollection;
+                            }
+                            else
+                            {
+                                tempDelegate = new JsonFormatReaderGenerator().GenerateGetOnlyCollectionReader(TraditionalCollectionDataContract);
+                            }
+
                             Interlocked.MemoryBarrier();
 #else
                             JsonFormatGetOnlyCollectionReaderDelegate tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).GetOnlyCollectionReaderDelegate;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonDataContract.cs
@@ -83,6 +83,12 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
+        internal static JsonReadWriteDelegates TryGetReadWriteDelegatesFromGeneratedAssembly(DataContract c)
+        {
+            JsonReadWriteDelegates result = GetGeneratedReadWriteDelegates(c);
+            return result;
+        }
+
         [SecuritySafeCritical]
         public static JsonDataContract GetJsonDataContract(DataContract traditionalDataContract)
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
@@ -84,9 +84,6 @@ namespace System.Runtime.Serialization
         private static MethodInfo s_writeEndElementMethod;
 
         [SecurityCritical]
-        private static MethodInfo s_writeJsonISerializableMethod;
-
-        [SecurityCritical]
         private static MethodInfo s_writeJsonNameWithMappingMethod;
 
         [SecurityCritical]
@@ -402,19 +399,6 @@ namespace System.Runtime.Serialization
                     Debug.Assert(s_writeEndElementMethod != null);
                 }
                 return s_writeEndElementMethod;
-            }
-        }
-        public static MethodInfo WriteJsonISerializableMethod
-        {
-            [SecuritySafeCritical]
-            get
-            {
-                if (s_writeJsonISerializableMethod == null)
-                {
-                    s_writeJsonISerializableMethod = typeof(XmlObjectSerializerWriteContextComplexJson).GetMethod("WriteJsonISerializable", Globals.ScanAllMembers);
-                    Debug.Assert(s_writeJsonISerializableMethod != null);
-                }
-                return s_writeJsonISerializableMethod;
             }
         }
         public static MethodInfo WriteJsonNameWithMappingMethod

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
@@ -187,15 +187,7 @@ namespace System.Runtime.Serialization.Json
             private void WriteClass(ClassDataContract classContract)
             {
                 InvokeOnSerializing(classContract);
-
-                if (classContract.IsISerializable)
-                {
-                    _ilg.Call(_contextArg, JsonFormatGeneratorStatics.WriteJsonISerializableMethod, _xmlWriterArg, _objectLocal);
-                }
-                else
-                {
-                    WriteMembers(classContract, null, classContract);
-                }
+                WriteMembers(classContract, null, classContract);
                 InvokeOnSerialized(classContract);
             }
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonReaderDelegator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonReaderDelegator.cs
@@ -236,6 +236,17 @@ namespace System.Runtime.Serialization.Json
             return ParseJsonDate(ReadElementContentAsString(), _dateTimeFormat);
         }
 
+        #if USE_REFEMIT
+        public override bool TryReadDateTimeArray(XmlObjectSerializerReadContext context,
+#else
+        internal override bool TryReadDateTimeArray(XmlObjectSerializerReadContext context,
+#endif
+        XmlDictionaryString itemName, XmlDictionaryString itemNamespace,
+            int arrayLength, out DateTime[] array)
+        {
+            return TryReadJsonDateTimeArray(context, itemName, itemNamespace, arrayLength, out array);
+        }
+
         internal bool TryReadJsonDateTimeArray(XmlObjectSerializerReadContext context,
             XmlDictionaryString itemName, XmlDictionaryString itemNamespace,
             int arrayLength, out DateTime[] array)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
@@ -101,9 +101,7 @@ namespace System.Runtime.Serialization.Json
             Debug.Assert(collectionContract.Kind == CollectionKind.Dictionary || collectionContract.Kind == CollectionKind.GenericDictionary);
             context.ReadAttributes(xmlReader);
 
-            // We need a test for GetRevisedItemContract.
-            //var itemContract = XmlObjectSerializerWriteContextComplexJson.GetRevisedItemContract(collectionContract.ItemContract);
-            var itemContract = collectionContract.ItemContract;
+            var itemContract = XmlObjectSerializerWriteContextComplexJson.GetRevisedItemContract(collectionContract.ItemContract);
             return DataContractJsonSerializer.ReadJsonValue(itemContract, xmlReader, jsonContext);
         }
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
@@ -22,7 +22,6 @@ namespace System.Runtime.Serialization.Json
 
         public ReflectionJsonFormatReader(ClassDataContract classDataContract) : base(classDataContract)
         {
-
         }
 
         public ReflectionJsonFormatReader(CollectionDataContract collectionContract) : base(collectionContract)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
@@ -1,0 +1,208 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace System.Runtime.Serialization.Json
+{
+    internal sealed class ReflectionJsonFormatReader : ReflectionReader
+    {
+        
+
+        private XmlObjectSerializerReadContextComplexJson _jsonContextArg;
+
+        public ReflectionJsonFormatReader(ClassDataContract classDataContract) : base(classDataContract)
+        {
+
+        }
+
+        public ReflectionJsonFormatReader(CollectionDataContract collectionContract) : base(collectionContract)
+        {
+        }
+
+        public object ReflectionReadClass(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContextComplexJson context, XmlDictionaryString emptyDictionaryString, XmlDictionaryString[] memberNames)
+        {
+
+            _jsonContextArg = context;
+            return ReflectionReadClassInternal(xmlReader, context, memberNames, null /*memberNamespaces*/);
+        }
+
+        public object ReflectionReadCollection(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContextComplexJson context, XmlDictionaryString emptyDictionaryString, XmlDictionaryString itemName, CollectionDataContract collectionContract)
+        {
+            _jsonContextArg = context;
+            return ReflectionReadCollectionInternal(xmlReader, context, itemName, emptyDictionaryString/*itemNamespace*/, collectionContract);
+        }
+
+        public void ReflectionReadGetOnlyCollection(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContextComplexJson context, XmlDictionaryString emptyDictionaryString, XmlDictionaryString itemName, CollectionDataContract collectionContract)
+        {
+            _jsonContextArg = context;
+            ReflectionReadGetOnlyCollectionInternal(xmlReader, context, itemName, emptyDictionaryString/*itemNamespace*/, collectionContract);
+        }
+
+        protected override void ReflectionReadMembers(ref object obj)
+        {
+            var classContract = _classContract;
+
+            int memberCount = classContract.MemberNames.Length;
+            _contextArg.IncrementItemCount(memberCount);
+
+            DataMember[] members = new DataMember[memberCount];
+            int reflectedMemberCount = ReflectionGetMembers(_classContract, members);
+
+            int memberIndex = -1;
+            while (true)
+            {
+                if (!XmlObjectSerializerReadContext.MoveToNextElement(_xmlReaderArg))
+                {
+                    return;
+                }
+
+                memberIndex = _jsonContextArg.GetJsonMemberIndex(_xmlReaderArg, _memberNamesArg, memberIndex, extensionData: null);
+                // GetMemberIndex returns memberNames.Length if member not found
+                if (memberIndex < members.Length)
+                {
+                    ReflectionReadMember(ref obj, memberIndex, _xmlReaderArg, _contextArg, members);
+                }
+            }
+                        
+        }
+
+        protected override string GetClassContractNamespace(ClassDataContract classContract)
+        {
+            return string.Empty;
+        }
+
+        protected override string GetCollectionContractItemName(CollectionDataContract collectionContract)
+        {
+            return JsonGlobals.itemString;
+        }
+
+        protected override string GetCollectionContractNamespace(CollectionDataContract collectionContract)
+        {
+            return string.Empty;
+        }
+
+        protected override object ReflectionReadDictionaryItem(CollectionDataContract collectionContract)
+        {
+            Debug.Assert(collectionContract.Kind == CollectionKind.Dictionary || collectionContract.Kind == CollectionKind.GenericDictionary);
+            _contextArg.ReadAttributes(_xmlReaderArg);
+
+            // We need a test for GetRevisedItemContract.
+            //var itemContract = XmlObjectSerializerWriteContextComplexJson.GetRevisedItemContract(collectionContract.ItemContract);
+            var itemContract = collectionContract.ItemContract;
+            return DataContractJsonSerializer.ReadJsonValue(itemContract, _xmlReaderArg, _jsonContextArg);
+        }
+
+        protected override bool ReflectionReadSpecialCollection(CollectionDataContract collectionContract, object resultCollection)
+        {
+            bool canReadSimpleDictionary = collectionContract.Kind == CollectionKind.Dictionary
+                                        || collectionContract.Kind == CollectionKind.GenericDictionary;
+            if (canReadSimpleDictionary && _jsonContextArg.UseSimpleDictionaryFormat)
+            {
+                ReadSimpleDictionary(collectionContract, collectionContract.ItemType, resultCollection);
+            }
+
+            return false;
+        }
+
+        private void ReadSimpleDictionary(CollectionDataContract collectionContract, Type keyValueType, object dictionary)
+        {
+            Type[] keyValueTypes = keyValueType.GetGenericArguments();
+            Type keyType = keyValueTypes[0];
+            Type valueType = keyValueTypes[1];
+
+            int keyTypeNullableDepth = 0;
+            Type keyTypeOriginal = keyType;
+            while (keyType.GetTypeInfo().IsGenericType && keyType.GetGenericTypeDefinition() == Globals.TypeOfNullable)
+            {
+                keyTypeNullableDepth++;
+                keyType = keyType.GetGenericArguments()[0];
+            }
+
+            ClassDataContract keyValueDataContract = (ClassDataContract)collectionContract.ItemContract;
+            DataContract keyDataContract = keyValueDataContract.Members[0].MemberTypeContract;
+
+            KeyParseMode keyParseMode = KeyParseMode.Fail;
+
+            if (keyType == Globals.TypeOfString || keyType == Globals.TypeOfObject)
+            {
+                keyParseMode = KeyParseMode.AsString;
+            }
+            else if (keyType.GetTypeInfo().IsEnum)
+            {
+                keyParseMode = KeyParseMode.UsingParseEnum;
+            }
+            else if (keyDataContract.ParseMethod != null)
+            {
+                keyParseMode = KeyParseMode.UsingCustomParse;
+            }
+
+            if (keyParseMode == KeyParseMode.Fail)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                    new InvalidOperationException(
+                        SR.Format(SR.KeyTypeCannotBeParsedInSimpleDictionary,
+                            DataContract.GetClrTypeFullName(collectionContract.UnderlyingType),
+                            DataContract.GetClrTypeFullName(keyType))
+                    ));
+            }
+
+            while (true)
+            {
+                XmlNodeType nodeType = _xmlReaderArg.MoveToContent();
+                if (nodeType == XmlNodeType.EndElement)
+                {
+                    return;
+                }
+                if (nodeType != XmlNodeType.Element)
+                {
+                    throw XmlObjectSerializerReadContext.CreateUnexpectedStateException(XmlNodeType.Element, _xmlReaderArg);
+                }
+
+                _contextArg.IncrementItemCount(1);
+                string keyString = XmlObjectSerializerReadContextComplexJson.GetJsonMemberName(_xmlReaderArg);
+                object pairKey;
+
+                if (keyParseMode == KeyParseMode.UsingParseEnum)
+                {
+                    pairKey = Enum.Parse(keyType, keyString);
+                }
+                else if (keyParseMode == KeyParseMode.UsingCustomParse)
+                {
+                    pairKey = keyDataContract.ParseMethod.Invoke(null, new object[] { keyString });
+                }
+                else
+                {
+                    pairKey = keyString;
+                }
+
+                if (keyTypeNullableDepth > 0)
+                {
+                    throw new NotImplementedException("keyTypeNullableDepth > 0");
+                }
+
+                object pairValue = ReflectionReadValue(valueType, string.Empty, string.Empty);
+
+
+                ((IDictionary)dictionary).Add(pairKey, pairValue);
+            }
+        }
+
+        private enum KeyParseMode
+        {
+            Fail,
+            AsString,
+            UsingParseEnum,
+            UsingCustomParse
+        }
+    }
+}

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
@@ -35,12 +35,7 @@ namespace System.Runtime.Serialization.Json
 
     internal sealed class ReflectionJsonCollectionReader
     {
-        private ReflectionReader _reflectionReader;
-
-        public ReflectionJsonCollectionReader()
-        {
-            _reflectionReader = new ReflectionJsonReader();
-        }
+        private ReflectionReader _reflectionReader = new ReflectionJsonReader();
 
         public object ReflectionReadCollection(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContextComplexJson context, XmlDictionaryString emptyDictionaryString, XmlDictionaryString itemName, CollectionDataContract collectionContract)
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
@@ -16,8 +16,8 @@ namespace System.Runtime.Serialization.Json
 {
     internal sealed class ReflectionJsonClassReader
     {
-        private ClassDataContract _classContract;
-        private ReflectionReader _reflectionReader;
+        private readonly ClassDataContract _classContract;
+        private readonly ReflectionReader _reflectionReader;
 
         public ReflectionJsonClassReader(ClassDataContract classDataContract)
         {
@@ -35,7 +35,7 @@ namespace System.Runtime.Serialization.Json
 
     internal sealed class ReflectionJsonCollectionReader
     {
-        private ReflectionReader _reflectionReader = new ReflectionJsonReader();
+        private readonly ReflectionReader _reflectionReader = new ReflectionJsonReader();
 
         public object ReflectionReadCollection(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContextComplexJson context, XmlDictionaryString emptyDictionaryString, XmlDictionaryString itemName, CollectionDataContract collectionContract)
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
@@ -15,204 +15,11 @@ namespace System.Runtime.Serialization.Json
 {
     internal class ReflectionJsonFormatWriter
     {
+        private ReflectionJsonClassWriter _reflectionClassWriter = new ReflectionJsonClassWriter();
+
         public void ReflectionWriteClass(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContextComplexJson context, ClassDataContract classContract, XmlDictionaryString[] memberNames)
         {
-            InvokeOnSerializing(obj, context, classContract);
-            obj = ResolveAdapterType(obj, classContract);
-            ReflectionWriteMembers(xmlWriter, obj, context, classContract, classContract, 0 /*childElementIndex*/, memberNames);
-            InvokeOnSerialized(obj, context, classContract);
-        }
-
-        private int ReflectionWriteMembers(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContextComplexJson context, ClassDataContract classContract, ClassDataContract derivedMostClassContract, int childElementIndex, XmlDictionaryString[] memberNames)
-        {
-            int memberCount = (classContract.BaseContract == null) ? 0 :
-                ReflectionWriteMembers(xmlWriter, obj, context, classContract.BaseContract, derivedMostClassContract, childElementIndex, memberNames);
-
-            childElementIndex += memberCount;
-
-            Type classType = classContract.UnadaptedClassType;
-            context.IncrementItemCount(classContract.Members.Count);
-            for (int i = 0; i < classContract.Members.Count; i++, memberCount++)
-            {
-                DataMember member = classContract.Members[i];
-                Type memberType = member.MemberType;
-                if (member.IsGetOnlyCollection)
-                {
-                    context.StoreIsGetOnlyCollection();
-                }
-
-                if (!member.EmitDefaultValue)
-                {
-                    // We need to add tests for this case.
-                    throw new NotImplementedException("EmitDefaultValue = false");
-                }
-
-                object memberValue = ReflectionGetMemberValue(obj, member);
-
-                bool requiresNameAttribute = DataContractJsonSerializerImpl.CheckIfXmlNameRequiresMapping(classContract.MemberNames[i]);
-                PrimitiveDataContract primitiveContract = member.MemberPrimitiveContract;
-                if (requiresNameAttribute || !ReflectionTryWritePrimitive(xmlWriter, context, memberType, memberValue, memberNames[i + childElementIndex] /*name*/, primitiveContract))
-                {
-                    // Note: DataContractSerializer has member-conflict logic here to deal with the schema export
-                    //       requirement that the same member can't be of two different types.
-                    if (requiresNameAttribute)
-                    {
-                        XmlObjectSerializerWriteContextComplexJson.WriteJsonNameWithMapping(xmlWriter, memberNames, i + childElementIndex);
-                    }
-                    else
-                    {
-                        ReflectionWriteStartElement(xmlWriter, memberNames[i + childElementIndex]);
-                    }
-
-                    ReflectionWriteValue(xmlWriter, context, memberType, memberValue, false/*writeXsiType*/, primitiveContractForParamType: null);
-                    ReflectionWriteEndElement(xmlWriter);
-                }
-
-            }
-
-            return memberCount;
-        }
-
-        private void ReflectionWriteEndElement(XmlWriterDelegator xmlWriter)
-        {
-            xmlWriter.WriteEndElement();
-        }
-
-        // This method is identical to ReflectionXmlFormatWriter.ReflectionWriteValue
-        private void ReflectionWriteValue(XmlWriterDelegator xmlWriter, XmlObjectSerializerWriteContext context, Type type, object value, bool writeXsiType, PrimitiveDataContract primitiveContractForParamType)
-        {
-            Type memberType = type;
-            object memberValue = value;
-            TypeInfo memberTypeInfo = memberType.GetTypeInfo();
-            bool originValueIsNullableOfT = (memberTypeInfo.IsGenericType && memberType.GetGenericTypeDefinition() == Globals.TypeOfNullable);
-            if (memberTypeInfo.IsValueType && !originValueIsNullableOfT)
-            {
-                PrimitiveDataContract primitiveContract = primitiveContractForParamType;
-                if (primitiveContract != null && !writeXsiType)
-                {
-                    primitiveContract.WriteXmlValue(xmlWriter, memberValue, context);
-                }
-                else
-                {
-                    ReflectionInternalSerialize(xmlWriter, context, memberValue, memberValue.GetType().TypeHandle.Equals(memberType.TypeHandle), writeXsiType, memberType);
-                }
-            }
-            else
-            {
-                if (originValueIsNullableOfT)
-                {
-                    if (memberValue == null)
-                    {
-                        memberType = Nullable.GetUnderlyingType(memberType);
-                    }
-                    else
-                    {
-                        MethodInfo getValue = memberType.GetMethod("get_Value", Array.Empty<Type>());
-                        memberValue = getValue.Invoke(memberValue, Array.Empty<object>());
-                        memberType = memberValue.GetType();
-                    }
-                }
-
-                if (memberValue == null)
-                {
-                    context.WriteNull(xmlWriter, memberType, DataContract.IsTypeSerializable(memberType));
-                }
-                else
-                {
-                    PrimitiveDataContract primitiveContract = originValueIsNullableOfT ? PrimitiveDataContract.GetPrimitiveDataContract(memberType) : primitiveContractForParamType;
-                    if (primitiveContract != null && primitiveContract.UnderlyingType != Globals.TypeOfObject && !writeXsiType)
-                    {
-                        primitiveContract.WriteXmlValue(xmlWriter, memberValue, context);
-                    }
-                    else
-                    {
-                        if (memberValue == null &&
-                            (memberType == Globals.TypeOfObject
-                            || (originValueIsNullableOfT && memberType.GetTypeInfo().IsValueType)))
-                        {
-                            context.WriteNull(xmlWriter, memberType, DataContract.IsTypeSerializable(memberType));
-                        }
-                        else
-                        {
-                            ReflectionInternalSerialize(xmlWriter, context, memberValue, memberValue.GetType().TypeHandle.Equals(memberType.TypeHandle), writeXsiType, memberType, originValueIsNullableOfT);
-                        }
-                    }
-                }
-            }
-        }
-
-        private void ReflectionInternalSerialize(XmlWriterDelegator xmlWriter, XmlObjectSerializerWriteContext context, object obj, bool isDeclaredType, bool writeXsiType, Type memberType, bool isNullableOfT = false)
-        {
-            if (isNullableOfT)
-            {
-                context.InternalSerialize(xmlWriter, obj, isDeclaredType, writeXsiType, DataContract.GetId(memberType.TypeHandle), memberType.TypeHandle);
-            }
-            else
-            {
-                context.InternalSerializeReference(xmlWriter, obj, isDeclaredType, writeXsiType, DataContract.GetId(memberType.TypeHandle), memberType.TypeHandle);
-            }
-        }
-
-        private void ReflectionWriteStartElement(XmlWriterDelegator xmlWriter, XmlDictionaryString name)
-        {
-            xmlWriter.WriteStartElement(name, null);
-        }
-
-        private void ReflectionWriteStartElement(XmlWriterDelegator xmlWriter, string name)
-        {
-            xmlWriter.WriteStartElement(name, null);
-        }
-
-        private bool ReflectionTryWritePrimitive(XmlWriterDelegator xmlWriter, XmlObjectSerializerWriteContext context, Type type, object value, XmlDictionaryString name, PrimitiveDataContract primitiveContract)
-        {
-            if (primitiveContract == null || primitiveContract.UnderlyingType == Globals.TypeOfObject)
-                return false;
-
-            primitiveContract.WriteXmlElement(xmlWriter, value, context, name, null /*namespace*/);
-
-            return true;
-        }
-
-        private object ReflectionGetMemberValue(object obj, DataMember dataMember)
-        {
-            return dataMember.Getter(obj);
-        }
-
-        private void InvokeOnSerializing(object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract)
-        {
-            if (classContract.BaseContract != null)
-                InvokeOnSerializing(obj, context, classContract.BaseContract);
-            if (classContract.OnSerializing != null)
-            {
-                var contextArg = context.GetStreamingContext() ;
-                classContract.OnSerializing.Invoke(obj, new object[] { contextArg });
-            }
-        }
-
-        private void InvokeOnSerialized(object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract)
-        {
-            if (classContract.BaseContract != null)
-                InvokeOnSerialized(obj, context, classContract.BaseContract);
-            if (classContract.OnSerialized != null)
-            {
-                var contextArg = context.GetStreamingContext() ;
-                classContract.OnSerialized.Invoke(obj, new object[] { contextArg });
-            }
-        }
-
-        private object ResolveAdapterType(object obj, ClassDataContract classContract)
-        {
-            Type type = obj.GetType();
-            if (type == Globals.TypeOfDateTimeOffset)
-            {
-                obj = DateTimeOffsetAdapter.GetDateTimeOffsetAdapter((DateTimeOffset)obj);
-            }
-            else if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == Globals.TypeOfKeyValuePair)
-            {
-                obj = classContract.KeyValuePairAdapterConstructorInfo.Invoke(new object[] { obj });
-            }
-
-            return obj;
+            _reflectionClassWriter.ReflectionWriteClass(xmlWriter, obj, context, classContract, memberNames);
         }
 
         public void ReflectionWriteCollection(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContextComplexJson context, CollectionDataContract collectionContract)
@@ -237,9 +44,9 @@ namespace System.Runtime.Serialization.Json
                     PrimitiveDataContract primitiveContract = PrimitiveDataContract.GetPrimitiveDataContract(itemType);
                     for (int i = 0; i < array.Length; ++i)
                     {
-                        ReflectionWriteStartElement(jsonWriter, itemName);
-                        ReflectionWriteValue(jsonWriter, context, itemType, array.GetValue(i), false, primitiveContract);
-                        ReflectionWriteEndElement(jsonWriter);
+                        _reflectionClassWriter.ReflectionWriteStartElement(jsonWriter, itemName);
+                        _reflectionClassWriter.ReflectionWriteValue(jsonWriter, context, itemType, array.GetValue(i), false, primitiveContract);
+                        _reflectionClassWriter.ReflectionWriteEndElement(jsonWriter);
                     }
                 }
             }
@@ -264,9 +71,9 @@ namespace System.Runtime.Serialization.Json
                         object current = enumerator.Current;
                         object key = ((IKeyValue)current).Key;
                         object value = ((IKeyValue)current).Value;
-                        ReflectionWriteStartElement(jsonWriter, key.ToString());
-                        ReflectionWriteValue(jsonWriter, context, value.GetType(), value, false, primitiveContractForParamType: null);
-                        ReflectionWriteEndElement(jsonWriter);
+                        _reflectionClassWriter.ReflectionWriteStartElement(jsonWriter, key.ToString());
+                        _reflectionClassWriter.ReflectionWriteValue(jsonWriter, context, value.GetType(), value, false, primitiveContractForParamType: null);
+                        _reflectionClassWriter.ReflectionWriteEndElement(jsonWriter);
                     }
                 }
                 else
@@ -290,7 +97,7 @@ namespace System.Runtime.Serialization.Json
                         {
                             object current = enumerator.Current;
                             context.IncrementItemCount(1);
-                            ReflectionWriteStartElement(jsonWriter, itemName);
+                            _reflectionClassWriter.ReflectionWriteStartElement(jsonWriter, itemName);
                             if (isDictionary)
                             {
                                 var itemContract = XmlObjectSerializerWriteContextComplexJson.GetRevisedItemContract(collectionContract.ItemContract);
@@ -300,10 +107,10 @@ namespace System.Runtime.Serialization.Json
                             }
                             else
                             {
-                                ReflectionWriteValue(jsonWriter, context, enumeratorReturnType, current, false, primitiveContractForParamType: null);
+                                _reflectionClassWriter.ReflectionWriteValue(jsonWriter, context, enumeratorReturnType, current, false, primitiveContractForParamType: null);
                             }
 
-                            ReflectionWriteEndElement(jsonWriter);
+                            _reflectionClassWriter.ReflectionWriteEndElement(jsonWriter);
                         }
                     }
                 }
@@ -371,5 +178,73 @@ namespace System.Runtime.Serialization.Json
                 string.Empty /* namespace */,
                 JsonGlobals.arrayString /* value */);
         }
+    }
+
+    internal class ReflectionJsonClassWriter : ReflectionClassWriter
+    {
+        protected override int ReflectionWriteMembers(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract, ClassDataContract derivedMostClassContract, int childElementIndex, XmlDictionaryString[] memberNames)
+        {
+            int memberCount = (classContract.BaseContract == null) ? 0 :
+                ReflectionWriteMembers(xmlWriter, obj, context, classContract.BaseContract, derivedMostClassContract, childElementIndex, memberNames);
+
+            childElementIndex += memberCount;
+
+            Type classType = classContract.UnadaptedClassType;
+            context.IncrementItemCount(classContract.Members.Count);
+            for (int i = 0; i < classContract.Members.Count; i++, memberCount++)
+            {
+                DataMember member = classContract.Members[i];
+                Type memberType = member.MemberType;
+                if (member.IsGetOnlyCollection)
+                {
+                    context.StoreIsGetOnlyCollection();
+                }
+
+                if (!member.EmitDefaultValue)
+                {
+                    // We need to add tests for this case.
+                    throw new NotImplementedException("EmitDefaultValue = false");
+                }
+
+                object memberValue = ReflectionGetMemberValue(obj, member);
+
+                bool requiresNameAttribute = DataContractJsonSerializerImpl.CheckIfXmlNameRequiresMapping(classContract.MemberNames[i]);
+                PrimitiveDataContract primitiveContract = member.MemberPrimitiveContract;
+                if (requiresNameAttribute || !ReflectionTryWritePrimitive(xmlWriter, context, memberType, memberValue, memberNames[i + childElementIndex] /*name*/, null/*ns*/, primitiveContract))
+                {
+                    // Note: DataContractSerializer has member-conflict logic here to deal with the schema export
+                    //       requirement that the same member can't be of two different types.
+                    if (requiresNameAttribute)
+                    {
+                        XmlObjectSerializerWriteContextComplexJson.WriteJsonNameWithMapping(xmlWriter, memberNames, i + childElementIndex);
+                    }
+                    else
+                    {
+                        ReflectionWriteStartElement(xmlWriter, memberNames[i + childElementIndex]);
+                    }
+
+                    ReflectionWriteValue(xmlWriter, context, memberType, memberValue, false/*writeXsiType*/, primitiveContractForParamType: null);
+                    ReflectionWriteEndElement(xmlWriter);
+                }
+
+            }
+
+            return memberCount;
+        }        
+
+        public void ReflectionWriteStartElement(XmlWriterDelegator xmlWriter, XmlDictionaryString name)
+        {
+            xmlWriter.WriteStartElement(name, null);
+        }
+
+        public void ReflectionWriteStartElement(XmlWriterDelegator xmlWriter, string name)
+        {
+            xmlWriter.WriteStartElement(name, null);
+        }
+
+        public void ReflectionWriteEndElement(XmlWriterDelegator xmlWriter)
+        {
+            xmlWriter.WriteEndElement();
+        }        
     }
 }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
@@ -1,0 +1,375 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace System.Runtime.Serialization.Json
+{
+    internal class ReflectionJsonFormatWriter
+    {
+        public void ReflectionWriteClass(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContextComplexJson context, ClassDataContract classContract, XmlDictionaryString[] memberNames)
+        {
+            InvokeOnSerializing(obj, context, classContract);
+            obj = ResolveAdapterType(obj, classContract);
+            ReflectionWriteMembers(xmlWriter, obj, context, classContract, classContract, 0 /*childElementIndex*/, memberNames);
+            InvokeOnSerialized(obj, context, classContract);
+        }
+
+        private int ReflectionWriteMembers(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContextComplexJson context, ClassDataContract classContract, ClassDataContract derivedMostClassContract, int childElementIndex, XmlDictionaryString[] memberNames)
+        {
+            int memberCount = (classContract.BaseContract == null) ? 0 :
+                ReflectionWriteMembers(xmlWriter, obj, context, classContract.BaseContract, derivedMostClassContract, childElementIndex, memberNames);
+
+            childElementIndex += memberCount;
+
+            Type classType = classContract.UnadaptedClassType;
+            context.IncrementItemCount(classContract.Members.Count);
+            for (int i = 0; i < classContract.Members.Count; i++, memberCount++)
+            {
+                DataMember member = classContract.Members[i];
+                Type memberType = member.MemberType;
+                if (member.IsGetOnlyCollection)
+                {
+                    context.StoreIsGetOnlyCollection();
+                }
+
+                if (!member.EmitDefaultValue)
+                {
+                    // We need to add tests for this case.
+                    throw new NotImplementedException("EmitDefaultValue = false");
+                }
+
+                object memberValue = ReflectionGetMemberValue(obj, member);
+
+                bool requiresNameAttribute = DataContractJsonSerializerImpl.CheckIfXmlNameRequiresMapping(classContract.MemberNames[i]);
+                PrimitiveDataContract primitiveContract = member.MemberPrimitiveContract;
+                if (requiresNameAttribute || !ReflectionTryWritePrimitive(xmlWriter, context, memberType, memberValue, memberNames[i + childElementIndex] /*name*/, primitiveContract))
+                {
+                    // Note: DataContractSerializer has member-conflict logic here to deal with the schema export
+                    //       requirement that the same member can't be of two different types.
+                    if (requiresNameAttribute)
+                    {
+                        XmlObjectSerializerWriteContextComplexJson.WriteJsonNameWithMapping(xmlWriter, memberNames, i + childElementIndex);
+                    }
+                    else
+                    {
+                        ReflectionWriteStartElement(xmlWriter, memberNames[i + childElementIndex]);
+                    }
+
+                    ReflectionWriteValue(xmlWriter, context, memberType, memberValue, false/*writeXsiType*/, primitiveContractForParamType: null);
+                    ReflectionWriteEndElement(xmlWriter);
+                }
+
+            }
+
+            return memberCount;
+        }
+
+        private void ReflectionWriteEndElement(XmlWriterDelegator xmlWriter)
+        {
+            xmlWriter.WriteEndElement();
+        }
+
+        // This method is identical to ReflectionXmlFormatWriter.ReflectionWriteValue
+        private void ReflectionWriteValue(XmlWriterDelegator xmlWriter, XmlObjectSerializerWriteContext context, Type type, object value, bool writeXsiType, PrimitiveDataContract primitiveContractForParamType)
+        {
+            Type memberType = type;
+            object memberValue = value;
+            TypeInfo memberTypeInfo = memberType.GetTypeInfo();
+            bool originValueIsNullableOfT = (memberTypeInfo.IsGenericType && memberType.GetGenericTypeDefinition() == Globals.TypeOfNullable);
+            if (memberTypeInfo.IsValueType && !originValueIsNullableOfT)
+            {
+                PrimitiveDataContract primitiveContract = primitiveContractForParamType;
+                if (primitiveContract != null && !writeXsiType)
+                {
+                    primitiveContract.WriteXmlValue(xmlWriter, memberValue, context);
+                }
+                else
+                {
+                    ReflectionInternalSerialize(xmlWriter, context, memberValue, memberValue.GetType().TypeHandle.Equals(memberType.TypeHandle), writeXsiType, memberType);
+                }
+            }
+            else
+            {
+                if (originValueIsNullableOfT)
+                {
+                    if (memberValue == null)
+                    {
+                        memberType = Nullable.GetUnderlyingType(memberType);
+                    }
+                    else
+                    {
+                        MethodInfo getValue = memberType.GetMethod("get_Value", Array.Empty<Type>());
+                        memberValue = getValue.Invoke(memberValue, Array.Empty<object>());
+                        memberType = memberValue.GetType();
+                    }
+                }
+
+                if (memberValue == null)
+                {
+                    context.WriteNull(xmlWriter, memberType, DataContract.IsTypeSerializable(memberType));
+                }
+                else
+                {
+                    PrimitiveDataContract primitiveContract = originValueIsNullableOfT ? PrimitiveDataContract.GetPrimitiveDataContract(memberType) : primitiveContractForParamType;
+                    if (primitiveContract != null && primitiveContract.UnderlyingType != Globals.TypeOfObject && !writeXsiType)
+                    {
+                        primitiveContract.WriteXmlValue(xmlWriter, memberValue, context);
+                    }
+                    else
+                    {
+                        if (memberValue == null &&
+                            (memberType == Globals.TypeOfObject
+                            || (originValueIsNullableOfT && memberType.GetTypeInfo().IsValueType)))
+                        {
+                            context.WriteNull(xmlWriter, memberType, DataContract.IsTypeSerializable(memberType));
+                        }
+                        else
+                        {
+                            ReflectionInternalSerialize(xmlWriter, context, memberValue, memberValue.GetType().TypeHandle.Equals(memberType.TypeHandle), writeXsiType, memberType, originValueIsNullableOfT);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void ReflectionInternalSerialize(XmlWriterDelegator xmlWriter, XmlObjectSerializerWriteContext context, object obj, bool isDeclaredType, bool writeXsiType, Type memberType, bool isNullableOfT = false)
+        {
+            if (isNullableOfT)
+            {
+                context.InternalSerialize(xmlWriter, obj, isDeclaredType, writeXsiType, DataContract.GetId(memberType.TypeHandle), memberType.TypeHandle);
+            }
+            else
+            {
+                context.InternalSerializeReference(xmlWriter, obj, isDeclaredType, writeXsiType, DataContract.GetId(memberType.TypeHandle), memberType.TypeHandle);
+            }
+        }
+
+        private void ReflectionWriteStartElement(XmlWriterDelegator xmlWriter, XmlDictionaryString name)
+        {
+            xmlWriter.WriteStartElement(name, null);
+        }
+
+        private void ReflectionWriteStartElement(XmlWriterDelegator xmlWriter, string name)
+        {
+            xmlWriter.WriteStartElement(name, null);
+        }
+
+        private bool ReflectionTryWritePrimitive(XmlWriterDelegator xmlWriter, XmlObjectSerializerWriteContext context, Type type, object value, XmlDictionaryString name, PrimitiveDataContract primitiveContract)
+        {
+            if (primitiveContract == null || primitiveContract.UnderlyingType == Globals.TypeOfObject)
+                return false;
+
+            primitiveContract.WriteXmlElement(xmlWriter, value, context, name, null /*namespace*/);
+
+            return true;
+        }
+
+        private object ReflectionGetMemberValue(object obj, DataMember dataMember)
+        {
+            return dataMember.Getter(obj);
+        }
+
+        private void InvokeOnSerializing(object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract)
+        {
+            if (classContract.BaseContract != null)
+                InvokeOnSerializing(obj, context, classContract.BaseContract);
+            if (classContract.OnSerializing != null)
+            {
+                var contextArg = context.GetStreamingContext() ;
+                classContract.OnSerializing.Invoke(obj, new object[] { contextArg });
+            }
+        }
+
+        private void InvokeOnSerialized(object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract)
+        {
+            if (classContract.BaseContract != null)
+                InvokeOnSerialized(obj, context, classContract.BaseContract);
+            if (classContract.OnSerialized != null)
+            {
+                var contextArg = context.GetStreamingContext() ;
+                classContract.OnSerialized.Invoke(obj, new object[] { contextArg });
+            }
+        }
+
+        private object ResolveAdapterType(object obj, ClassDataContract classContract)
+        {
+            Type type = obj.GetType();
+            if (type == Globals.TypeOfDateTimeOffset)
+            {
+                obj = DateTimeOffsetAdapter.GetDateTimeOffsetAdapter((DateTimeOffset)obj);
+            }
+            else if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == Globals.TypeOfKeyValuePair)
+            {
+                obj = classContract.KeyValuePairAdapterConstructorInfo.Invoke(new object[] { obj });
+            }
+
+            return obj;
+        }
+
+        public void ReflectionWriteCollection(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContextComplexJson context, CollectionDataContract collectionContract)
+        {
+            JsonWriterDelegator jsonWriter = xmlWriter as JsonWriterDelegator;
+            if (jsonWriter == null)
+            {
+                throw new ArgumentException(nameof(xmlWriter));
+            }
+
+            XmlDictionaryString itemName = context.CollectionItemName;
+
+            if (collectionContract.Kind == CollectionKind.Array)
+            {
+                context.IncrementArrayCount(jsonWriter, (Array)obj);
+                Type itemType = collectionContract.ItemType;
+                if (!ReflectionTryWritePrimitiveArray(jsonWriter, obj, collectionContract.UnderlyingType, itemType, itemName))
+                {
+                    ReflectionWriteArrayAttribute(jsonWriter);
+
+                    Array array = (Array)obj;
+                    PrimitiveDataContract primitiveContract = PrimitiveDataContract.GetPrimitiveDataContract(itemType);
+                    for (int i = 0; i < array.Length; ++i)
+                    {
+                        ReflectionWriteStartElement(jsonWriter, itemName);
+                        ReflectionWriteValue(jsonWriter, context, itemType, array.GetValue(i), false, primitiveContract);
+                        ReflectionWriteEndElement(jsonWriter);
+                    }
+                }
+            }
+            else
+            {
+                collectionContract.IncrementCollectionCount(jsonWriter, obj, context);
+
+                Type enumeratorReturnType;
+                IEnumerator enumerator = collectionContract.GetEnumeratorForCollection(obj, out enumeratorReturnType);
+
+                bool canWriteSimpleDictionary = collectionContract.Kind == CollectionKind.GenericDictionary
+                                             || collectionContract.Kind == CollectionKind.Dictionary;
+
+                bool useSimpleDictionaryFormat = context.UseSimpleDictionaryFormat;
+
+                if (canWriteSimpleDictionary && useSimpleDictionaryFormat)
+                {
+                    ReflectionWriteObjectAttribute(jsonWriter);
+
+                    while (enumerator.MoveNext())
+                    {
+                        object current = enumerator.Current;
+                        object key = ((IKeyValue)current).Key;
+                        object value = ((IKeyValue)current).Value;
+                        ReflectionWriteStartElement(jsonWriter, key.ToString());
+                        ReflectionWriteValue(jsonWriter, context, value.GetType(), value, false, primitiveContractForParamType: null);
+                        ReflectionWriteEndElement(jsonWriter);
+                    }
+                }
+                else
+                {
+                    ReflectionWriteArrayAttribute(jsonWriter);
+
+                    PrimitiveDataContract primitiveContractForType = PrimitiveDataContract.GetPrimitiveDataContract(enumeratorReturnType);
+                    if (primitiveContractForType != null && primitiveContractForType.UnderlyingType != Globals.TypeOfObject)
+                    {
+                        while (enumerator.MoveNext())
+                        {
+                            object current = enumerator.Current;
+                            context.IncrementItemCount(1);
+                            primitiveContractForType.WriteXmlElement(jsonWriter, current, context, itemName, null /*namespace*/);
+                        }
+                    }
+                    else
+                    {
+                        bool isDictionary = collectionContract.Kind == CollectionKind.Dictionary || collectionContract.Kind == CollectionKind.GenericDictionary;
+                        while (enumerator.MoveNext())
+                        {
+                            object current = enumerator.Current;
+                            context.IncrementItemCount(1);
+                            ReflectionWriteStartElement(jsonWriter, itemName);
+                            if (isDictionary)
+                            {
+                                var itemContract = XmlObjectSerializerWriteContextComplexJson.GetRevisedItemContract(collectionContract.ItemContract);
+                                var jsonDataContract = JsonDataContract.GetJsonDataContract(itemContract);
+
+                                jsonDataContract.WriteJsonValue(jsonWriter, current, context, collectionContract.ItemType.TypeHandle);
+                            }
+                            else
+                            {
+                                ReflectionWriteValue(jsonWriter, context, enumeratorReturnType, current, false, primitiveContractForParamType: null);
+                            }
+
+                            ReflectionWriteEndElement(jsonWriter);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void ReflectionWriteObjectAttribute(XmlWriterDelegator xmlWriter)
+        {
+            xmlWriter.WriteAttributeString(
+                null /* prefix */,
+                JsonGlobals.typeString /* local name */,
+                null /* namespace */,
+                JsonGlobals.objectString /* value */);
+        }
+
+        private bool ReflectionTryWritePrimitiveArray(JsonWriterDelegator jsonWriter, object obj, Type underlyingType, Type itemType, XmlDictionaryString collectionItemName)
+        {
+            PrimitiveDataContract primitiveContract = PrimitiveDataContract.GetPrimitiveDataContract(itemType);
+            if (primitiveContract == null)
+                return false;
+
+            XmlDictionaryString itemNamespace = null;
+
+            switch (itemType.GetTypeCode())
+            {
+                case TypeCode.Boolean:
+                    ReflectionWriteArrayAttribute(jsonWriter);
+                    jsonWriter.WriteJsonBooleanArray((bool[])obj, collectionItemName, itemNamespace);
+                    break;
+                case TypeCode.DateTime:
+                    ReflectionWriteArrayAttribute(jsonWriter);
+                    jsonWriter.WriteJsonDateTimeArray((DateTime[])obj, collectionItemName, itemNamespace);
+                    break;
+                case TypeCode.Decimal:
+                    ReflectionWriteArrayAttribute(jsonWriter);
+                    jsonWriter.WriteJsonDecimalArray((decimal[])obj, collectionItemName, itemNamespace);
+                    break;
+                case TypeCode.Int32:
+                    ReflectionWriteArrayAttribute(jsonWriter);
+                    jsonWriter.WriteJsonInt32Array((int[])obj, collectionItemName, itemNamespace);
+                    break;
+                case TypeCode.Int64:
+                    ReflectionWriteArrayAttribute(jsonWriter);
+                    jsonWriter.WriteJsonInt64Array((long[])obj, collectionItemName, itemNamespace);
+                    break;
+                case TypeCode.Single:
+                    ReflectionWriteArrayAttribute(jsonWriter);
+                    jsonWriter.WriteJsonSingleArray((float[])obj, collectionItemName, itemNamespace);
+                    break;
+                case TypeCode.Double:
+                    ReflectionWriteArrayAttribute(jsonWriter);
+                    jsonWriter.WriteJsonDoubleArray((double[])obj, collectionItemName, itemNamespace);
+                    break;
+                default:
+                    return false;
+            }
+            return true;
+        }
+
+        private void ReflectionWriteArrayAttribute(XmlWriterDelegator xmlWriter)
+        {
+            xmlWriter.WriteAttributeString(
+                null /* prefix */,
+                JsonGlobals.typeString /* local name */,
+                string.Empty /* namespace */,
+                JsonGlobals.arrayString /* value */);
+        }
+    }
+}

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.Serialization.Json
 {
     internal class ReflectionJsonFormatWriter
     {
-        private ReflectionJsonClassWriter _reflectionClassWriter = new ReflectionJsonClassWriter();
+        private readonly ReflectionJsonClassWriter _reflectionClassWriter = new ReflectionJsonClassWriter();
 
         public void ReflectionWriteClass(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContextComplexJson context, ClassDataContract classContract, XmlDictionaryString[] memberNames)
         {
@@ -120,10 +120,10 @@ namespace System.Runtime.Serialization.Json
         private void ReflectionWriteObjectAttribute(XmlWriterDelegator xmlWriter)
         {
             xmlWriter.WriteAttributeString(
-                null /* prefix */,
-                JsonGlobals.typeString /* local name */,
-                null /* namespace */,
-                JsonGlobals.objectString /* value */);
+                prefix: null,
+                localName: JsonGlobals.typeString,
+                ns: null,
+                value: JsonGlobals.objectString);
         }
 
         private bool ReflectionTryWritePrimitiveArray(JsonWriterDelegator jsonWriter, object obj, Type underlyingType, Type itemType, XmlDictionaryString collectionItemName)
@@ -173,10 +173,10 @@ namespace System.Runtime.Serialization.Json
         private void ReflectionWriteArrayAttribute(XmlWriterDelegator xmlWriter)
         {
             xmlWriter.WriteAttributeString(
-                null /* prefix */,
-                JsonGlobals.typeString /* local name */,
-                string.Empty /* namespace */,
-                JsonGlobals.arrayString /* value */);
+                prefix: null,
+                localName: JsonGlobals.typeString,
+                ns: string.Empty,
+                value: JsonGlobals.arrayString);
         }
     }
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionClassWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionClassWriter.cs
@@ -1,0 +1,156 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization.Json;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace System.Runtime.Serialization
+{
+    internal abstract class ReflectionClassWriter
+    {
+        public void ReflectionWriteClass(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract, XmlDictionaryString[] memberNames)
+        {
+            InvokeOnSerializing(obj, context, classContract);
+            obj = ResolveAdapterType(obj, classContract);
+            ReflectionWriteMembers(xmlWriter, obj, context, classContract, classContract, 0 /*childElementIndex*/, memberNames);
+            InvokeOnSerialized(obj, context, classContract);
+        }
+
+        public void ReflectionWriteValue(XmlWriterDelegator xmlWriter, XmlObjectSerializerWriteContext context, Type type, object value, bool writeXsiType, PrimitiveDataContract primitiveContractForParamType)
+        {
+            Type memberType = type;
+            object memberValue = value;
+            TypeInfo memberTypeInfo = memberType.GetTypeInfo();
+            bool originValueIsNullableOfT = (memberTypeInfo.IsGenericType && memberType.GetGenericTypeDefinition() == Globals.TypeOfNullable);
+            if (memberTypeInfo.IsValueType && !originValueIsNullableOfT)
+            {
+                PrimitiveDataContract primitiveContract = primitiveContractForParamType;
+                if (primitiveContract != null && !writeXsiType)
+                {
+                    primitiveContract.WriteXmlValue(xmlWriter, memberValue, context);
+                }
+                else
+                {
+                    ReflectionInternalSerialize(xmlWriter, context, memberValue, memberValue.GetType().TypeHandle.Equals(memberType.TypeHandle), writeXsiType, memberType);
+                }
+            }
+            else
+            {
+                if (originValueIsNullableOfT)
+                {
+                    if (memberValue == null)
+                    {
+                        memberType = Nullable.GetUnderlyingType(memberType);
+                    }
+                    else
+                    {
+                        MethodInfo getValue = memberType.GetMethod("get_Value", Array.Empty<Type>());
+                        memberValue = getValue.Invoke(memberValue, Array.Empty<object>());
+                        memberType = memberValue.GetType();
+                    }
+                }
+
+                if (memberValue == null)
+                {
+                    context.WriteNull(xmlWriter, memberType, DataContract.IsTypeSerializable(memberType));
+                }
+                else
+                {
+                    PrimitiveDataContract primitiveContract = originValueIsNullableOfT ? PrimitiveDataContract.GetPrimitiveDataContract(memberType) : primitiveContractForParamType;
+                    if (primitiveContract != null && primitiveContract.UnderlyingType != Globals.TypeOfObject && !writeXsiType)
+                    {
+                        primitiveContract.WriteXmlValue(xmlWriter, memberValue, context);
+                    }
+                    else
+                    {
+                        if (memberValue == null &&
+                            (memberType == Globals.TypeOfObject
+                            || (originValueIsNullableOfT && memberType.GetTypeInfo().IsValueType)))
+                        {
+                            context.WriteNull(xmlWriter, memberType, DataContract.IsTypeSerializable(memberType));
+                        }
+                        else
+                        {
+                            ReflectionInternalSerialize(xmlWriter, context, memberValue, memberValue.GetType().TypeHandle.Equals(memberType.TypeHandle), writeXsiType, memberType, originValueIsNullableOfT);
+                        }
+                    }
+                }
+            }
+        }
+
+        protected abstract int ReflectionWriteMembers(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract, ClassDataContract derivedMostClassContract, int childElementIndex, XmlDictionaryString[] memberNames);
+
+        protected object ReflectionGetMemberValue(object obj, DataMember dataMember)
+        {
+            return dataMember.Getter(obj);
+        }
+
+        protected bool ReflectionTryWritePrimitive(XmlWriterDelegator xmlWriter, XmlObjectSerializerWriteContext context, Type type, object value, XmlDictionaryString name, XmlDictionaryString ns, PrimitiveDataContract primitiveContract)
+        {
+            if (primitiveContract == null || primitiveContract.UnderlyingType == Globals.TypeOfObject)
+                return false;
+
+            primitiveContract.WriteXmlElement(xmlWriter, value, context, name, ns);
+
+            return true;
+        } 
+
+        private void InvokeOnSerializing(object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract)
+        {
+            if (classContract.BaseContract != null)
+                InvokeOnSerializing(obj, context, classContract.BaseContract);
+            if (classContract.OnSerializing != null)
+            {
+                var contextArg = context.GetStreamingContext();
+                classContract.OnSerializing.Invoke(obj, new object[] { contextArg });
+            }
+        }
+
+        private void InvokeOnSerialized(object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract)
+        {
+            if (classContract.BaseContract != null)
+                InvokeOnSerialized(obj, context, classContract.BaseContract);
+            if (classContract.OnSerialized != null)
+            {
+                var contextArg = context.GetStreamingContext();
+                classContract.OnSerialized.Invoke(obj, new object[] { contextArg });
+            }
+        }
+
+        private object ResolveAdapterType(object obj, ClassDataContract classContract)
+        {
+            Type type = obj.GetType();
+            if (type == Globals.TypeOfDateTimeOffset)
+            {
+                obj = DateTimeOffsetAdapter.GetDateTimeOffsetAdapter((DateTimeOffset)obj);
+            }
+            else if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == Globals.TypeOfKeyValuePair)
+            {
+                obj = classContract.KeyValuePairAdapterConstructorInfo.Invoke(new object[] { obj });
+            }
+
+            return obj;
+        }
+
+        private void ReflectionInternalSerialize(XmlWriterDelegator xmlWriter, XmlObjectSerializerWriteContext context, object obj, bool isDeclaredType, bool writeXsiType, Type memberType, bool isNullableOfT = false)
+        {
+            if (isNullableOfT)
+            {
+                context.InternalSerialize(xmlWriter, obj, isDeclaredType, writeXsiType, DataContract.GetId(memberType.TypeHandle), memberType.TypeHandle);
+            }
+            else
+            {
+                context.InternalSerializeReference(xmlWriter, obj, isDeclaredType, writeXsiType, DataContract.GetId(memberType.TypeHandle), memberType.TypeHandle);
+            }
+        }
+    }
+}

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionReader.cs
@@ -1,0 +1,663 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace System.Runtime.Serialization
+{
+    internal abstract class ReflectionReader
+    {
+        private delegate object ReflectionReadValueDelegate(Type itemType, string itemName, string itemNs);
+        private delegate object CollectionSetItemDelegate(object resultCollection, object collectionItem, int itemIndex);
+
+        private readonly static MethodInfo s_getCollectionSetItemDelegateMethod = typeof(ReflectionReader).GetMethod(nameof(GetCollectionSetItemDelegate), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+        private readonly static MethodInfo s_objectToKeyValuePairGetKey = typeof(ReflectionReader).GetMethod(nameof(ObjectToKeyValuePairGetKey), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+        private readonly static MethodInfo s_objectToKeyValuePairGetValue = typeof(ReflectionReader).GetMethod(nameof(ObjectToKeyValuePairGetValue), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+
+        protected ClassDataContract _classContract;
+        protected XmlReaderDelegator _xmlReaderArg;
+        protected XmlObjectSerializerReadContext _contextArg;
+        protected XmlDictionaryString[] _memberNamesArg;
+        protected XmlDictionaryString[] _memberNamespacesArg;
+
+        protected CollectionDataContract _collectionContract;
+        protected XmlDictionaryString _collectionItemName;
+        protected XmlDictionaryString _collectionItemNamespace;
+
+        public ReflectionReader(ClassDataContract classDataContract)
+        {
+            _classContract = classDataContract;
+        }
+
+        public ReflectionReader(CollectionDataContract collectionContract)
+        {
+            _collectionContract = collectionContract;
+        }
+
+        protected void ReflectionInitArgs(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString[] memberNames, XmlDictionaryString[] memberNamespaces)
+        {
+            _xmlReaderArg = xmlReader;
+            _contextArg = context;
+            _memberNamesArg = memberNames;
+            _memberNamespacesArg = memberNamespaces;
+        }
+
+        protected object ReflectionReadClassInternal(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString[] memberNames, XmlDictionaryString[] memberNamespaces)
+        {
+            var classContract = _classContract;
+            ReflectionInitArgs(xmlReader, context, memberNames, memberNamespaces);
+            object obj = CreateObject(_classContract);
+            context.AddNewObject(obj);
+            InvokeOnDeserializing(obj, context, _classContract);
+
+            ReflectionReadMembers(ref obj);
+            obj = ResolveAdapterObject(obj, classContract);
+
+            InvokeOnDeserialized(obj, context, _classContract);
+
+            return obj;
+        }
+
+        protected abstract void ReflectionReadMembers(ref object obj);
+
+        protected int ReflectionGetMembers(ClassDataContract classContract, DataMember[] members)
+        {
+            int memberCount = (classContract.BaseContract == null) ? 0 : ReflectionGetMembers(classContract.BaseContract, members);
+            int childElementIndex = memberCount;
+            for (int i = 0; i < classContract.Members.Count; i++, memberCount++)
+            {
+                members[childElementIndex + i] = classContract.Members[i];
+            }
+
+            return memberCount;
+        }
+
+        protected void ReflectionReadMember(ref object obj, int memberIndex, XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, DataMember[] members)
+        {
+            DataMember dataMember = members[memberIndex];
+
+            Debug.Assert(dataMember != null);
+            Type memberType = dataMember.MemberType;
+            if (dataMember.IsGetOnlyCollection)
+            {
+                var memberValue = ReflectionGetMemberValue(obj, dataMember);
+                context.StoreCollectionMemberInfo(memberValue);
+                ReflectionReadValue(dataMember, GetClassContractNamespace(_classContract));
+            }
+            else
+            {
+                var value = ReflectionReadValue(dataMember, _classContract.StableName.Namespace);
+                MemberInfo memberInfo = dataMember.MemberInfo;
+                Debug.Assert(memberInfo != null);
+
+                ReflectionSetMemberValue(ref obj, value, dataMember);
+            }
+        }
+
+        protected abstract string GetClassContractNamespace(ClassDataContract _classContract);
+
+        private object ReflectionGetMemberValue(object obj, DataMember dataMember)
+        {
+            return dataMember.Getter(obj);
+        }
+
+        private void ReflectionSetMemberValue(ref object obj, object memberValue, DataMember dataMember)
+        {
+            dataMember.Setter(ref obj, memberValue);
+        }
+
+        private object ReflectionReadValue(DataMember dataMember, string ns)
+        {
+            Type type = dataMember.MemberType;
+            string name = dataMember.Name;
+
+            return ReflectionReadValue(type, name, ns, dataMember.MemberPrimitiveContract);
+        }
+
+        protected object ReflectionReadValue(Type type, string name, string ns, PrimitiveDataContract primitiveContractForOriginalType = null)
+        {
+            object value = null;
+            int nullables = 0;
+            while (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == Globals.TypeOfNullable)
+            {
+                nullables++;
+                type = type.GetGenericArguments()[0];
+            }
+
+            PrimitiveDataContract primitiveContract = nullables != 0 ?
+                PrimitiveDataContract.GetPrimitiveDataContract(type)
+                : (primitiveContractForOriginalType ?? PrimitiveDataContract.GetPrimitiveDataContract(type));
+
+            if ((primitiveContract != null && primitiveContract.UnderlyingType != Globals.TypeOfObject) || nullables != 0 || type.GetTypeInfo().IsValueType)
+            {
+                _contextArg.ReadAttributes(_xmlReaderArg);
+                string objectId = _contextArg.ReadIfNullOrRef(_xmlReaderArg, Globals.TypeOfString, true);
+                if (objectId != null)
+                {
+                    if (objectId.Length == 0)
+                    {
+                        objectId = _contextArg.GetObjectId();
+                        if (primitiveContract != null && primitiveContract.UnderlyingType != Globals.TypeOfObject)
+                        {
+                            value = primitiveContract.ReadXmlValue(_xmlReaderArg, _contextArg);
+                            _contextArg.AddNewObject(value);
+                        }
+                        else
+                        {
+                            value = ReflectionInternalDeserialize(type, name, ns);
+                        }
+                    }
+                    else if (type.GetTypeInfo().IsValueType)
+                    {
+                        throw new SerializationException(SR.Format(SR.ValueTypeCannotHaveId, DataContract.GetClrTypeFullName(type)));
+                    }
+                }
+                else
+                {
+                    value = null;
+                }
+            }
+            else
+            {
+                value = ReflectionInternalDeserialize(type, name, ns);
+            }
+
+            return value;
+        }
+
+        // This method is a perf optimization for collections. The original method is ReflectionReadValue.
+        private ReflectionReadValueDelegate GetReflectionReadValueDelegate(Type type, string name, string ns)
+        {
+            object value = null;
+            int nullables = 0;
+            while (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == Globals.TypeOfNullable)
+            {
+                nullables++;
+                type = type.GetGenericArguments()[0];
+            }
+
+            PrimitiveDataContract primitiveContract = PrimitiveDataContract.GetPrimitiveDataContract(type);
+            bool hasValidPrimitiveContract = primitiveContract != null && primitiveContract.UnderlyingType != Globals.TypeOfObject;
+            if ((primitiveContract != null && primitiveContract.UnderlyingType != Globals.TypeOfObject) || nullables != 0 || type.GetTypeInfo().IsValueType)
+            {
+
+                return (typeArg, nameArg, nsArg) =>
+                {
+                    _contextArg.ReadAttributes(_xmlReaderArg);
+                    string objectId = _contextArg.ReadIfNullOrRef(_xmlReaderArg, Globals.TypeOfString, true);
+                    if (objectId != null)
+                    {
+                        if (objectId.Length == 0)
+                        {
+                            objectId = _contextArg.GetObjectId();
+                            if (hasValidPrimitiveContract)
+                            {
+                                value = primitiveContract.ReadXmlValue(_xmlReaderArg, _contextArg);
+                                _contextArg.AddNewObject(value);
+                            }
+                            else
+                            {
+                                value = ReflectionInternalDeserialize(type, name, ns);
+                            }
+                        }
+                        else if (type.GetTypeInfo().IsValueType)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SerializationException(SR.Format(SR.ValueTypeCannotHaveId, DataContract.GetClrTypeFullName(type))));
+                        }
+                    }
+                    else
+                    {
+                        value = null;
+                    }
+
+                    return value;
+                };
+            }
+            else
+            {
+                return ReflectionInternalDeserialize;
+            }
+        }
+
+        private object ReflectionInternalDeserialize(Type type, string name, string ns)
+        {
+            return _contextArg.InternalDeserialize(_xmlReaderArg, DataContract.GetId(type.TypeHandle), type.TypeHandle, name, ns);
+        }
+
+        private void InvokeOnDeserializing(object obj, XmlObjectSerializerReadContext context, ClassDataContract classContract)
+        {
+            if (classContract.BaseContract != null)
+                InvokeOnDeserializing(obj, context, classContract.BaseContract);
+            if (classContract.OnDeserializing != null)
+            {
+                var contextArg = context.GetStreamingContext();
+                classContract.OnDeserializing.Invoke(obj, new object[] { contextArg });
+            }
+        }
+
+        private void InvokeOnDeserialized(object obj, XmlObjectSerializerReadContext context, ClassDataContract classContract)
+        {
+            if (classContract.BaseContract != null)
+                InvokeOnDeserialized(obj, context, classContract.BaseContract);
+            if (classContract.OnDeserialized != null)
+            {
+                var contextArg = context.GetStreamingContext();
+                classContract.OnDeserialized.Invoke(obj, new object[] { contextArg });
+            }
+        }
+
+        private static object CreateObject(ClassDataContract classContract)
+        {
+            object obj;
+            if (!classContract.CreateNewInstanceViaDefaultConstructor(out obj))
+            {
+                Type classType = classContract.UnderlyingType;
+                obj = XmlFormatReaderGenerator.UnsafeGetUninitializedObject(classType);
+            }
+
+            return obj;
+        }
+
+        private static object ResolveAdapterObject(object obj, ClassDataContract classContract)
+        {
+            Type objType = obj.GetType();
+            if (objType == Globals.TypeOfDateTimeOffsetAdapter)
+            {
+                obj = DateTimeOffsetAdapter.GetDateTimeOffset((DateTimeOffsetAdapter)obj);
+            }
+            else if (obj is IKeyValuePairAdapter)
+            {
+                obj = classContract.GetKeyValuePairMethodInfo.Invoke(obj, Array.Empty<object>());
+            }
+
+            return obj;
+        }
+
+        protected object ReflectionReadCollectionInternal(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString itemName, XmlDictionaryString itemNamespace, CollectionDataContract collectionContract)
+        {
+            ReflectionInitArgs(xmlReader, context, null, null);
+            _collectionItemName = itemName;
+            _collectionItemNamespace = itemNamespace;
+
+            return ReflectionReadCollectionCore(collectionContract);
+        }
+
+        protected abstract string GetCollectionContractItemName(CollectionDataContract collectionContract);
+        protected abstract string GetCollectionContractNamespace(CollectionDataContract collectionContract);
+
+
+        private object ReflectionReadCollectionCore(CollectionDataContract collectionContract)
+        {
+            bool isArray = (collectionContract.Kind == CollectionKind.Array);
+
+            int arraySize = _contextArg.GetArraySize();
+            string objectId = _contextArg.GetObjectId();
+            object resultArray = null;
+            if (isArray && ReflectionTryReadPrimitiveArray(collectionContract.UnderlyingType, collectionContract.ItemType, arraySize, out resultArray))
+            {
+                return resultArray;
+            }
+
+            if (arraySize != -1)
+            {
+                throw new NotImplementedException();
+            }
+
+            string itemName = GetCollectionContractItemName(collectionContract);
+            string itemNs = GetCollectionContractNamespace(collectionContract);
+            object resultCollection = ReflectionCreateCollection(collectionContract);
+            _contextArg.AddNewObject(resultCollection);
+            _contextArg.IncrementItemCount(1);
+
+            if (!ReflectionReadSpecialCollection(collectionContract, resultCollection))
+            {
+                ReflectionReadValueDelegate reflectionReadValueDelegate = null;
+                CollectionSetItemDelegate collectionSetItemDelegate = null;
+
+                int index = 0;
+                for (; index < int.MaxValue; index++)
+                {
+                    if (_xmlReaderArg.IsStartElement(_collectionItemName, _collectionItemNamespace))
+                    {
+                        _contextArg.IncrementItemCount(1);
+                        object collectionItem = ReflectionReadCollectionItem(collectionContract, collectionContract.ItemType, itemName, itemNs, ref reflectionReadValueDelegate);
+                        if (collectionSetItemDelegate == null)
+                        {
+                            MethodInfo getCollectionSetItemDelegateMethod = s_getCollectionSetItemDelegateMethod.MakeGenericMethod(collectionContract.ItemType);
+                            collectionSetItemDelegate = (CollectionSetItemDelegate)getCollectionSetItemDelegateMethod.Invoke(this, new object[] { collectionContract, resultCollection, false/*isReadOnlyCollection*/ });
+                        }
+
+                        resultCollection = collectionSetItemDelegate(resultCollection, collectionItem, index);
+                    }
+                    else
+                    {
+                        if (_xmlReaderArg.NodeType == XmlNodeType.EndElement)
+                        {
+                            break;
+                        }
+                        if (!_xmlReaderArg.IsStartElement())
+                        {
+                            throw XmlObjectSerializerReadContext.CreateUnexpectedStateException(XmlNodeType.Element, _xmlReaderArg);
+                        }
+                        _contextArg.SkipUnknownElement(_xmlReaderArg);
+                        index--;
+                    }
+                }
+
+                if (IsArrayLikeCollection(collectionContract))
+                {
+                    MethodInfo trimArraySizeMethod = XmlFormatGeneratorStatics.TrimArraySizeMethod.MakeGenericMethod(collectionContract.ItemType);
+                    resultCollection = trimArraySizeMethod.Invoke(null, new object[] { resultCollection, index });
+                }
+            }
+
+            return resultCollection;
+        }
+
+        protected virtual bool ReflectionReadSpecialCollection(CollectionDataContract collectionContract, object resultCollection)
+        {
+            return false;
+        }
+
+        bool IsArrayLikeInterface(CollectionDataContract collectionContract)
+        {
+            if (collectionContract.UnderlyingType.GetTypeInfo().IsInterface)
+            {
+                switch (collectionContract.Kind)
+                {
+                    case CollectionKind.Collection:
+                    case CollectionKind.GenericCollection:
+                    case CollectionKind.Enumerable:
+                    case CollectionKind.GenericEnumerable:
+                    case CollectionKind.List:
+                    case CollectionKind.GenericList:
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        bool IsArrayLikeCollection(CollectionDataContract collectionContract)
+        {
+            return collectionContract.Kind == CollectionKind.Array || IsArrayLikeInterface(collectionContract);
+        }
+
+        Type[] arrayConstructorParameters = new Type[] { Globals.TypeOfInt };
+        object[] arrayConstructorArguments = new object[] { 1 };
+        private object ReflectionCreateCollection(CollectionDataContract collectionContract)
+        {
+            if (IsArrayLikeCollection(collectionContract))
+            {
+                Type arrayType = collectionContract.ItemType.MakeArrayType();
+                var ci = arrayType.GetConstructor(arrayConstructorParameters);
+                arrayConstructorArguments[0] = 32;
+                var newArray = ci.Invoke(arrayConstructorArguments);
+                return newArray;
+            }
+            else if (collectionContract.Kind == CollectionKind.GenericDictionary && collectionContract.UnderlyingType.GetTypeInfo().IsInterface)
+            {
+                Type type = Globals.TypeOfDictionaryGeneric.MakeGenericType(collectionContract.ItemType.GetGenericArguments());
+                ConstructorInfo ci = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
+                object newGenericDict = ci.Invoke(Array.Empty<object>());
+                return newGenericDict;
+            }
+            else
+            {
+                if (collectionContract.UnderlyingType.GetTypeInfo().IsValueType)
+                {
+                    object newValueObject = Activator.CreateInstance(collectionContract.UnderlyingType);
+                    return newValueObject;
+                }
+                else if (collectionContract.UnderlyingType == Globals.TypeOfIDictionary)
+                {
+                    object newGenericDict = new Dictionary<object, object>();
+                    return newGenericDict;
+                }
+                else
+                {
+                    ConstructorInfo ci = collectionContract.UnderlyingType.GetConstructor(Array.Empty<Type>());
+                    object newCollection = ci.Invoke(Array.Empty<object>());
+                    return newCollection;
+                }
+            }
+        }
+
+        private static object ObjectToKeyValuePairGetKey<K, V>(object o)
+        {
+            return ((KeyValue<K, V>)o).Key;
+        }
+
+        private static object ObjectToKeyValuePairGetValue<K, V>(object o)
+        {
+            return ((KeyValue<K, V>)o).Value;
+        }
+
+        private CollectionSetItemDelegate GetCollectionSetItemDelegate<T>(CollectionDataContract collectionContract, object resultCollectionObject, bool isReadOnlyCollection)
+        {
+            if (isReadOnlyCollection && collectionContract.Kind == CollectionKind.Array)
+            {
+                int arraySize = ((Array)resultCollectionObject).Length;
+                return (resultCollection, collectionItem, index) =>
+                {
+                    if (index == arraySize)
+                    {
+                        XmlObjectSerializerReadContext.ThrowArrayExceededSizeException(arraySize, collectionContract.UnderlyingType);
+                    }
+
+                    ((T[])resultCollection)[index] = (T)collectionItem;
+                    return resultCollection;
+                };
+            }
+            else if (!isReadOnlyCollection && IsArrayLikeCollection(collectionContract))
+            {
+                return (resultCollection, collectionItem, index) =>
+                {
+                    resultCollection = XmlObjectSerializerReadContext.EnsureArraySize((T[])resultCollection, index);
+                    ((T[])resultCollection)[index] = (T)collectionItem;
+                    return resultCollection;
+                };
+            }
+            else if (collectionContract.Kind == CollectionKind.GenericDictionary || collectionContract.Kind == CollectionKind.Dictionary)
+            {
+                Type keyType = collectionContract.ItemType.GenericTypeArguments[0];
+                Type valueType = collectionContract.ItemType.GenericTypeArguments[1];
+                Func<object, object> objectToKeyValuePairGetKey = (Func<object, object>)s_objectToKeyValuePairGetKey.MakeGenericMethod(keyType, valueType).CreateDelegate(typeof(Func<object, object>));
+                Func<object, object> objectToKeyValuePairGetValue = (Func<object, object>)s_objectToKeyValuePairGetValue.MakeGenericMethod(keyType, valueType).CreateDelegate(typeof(Func<object, object>));
+
+                return (resultCollection, collectionItem, index) =>
+                {
+                    object key = objectToKeyValuePairGetKey(collectionItem);
+                    object value = objectToKeyValuePairGetValue(collectionItem);
+
+                    IDictionary dict = (IDictionary)resultCollection;
+                    dict.Add(key, value);
+                    return resultCollection;
+                };
+            }
+            else
+            {
+                Type collectionType = resultCollectionObject.GetType();
+                Type genericCollectionType = typeof(ICollection<T>);
+                Type typeIList = Globals.TypeOfIList;
+                if (genericCollectionType.IsAssignableFrom(collectionType))
+                {
+                    return (resultCollection, collectionItem, index) =>
+                    {
+                        ((ICollection<T>)resultCollection).Add((T)collectionItem);
+                        return resultCollection;
+                    };
+                }
+                else if (typeIList.IsAssignableFrom(collectionType))
+                {
+                    return (resultCollection, collectionItem, index) =>
+                    {
+                        ((IList)resultCollection).Add(collectionItem);
+                        return resultCollection;
+                    };
+                }
+                else
+                {
+                    MethodInfo addMethod = collectionType.GetMethod("Add");
+                    if (addMethod == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.CollectionMustHaveAddMethod, DataContract.GetClrTypeFullName(collectionContract.UnderlyingType))));
+                    }
+
+                    return (resultCollection, collectionItem, index) =>
+                    {
+                        addMethod.Invoke(resultCollection, new object[] { collectionItem });
+                        return resultCollection;
+                    };
+                }
+            }
+        }
+
+        private object ReflectionReadCollectionItem(CollectionDataContract collectionContract, Type itemType, string itemName, string itemNs,
+            ref ReflectionReadValueDelegate reflectionReadValueDelegate)
+        {
+            if (collectionContract.Kind == CollectionKind.Dictionary || collectionContract.Kind == CollectionKind.GenericDictionary)
+            {
+                return ReflectionReadDictionaryItem(collectionContract);
+            }
+            else
+            {
+                reflectionReadValueDelegate = reflectionReadValueDelegate ?? GetReflectionReadValueDelegate(itemType, itemName, itemNs);
+                return reflectionReadValueDelegate(itemType, itemName, itemNs);
+            }
+        }
+
+        protected abstract object ReflectionReadDictionaryItem(CollectionDataContract collectionContract);
+
+        private bool ReflectionTryReadPrimitiveArray(Type type, Type itemType, int arraySize, out object resultArray)
+        {
+            XmlDictionaryString collectionItemName = _collectionItemName;
+            XmlDictionaryString itemNamespace = _collectionItemNamespace;
+            resultArray = null;
+
+            PrimitiveDataContract primitiveContract = PrimitiveDataContract.GetPrimitiveDataContract(itemType);
+            if (primitiveContract == null)
+                return false;
+
+            switch (itemType.GetTypeCode())
+            {
+                case TypeCode.Boolean:
+                    {
+                        bool[] boolArray = null;
+                        _xmlReaderArg.TryReadBooleanArray(_contextArg, collectionItemName, itemNamespace, arraySize, out boolArray);
+                        resultArray = boolArray;
+                    }
+                    break;
+                case TypeCode.DateTime:
+                    {
+                        DateTime[] dateTimeArray = null;
+                        _xmlReaderArg.TryReadDateTimeArray(_contextArg, collectionItemName, itemNamespace, arraySize, out dateTimeArray);
+                        resultArray = dateTimeArray;
+                    }
+                    break;
+                case TypeCode.Decimal:
+                    {
+                        decimal[] decimalArray = null;
+                        _xmlReaderArg.TryReadDecimalArray(_contextArg, collectionItemName, itemNamespace, arraySize, out decimalArray);
+                        resultArray = decimalArray;
+                    }
+                    break;
+                case TypeCode.Int32:
+                    {
+                        int[] intArray = null;
+                        _xmlReaderArg.TryReadInt32Array(_contextArg, collectionItemName, itemNamespace, arraySize, out intArray);
+                        resultArray = intArray;
+                    }
+                    break;
+                case TypeCode.Int64:
+                    {
+                        long[] longArray = null;
+                        _xmlReaderArg.TryReadInt64Array(_contextArg, collectionItemName, itemNamespace, arraySize, out longArray);
+                        resultArray = longArray;
+                    }
+                    break;
+                case TypeCode.Single:
+                    {
+                        float[] floatArray = null;
+                        _xmlReaderArg.TryReadSingleArray(_contextArg, collectionItemName, itemNamespace, arraySize, out floatArray);
+                        resultArray = floatArray;
+                    }
+                    break;
+                case TypeCode.Double:
+                    {
+                        double[] doubleArray = null;
+                        _xmlReaderArg.TryReadDoubleArray(_contextArg, collectionItemName, itemNamespace, arraySize, out doubleArray);
+                        resultArray = doubleArray;
+                    }
+                    break;
+                default:
+                    return false;
+            }
+            return true;
+        }
+
+        protected void ReflectionReadGetOnlyCollectionInternal(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString itemName, XmlDictionaryString itemNs, CollectionDataContract collectionContract)
+        {
+            ReflectionInitArgs(xmlReader, context, null, null);
+            _collectionItemName = itemName;
+            _collectionItemNamespace = itemNs;
+
+            object resultCollection = _contextArg.GetCollectionMember();
+            if (ReflectionReadSpecialCollection(collectionContract, resultCollection))
+            {
+                return;
+            }
+
+            if (_xmlReaderArg.IsStartElement(_collectionItemName, _collectionItemNamespace))
+            {
+                
+                if (resultCollection == null)
+                {
+                    XmlObjectSerializerReadContext.ThrowNullValueReturnedForGetOnlyCollectionException(collectionContract.UnderlyingType);
+                }
+
+                string itemNameStr = collectionContract.ItemName;
+                string itemNsStr = collectionContract.StableName.Namespace;
+
+                ReflectionReadValueDelegate reflectionReadValueDelegate = null;
+                CollectionSetItemDelegate collectionSetItemDelegate = null;
+                for (int index = 0; index < int.MaxValue; index++)
+                {
+                    if (_xmlReaderArg.IsStartElement(_collectionItemName, _collectionItemNamespace))
+                    {
+                        _contextArg.IncrementItemCount(1);
+                        object collectionItem = ReflectionReadCollectionItem(collectionContract, collectionContract.ItemType, itemNameStr, itemNsStr, ref reflectionReadValueDelegate);
+                        if (collectionSetItemDelegate == null)
+                        {
+                            MethodInfo getCollectionSetItemDelegateMethod = s_getCollectionSetItemDelegateMethod.MakeGenericMethod(collectionContract.ItemType);
+                            collectionSetItemDelegate = (CollectionSetItemDelegate)getCollectionSetItemDelegateMethod.Invoke(this, new object[] { collectionContract, resultCollection, true/*isReadOnlyCollection*/ });
+                        }
+
+                        collectionSetItemDelegate(resultCollection, collectionItem, index);
+                    }
+                    else
+                    {
+                        if (_xmlReaderArg.NodeType == XmlNodeType.EndElement)
+                        {
+                            break;
+                        }
+                        if (!_xmlReaderArg.IsStartElement())
+                        {
+                            throw XmlObjectSerializerReadContext.CreateUnexpectedStateException(XmlNodeType.Element, _xmlReaderArg);
+                        }
+                        _contextArg.SkipUnknownElement(_xmlReaderArg);
+                        index--;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionReader.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization.Json;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
@@ -570,7 +571,16 @@ namespace System.Runtime.Serialization
                 case TypeCode.DateTime:
                     {
                         DateTime[] dateTimeArray = null;
-                        xmlReader.TryReadDateTimeArray(context, collectionItemName, collectionItemNamespace, arraySize, out dateTimeArray);
+                        var jsonReader = xmlReader as JsonReaderDelegator;
+                        if (jsonReader != null)
+                        {
+                            jsonReader.TryReadJsonDateTimeArray(context, collectionItemName, collectionItemNamespace, arraySize, out dateTimeArray);
+                        }
+                        else
+                        {
+                            xmlReader.TryReadDateTimeArray(context, collectionItemName, collectionItemNamespace, arraySize, out dateTimeArray);
+                        }
+
                         resultArray = dateTimeArray;
                     }
                     break;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatReader.cs
@@ -17,645 +17,89 @@ using Internal.Runtime.Augments;
 
 namespace System.Runtime.Serialization
 {
-    internal sealed class ReflectionXmlFormatReader
+    internal sealed class ReflectionXmlFormatReader : ReflectionReader
     {
-        private delegate object ReflectionReadValueDelegate(Type itemType, string itemName, string itemNs);
-        private delegate object CollectionSetItemDelegate(object resultCollection, object collectionItem, int itemIndex);
-
-        private ClassDataContract _classContract;
-        private CollectionDataContract _collectionContract;
-        private XmlReaderDelegator _arg0XmlReader;
-        private XmlObjectSerializerReadContext _arg1Context;
-        private XmlDictionaryString[] _arg2MemberNames;
-        private XmlDictionaryString[] _arg3MemberNamespaces;
-        private XmlDictionaryString _arg2CollectionItemName;
-        private XmlDictionaryString _arg3CollectionItemNamespace;
-
-        internal ReflectionXmlFormatReader(ClassDataContract classContract)
+        public ReflectionXmlFormatReader(ClassDataContract classDataContract) : base(classDataContract)
         {
-            _classContract = classContract;
         }
 
-        internal ReflectionXmlFormatReader(CollectionDataContract collectionContract)
+        public ReflectionXmlFormatReader(CollectionDataContract collectionContract) :base(collectionContract)
         {
-            _collectionContract = collectionContract;
         }
 
-        internal object ReflectionReadClass(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString[] memberNames, XmlDictionaryString[] memberNamespaces)
+        public object ReflectionReadClass(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString[] memberNames, XmlDictionaryString[] memberNamespaces)
         {
-            ReflectionInitArgs(xmlReader, context, memberNames, memberNamespaces);
-            object obj = ReflectionCreateObject(_classContract);
-            context.AddNewObject(obj);
-            InvokeOnDeserializing(obj, context, _classContract);
-            ReflectionReadMembers(ref obj, xmlReader, context, memberNames, memberNamespaces);
-
-            Type objType = obj.GetType();
-            if (objType == Globals.TypeOfDateTimeOffsetAdapter)
-            {
-                obj = DateTimeOffsetAdapter.GetDateTimeOffset((DateTimeOffsetAdapter)obj);
-            }
-            else if (obj is IKeyValuePairAdapter)
-            {
-                obj = _classContract.GetKeyValuePairMethodInfo.Invoke(obj, Array.Empty<object>());
-            }
-
-            InvokeOnDeserialized(obj, context, _classContract);
-
-            return obj;
+            return ReflectionReadClassInternal(xmlReader, context, memberNames, memberNamespaces);
         }
 
-        private void ReflectionInitArgs(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString[] memberNames, XmlDictionaryString[] memberNamespaces)
-        {
-            _arg0XmlReader = xmlReader;
-            _arg1Context = context;
-            _arg2MemberNames = memberNames;
-            _arg3MemberNamespaces = memberNamespaces;
-        }
-
-        private void InvokeOnDeserializing(object obj, XmlObjectSerializerReadContext context, ClassDataContract classContract)
-        {
-            if (classContract.BaseContract != null)
-                InvokeOnDeserializing(obj, context, classContract.BaseContract);
-            if (classContract.OnDeserializing != null)
-            {
-                var contextArg = context.GetStreamingContext();
-                classContract.OnDeserializing.Invoke(obj, new object[] { contextArg });
-            }
-        }
-
-        private void InvokeOnDeserialized(object obj, XmlObjectSerializerReadContext context, ClassDataContract classContract)
-        {
-            if (classContract.BaseContract != null)
-                InvokeOnDeserialized(obj, context, classContract.BaseContract);
-            if (classContract.OnDeserialized != null)
-            {
-                var contextArg = context.GetStreamingContext() ;
-                classContract.OnDeserialized.Invoke(obj, new object[] { contextArg });
-            }
-        }
-
-        private void ReflectionReadMembers(ref object obj, XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString[] memberNames, XmlDictionaryString[] memberNamespaces)
+        protected override void ReflectionReadMembers(ref object obj)
         {
             int memberCount = _classContract.MemberNames.Length;
-            context.IncrementItemCount(memberCount);
+            _contextArg.IncrementItemCount(memberCount);
             int memberIndex = -1;
             int firstRequiredMember;
             bool[] requiredMembers = GetRequiredMembers(_classContract, out firstRequiredMember);
             bool hasRequiredMembers = (firstRequiredMember < memberCount);
             int requiredIndex = hasRequiredMembers ? firstRequiredMember : -1;
-            int index = -1;
             DataMember[] members = new DataMember[memberCount];
             int reflectedMemberCount = ReflectionGetMembers(_classContract, members);
             Debug.Assert(reflectedMemberCount == memberCount, "The value returned by ReflectionGetMembers() should equal to memberCount.");
 
             while (true)
             {
-                if (!XmlObjectSerializerReadContext.MoveToNextElement(xmlReader))
+                if (!XmlObjectSerializerReadContext.MoveToNextElement(_xmlReaderArg))
                 {
                     return;
                 }
                 if (hasRequiredMembers)
                 {
-                    index = context.GetMemberIndexWithRequiredMembers(xmlReader, memberNames, memberNamespaces, memberIndex, requiredIndex, null);
+                    memberIndex = _contextArg.GetMemberIndexWithRequiredMembers(_xmlReaderArg, _memberNamesArg, _memberNamespacesArg, memberIndex, requiredIndex, null);
                 }
                 else
                 {
-                    index = context.GetMemberIndex(xmlReader, memberNames, memberNamespaces, memberIndex, null);
+                    memberIndex = _contextArg.GetMemberIndex(_xmlReaderArg, _memberNamesArg, _memberNamespacesArg, memberIndex, null);
                 }
 
                 // GetMemberIndex returns memberNames.Length if member not found
-                if (index < members.Length)
+                if (memberIndex < members.Length)
                 {
-                    ReflectionReadMember(ref obj, index, xmlReader, context, members);
-                    memberIndex = index;
-                    requiredIndex = index + 1;
+                    ReflectionReadMember(ref obj, memberIndex, _xmlReaderArg, _contextArg, members);
+                    requiredIndex = memberIndex + 1;
                 }
             }
         }
 
-        // Put all members of the contract (including types from base contract) into 'members'.
-        private int ReflectionGetMembers(ClassDataContract classContract, DataMember[] members)
+        protected override string GetClassContractNamespace(ClassDataContract classContract)
         {
-            int memberCount = (classContract.BaseContract == null) ? 0 : ReflectionGetMembers(classContract.BaseContract, members);
-            int childElementIndex = memberCount;
-            for (int i = 0; i < classContract.Members.Count; i++, memberCount++)
-            {
-                members[childElementIndex + i] = classContract.Members[i];
-            }
-
-            return memberCount;
+            return classContract.StableName.Namespace;
         }
 
-        private void ReflectionReadMember(ref object obj, int memberIndex, XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, DataMember[] members)
+        protected override string GetCollectionContractItemName(CollectionDataContract collectionContract)
         {
-            DataMember dataMember = members[memberIndex];
-
-            Debug.Assert(dataMember != null);
-            Type memberType = dataMember.MemberType;
-            if (dataMember.IsGetOnlyCollection)
-            {
-                var memberValue = ReflectionGetMemberValue(obj, dataMember);
-                context.StoreCollectionMemberInfo(memberValue);
-                ReflectionReadValue(dataMember, _classContract.StableName.Namespace);
-            }
-            else
-            {
-                var value = ReflectionReadValue(dataMember, _classContract.StableName.Namespace);
-                MemberInfo memberInfo = dataMember.MemberInfo;
-                Debug.Assert(memberInfo != null);
-
-                ReflectionSetMemberValue(ref obj, value, dataMember);
-            }
+            return collectionContract.ItemName;
         }
 
-        private object ReflectionGetMemberValue(object obj, DataMember dataMember)
+        protected override string GetCollectionContractNamespace(CollectionDataContract collectionContract)
         {
-            return dataMember.Getter(obj);
+            return collectionContract.StableName.Namespace;
         }
 
-        private void ReflectionSetMemberValue(ref object obj, object memberValue, DataMember dataMember)
+        public object ReflectionReadCollection(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString itemName, XmlDictionaryString itemNamespace, CollectionDataContract collectionContract)
         {
-            dataMember.Setter(ref obj, memberValue);
+            return ReflectionReadCollectionInternal(xmlReader, context, itemName, itemNamespace/*itemNamespace*/, collectionContract);
+        }
+        
+
+        public void ReflectionReadGetOnlyCollection(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString itemName, XmlDictionaryString itemNs, CollectionDataContract collectionContract)
+        {
+            ReflectionReadGetOnlyCollectionInternal(xmlReader, context, itemName, itemNs, collectionContract);
         }
 
-        private object ReflectionReadValue(DataMember dataMember, string ns)
+        protected override object ReflectionReadDictionaryItem(CollectionDataContract collectionContract)
         {
-            Type type = dataMember.MemberType;
-            string name = dataMember.Name;
-            object value = null;
-            int nullables = 0;
-            while (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == Globals.TypeOfNullable)
-            {
-                nullables++;
-                type = type.GetGenericArguments()[0];
-            }
-
-            PrimitiveDataContract primitiveContract = nullables != 0 ? PrimitiveDataContract.GetPrimitiveDataContract(type) : dataMember.MemberPrimitiveContract;
-            if ((primitiveContract != null && primitiveContract.UnderlyingType != Globals.TypeOfObject) || nullables != 0 || type.GetTypeInfo().IsValueType)
-            {
-                _arg1Context.ReadAttributes(_arg0XmlReader);
-                string objectId = _arg1Context.ReadIfNullOrRef(_arg0XmlReader, Globals.TypeOfString, true);
-                if (objectId != null)
-                {
-                    if (objectId.Length == 0)
-                    {
-                        objectId = _arg1Context.GetObjectId();
-                        if (primitiveContract != null && primitiveContract.UnderlyingType != Globals.TypeOfObject)
-                        {
-                            value = primitiveContract.ReadXmlValue(_arg0XmlReader, _arg1Context);
-                            _arg1Context.AddNewObject(value);
-                        }
-                        else
-                        {
-                            value = ReflectionInternalDeserialize(type, name, ns);
-                        }
-                    }
-                    else if (type.GetTypeInfo().IsValueType)
-                    {
-                        throw new SerializationException(SR.Format(SR.ValueTypeCannotHaveId, DataContract.GetClrTypeFullName(type)));
-                    }
-                }
-                else
-                {
-                    value = null;
-                }
-            }
-            else
-            {
-                value = ReflectionInternalDeserialize(type, name, ns);
-            }
-
-            return value;
-        }
-
-        // This method is a perf optimization for collections. The original method is ReflectionReadValue.
-        private ReflectionReadValueDelegate GetReflectionReadValueDelegate(Type type, string name, string ns)
-        {
-            object value = null;
-            int nullables = 0;
-            while (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == Globals.TypeOfNullable)
-            {
-                nullables++;
-                type = type.GetGenericArguments()[0];
-            }
-
-            PrimitiveDataContract primitiveContract = PrimitiveDataContract.GetPrimitiveDataContract(type);
-            bool hasValidPrimitiveContract = primitiveContract != null && primitiveContract.UnderlyingType != Globals.TypeOfObject;
-            if ((primitiveContract != null && primitiveContract.UnderlyingType != Globals.TypeOfObject) || nullables != 0 || type.GetTypeInfo().IsValueType)
-            {
-
-                return (typeArg, nameArg, nsArg) =>
-                {
-                    _arg1Context.ReadAttributes(_arg0XmlReader);
-                    string objectId = _arg1Context.ReadIfNullOrRef(_arg0XmlReader, Globals.TypeOfString, true);
-                    if (objectId != null)
-                    {
-                        if (objectId.Length == 0)
-                        {
-                            objectId = _arg1Context.GetObjectId();
-                            if (hasValidPrimitiveContract)
-                            {
-                                value = primitiveContract.ReadXmlValue(_arg0XmlReader, _arg1Context);
-                                _arg1Context.AddNewObject(value);
-                            }
-                            else
-                            {
-                                value = ReflectionInternalDeserialize(type, name, ns);
-                            }
-                        }
-                        else if (type.GetTypeInfo().IsValueType)
-                        {
-                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SerializationException(SR.Format(SR.ValueTypeCannotHaveId, DataContract.GetClrTypeFullName(type))));
-                        }
-                    }
-                    else
-                    {
-                        value = null;
-                    }
-
-                    return value;
-                };
-            }
-            else
-            {
-                return ReflectionInternalDeserialize;
-            }
-        }
-
-        private object ReflectionInternalDeserialize(Type type, string name, string ns)
-        {
-            return _arg1Context.InternalDeserialize(_arg0XmlReader, DataContract.GetId(type.TypeHandle), type.TypeHandle, name, ns);
-        }
-
-        private object ReflectionCreateObject(ClassDataContract classContract)
-        {
-            object obj;
-            if (!classContract.CreateNewInstanceViaDefaultConstructor(out obj))
-            {
-                Type classType = classContract.UnderlyingType;
-                obj = XmlFormatReaderGenerator.UnsafeGetUninitializedObject(classType);
-            }
-
-            return obj;
-        }
-
-        bool IsArrayLikeInterface(CollectionDataContract collectionContract)
-        {
-            if (collectionContract.UnderlyingType.GetTypeInfo().IsInterface)
-            {
-                switch (collectionContract.Kind)
-                {
-                    case CollectionKind.Collection:
-                    case CollectionKind.GenericCollection:
-                    case CollectionKind.Enumerable:
-                    case CollectionKind.GenericEnumerable:
-                    case CollectionKind.List:
-                    case CollectionKind.GenericList:
-                        return true;
-                }
-            }
-            return false;
-        }
-
-        bool IsArrayLikeCollection(CollectionDataContract collectionContract)
-        {
-            return collectionContract.Kind == CollectionKind.Array || IsArrayLikeInterface(collectionContract);
-        }
-
-        Type[] arrayConstructorParameters = new Type[] { Globals.TypeOfInt };
-        object[] arrayConstructorArguments = new object[] { 1 };
-        private object ReflectionCreateCollection(CollectionDataContract collectionContract)
-        {
-            if (IsArrayLikeCollection(collectionContract))
-            {
-                Type arrayType = collectionContract.ItemType.MakeArrayType();
-                var ci = arrayType.GetConstructor(arrayConstructorParameters);
-                arrayConstructorArguments[0] = 32;
-                var newArray = ci.Invoke(arrayConstructorArguments);
-                return newArray;
-            }
-            else if (collectionContract.Kind == CollectionKind.GenericDictionary && collectionContract.UnderlyingType.GetTypeInfo().IsInterface)
-            {
-                Type type = Globals.TypeOfDictionaryGeneric.MakeGenericType(collectionContract.ItemType.GetGenericArguments());
-                ConstructorInfo ci = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
-                object newGenericDict = ci.Invoke(Array.Empty<object>());
-                return newGenericDict;
-            }
-            else
-            {
-                if (collectionContract.UnderlyingType.GetTypeInfo().IsValueType)
-                {
-                    object newValueObject = Activator.CreateInstance(collectionContract.UnderlyingType);
-                    return newValueObject;
-                }
-                else if (collectionContract.UnderlyingType == Globals.TypeOfIDictionary)
-                {
-                    object newGenericDict = new Dictionary<object, object>();
-                    return newGenericDict;
-                }
-                else
-                {
-                    ConstructorInfo ci = collectionContract.UnderlyingType.GetConstructor(Array.Empty<Type>());
-                    object newCollection = ci.Invoke(Array.Empty<object>());
-                    return newCollection;
-                }
-            }
-        }
-
-        internal object ReflectionReadCollection(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString itemName, XmlDictionaryString itemNamespace, CollectionDataContract collectionContract)
-        {
-            ReflectionInitArgs(xmlReader, context, null, null);
-            _arg2CollectionItemName = itemName;
-            _arg3CollectionItemNamespace = itemNamespace;
-
-            return ReflectionReadCollectionCore(collectionContract);
-        }
-
-        private object ReflectionReadCollectionCore(CollectionDataContract collectionContract)
-        {
-            bool isArray = (collectionContract.Kind == CollectionKind.Array);
-
-            int arraySize = _arg1Context.GetArraySize();
-            string objectId = _arg1Context.GetObjectId();
-            object resultArray = null;
-            if (isArray && ReflectionTryReadPrimitiveArray(collectionContract.UnderlyingType, collectionContract.ItemType, arraySize, out resultArray))
-            {
-                return resultArray;
-            }
-
-            if (arraySize != -1)
-            {
-                throw new NotImplementedException();
-            }
-
-            string itemName = collectionContract.ItemName;
-            string itemNs = collectionContract.StableName.Namespace;
-            object resultCollection = ReflectionCreateCollection(collectionContract);
-            int index = 0;
-
-            ReflectionReadValueDelegate reflectionReadValueDelegate = null;
-            CollectionSetItemDelegate collectionSetItemDelegate = null;
-            for (; index < int.MaxValue; index++)
-            {
-                if (_arg0XmlReader.IsStartElement(_arg2CollectionItemName, _arg3CollectionItemNamespace))
-                {
-                    _arg1Context.IncrementItemCount(1);
-                    object collectionItem = ReflectionReadCollectionItem(collectionContract, collectionContract.ItemType, itemName, itemNs, ref reflectionReadValueDelegate);
-                    if (collectionSetItemDelegate == null)
-                    {
-                        MethodInfo getCollectionSetItemDelegateMethod = s_getCollectionSetItemDelegateMethod.MakeGenericMethod(collectionContract.ItemType);
-                        collectionSetItemDelegate = (CollectionSetItemDelegate)getCollectionSetItemDelegateMethod.Invoke(this, new object[] { collectionContract, resultCollection, false/*isReadOnlyCollection*/ });
-                    }
-
-                    resultCollection = collectionSetItemDelegate(resultCollection, collectionItem, index);
-                }
-                else
-                {
-                    if (_arg0XmlReader.NodeType == XmlNodeType.EndElement)
-                    {
-                        break;
-                    }
-                    if (!_arg0XmlReader.IsStartElement())
-                    {
-                        throw XmlObjectSerializerReadContext.CreateUnexpectedStateException(XmlNodeType.Element, _arg0XmlReader);
-                    }
-                    _arg1Context.SkipUnknownElement(_arg0XmlReader);
-                    index--;
-                }
-            }
-
-            if (IsArrayLikeCollection(collectionContract))
-            {
-                MethodInfo trimArraySizeMethod = XmlFormatGeneratorStatics.TrimArraySizeMethod.MakeGenericMethod(collectionContract.ItemType);
-                resultCollection = trimArraySizeMethod.Invoke(null, new object[] { resultCollection, index });
-            }
-            return resultCollection;
-        }
-
-        private readonly static MethodInfo s_getCollectionSetItemDelegateMethod = typeof(ReflectionXmlFormatReader).GetMethod(nameof(GetCollectionSetItemDelegate), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
-        private readonly static MethodInfo s_objectToKeyValuePairGetKey = typeof(ReflectionXmlFormatReader).GetMethod(nameof(ObjectToKeyValuePairGetKey), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
-        private readonly static MethodInfo s_objectToKeyValuePairGetValue = typeof(ReflectionXmlFormatReader).GetMethod(nameof(ObjectToKeyValuePairGetValue), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
-
-        private static object ObjectToKeyValuePairGetKey<K, V>(object o)
-        {
-            return ((KeyValue<K, V>)o).Key;
-        }
-
-        private static object ObjectToKeyValuePairGetValue<K, V>(object o)
-        {
-            return ((KeyValue<K, V>)o).Value;
-        }
-
-        private CollectionSetItemDelegate GetCollectionSetItemDelegate<T>(CollectionDataContract collectionContract, object resultCollectionObject, bool isReadOnlyCollection)
-        {
-            if (isReadOnlyCollection && collectionContract.Kind == CollectionKind.Array)
-            {
-                int arraySize = ((Array)resultCollectionObject).Length;
-                return (resultCollection, collectionItem, index) =>
-                {
-                    if (index == arraySize)
-                    {
-                        XmlObjectSerializerReadContext.ThrowArrayExceededSizeException(arraySize, collectionContract.UnderlyingType);
-                    }
-
-                    ((T[])resultCollection)[index] = (T)collectionItem;
-                    return resultCollection;
-                };
-            }
-            else if (!isReadOnlyCollection && IsArrayLikeCollection(collectionContract))
-            {
-                return (resultCollection, collectionItem, index) =>
-                {
-                    resultCollection = XmlObjectSerializerReadContext.EnsureArraySize((T[])resultCollection, index);
-                    ((T[])resultCollection)[index] = (T)collectionItem;
-                    return resultCollection;
-                };
-            }
-            else if (collectionContract.Kind == CollectionKind.GenericDictionary || collectionContract.Kind == CollectionKind.Dictionary)
-            {
-                Type keyType = collectionContract.ItemType.GenericTypeArguments[0];
-                Type valueType = collectionContract.ItemType.GenericTypeArguments[1];
-                Func<object, object> objectToKeyValuePairGetKey = (Func<object, object>)s_objectToKeyValuePairGetKey.MakeGenericMethod(keyType, valueType).CreateDelegate(typeof(Func<object, object>));
-                Func<object, object> objectToKeyValuePairGetValue = (Func<object, object>)s_objectToKeyValuePairGetValue.MakeGenericMethod(keyType, valueType).CreateDelegate(typeof(Func<object, object>));
-
-                return (resultCollection, collectionItem, index) =>
-                {
-                    object key = objectToKeyValuePairGetKey(collectionItem);
-                    object value = objectToKeyValuePairGetValue(collectionItem);
-
-                    IDictionary dict = (IDictionary)resultCollection;
-                    dict.Add(key, value);
-                    return resultCollection;
-                };
-            }
-            else
-            {
-                Type collectionType = resultCollectionObject.GetType();
-                Type genericCollectionType = typeof(ICollection<T>);
-                Type typeIList = Globals.TypeOfIList;
-                if (genericCollectionType.IsAssignableFrom(collectionType))
-                {
-                    return (resultCollection, collectionItem, index) =>
-                    {
-                        ((ICollection<T>)resultCollection).Add((T)collectionItem);
-                        return resultCollection;
-                    };
-                }
-                else if (typeIList.IsAssignableFrom(collectionType))
-                {
-                    return (resultCollection, collectionItem, index) =>
-                    {
-                        ((IList)resultCollection).Add(collectionItem);
-                        return resultCollection;
-                    };
-                }
-                else
-                {
-                    MethodInfo addMethod = collectionType.GetMethod("Add");
-                    if (addMethod == null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.CollectionMustHaveAddMethod, DataContract.GetClrTypeFullName(collectionContract.UnderlyingType))));
-                    }
-
-                    return (resultCollection, collectionItem, index) =>
-                    {
-                        addMethod.Invoke(resultCollection, new object[] { collectionItem });
-                        return resultCollection;
-                    };
-                }
-            }
-        }
-
-        private object ReflectionReadCollectionItem(CollectionDataContract collectionContract, Type itemType, string itemName, string itemNs,
-            ref ReflectionReadValueDelegate reflectionReadValueDelegate)
-        {
-            if (collectionContract.Kind == CollectionKind.Dictionary || collectionContract.Kind == CollectionKind.GenericDictionary)
-            {
-                _arg1Context.ReadAttributes(_arg0XmlReader);
-                return collectionContract.ItemContract.ReadXmlValue(_arg0XmlReader, _arg1Context);
-            }
-            else
-            {
-                reflectionReadValueDelegate = reflectionReadValueDelegate ?? GetReflectionReadValueDelegate(itemType, itemName, itemNs);
-                return reflectionReadValueDelegate(itemType, itemName, itemNs);
-            }
-        }
-
-        private bool ReflectionTryReadPrimitiveArray(Type type, Type itemType, int arraySize, out object resultArray)
-        {
-            XmlDictionaryString collectionItemName = _arg2CollectionItemName;
-            XmlDictionaryString itemNamespace = _arg3CollectionItemNamespace;
-            resultArray = null;
-
-            PrimitiveDataContract primitiveContract = PrimitiveDataContract.GetPrimitiveDataContract(itemType);
-            if (primitiveContract == null)
-                return false;
-
-            switch (itemType.GetTypeCode())
-            {
-                case TypeCode.Boolean:
-                    {
-                        bool[] boolArray = null;
-                        _arg0XmlReader.TryReadBooleanArray(_arg1Context, collectionItemName, itemNamespace, arraySize, out boolArray);
-                        resultArray = boolArray;
-                    }
-                    break;
-                case TypeCode.DateTime:
-                    {
-                        DateTime[] dateTimeArray = null;
-                        _arg0XmlReader.TryReadDateTimeArray(_arg1Context, collectionItemName, itemNamespace, arraySize, out dateTimeArray);
-                        resultArray = dateTimeArray;
-                    }
-                    break;
-                case TypeCode.Decimal:
-                    {
-                        decimal[] decimalArray = null;
-                        _arg0XmlReader.TryReadDecimalArray(_arg1Context, collectionItemName, itemNamespace, arraySize, out decimalArray);
-                        resultArray = decimalArray;
-                    }
-                    break;
-                case TypeCode.Int32:
-                    {
-                        int[] intArray = null;
-                        _arg0XmlReader.TryReadInt32Array(_arg1Context, collectionItemName, itemNamespace, arraySize, out intArray);
-                        resultArray = intArray;
-                    }
-                    break;
-                case TypeCode.Int64:
-                    {
-                        long[] longArray = null;
-                        _arg0XmlReader.TryReadInt64Array(_arg1Context, collectionItemName, itemNamespace, arraySize, out longArray);
-                        resultArray = longArray;
-                    }
-                    break;
-                case TypeCode.Single:
-                    {
-                        float[] floatArray = null;
-                        _arg0XmlReader.TryReadSingleArray(_arg1Context, collectionItemName, itemNamespace, arraySize, out floatArray);
-                        resultArray = floatArray;
-                    }
-                    break;
-                case TypeCode.Double:
-                    {
-                        double[] doubleArray = null;
-                        _arg0XmlReader.TryReadDoubleArray(_arg1Context, collectionItemName, itemNamespace, arraySize, out doubleArray);
-                        resultArray = doubleArray;
-                    }
-                    break;
-                default:
-                    return false;
-            }
-            return true;
-        }
-
-        internal void ReflectionReadGetOnlyCollection(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString itemName, XmlDictionaryString itemNs, CollectionDataContract collectionContract)
-        {
-            ReflectionInitArgs(xmlReader, context, null, null);
-            _arg2CollectionItemName = itemName;
-            _arg3CollectionItemNamespace = itemNs;
-
-            if (_arg0XmlReader.IsStartElement(_arg2CollectionItemName, _arg3CollectionItemNamespace))
-            {
-                object resultCollection = _arg1Context.GetCollectionMember();
-                if (resultCollection == null)
-                {
-                    XmlObjectSerializerReadContext.ThrowNullValueReturnedForGetOnlyCollectionException(collectionContract.UnderlyingType);
-                }
-
-                string itemNameStr = collectionContract.ItemName;
-                string itemNsStr = collectionContract.StableName.Namespace;
-
-                ReflectionReadValueDelegate reflectionReadValueDelegate = null;
-                CollectionSetItemDelegate collectionSetItemDelegate = null;
-                for (int index = 0; index < int.MaxValue; index++)
-                {
-                    if (_arg0XmlReader.IsStartElement(_arg2CollectionItemName, _arg3CollectionItemNamespace))
-                    {
-                        _arg1Context.IncrementItemCount(1);
-                        object collectionItem = ReflectionReadCollectionItem(collectionContract, collectionContract.ItemType, itemNameStr, itemNsStr, ref reflectionReadValueDelegate);
-                        if (collectionSetItemDelegate == null)
-                        {
-                            MethodInfo getCollectionSetItemDelegateMethod = s_getCollectionSetItemDelegateMethod.MakeGenericMethod(collectionContract.ItemType);
-                            collectionSetItemDelegate = (CollectionSetItemDelegate)getCollectionSetItemDelegateMethod.Invoke(this, new object[] { collectionContract, resultCollection, true/*isReadOnlyCollection*/ });
-                        }
-
-                        collectionSetItemDelegate(resultCollection, collectionItem, index);
-                    }
-                    else
-                    {
-                        if (_arg0XmlReader.NodeType == XmlNodeType.EndElement)
-                        {
-                            break;
-                        }
-                        if (!_arg0XmlReader.IsStartElement())
-                        {
-                            throw XmlObjectSerializerReadContext.CreateUnexpectedStateException(XmlNodeType.Element, _arg0XmlReader);
-                        }
-                        _arg1Context.SkipUnknownElement(_arg0XmlReader);
-                        index--;
-                    }
-                }
-            }
+            Debug.Assert(collectionContract.Kind == CollectionKind.Dictionary || collectionContract.Kind == CollectionKind.GenericDictionary);
+            _contextArg.ReadAttributes(_xmlReaderArg);
+            return collectionContract.ItemContract.ReadXmlValue(_xmlReaderArg, _contextArg);
         }
 
         private bool[] GetRequiredMembers(ClassDataContract contract, out int firstRequiredMember)
@@ -679,6 +123,5 @@ namespace System.Runtime.Serialization
             }
             return memberCount;
         }
-
     }
 }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatReader.cs
@@ -21,6 +21,7 @@ namespace System.Runtime.Serialization
     {
         private ClassDataContract _classContract;
         private ReflectionReader _reflectionReader;
+
         public ReflectionXmlClassReader(ClassDataContract classDataContract)
         {
             Debug.Assert(classDataContract != null);
@@ -36,12 +37,7 @@ namespace System.Runtime.Serialization
 
     internal sealed class ReflectionXmlCollectionReader
     {
-        private ReflectionReader _reflectionReader;
-
-        public ReflectionXmlCollectionReader()
-        {
-            _reflectionReader = new ReflectionXmlReader();
-        }
+        private ReflectionReader _reflectionReader = new ReflectionXmlReader();
 
         public object ReflectionReadCollection(XmlReaderDelegator xmlReader, XmlObjectSerializerReadContext context, XmlDictionaryString itemName, XmlDictionaryString itemNamespace, CollectionDataContract collectionContract)
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatWriter.cs
@@ -13,7 +13,7 @@ namespace System.Runtime.Serialization
 {
     internal class ReflectionXmlFormatWriter
     {
-        private ReflectionXmlClassWriter _reflectionClassWriter = new ReflectionXmlClassWriter();
+        private readonly ReflectionXmlClassWriter _reflectionClassWriter = new ReflectionXmlClassWriter();
 
         public void ReflectionWriteClass(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract)
         {
@@ -27,9 +27,7 @@ namespace System.Runtime.Serialization
 
             if (collectionDataContract.ChildElementNamespace != null)
             {
-                // TODO: should add tests for this.
-                // xmlWriter.WriteNamespaceDecl(collectionContract.ChildElementNamespace);
-                throw new NotImplementedException("collectionContract.ChildElementNamespace != null");
+                xmlWriter.WriteNamespaceDecl(collectionDataContract.ChildElementNamespace);
             }
 
             if (collectionDataContract.Kind == CollectionKind.Array)
@@ -125,8 +123,7 @@ namespace System.Runtime.Serialization
         }
     }
 
-
-    internal sealed class ReflectionXmlClassWriter :ReflectionClassWriter
+    internal sealed class ReflectionXmlClassWriter : ReflectionClassWriter
     {
         protected override int ReflectionWriteMembers(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract, ClassDataContract derivedMostClassContract, int childElementIndex, XmlDictionaryString[] emptyStringArray)
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -762,11 +762,16 @@ namespace System.Runtime.Serialization
             {
                 if (s_getDefaultValueMethod == null)
                 {
-                    s_getDefaultValueMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("GetDefaultValue", Globals.ScanAllMembers);
+                    s_getDefaultValueMethod = typeof(XmlObjectSerializerWriteContext).GetMethod(nameof(XmlObjectSerializerWriteContext.GetDefaultValue), Globals.ScanAllMembers);
                     Debug.Assert(s_getDefaultValueMethod != null);
                 }
                 return s_getDefaultValueMethod;
             }
+        }
+
+        internal static object GetDefaultValue(Type type)
+        {
+            return GetDefaultValueMethod.MakeGenericMethod(type).Invoke(null, Array.Empty<object>());
         }
 
         [SecurityCritical]

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -104,7 +104,7 @@ namespace System.Runtime.Serialization
             {
                 if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                 {
-                    return new ReflectionXmlFormatReader(classContract).ReflectionReadClass;
+                    return new ReflectionXmlClassReader(classContract).ReflectionReadClass;
                 }
 #if NET_NATIVE
                 else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
@@ -177,7 +177,7 @@ namespace System.Runtime.Serialization
             {
                 if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                 {
-                    return new ReflectionXmlFormatReader(collectionContract).ReflectionReadCollection;
+                    return new ReflectionXmlCollectionReader().ReflectionReadCollection;
                 }
 #if NET_NATIVE
                 else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
@@ -203,7 +203,7 @@ namespace System.Runtime.Serialization
             {
                 if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                 {
-                    return new ReflectionXmlFormatReader(collectionContract).ReflectionReadGetOnlyCollection;
+                    return new ReflectionXmlCollectionReader().ReflectionReadGetOnlyCollection;
                 }
 #if NET_NATIVE
                 else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -109,7 +109,7 @@ namespace System.Runtime.Serialization
 #if NET_NATIVE
                 else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                 {
-                    return new ReflectionXmlFormatReader(classContract).ReflectionReadClass;
+                    return new ReflectionXmlClassReader(classContract).ReflectionReadClass;
                 }
 #endif
                 else
@@ -182,7 +182,7 @@ namespace System.Runtime.Serialization
 #if NET_NATIVE
                 else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                 {
-                    return new ReflectionXmlFormatReader(collectionContract).ReflectionReadCollection;
+                    return new ReflectionXmlCollectionReader().ReflectionReadCollection;
                 }
 #endif
                 else
@@ -208,7 +208,7 @@ namespace System.Runtime.Serialization
 #if NET_NATIVE
                 else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                 {
-                    return new ReflectionXmlFormatReader(collectionContract).ReflectionReadGetOnlyCollection;
+                    return new ReflectionXmlCollectionReader().ReflectionReadGetOnlyCollection;
                 }
 #endif
                 else

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlReaderDelegator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlReaderDelegator.cs
@@ -667,9 +667,9 @@ namespace System.Runtime.Serialization
         }
 
 #if USE_REFEMIT
-        public bool TryReadDateTimeArray(XmlObjectSerializerReadContext context,
+        public virtual bool TryReadDateTimeArray(XmlObjectSerializerReadContext context,
 #else
-        internal bool TryReadDateTimeArray(XmlObjectSerializerReadContext context,
+        internal virtual bool TryReadDateTimeArray(XmlObjectSerializerReadContext context,
 #endif
         XmlDictionaryString itemName, XmlDictionaryString itemNamespace,
             int arrayLength, out DateTime[] array)

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1852,6 +1852,304 @@ public static partial class DataContractJsonSerializerTests
         });
     }
 
+    [Fact]
+    public static void DCS_TypeWithPrimitiveProperties()
+    {
+        TypeWithPrimitiveProperties x = new TypeWithPrimitiveProperties { P1 = "abc", P2 = 11 };
+        TypeWithPrimitiveProperties y = SerializeAndDeserialize<TypeWithPrimitiveProperties>(x, "{\"P1\":\"abc\",\"P2\":11}");
+        Assert.StrictEqual(x.P1, y.P1);
+        Assert.StrictEqual(x.P2, y.P2);
+    }
+
+    [Fact]
+    public static void DCS_TypeWithPrimitiveFields()
+    {
+        TypeWithPrimitiveFields x = new TypeWithPrimitiveFields { P1 = "abc", P2 = 11 };
+        TypeWithPrimitiveFields y = SerializeAndDeserialize<TypeWithPrimitiveFields>(x, "{\"P1\":\"abc\",\"P2\":11}");
+        Assert.StrictEqual(x.P1, y.P1);
+        Assert.StrictEqual(x.P2, y.P2);
+    }
+
+    [Fact]
+    public static void DCS_TypeWithAllPrimitiveProperties()
+    {
+        TypeWithAllPrimitiveProperties x = new TypeWithAllPrimitiveProperties
+        {
+            BooleanMember = true,
+            //ByteArrayMember = new byte[] { 1, 2, 3, 4 },
+            CharMember = 'C',
+            DateTimeMember = new DateTime(2016, 7, 8, 9, 10, 11),
+            DecimalMember = new decimal(123, 456, 789, true, 0),
+            DoubleMember = 123.456,
+            FloatMember = 456.789f,
+            GuidMember = Guid.Parse("2054fd3e-e118-476a-9962-1a882be51860"),
+            //public byte[] HexBinaryMember 
+            StringMember = "abc",
+            IntMember = 123
+        };
+        TypeWithAllPrimitiveProperties y = SerializeAndDeserialize<TypeWithAllPrimitiveProperties>(x, "{\"BooleanMember\":true,\"CharMember\":\"C\",\"DateTimeMember\":\"\\/Date(1467994211000-0700)\\/\",\"DecimalMember\":-14554481076115341312123,\"DoubleMember\":123.456,\"FloatMember\":456.789,\"GuidMember\":\"2054fd3e-e118-476a-9962-1a882be51860\",\"IntMember\":123,\"StringMember\":\"abc\"}");
+        Assert.StrictEqual(x.BooleanMember, y.BooleanMember);
+        //Assert.StrictEqual(x.ByteArrayMember, y.ByteArrayMember);
+        Assert.StrictEqual(x.CharMember, y.CharMember);
+        Assert.StrictEqual(x.DateTimeMember, y.DateTimeMember);
+        Assert.StrictEqual(x.DecimalMember, y.DecimalMember);
+        Assert.StrictEqual(x.DoubleMember, y.DoubleMember);
+        Assert.StrictEqual(x.FloatMember, y.FloatMember);
+        Assert.StrictEqual(x.GuidMember, y.GuidMember);
+        Assert.StrictEqual(x.StringMember, y.StringMember);
+        Assert.StrictEqual(x.IntMember, y.IntMember);
+    }
+
+    #region Array of primitive types
+
+    [Fact]
+    public static void DCS_ArrayOfBoolean()
+    {
+        var value = new bool[] { true, false, true };
+        var deserialized = SerializeAndDeserialize(value, "[true,false,true]");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_ArrayOfDateTime()
+    {
+        var value = new DateTime[] { new DateTime(2000, 1, 2, 3, 4, 5), new DateTime(2011, 2, 3, 4, 5, 6) };
+        var deserialized = SerializeAndDeserialize(value, "[\"\\/Date(946811045000-0800)\\/\",\"\\/Date(1296734706000-0800)\\/\"]");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_ArrayOfDecimal()
+    {
+        var value = new decimal[] { new decimal(1, 2, 3, false, 1), new decimal(4, 5, 6, true, 2) };
+        var deserialized = SerializeAndDeserialize(value, "[5534023222971858944.1,-1106804644637321461.80]");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_ArrayOfInt32()
+    {
+        var value = new int[] { 123, int.MaxValue, int.MinValue };
+        var deserialized = SerializeAndDeserialize(value, "[123,2147483647,-2147483648]");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_ArrayOfInt64()
+    {
+        var value = new long[] { 123, long.MaxValue, long.MinValue };
+        var deserialized = SerializeAndDeserialize(value, "[123,9223372036854775807,-9223372036854775808]");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_ArrayOfSingle()
+    {
+        var value = new float[] { 1.23f, 4.56f, 7.89f };
+        var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_ArrayOfDouble()
+    {
+        var value = new double[] { 1.23, 4.56, 7.89 };
+        var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_ArrayOfString()
+    {
+        var value = new string[] { "abc", "def", "xyz" };
+        var deserialized = SerializeAndDeserialize(value, "[\"abc\",\"def\",\"xyz\"]");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_ArrayOfTypeWithPrimitiveProperties()
+    {
+        var value = new TypeWithPrimitiveProperties[]
+        {
+            new TypeWithPrimitiveProperties() { P1 = "abc" , P2 = 123 },
+            new TypeWithPrimitiveProperties() { P1 = "def" , P2 = 456 },
+        };
+        var deserialized = SerializeAndDeserialize(value, "[{\"P1\":\"abc\",\"P2\":123},{\"P1\":\"def\",\"P2\":456}]");
+        Assert.StrictEqual(value.Length, deserialized.Length);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    #endregion
+
+    #region Collection
+
+    [Fact]
+    public static void DCS_GenericICollectionOfBoolean()
+    {
+        var value = new TypeImplementsGenericICollection<bool>() { true, false, true };
+        var deserialized = SerializeAndDeserialize(value, "[true,false,true]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_GenericICollectionOfDecimal()
+    {
+        var value = new TypeImplementsGenericICollection<decimal>() { new decimal(1, 2, 3, false, 1), new decimal(4, 5, 6, true, 2) };
+        var deserialized = SerializeAndDeserialize(value, "[5534023222971858944.1,-1106804644637321461.80]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_GenericICollectionOfInt32()
+    {
+        TypeImplementsGenericICollection<int> x = new TypeImplementsGenericICollection<int>(123, int.MaxValue, int.MinValue);
+        TypeImplementsGenericICollection<int> y = SerializeAndDeserialize(x, "[123,2147483647,-2147483648]");
+
+        Assert.NotNull(y);
+        Assert.StrictEqual(x.Count, y.Count);
+        Assert.True(x.SequenceEqual(y));
+    }
+
+    [Fact]
+    public static void DCS_GenericICollectionOfInt64()
+    {
+        var value = new TypeImplementsGenericICollection<long>() { 123, long.MaxValue, long.MinValue };
+        var deserialized = SerializeAndDeserialize(value, "[123,9223372036854775807,-9223372036854775808]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_GenericICollectionOfSingle()
+    {
+        var value = new TypeImplementsGenericICollection<float>() { 1.23f, 4.56f, 7.89f };
+        var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_GenericICollectionOfDouble()
+    {
+        var value = new TypeImplementsGenericICollection<double>() { 1.23, 4.56, 7.89 };
+        var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_GenericICollectionOfString()
+    {
+        TypeImplementsGenericICollection<string> value = new TypeImplementsGenericICollection<string>("a1", "a2");
+        TypeImplementsGenericICollection<string> deserialized = SerializeAndDeserialize(value, "[\"a1\",\"a2\"]");
+
+        Assert.NotNull(deserialized);
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.True(value.SequenceEqual(deserialized));
+    }
+
+    [Fact]
+    public static void DCS_GenericICollectionOfTypeWithPrimitiveProperties()
+    {
+        var value = new TypeImplementsGenericICollection<TypeWithPrimitiveProperties>()
+        {
+            new TypeWithPrimitiveProperties() { P1 = "abc" , P2 = 123 },
+            new TypeWithPrimitiveProperties() { P1 = "def" , P2 = 456 },
+        };
+        var deserialized = SerializeAndDeserialize(value, "[{\"P1\":\"abc\",\"P2\":123},{\"P1\":\"def\",\"P2\":456}]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    #endregion
+
+    #region Generic Dictionary
+
+    [Fact]
+    public static void DCS_GenericDictionaryOfInt32Boolean()
+    {
+        var value = new Dictionary<int, bool>();
+        value.Add(123, true);
+        value.Add(456, false);
+        var deserialized = SerializeAndDeserialize(value, "[{\"Key\":123,\"Value\":true},{\"Key\":456,\"Value\":false}]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value.ToArray(), deserialized.ToArray()));
+    }
+
+    [Fact]
+    public static void DCS_GenericDictionaryOfInt32String()
+    {
+        var value = new Dictionary<int, string>();
+        value.Add(123, "abc");
+        value.Add(456, "def");
+        var deserialized = SerializeAndDeserialize(value, "[{\"Key\":123,\"Value\":\"abc\"},{\"Key\":456,\"Value\":\"def\"}]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value.ToArray(), deserialized.ToArray()));
+    }
+
+    [Fact]
+    public static void DCS_GenericDictionaryOfStringInt32()
+    {
+        var value = new Dictionary<string, int>();
+        value.Add("abc", 123);
+        value.Add("def", 456);
+        var deserialized = SerializeAndDeserialize(value, "[{\"Key\":\"abc\",\"Value\":123},{\"Key\":\"def\",\"Value\":456}]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value.ToArray(), deserialized.ToArray()));
+    }
+
+    #endregion
+
+    #region Non-Generic Dictionary
+
+    [Fact]
+    public static void DCS_NonGenericDictionaryOfInt32Boolean()
+    {
+        var value = new MyNonGenericDictionary();
+        value.Add(123, true);
+        value.Add(456, false);
+        var deserialized = SerializeAndDeserialize(value, "[{\"Key\":123,\"Value\":true},{\"Key\":456,\"Value\":false}]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value.Keys.Cast<int>().ToArray(), deserialized.Keys.Cast<int>().ToArray()));
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value.Values.Cast<bool>().ToArray(), deserialized.Values.Cast<bool>().ToArray()));
+    }
+
+    [Fact]
+    public static void DCS_NonGenericDictionaryOfInt32String()
+    {
+        var value = new MyNonGenericDictionary();
+        value.Add(123, "abc");
+        value.Add(456, "def");
+        var deserialized = SerializeAndDeserialize(value, "[{\"Key\":123,\"Value\":\"abc\"},{\"Key\":456,\"Value\":\"def\"}]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value.Keys.Cast<int>().ToArray(), deserialized.Keys.Cast<int>().ToArray()));
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value.Values.Cast<string>().ToArray(), deserialized.Values.Cast<string>().ToArray()));
+    }
+
+    [Fact]
+    public static void DCS_NonGenericDictionaryOfStringInt32()
+    {
+        var value = new MyNonGenericDictionary();
+        value.Add("abc", 123);
+        value.Add("def", 456);
+        var deserialized = SerializeAndDeserialize(value, "[{\"Key\":\"abc\",\"Value\":123},{\"Key\":\"def\",\"Value\":456}]");
+        Assert.StrictEqual(value.Count, deserialized.Count);
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value.Keys.Cast<string>().ToArray(), deserialized.Keys.Cast<string>().ToArray()));
+        Assert.StrictEqual(true, Enumerable.SequenceEqual(value.Values.Cast<int>().ToArray(), deserialized.Values.Cast<int>().ToArray()));
+    }
+
+    #endregion
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractJsonSerializer dcjs;
@@ -1871,10 +2169,10 @@ public static partial class DataContractJsonSerializerTests
 
             string actualOutput = new StreamReader(ms).ReadToEnd();
             ms.Position = 0;
-            Utils.CompareResult result = Utils.Compare(baseline, actualOutput, false);
 
             if (!skipStringCompare)
             {
+                Utils.CompareResult result = Utils.Compare(baseline, actualOutput, false);
                 Assert.True(result.Equal, string.Format("{1}{0}Test failed for input: {2}{0}Expected: {3}{0}Actual: {4}",
                     Environment.NewLine, result.ErrorMessage, value, baseline, actualOutput));
             }

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -427,6 +427,33 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
+    public static void DCJS_GetOonlyDictionary_UseSimpleDictionaryFormat()
+    {
+        TypeWithDictionaryGenericMembers x = new TypeWithDictionaryGenericMembers();
+
+        x.RO1.Add(true, 't');
+        x.RO1.Add(false, 'f');
+
+        x.RO2.Add(true, 'a');
+        x.RO2.Add(false, 'b');
+
+        var settings = new DataContractJsonSerializerSettings { UseSimpleDictionaryFormat = true };
+        string baseline = "{\"F1\":null,\"F2\":null,\"P1\":null,\"P2\":null,\"RO1\":{\"True\":\"t\",\"False\":\"f\"},\"RO2\":{\"True\":\"a\",\"False\":\"b\"}}";
+        TypeWithDictionaryGenericMembers y = SerializeAndDeserialize<TypeWithDictionaryGenericMembers>(x, baseline, settings);
+        Assert.NotNull(y);
+
+        Assert.NotNull(y.RO1);
+        Assert.True(y.RO1.Count == 2);
+        Assert.True(y.RO1[true] == 't');
+        Assert.True(y.RO1[false] == 'f');
+
+        Assert.NotNull(y.RO2);
+        Assert.True(y.RO2.Count == 2);
+        Assert.True(y.RO2[true] == 'a');
+        Assert.True(y.RO2[false] == 'b');
+    }
+
+    [Fact]
     public static void DCJS_DictionaryRoot()
     {
         MyDictionary x = new MyDictionary();

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -228,7 +228,7 @@ public static partial class DataContractJsonSerializerTests
             new { value = "\u0027", baseline = "'" },
         };
 
-        foreach(var pair in testStrings)
+        foreach (var pair in testStrings)
         {
             Assert.StrictEqual(SerializeAndDeserialize<string>(pair.value, string.Format(@"""{0}""", pair.baseline)), pair.value);
         }
@@ -247,7 +247,7 @@ public static partial class DataContractJsonSerializerTests
         };
 
         var serializer = new DataContractJsonSerializer(typeof(string));
-        foreach(var pair in testStrings)
+        foreach (var pair in testStrings)
         {
             using (var ms = new MemoryStream())
             {
@@ -1629,7 +1629,7 @@ public static partial class DataContractJsonSerializerTests
     [Fact]
     public static void DCJS_DeserializeEmptyString()
     {
-        var serializer = new DataContractJsonSerializer(typeof (object));
+        var serializer = new DataContractJsonSerializer(typeof(object));
         Assert.Throws<SerializationException>(() =>
         {
             serializer.ReadObject(new MemoryStream());
@@ -2146,6 +2146,18 @@ public static partial class DataContractJsonSerializerTests
         Assert.StrictEqual(value.Count, deserialized.Count);
         Assert.StrictEqual(true, Enumerable.SequenceEqual(value.Keys.Cast<string>().ToArray(), deserialized.Keys.Cast<string>().ToArray()));
         Assert.StrictEqual(true, Enumerable.SequenceEqual(value.Values.Cast<int>().ToArray(), deserialized.Values.Cast<int>().ToArray()));
+    }
+
+    [Fact]
+    public static void DCJS_TypeWithEmitDefaultValueFalse()
+    {
+        var value = new TypeWithEmitDefaultValueFalse();
+
+        var actual = SerializeAndDeserialize(value, "{}");
+
+        Assert.NotNull(actual);
+        Assert.Equal(value.Name, actual.Name);
+        Assert.Equal(value.ID, actual.ID);
     }
 
     #endregion

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -429,7 +429,7 @@ public static partial class DataContractJsonSerializerTests
     [Fact]
     public static void DCJS_GetOonlyDictionary_UseSimpleDictionaryFormat()
     {
-        TypeWithDictionaryGenericMembers x = new TypeWithDictionaryGenericMembers();
+        var x = new TypeWithDictionaryGenericMembers();
 
         x.RO1.Add(true, 't');
         x.RO1.Add(false, 'f');
@@ -439,7 +439,7 @@ public static partial class DataContractJsonSerializerTests
 
         var settings = new DataContractJsonSerializerSettings { UseSimpleDictionaryFormat = true };
         string baseline = "{\"F1\":null,\"F2\":null,\"P1\":null,\"P2\":null,\"RO1\":{\"True\":\"t\",\"False\":\"f\"},\"RO2\":{\"True\":\"a\",\"False\":\"b\"}}";
-        TypeWithDictionaryGenericMembers y = SerializeAndDeserialize<TypeWithDictionaryGenericMembers>(x, baseline, settings);
+        var y = SerializeAndDeserialize(x, baseline, settings);
         Assert.NotNull(y);
 
         Assert.NotNull(y.RO1);
@@ -1844,16 +1844,16 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_RecursiveCollection()
+    public static void DCJS_RecursiveCollection()
     {
         Assert.Throws<InvalidDataContractException>(() =>
         {
-            (new DataContractSerializer(typeof(RecursiveCollection))).WriteObject(new MemoryStream(), new RecursiveCollection());
+            (new DataContractJsonSerializer(typeof(RecursiveCollection))).WriteObject(new MemoryStream(), new RecursiveCollection());
         });
     }
 
     [Fact]
-    public static void DCS_TypeWithPrimitiveProperties()
+    public static void DCJS_TypeWithPrimitiveProperties()
     {
         TypeWithPrimitiveProperties x = new TypeWithPrimitiveProperties { P1 = "abc", P2 = 11 };
         TypeWithPrimitiveProperties y = SerializeAndDeserialize<TypeWithPrimitiveProperties>(x, "{\"P1\":\"abc\",\"P2\":11}");
@@ -1862,7 +1862,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_TypeWithPrimitiveFields()
+    public static void DCJS_TypeWithPrimitiveFields()
     {
         TypeWithPrimitiveFields x = new TypeWithPrimitiveFields { P1 = "abc", P2 = 11 };
         TypeWithPrimitiveFields y = SerializeAndDeserialize<TypeWithPrimitiveFields>(x, "{\"P1\":\"abc\",\"P2\":11}");
@@ -1871,7 +1871,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_TypeWithAllPrimitiveProperties()
+    public static void DCJS_TypeWithAllPrimitiveProperties()
     {
         TypeWithAllPrimitiveProperties x = new TypeWithAllPrimitiveProperties
         {
@@ -1903,7 +1903,7 @@ public static partial class DataContractJsonSerializerTests
     #region Array of primitive types
 
     [Fact]
-    public static void DCS_ArrayOfBoolean()
+    public static void DCJS_ArrayOfBoolean()
     {
         var value = new bool[] { true, false, true };
         var deserialized = SerializeAndDeserialize(value, "[true,false,true]");
@@ -1912,7 +1912,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_ArrayOfDateTime()
+    public static void DCJS_ArrayOfDateTime()
     {
         var value = new DateTime[] { new DateTime(2000, 1, 2, 3, 4, 5), new DateTime(2011, 2, 3, 4, 5, 6) };
         var deserialized = SerializeAndDeserialize(value, "[\"\\/Date(946811045000-0800)\\/\",\"\\/Date(1296734706000-0800)\\/\"]");
@@ -1921,7 +1921,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_ArrayOfDecimal()
+    public static void DCJS_ArrayOfDecimal()
     {
         var value = new decimal[] { new decimal(1, 2, 3, false, 1), new decimal(4, 5, 6, true, 2) };
         var deserialized = SerializeAndDeserialize(value, "[5534023222971858944.1,-1106804644637321461.80]");
@@ -1930,7 +1930,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_ArrayOfInt32()
+    public static void DCJS_ArrayOfInt32()
     {
         var value = new int[] { 123, int.MaxValue, int.MinValue };
         var deserialized = SerializeAndDeserialize(value, "[123,2147483647,-2147483648]");
@@ -1939,7 +1939,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_ArrayOfInt64()
+    public static void DCJS_ArrayOfInt64()
     {
         var value = new long[] { 123, long.MaxValue, long.MinValue };
         var deserialized = SerializeAndDeserialize(value, "[123,9223372036854775807,-9223372036854775808]");
@@ -1948,7 +1948,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_ArrayOfSingle()
+    public static void DCJS_ArrayOfSingle()
     {
         var value = new float[] { 1.23f, 4.56f, 7.89f };
         var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
@@ -1957,7 +1957,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_ArrayOfDouble()
+    public static void DCJS_ArrayOfDouble()
     {
         var value = new double[] { 1.23, 4.56, 7.89 };
         var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
@@ -1966,7 +1966,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_ArrayOfString()
+    public static void DCJS_ArrayOfString()
     {
         var value = new string[] { "abc", "def", "xyz" };
         var deserialized = SerializeAndDeserialize(value, "[\"abc\",\"def\",\"xyz\"]");
@@ -1975,7 +1975,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_ArrayOfTypeWithPrimitiveProperties()
+    public static void DCJS_ArrayOfTypeWithPrimitiveProperties()
     {
         var value = new TypeWithPrimitiveProperties[]
         {
@@ -1992,7 +1992,7 @@ public static partial class DataContractJsonSerializerTests
     #region Collection
 
     [Fact]
-    public static void DCS_GenericICollectionOfBoolean()
+    public static void DCJS_GenericICollectionOfBoolean()
     {
         var value = new TypeImplementsGenericICollection<bool>() { true, false, true };
         var deserialized = SerializeAndDeserialize(value, "[true,false,true]");
@@ -2001,7 +2001,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericICollectionOfDecimal()
+    public static void DCJS_GenericICollectionOfDecimal()
     {
         var value = new TypeImplementsGenericICollection<decimal>() { new decimal(1, 2, 3, false, 1), new decimal(4, 5, 6, true, 2) };
         var deserialized = SerializeAndDeserialize(value, "[5534023222971858944.1,-1106804644637321461.80]");
@@ -2010,7 +2010,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericICollectionOfInt32()
+    public static void DCJS_GenericICollectionOfInt32()
     {
         TypeImplementsGenericICollection<int> x = new TypeImplementsGenericICollection<int>(123, int.MaxValue, int.MinValue);
         TypeImplementsGenericICollection<int> y = SerializeAndDeserialize(x, "[123,2147483647,-2147483648]");
@@ -2021,7 +2021,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericICollectionOfInt64()
+    public static void DCJS_GenericICollectionOfInt64()
     {
         var value = new TypeImplementsGenericICollection<long>() { 123, long.MaxValue, long.MinValue };
         var deserialized = SerializeAndDeserialize(value, "[123,9223372036854775807,-9223372036854775808]");
@@ -2030,7 +2030,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericICollectionOfSingle()
+    public static void DCJS_GenericICollectionOfSingle()
     {
         var value = new TypeImplementsGenericICollection<float>() { 1.23f, 4.56f, 7.89f };
         var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
@@ -2039,7 +2039,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericICollectionOfDouble()
+    public static void DCJS_GenericICollectionOfDouble()
     {
         var value = new TypeImplementsGenericICollection<double>() { 1.23, 4.56, 7.89 };
         var deserialized = SerializeAndDeserialize(value, "[1.23,4.56,7.89]");
@@ -2048,7 +2048,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericICollectionOfString()
+    public static void DCJS_GenericICollectionOfString()
     {
         TypeImplementsGenericICollection<string> value = new TypeImplementsGenericICollection<string>("a1", "a2");
         TypeImplementsGenericICollection<string> deserialized = SerializeAndDeserialize(value, "[\"a1\",\"a2\"]");
@@ -2059,7 +2059,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericICollectionOfTypeWithPrimitiveProperties()
+    public static void DCJS_GenericICollectionOfTypeWithPrimitiveProperties()
     {
         var value = new TypeImplementsGenericICollection<TypeWithPrimitiveProperties>()
         {
@@ -2076,7 +2076,7 @@ public static partial class DataContractJsonSerializerTests
     #region Generic Dictionary
 
     [Fact]
-    public static void DCS_GenericDictionaryOfInt32Boolean()
+    public static void DCJS_GenericDictionaryOfInt32Boolean()
     {
         var value = new Dictionary<int, bool>();
         value.Add(123, true);
@@ -2087,7 +2087,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericDictionaryOfInt32String()
+    public static void DCJS_GenericDictionaryOfInt32String()
     {
         var value = new Dictionary<int, string>();
         value.Add(123, "abc");
@@ -2098,7 +2098,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_GenericDictionaryOfStringInt32()
+    public static void DCJS_GenericDictionaryOfStringInt32()
     {
         var value = new Dictionary<string, int>();
         value.Add("abc", 123);
@@ -2113,7 +2113,7 @@ public static partial class DataContractJsonSerializerTests
     #region Non-Generic Dictionary
 
     [Fact]
-    public static void DCS_NonGenericDictionaryOfInt32Boolean()
+    public static void DCJS_NonGenericDictionaryOfInt32Boolean()
     {
         var value = new MyNonGenericDictionary();
         value.Add(123, true);
@@ -2125,7 +2125,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_NonGenericDictionaryOfInt32String()
+    public static void DCJS_NonGenericDictionaryOfInt32String()
     {
         var value = new MyNonGenericDictionary();
         value.Add(123, "abc");
@@ -2137,7 +2137,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    public static void DCS_NonGenericDictionaryOfStringInt32()
+    public static void DCJS_NonGenericDictionaryOfStringInt32()
     {
         var value = new MyNonGenericDictionary();
         value.Add("abc", 123);

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -904,7 +904,7 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    public static void DCJS_DataMemberNames()
+    public static void DCS_DataMemberNames()
     {
         var obj = new AppEnvironment()
         {
@@ -2315,6 +2315,18 @@ public static partial class DataContractSerializerTests
         var deserialized = SerializeAndDeserialize(value, @"<ArrayOfTypeWithPrimitiveProperties xmlns=""http://schemas.datacontract.org/2004/07/SerializationTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><TypeWithPrimitiveProperties><P1>abc</P1><P2>123</P2></TypeWithPrimitiveProperties><TypeWithPrimitiveProperties><P1>def</P1><P2>456</P2></TypeWithPrimitiveProperties></ArrayOfTypeWithPrimitiveProperties>");
         Assert.StrictEqual(value.Count, deserialized.Count);
         Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
+    }
+
+    [Fact]
+    public static void DCS_CollectionOfTypeWithNonDefaultNamcespace()
+    {
+        var value = new CollectionOfTypeWithNonDefaultNamcespace();
+        value.Add(new TypeWithNonDefaultNamcespace() { Name = "foo" });
+
+        var actual = SerializeAndDeserialize(value, "<CollectionOfTypeWithNonDefaultNamcespace xmlns=\"CollectionNamespace\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:a=\"ItemTypeNamespace\"><TypeWithNonDefaultNamcespace><a:Name>foo</a:Name></TypeWithNonDefaultNamcespace></CollectionOfTypeWithNonDefaultNamcespace>");
+        Assert.NotNull(actual);
+        Assert.NotNull(actual[0]);
+        Assert.Equal(value[0].Name, actual[0].Name);
     }
 
     #endregion

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2211,6 +2211,18 @@ public static partial class DataContractSerializerTests
         Assert.StrictEqual(count-1, deserialized[count-1].P2);
     }
 
+    [Fact]
+    public static void DCS_TypeWithEmitDefaultValueFalse()
+    {
+        var value = new TypeWithEmitDefaultValueFalse();
+
+        var actual = SerializeAndDeserialize(value, "<TypeWithEmitDefaultValueFalse xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"/>");
+
+        Assert.NotNull(actual);
+        Assert.Equal(value.Name, actual.Name);
+        Assert.Equal(value.ID, actual.ID);
+    }
+
     #endregion
 
     #region Collection

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -904,6 +904,19 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
+    public static void DCJS_DataMemberNames()
+    {
+        var obj = new AppEnvironment()
+        {
+            ScreenDpi = 440,
+            ScreenOrientation = "horizontal"
+        };
+        var actual = SerializeAndDeserialize(obj, "<AppEnvironment xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><screen_dpi_x0028_x_x003A_y_x0029_>440</screen_dpi_x0028_x_x003A_y_x0029_><screen_x003A_orientation>horizontal</screen_x003A_orientation></AppEnvironment>");
+        Assert.StrictEqual(obj.ScreenDpi, actual.ScreenDpi);
+        Assert.StrictEqual(obj.ScreenOrientation, actual.ScreenOrientation);
+    }
+
+    [Fact]
     public static void DCS_GenericBase()
     {
         var actual = SerializeAndDeserialize<GenericBase2<SimpleBaseDerived, SimpleBaseDerived2>>(new GenericBase2<SimpleBaseDerived, SimpleBaseDerived2>(true), @"<GenericBase2OfSimpleBaseDerivedSimpleBaseDerived2zbP0weY4 z:Id=""i1"" xmlns=""http://schemas.datacontract.org/2004/07/SerializationTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:z=""http://schemas.microsoft.com/2003/10/Serialization/""><genericData1 z:Id=""i2""><BaseData/><DerivedData/></genericData1><genericData2 z:Id=""i3""><BaseData/><DerivedData/></genericData2></GenericBase2OfSimpleBaseDerivedSimpleBaseDerived2zbP0weY4>");

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/PerformanceTestsCommon.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/PerformanceTestsCommon.cs
@@ -130,16 +130,16 @@ namespace System.Runtime.Serialization
             return obj;
         }
 
-        public static SimpleTypeWihtMoreFields CreateSimpleTypeWithFields(int height, int parentId, int currentId, int collectionSize, int childListSize)
+        public static SimpleTypeWithMoreFields CreateSimpleTypeWithFields(int height, int parentId, int currentId, int collectionSize, int childListSize)
         {
             int index = parentId * childListSize + (currentId + 1);
-            var obj = new SimpleTypeWihtMoreFields()
+            var obj = new SimpleTypeWithMoreFields()
             {
                 IntField = index,
                 StringField = index + " string value",
                 EnumField = (MyEnum)(index % (Enum.GetNames(typeof(MyEnum)).Length)),
                 CollectionField = new List<string>(collectionSize),
-                SimpleTypeList = new List<SimpleTypeWihtMoreFields>(childListSize)
+                SimpleTypeList = new List<SimpleTypeWithMoreFields>(childListSize)
             };
             for (int i = 0; i < collectionSize; ++i)
             {

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2397,13 +2397,13 @@ namespace SerializationTypes
         public List<SimpleTypeWihtMoreProperties> SimpleTypeList { get; set; }
     }
 
-    public class SimpleTypeWihtMoreFields
+    public class SimpleTypeWithMoreFields
     {
         public string StringField;
         public int IntField;
         public MyEnum EnumField;
         public List<string> CollectionField;
-        public List<SimpleTypeWihtMoreFields> SimpleTypeList;
+        public List<SimpleTypeWithMoreFields> SimpleTypeList;
     }
 
     // New types

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -3113,3 +3113,12 @@ public class RecursiveCollection3 : List<RecursiveCollection>
 {
 
 }
+
+[DataContract]
+public class TypeWithEmitDefaultValueFalse
+{
+    [DataMember(EmitDefaultValue = false)]
+    public string Name = null;
+    [DataMember(EmitDefaultValue = false)]
+    public int ID = 0;
+}

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -3122,3 +3122,17 @@ public class TypeWithEmitDefaultValueFalse
     [DataMember(EmitDefaultValue = false)]
     public int ID = 0;
 }
+
+[DataContract(Namespace = "ItemTypeNamespace")]
+public class TypeWithNonDefaultNamcespace
+{
+    [DataMember]
+    public string Name;
+}
+
+[CollectionDataContract(Namespace = "CollectionNamespace")]
+public class CollectionOfTypeWithNonDefaultNamcespace : List<TypeWithNonDefaultNamcespace>
+{
+
+}
+


### PR DESCRIPTION
The PR is enable DataContractJsonSerializer to do reflection based serialization/de-serialization.

All tests passed when running on CoreCLR. Most of the tests passed in NetNative. Failed test cases are the same as those failed for DCS in NetNative.

@mconnew @roncain @huanwu @zhenlan Can you please review the PR? Thanks!