### PR TITLE
Remove some random data from System.Reflection.Emit.Tests

### DIFF
--- a/src/System.Reflection.Emit/tests/FieldBuilder/FieldBuilderSetConstant.cs
+++ b/src/System.Reflection.Emit/tests/FieldBuilder/FieldBuilderSetConstant.cs
@@ -148,7 +148,7 @@ namespace System.Reflection.Emit.Tests
             FieldBuilder field = s_type.DefineField("StringField", typeof(string), FieldAttributes.Public);
             
             field.SetConstant(null);
-            field.SetConstant(_generator.GetString(false, 1, 30));
+            field.SetConstant("TestString");
         }
 
         [Fact]

--- a/src/System.Reflection.Emit/tests/PropertyBuilder/PropertyBuilderName.cs
+++ b/src/System.Reflection.Emit/tests/PropertyBuilder/PropertyBuilderName.cs
@@ -12,6 +12,8 @@ namespace System.Reflection.Emit.Tests
         public static IEnumerable<object[]> Names_TestData()
         {
             yield return new object[] { "TestName" };
+            yield return new object[] { "\uD800\uDC00" };
+            yield return new object[] { "привет" };
             yield return new object[] { "class" };
             yield return new object[] { new string('a', short.MaxValue) };
         }
@@ -29,6 +31,8 @@ namespace System.Reflection.Emit.Tests
         public void Name_InvalidString()
         {
             // TODO: move into Names_TestData when #7166 is fixed
+            Name("\uDC00");
+            Name("\uD800");
             Name("1A\0\t\v\r\n\n\uDC81\uDC91");
         }
     }

--- a/src/System.Reflection.Emit/tests/PropertyBuilder/PropertyBuilderName.cs
+++ b/src/System.Reflection.Emit/tests/PropertyBuilder/PropertyBuilderName.cs
@@ -8,12 +8,10 @@ using Xunit;
 namespace System.Reflection.Emit.Tests
 {
     public class PropertyBuilderTest9
-    {
-        private static readonly RandomDataGenerator s_randomDataGenerator = new RandomDataGenerator();
-        
+    {        
         public static IEnumerable<object[]> Names_TestData()
         {
-            yield return new object[] { new string((char)(s_randomDataGenerator.GetInt32() % ushort.MaxValue + 1), 1) + s_randomDataGenerator.GetString(false, 1, 260) };
+            yield return new object[] { "TestName" };
             yield return new object[] { "class" };
             yield return new object[] { new string('a', short.MaxValue) };
         }

--- a/src/System.Reflection.Emit/tests/PropertyBuilder/PropertyBuilderSetConstant.cs
+++ b/src/System.Reflection.Emit/tests/PropertyBuilder/PropertyBuilderSetConstant.cs
@@ -9,8 +9,6 @@ namespace System.Reflection.Emit.Tests
 {
     public class PropertyBuilderTest11
     {
-        private readonly RandomDataGenerator _generator = new RandomDataGenerator();
-
         private enum Colors
         {
             Red = 0,


### PR DESCRIPTION
Currently, we generate random data in some of the System.Reflection.Emit
tests
One example is om the test for PropertyBuilder.Name that generates a
random char.

Due to bug #7166 xunit crashes when there is an invalid char (e.g. lone
high surrogate) in a MemberData or InlineData

Should hopefully fix #9820

/cc @stephentoub