### PR TITLE
Potential workaround for Unix issue #9780

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -148,7 +148,8 @@ namespace System.Net.Sockets
 
                 return;
             }
-
+            // ReuseAddress is required by Unix.
+            _serverSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
             _serverSocket.Bind(_serverSocketEP);
             try
             {


### PR DESCRIPTION
Had another chance to look into this. Apparently you need to set socket option "SO_REUSEADDR" in order to prevent that socket re-binding issue. See notes bottom of the page on http://linux.die.net/man/7/socket.

Doing a unix specific thing inside of the TcpListener class feels wrong, but it's the only place that makes sense. It doesn't seem to have any negative impact on Windows. Discuss.