### PR TITLE
Share query settings between PLINQ SequenceEqual operators.

### DIFF
--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -882,7 +882,8 @@ namespace System.Linq.Parallel.Tests
             Action canceler = () => { throw new OperationCanceledException(cs.Token); };
 
             AggregateException outer = Assert.Throws<AggregateException>(() => query(new CancellationTokenSource().Token, canceler));
-            AggregateException ae = Assert.Single<AggregateException>(outer.InnerExceptions.Cast<AggregateException>());
+            Exception inner = Assert.Single(outer.InnerExceptions);
+            AggregateException ae = Assert.IsType<AggregateException>(inner);
             Assert.All(ae.InnerExceptions, e => Assert.IsType<OperationCanceledException>(e));
         }
 
@@ -892,7 +893,8 @@ namespace System.Linq.Parallel.Tests
             Action canceler = () => { throw new OperationCanceledException(token); };
 
             AggregateException outer = Assert.Throws<AggregateException>(() => query(token, canceler));
-            AggregateException ae = Assert.Single<AggregateException>(outer.InnerExceptions.Cast<AggregateException>());
+            Exception inner = Assert.Single(outer.InnerExceptions);
+            AggregateException ae = Assert.IsType<AggregateException>(inner);
             Assert.All(ae.InnerExceptions, e => Assert.IsType<OperationCanceledException>(e));
         }
     }

--- a/src/System.Linq.Parallel/tests/Combinatorial/FailingParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/FailingParallelQueryCombinationTests.cs
@@ -232,11 +232,9 @@ namespace System.Linq.Parallel.Tests
         private static void ThrowsWrapped(Action query)
         {
             AggregateException outer = Assert.Throws<AggregateException>(query);
-            Assert.All(outer.InnerExceptions, inner =>
-            {
-                Assert.IsType<AggregateException>(inner);
-                Assert.All(((AggregateException)inner).InnerExceptions, e => Assert.IsType<DeliberateTestException>(e));
-            });
+            Exception inner = Assert.Single(outer.InnerExceptions);
+            AggregateException ae = Assert.IsType<AggregateException>(inner);
+            Assert.All(ae.InnerExceptions, e => Assert.IsType<DeliberateTestException>(e));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
@@ -1383,6 +1383,43 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
+        public static void Union(Labeled<Operation> source, Labeled<Operation> operation)
+        {
+            Action<Operation, Operation> union = (left, right) =>
+            {
+                int seen = DefaultStart;
+                ParallelQuery<int> query = left(DefaultStart, DefaultSize * 3 / 4, source.Item)
+                    .Union(right(DefaultStart + DefaultSize / 2, DefaultSize / 2, source.Item));
+                foreach (int i in query)
+                {
+                    Assert.Equal(seen++, i);
+                }
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            union(operation.Item, DefaultSource);
+            union(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryOperators))]
+        [MemberData(nameof(BinaryOperators))]
+        public static void Union_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
+        {
+            Action<Operation, Operation> union = (left, right) =>
+            {
+                int seen = DefaultStart;
+                ParallelQuery<int> query = left(DefaultStart, DefaultSize * 3 / 4, source.Item)
+                    .Union(right(DefaultStart + DefaultSize / 2, DefaultSize / 2, source.Item));
+                Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            union(operation.Item, DefaultSource);
+            union(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryOperators))]
+        [MemberData(nameof(BinaryOperators))]
         public static void Where(Labeled<Operation> source, Labeled<Operation> operation)
         {
             int seen = DefaultStart;

--- a/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
@@ -137,13 +137,18 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Concat(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seen = DefaultStart;
-            foreach (int i in operation.Item(DefaultStart, DefaultSize / 2, source.Item)
-                .Concat(operation.Item(DefaultStart + DefaultSize / 2, DefaultSize / 2, source.Item)))
+            Action<Operation, Operation> concat = (left, right) =>
             {
-                Assert.Equal(seen++, i);
-            }
-            Assert.Equal(DefaultStart + DefaultSize, seen);
+                int seen = DefaultStart;
+                foreach (int i in left(DefaultStart, DefaultSize / 2, source.Item)
+                    .Concat(right(DefaultStart + DefaultSize / 2, DefaultSize / 2, source.Item)))
+                {
+                    Assert.Equal(seen++, i);
+                }
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            concat(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            concat(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -151,13 +156,18 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Concat_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seen = DefaultStart;
-            Assert.All(
-                operation.Item(DefaultStart, DefaultSize / 2, source.Item)
-                    .Concat(operation.Item(DefaultStart + DefaultSize / 2, DefaultSize / 2, source.Item)).ToList(),
-                x => Assert.Equal(seen++, x)
-                );
-            Assert.Equal(DefaultStart + DefaultSize, seen);
+            Action<Operation, Operation> concat = (left, right) =>
+            {
+                int seen = DefaultStart;
+                Assert.All(
+                    left(DefaultStart, DefaultSize / 2, source.Item)
+                        .Concat(right(DefaultStart + DefaultSize / 2, DefaultSize / 2, source.Item)).ToList(),
+                    x => Assert.Equal(seen++, x)
+                    );
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            concat(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            concat(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -284,14 +294,19 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Except(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seen = DefaultStart;
-            ParallelQuery<int> query = operation.Item(DefaultStart, DefaultSize + DefaultSize / 2, source.Item)
-                .Except(operation.Item(DefaultStart + DefaultSize, DefaultSize, source.Item));
-            foreach (int i in query)
+            Action<Operation, Operation> except = (left, right) =>
             {
-                Assert.Equal(seen++, i);
-            }
-            Assert.Equal(DefaultStart + DefaultSize, seen);
+                int seen = DefaultStart;
+                ParallelQuery<int> query = left(DefaultStart, DefaultSize + DefaultSize / 2, source.Item)
+                    .Except(right(DefaultStart + DefaultSize, DefaultSize, source.Item));
+                foreach (int i in query)
+                {
+                    Assert.Equal(seen++, i);
+                }
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            except(operation.Item, DefaultSource);
+            except(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -299,11 +314,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Except_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seen = DefaultStart;
-            ParallelQuery<int> query = operation.Item(DefaultStart, DefaultSize + DefaultSize / 2, source.Item)
-                .Except(operation.Item(DefaultStart + DefaultSize, DefaultSize, source.Item));
-            Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
-            Assert.Equal(DefaultStart + DefaultSize, seen);
+            Action<Operation, Operation> except = (left, right) =>
+            {
+                int seen = DefaultStart;
+                ParallelQuery<int> query = left(DefaultStart, DefaultSize + DefaultSize / 2, source.Item)
+                    .Except(right(DefaultStart + DefaultSize, DefaultSize, source.Item));
+                Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            except(operation.Item, DefaultSource);
+            except(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -445,16 +465,21 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void GroupJoin(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seenKey = DefaultStart / GroupFactor;
-            foreach (KeyValuePair<int, IEnumerable<int>> group in operation.Item(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
-                .GroupJoin(operation.Item(DefaultStart, DefaultSize, source.Item), x => x, y => y / GroupFactor, (k, g) => new KeyValuePair<int, IEnumerable<int>>(k, g)))
+            Action<Operation, Operation> groupJoin = (left, right) =>
             {
-                Assert.Equal(seenKey++, group.Key);
-                int seenElement = group.Key * GroupFactor;
-                Assert.All(group.Value, x => Assert.Equal(seenElement++, x));
-                Assert.Equal((group.Key + 1) * GroupFactor, seenElement);
-            }
-            Assert.Equal((DefaultStart + DefaultSize) / GroupFactor, seenKey);
+                int seenKey = DefaultStart / GroupFactor;
+                foreach (KeyValuePair<int, IEnumerable<int>> group in left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
+                    .GroupJoin(right(DefaultStart, DefaultSize, source.Item), x => x, y => y / GroupFactor, (k, g) => new KeyValuePair<int, IEnumerable<int>>(k, g)))
+                {
+                    Assert.Equal(seenKey++, group.Key);
+                    int seenElement = group.Key * GroupFactor;
+                    Assert.All(group.Value, x => Assert.Equal(seenElement++, x));
+                    Assert.Equal((group.Key + 1) * GroupFactor, seenElement);
+                }
+                Assert.Equal((DefaultStart + DefaultSize) / GroupFactor, seenKey);
+            };
+            groupJoin(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            groupJoin(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -463,16 +488,21 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void GroupJoin_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seenKey = DefaultStart / GroupFactor;
-            foreach (KeyValuePair<int, IEnumerable<int>> group in operation.Item(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
-                .GroupJoin(operation.Item(DefaultStart, DefaultSize, source.Item), x => x, y => y / GroupFactor, (k, g) => new KeyValuePair<int, IEnumerable<int>>(k, g)).ToList())
+            Action<Operation, Operation> groupJoin = (left, right) =>
             {
-                Assert.Equal(seenKey++, group.Key);
-                int seenElement = group.Key * GroupFactor;
-                Assert.All(group.Value, x => Assert.Equal(seenElement++, x));
-                Assert.Equal((group.Key + 1) * GroupFactor, seenElement);
-            }
-            Assert.Equal((DefaultStart + DefaultSize) / GroupFactor, seenKey);
+                int seenKey = DefaultStart / GroupFactor;
+                foreach (KeyValuePair<int, IEnumerable<int>> group in left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
+                    .GroupJoin(right(DefaultStart, DefaultSize, source.Item), x => x, y => y / GroupFactor, (k, g) => new KeyValuePair<int, IEnumerable<int>>(k, g)).ToList())
+                {
+                    Assert.Equal(seenKey++, group.Key);
+                    int seenElement = group.Key * GroupFactor;
+                    Assert.All(group.Value, x => Assert.Equal(seenElement++, x));
+                    Assert.Equal((group.Key + 1) * GroupFactor, seenElement);
+                }
+                Assert.Equal((DefaultStart + DefaultSize) / GroupFactor, seenKey);
+            };
+            groupJoin(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            groupJoin(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -480,14 +510,19 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Intersect(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seen = DefaultStart;
-            ParallelQuery<int> query = operation.Item(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, source.Item)
-                .Intersect(operation.Item(DefaultStart, DefaultSize + DefaultSize / 2, source.Item));
-            foreach (int i in query)
+            Action<Operation, Operation> intersect = (left, right) =>
             {
-                Assert.Equal(seen++, i);
-            }
-            Assert.Equal(DefaultStart + DefaultSize, seen);
+                int seen = DefaultStart;
+                ParallelQuery<int> query = left(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, source.Item)
+                    .Intersect(right(DefaultStart, DefaultSize + DefaultSize / 2, source.Item));
+                foreach (int i in query)
+                {
+                    Assert.Equal(seen++, i);
+                }
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            intersect(operation.Item, DefaultSource);
+            intersect(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -495,11 +530,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Intersect_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seen = DefaultStart;
-            ParallelQuery<int> query = operation.Item(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, source.Item)
-                .Intersect(operation.Item(DefaultStart, DefaultSize + DefaultSize / 2, source.Item));
-            Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
-            Assert.Equal(DefaultStart + DefaultSize, seen);
+            Action<Operation, Operation> intersect = (left, right) =>
+            {
+                int seen = DefaultStart;
+                ParallelQuery<int> query = left(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, source.Item)
+                    .Intersect(right(DefaultStart, DefaultSize + DefaultSize / 2, source.Item));
+                Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            intersect(operation.Item, DefaultSource);
+            intersect(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -508,15 +548,20 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Join(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seen = DefaultStart;
-            ParallelQuery<KeyValuePair<int, int>> query = operation.Item(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
-                  .Join(operation.Item(DefaultStart, DefaultSize, source.Item), x => x, y => y / GroupFactor, (x, y) => new KeyValuePair<int, int>(x, y));
-            foreach (KeyValuePair<int, int> p in query)
+            Action<Operation, Operation> join = (left, right) =>
             {
-                Assert.Equal(seen++, p.Value);
-                Assert.Equal(p.Key, p.Value / GroupFactor);
-            }
-            Assert.Equal(DefaultStart + DefaultSize, seen);
+                int seen = DefaultStart;
+                ParallelQuery<KeyValuePair<int, int>> query = left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
+                      .Join(right(DefaultStart, DefaultSize, source.Item), x => x, y => y / GroupFactor, (x, y) => new KeyValuePair<int, int>(x, y));
+                foreach (KeyValuePair<int, int> p in query)
+                {
+                    Assert.Equal(seen++, p.Value);
+                    Assert.Equal(p.Key, p.Value / GroupFactor);
+                }
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            join(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            join(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -525,15 +570,20 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Join_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seen = DefaultStart;
-            ParallelQuery<KeyValuePair<int, int>> query = operation.Item(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
-                 .Join(operation.Item(DefaultStart, DefaultSize, source.Item), x => x, y => y / GroupFactor, (x, y) => new KeyValuePair<int, int>(x, y));
-            foreach (KeyValuePair<int, int> p in query.ToList())
+            Action<Operation, Operation> join = (left, right) =>
             {
-                Assert.Equal(seen++, p.Value);
-                Assert.Equal(p.Key, p.Value / GroupFactor);
-            }
-            Assert.Equal(DefaultStart + DefaultSize, seen);
+                int seen = DefaultStart;
+                ParallelQuery<KeyValuePair<int, int>> query = left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
+                      .Join(right(DefaultStart, DefaultSize, source.Item), x => x, y => y / GroupFactor, (x, y) => new KeyValuePair<int, int>(x, y));
+                foreach (KeyValuePair<int, int> p in query.ToList())
+                {
+                    Assert.Equal(seen++, p.Value);
+                    Assert.Equal(p.Key, p.Value / GroupFactor);
+                }
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            join(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            join(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -950,14 +1000,6 @@ namespace System.Linq.Parallel.Tests
         {
             Assert.True(operation.Item(DefaultStart, DefaultSize, source.Item).SequenceEqual(ParallelEnumerable.Range(DefaultStart, DefaultSize).AsOrdered()));
             Assert.True(ParallelEnumerable.Range(DefaultStart, DefaultSize).AsOrdered().SequenceEqual(operation.Item(DefaultStart, DefaultSize, source.Item)));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void SequenceEqual_Self(Labeled<Operation> source, Labeled<Operation> operation)
-        {
-            Assert.True(operation.Item(DefaultStart, DefaultSize, source.Item).SequenceEqual(operation.Item(DefaultStart, DefaultSize, source.Item)));
         }
 
         [Theory]
@@ -1389,14 +1431,19 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Zip(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seen = DefaultStart;
-            ParallelQuery<int> query = operation.Item(DefaultStart * 2, DefaultSize, source.Item)
-                .Zip(operation.Item(0, DefaultSize, source.Item), (x, y) => (x + y) / 2);
-            foreach (int i in query)
+            Action<Operation, Operation> zip = (left, right) =>
             {
-                Assert.Equal(seen++, i);
-            }
-            Assert.Equal(DefaultStart + DefaultSize, seen);
+                int seen = DefaultStart;
+                ParallelQuery<int> query = left(DefaultStart * 2, DefaultSize, source.Item)
+                    .Zip(right(0, DefaultSize, source.Item), (x, y) => (x + y) / 2);
+                foreach (int i in query)
+                {
+                    Assert.Equal(seen++, i);
+                }
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            zip(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            zip(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -1404,11 +1451,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Zip_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            int seen = DefaultStart;
-            ParallelQuery<int> query = operation.Item(0, DefaultSize, source.Item)
-                .Zip(operation.Item(DefaultStart * 2, DefaultSize, source.Item), (x, y) => (x + y) / 2);
-            Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
-            Assert.Equal(DefaultStart + DefaultSize, seen);
+            Action<Operation, Operation> zip = (left, right) =>
+            {
+                int seen = DefaultStart;
+                ParallelQuery<int> query = left(DefaultStart * 2, DefaultSize, source.Item)
+                    .Zip(right(0, DefaultSize, source.Item), (x, y) => (x + y) / 2);
+                Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
+                Assert.Equal(DefaultStart + DefaultSize, seen);
+            };
+            zip(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            zip(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
     }
 }

--- a/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -117,6 +118,11 @@ namespace System.Linq.Parallel.Tests
 
             yield return new object[] { Label("Where", (start, count, source) => source(start - count / 2, count * 2).Where(x => x >= start && x < start + count)) };
             yield return new object[] { Label("Where-Index", (start, count, source) => source(start - count / 2, count * 2).Where((x, index) => x >= start && x < start + count)) };
+
+            yield return new object[] { Label("WithCancellation", (start, count, source) => source(start, count).WithCancellation(CancellationToken.None)) };
+            yield return new object[] { Label("WithDegreesOfParallelism", (start, count, source) => source(start, count).WithDegreeOfParallelism(Environment.ProcessorCount)) };
+            yield return new object[] { Label("WithExecutionMode", (start, count, source) => source(start, count).WithExecutionMode(ParallelExecutionMode.Default)) };
+            yield return new object[] { Label("WithMergeOptions", (start, count, source) => source(start, count).WithMergeOptions(ParallelMergeOptions.Default)) };
         }
 
         public static IEnumerable<object[]> UnaryUnorderedOperators()

--- a/src/System.Linq.Parallel/tests/Combinatorial/UnorderedParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/UnorderedParallelQueryCombinationTests.cs
@@ -598,6 +598,43 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(UnaryOperations))]
         [MemberData(nameof(BinaryOperations))]
+        public static void Union_Unordered(Labeled<Operation> operation)
+        {
+            Action<Operation, Operation> union = (left, right) =>
+            {
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                ParallelQuery<int> query = left(DefaultStart, DefaultSize * 3 / 4, DefaultSource)
+                    .Union(right(DefaultStart + DefaultSize / 2, DefaultSize / 2, DefaultSource));
+                foreach (int i in query)
+                {
+                    seen.Add(i);
+                }
+                seen.AssertComplete();
+            };
+            union(operation.Item, DefaultSource);
+            union(DefaultSource, operation.Item);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryOperations))]
+        [MemberData(nameof(BinaryOperations))]
+        public static void Union_Unordered_NotPipelined(Labeled<Operation> operation)
+        {
+            Action<Operation, Operation> union = (left, right) =>
+            {
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                ParallelQuery<int> query = left(DefaultStart, DefaultSize * 3 / 4, DefaultSource)
+                    .Union(right(DefaultStart + DefaultSize / 2, DefaultSize / 2, DefaultSource));
+                Assert.All(query.ToList(), x => seen.Add(x));
+                seen.AssertComplete();
+            };
+            union(operation.Item, DefaultSource);
+            union(DefaultSource, operation.Item);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryOperations))]
+        [MemberData(nameof(BinaryOperations))]
         public static void Where_Unordered(Labeled<Operation> operation)
         {
             IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize / 2);

--- a/src/System.Linq.Parallel/tests/Combinatorial/UnorderedParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/UnorderedParallelQueryCombinationTests.cs
@@ -38,13 +38,18 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Concat_Unordered(Labeled<Operation> operation)
         {
-            IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
-            foreach (int i in operation.Item(DefaultStart, DefaultSize / 2, DefaultSource)
-                .Concat(operation.Item(DefaultStart + DefaultSize / 2, DefaultSize / 2, DefaultSource)))
+            Action<Operation, Operation> concat = (left, right) =>
             {
-                seen.Add(i);
-            }
-            seen.AssertComplete();
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                foreach (int i in left(DefaultStart, DefaultSize / 2, DefaultSource)
+                    .Concat(right(DefaultStart + DefaultSize / 2, DefaultSize / 2, DefaultSource)))
+                {
+                    seen.Add(i);
+                }
+                seen.AssertComplete();
+            };
+            concat(operation.Item, DefaultSource);
+            concat(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -52,13 +57,17 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Concat_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
-            Assert.All(
-                operation.Item(DefaultStart, DefaultSize / 2, DefaultSource)
-                    .Concat(operation.Item(DefaultStart + DefaultSize / 2, DefaultSize / 2, DefaultSource)).ToList(),
-                x => seen.Add(x)
-                );
-            seen.AssertComplete();
+            Action<Operation, Operation> concat = (left, right) =>
+            {
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                Assert.All(
+                    left(DefaultStart, DefaultSize / 2, DefaultSource)
+                        .Concat(right(DefaultStart + DefaultSize / 2, DefaultSize / 2, DefaultSource)).ToList(),
+                    x => seen.Add(x));
+                seen.AssertComplete();
+            };
+            concat(operation.Item, DefaultSource);
+            concat(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -114,14 +123,19 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Except_Unordered(Labeled<Operation> operation)
         {
-            IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
-            ParallelQuery<int> query = operation.Item(DefaultStart, DefaultSize + DefaultSize / 2, DefaultSource)
-                .Except(operation.Item(DefaultStart + DefaultSize, DefaultSize, DefaultSource));
-            foreach (int i in query)
+            Action<Operation, Operation> except = (left, right) =>
             {
-                seen.Add(i);
-            }
-            seen.AssertComplete();
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                ParallelQuery<int> query = left(DefaultStart, DefaultSize + DefaultSize / 2, DefaultSource)
+                    .Except(right(DefaultStart + DefaultSize, DefaultSize, DefaultSource));
+                foreach (int i in query)
+                {
+                    seen.Add(i);
+                }
+                seen.AssertComplete();
+            };
+            except(operation.Item, DefaultSource);
+            except(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -129,11 +143,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Except_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
-            ParallelQuery<int> query = operation.Item(DefaultStart, DefaultSize + DefaultSize / 2, DefaultSource)
-                .Except(operation.Item(DefaultStart + DefaultSize, DefaultSize, DefaultSource));
-            Assert.All(query.ToList(), x => seen.Add((int)x));
-            seen.AssertComplete();
+            Action<Operation, Operation> except = (left, right) =>
+            {
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                ParallelQuery<int> query = left(DefaultStart, DefaultSize + DefaultSize / 2, DefaultSource)
+                    .Except(right(DefaultStart + DefaultSize, DefaultSize, DefaultSource));
+                Assert.All(query.ToList(), x => seen.Add((int)x));
+                seen.AssertComplete();
+            };
+            except(operation.Item, DefaultSource);
+            except(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -223,16 +242,21 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void GroupJoin_Unordered(Labeled<Operation> operation)
         {
-            IntegerRangeSet seenKey = new IntegerRangeSet(DefaultStart / GroupFactor, DefaultSize / GroupFactor);
-            foreach (KeyValuePair<int, IEnumerable<int>> group in operation.Item(DefaultStart / GroupFactor, DefaultSize / GroupFactor, DefaultSource)
-                .GroupJoin(operation.Item(DefaultStart, DefaultSize, DefaultSource), x => x, y => y / GroupFactor, (k, g) => new KeyValuePair<int, IEnumerable<int>>(k, g)))
+            Action<Operation, Operation> groupJoin = (left, right) =>
             {
-                Assert.True(seenKey.Add(group.Key));
-                IntegerRangeSet seenElement = new IntegerRangeSet(group.Key * GroupFactor, GroupFactor);
-                Assert.All(group.Value, x => seenElement.Add(x));
-                seenElement.AssertComplete();
-            }
-            seenKey.AssertComplete();
+                IntegerRangeSet seenKey = new IntegerRangeSet(DefaultStart / GroupFactor, DefaultSize / GroupFactor);
+                foreach (KeyValuePair<int, IEnumerable<int>> group in left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, DefaultSource)
+                    .GroupJoin(right(DefaultStart, DefaultSize, DefaultSource), x => x, y => y / GroupFactor, (k, g) => new KeyValuePair<int, IEnumerable<int>>(k, g)))
+                {
+                    Assert.True(seenKey.Add(group.Key));
+                    IntegerRangeSet seenElement = new IntegerRangeSet(group.Key * GroupFactor, GroupFactor);
+                    Assert.All(group.Value, x => seenElement.Add(x));
+                    seenElement.AssertComplete();
+                }
+                seenKey.AssertComplete();
+            };
+            groupJoin(operation.Item, DefaultSource);
+            groupJoin(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -240,16 +264,21 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void GroupJoin_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            IntegerRangeSet seenKey = new IntegerRangeSet(DefaultStart / GroupFactor, DefaultSize / GroupFactor);
-            foreach (KeyValuePair<int, IEnumerable<int>> group in operation.Item(DefaultStart / GroupFactor, DefaultSize / GroupFactor, DefaultSource)
-                .GroupJoin(operation.Item(DefaultStart, DefaultSize, DefaultSource), x => x, y => y / GroupFactor, (k, g) => new KeyValuePair<int, IEnumerable<int>>(k, g)).ToList())
+            Action<Operation, Operation> groupJoin = (left, right) =>
             {
-                Assert.True(seenKey.Add(group.Key));
-                IntegerRangeSet seenElement = new IntegerRangeSet(group.Key * GroupFactor, GroupFactor);
-                Assert.All(group.Value, x => seenElement.Add(x));
-                seenElement.AssertComplete();
-            }
-            seenKey.AssertComplete();
+                IntegerRangeSet seenKey = new IntegerRangeSet(DefaultStart / GroupFactor, DefaultSize / GroupFactor);
+                foreach (KeyValuePair<int, IEnumerable<int>> group in left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, DefaultSource)
+                    .GroupJoin(right(DefaultStart, DefaultSize, DefaultSource), x => x, y => y / GroupFactor, (k, g) => new KeyValuePair<int, IEnumerable<int>>(k, g)).ToList())
+                {
+                    Assert.True(seenKey.Add(group.Key));
+                    IntegerRangeSet seenElement = new IntegerRangeSet(group.Key * GroupFactor, GroupFactor);
+                    Assert.All(group.Value, x => seenElement.Add(x));
+                    seenElement.AssertComplete();
+                }
+                seenKey.AssertComplete();
+            };
+            groupJoin(operation.Item, DefaultSource);
+            groupJoin(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -257,14 +286,19 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Intersect_Unordered(Labeled<Operation> operation)
         {
-            IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
-            ParallelQuery<int> query = operation.Item(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, DefaultSource)
-                .Intersect(operation.Item(DefaultStart, DefaultSize + DefaultSize / 2, DefaultSource));
-            foreach (int i in query)
+            Action<Operation, Operation> intersect = (left, right) =>
             {
-                seen.Add(i);
-            }
-            seen.AssertComplete();
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                ParallelQuery<int> query = left(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, DefaultSource)
+                    .Intersect(right(DefaultStart, DefaultSize + DefaultSize / 2, DefaultSource));
+                foreach (int i in query)
+                {
+                    seen.Add(i);
+                }
+                seen.AssertComplete();
+            };
+            intersect(operation.Item, DefaultSource);
+            intersect(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -272,11 +306,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Intersect_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
-            ParallelQuery<int> query = operation.Item(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, DefaultSource)
-                .Intersect(operation.Item(DefaultStart, DefaultSize + DefaultSize / 2, DefaultSource));
-            Assert.All(query.ToList(), x => seen.Add((int)x));
-            seen.AssertComplete();
+            Action<Operation, Operation> intersect = (left, right) =>
+            {
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                ParallelQuery<int> query = left(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, DefaultSource)
+                    .Intersect(right(DefaultStart, DefaultSize + DefaultSize / 2, DefaultSource));
+                Assert.All(query.ToList(), x => seen.Add(x));
+                seen.AssertComplete();
+            };
+            intersect(operation.Item, DefaultSource);
+            intersect(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -284,15 +323,20 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Join_Unordered(Labeled<Operation> operation)
         {
-            IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
-            ParallelQuery<KeyValuePair<int, int>> query = operation.Item(DefaultStart / GroupFactor, DefaultSize / GroupFactor, DefaultSource)
-                .Join(operation.Item(DefaultStart, DefaultSize, DefaultSource), x => x, y => y / GroupFactor, (x, y) => new KeyValuePair<int, int>(x, y));
-            foreach (KeyValuePair<int, int> p in query)
+            Action<Operation, Operation> join = (left, right) =>
             {
-                Assert.Equal(p.Key, p.Value / GroupFactor);
-                seen.Add(p.Value);
-            }
-            seen.AssertComplete();
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                ParallelQuery<KeyValuePair<int, int>> query = left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, DefaultSource)
+                    .Join(right(DefaultStart, DefaultSize, DefaultSource), x => x, y => y / GroupFactor, (x, y) => new KeyValuePair<int, int>(x, y));
+                foreach (KeyValuePair<int, int> p in query)
+                {
+                    Assert.Equal(p.Key, p.Value / GroupFactor);
+                    seen.Add(p.Value);
+                }
+                seen.AssertComplete();
+            };
+            join(operation.Item, DefaultSource);
+            join(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -300,15 +344,20 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryUnorderedOperators))]
         public static void Join_Unordered_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
-            ParallelQuery<KeyValuePair<int, int>> query = operation.Item(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
-                .Join(operation.Item(DefaultStart, DefaultSize, source.Item), x => x, y => y / GroupFactor, (x, y) => new KeyValuePair<int, int>(x, y));
-            foreach (KeyValuePair<int, int> p in query.ToList())
+            Action<Operation, Operation> join = (left, right) =>
             {
-                Assert.Equal(p.Key, p.Value / GroupFactor);
-                seen.Add(p.Value);
-            }
-            seen.AssertComplete();
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                ParallelQuery<KeyValuePair<int, int>> query = left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, DefaultSource)
+                    .Join(right(DefaultStart, DefaultSize, DefaultSource), x => x, y => y / GroupFactor, (x, y) => new KeyValuePair<int, int>(x, y));
+                foreach (KeyValuePair<int, int> p in query.ToList())
+                {
+                    Assert.Equal(p.Key, p.Value / GroupFactor);
+                    seen.Add(p.Value);
+                }
+                seen.AssertComplete();
+            };
+            join(operation.Item, DefaultSource);
+            join(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -597,14 +646,19 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Zip_Unordered(Labeled<Operation> operation)
         {
-            IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
-            ParallelQuery<int> query = operation.Item(DefaultStart, DefaultSize, DefaultSource)
-                .Zip(operation.Item(0, DefaultSize, DefaultSource), (x, y) => x);
-            foreach (int i in query)
-            {
-                seen.Add(i);
-            }
-            seen.AssertComplete();
+            Action<Operation, Operation> zip = (left, right) =>
+             {
+                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                 ParallelQuery<int> query = left(DefaultStart, DefaultSize, DefaultSource)
+                     .Zip(right(0, DefaultSize, DefaultSource), (x, y) => x);
+                 foreach (int i in query)
+                 {
+                     seen.Add(i);
+                 }
+                 seen.AssertComplete();
+             };
+            zip(operation.Item, DefaultSource);
+            zip(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -612,11 +666,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Zip_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
-            ParallelQuery<int> query = operation.Item(0, DefaultSize, DefaultSource)
-                .Zip(operation.Item(DefaultStart, DefaultSize, DefaultSource), (x, y) => y);
-            Assert.All(query.ToList(), x => seen.Add(x));
-            seen.AssertComplete();
+            Action<Operation, Operation> zip = (left, right) =>
+            {
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                ParallelQuery<int> query = left(DefaultStart, DefaultSize, DefaultSource)
+                    .Zip(right(0, DefaultSize, DefaultSource), (x, y) => x);
+                Assert.All(query.ToList(), x => seen.Add(x));
+                seen.AssertComplete();
+            };
+            zip(operation.Item, DefaultSource);
+            zip(DefaultSource, operation.Item);
         }
     }
 }

--- a/src/System.Linq.Parallel/tests/Helpers/Functions.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Functions.cs
@@ -30,12 +30,6 @@ namespace System.Linq.Parallel.Tests
             return product;
         }
 
-        public static void AssertThrowsWrapped<T>(Action query)
-        {
-            AggregateException ae = Assert.Throws<AggregateException>(query);
-            Assert.All(ae.InnerExceptions, e => Assert.IsType<T>(e));
-        }
-
         public static void Enumerate<T>(this IEnumerable<T> e)
         {
             foreach (var x in e) { }

--- a/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
@@ -202,11 +202,8 @@ namespace System.Linq.Parallel.Tests
             ParallelQuery<int> leftQuery = left.Item;
             ParallelQuery<int> rightQuery = right.Item;
 
-            AggregateException ex = Assert.Throws<AggregateException>(() => leftQuery.SequenceEqual(new DisposeExceptionEnumerable<int>(rightQuery).AsParallel()));
-            Assert.All(ex.InnerExceptions, e => Assert.IsType<TestDisposeException>(e));
-
-            ex = Assert.Throws<AggregateException>(() => new DisposeExceptionEnumerable<int>(leftQuery).AsParallel().SequenceEqual(rightQuery));
-            Assert.All(ex.InnerExceptions, e => Assert.IsType<TestDisposeException>(e));
+            AssertThrows.Wrapped<TestDisposeException>(() => leftQuery.SequenceEqual(new DisposeExceptionEnumerable<int>(rightQuery).AsParallel()));
+            AssertThrows.Wrapped<TestDisposeException>(() => new DisposeExceptionEnumerable<int>(leftQuery).AsParallel().SequenceEqual(rightQuery));
         }
 
         private class DisposeExceptionEnumerable<T> : IEnumerable<T>

--- a/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
@@ -169,6 +169,34 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [ActiveIssue("Cancellation token not shared")]
+        [MemberData("SequenceEqualData", new int[] { 1024 })]
+        public static void SequenceEqual_SharedLeft_Cancellation(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
+        {
+            IntegerRangeSet seen = new IntegerRangeSet(0, count);
+            CancellationTokenSource cs = new CancellationTokenSource();
+
+            Assert.Throws<OperationCanceledException>(() => left.Item.WithCancellation(cs.Token)
+              .SequenceEqual(right.Item.Except(ParallelEnumerable.Range(0, count).Select(x => { cs.Cancel(); seen.Add(x); return x; }))));
+            // Canceled query means some elements should not be seen.
+            Assert.False(seen.All(x => x.Value));
+        }
+
+        [Theory]
+        [ActiveIssue("Cancellation token not shared")]
+        [MemberData("SequenceEqualData", new int[] { 1024 })]
+        public static void SequenceEqual_SharedRight_Cancellation(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
+        {
+            IntegerRangeSet seen = new IntegerRangeSet(0, count);
+            CancellationTokenSource cs = new CancellationTokenSource();
+
+            Assert.Throws<OperationCanceledException>(() => left.Item.Except(ParallelEnumerable.Range(0, count).Select(x => { cs.Cancel(); seen.Add(x); return x; }))
+              .SequenceEqual(right.Item.WithCancellation(cs.Token)));
+            // Canceled query means some elements should not be seen.
+            Assert.False(seen.All(x => x.Value));
+        }
+
+        [Theory]
         [MemberData(nameof(SequenceEqualData), new[] { 4 })]
         public static void SequenceEqual_AggregateException(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
@@ -169,7 +169,6 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [ActiveIssue("Cancellation token not shared")]
         [MemberData("SequenceEqualData", new int[] { 1024 })]
         public static void SequenceEqual_SharedLeft_Cancellation(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {
@@ -183,7 +182,6 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [ActiveIssue("Cancellation token not shared")]
         [MemberData("SequenceEqualData", new int[] { 1024 })]
         public static void SequenceEqual_SharedRight_Cancellation(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -106,9 +106,9 @@ namespace System.Linq.Parallel.Tests
             //the failure was an ODE coming out due to an ephemeral disposed merged cancellation token source.
             ParallelQuery<int> left = labeled.Item.AsUnordered().WithExecutionMode(ParallelExecutionMode.ForceParallelism);
             ParallelQuery<int> right = Enumerable.Range(0, 1024).Select(x => x).AsParallel().AsUnordered();
-            Functions.AssertThrowsWrapped<OperationCanceledException>(() => left.GroupJoin(right, x => { throw new OperationCanceledException(); }, y => y, (x, e) => x).ForAll(x => { }));
-            Functions.AssertThrowsWrapped<OperationCanceledException>(() => left.Join(right, x => { throw new OperationCanceledException(); }, y => y, (x, e) => x).ForAll(x => { }));
-            Functions.AssertThrowsWrapped<OperationCanceledException>(() => left.Zip<int, int, int>(right, (x, y) => { throw new OperationCanceledException(); }).ForAll(x => { }));
+            AssertThrows.Wrapped<OperationCanceledException>(() => left.GroupJoin(right, x => { throw new OperationCanceledException(); }, y => y, (x, e) => x).ForAll(x => { }));
+            AssertThrows.Wrapped<OperationCanceledException>(() => left.Join(right, x => { throw new OperationCanceledException(); }, y => y, (x, e) => x).ForAll(x => { }));
+            AssertThrows.Wrapped<OperationCanceledException>(() => left.Zip<int, int, int>(right, (x, y) => { throw new OperationCanceledException(); }).ForAll(x => { }));
         }
 
         // If a query is canceled and immediately disposed, the dispose should not throw an OCE.


### PR DESCRIPTION
Currently, `PLINQ.SequenceEqual` can't be canceled.  
Or rather, only _one_ of the operators can be canceled, the other one must continue to execute.

In many cases, this isn't much of an issue; `SequenceEqual` just grabs the iterators, so when cancellation happens it's picked up pretty fast.  
However, if an operator requires the entire input to be read before returning any - say, `OrderBy`, `Reverse`, `Except` - if the token is attached to the other operator it can't be canceled.  That is:
```
// Keeps track of visited elements
IntegerRangeSet seen = new IntegerRangeSet(0, count);  
CancellationTokenSource cs = new CancellationTokenSource();  

Assert.Throws<OperationCanceledException>(() => parallelA.WithCancellation(cs.Token)  
SequenceEqual(parallelB.Except(ParallelEnumerable.Range(0, count).Select(x => { cs.Cancel(); seen.Add(x); return x; }))));  
// Canceled query means some elements should not be seen.  
Assert.False(seen.All(x => x.Value)); 
```
... fails, because all elements are visited.  

At minimum, this is a non-intuitive gotcha (and isn't documented).  Additionally, the other settings aren't shared, including whether to force parallelism.  
This PR makes the operators actually share the settings, so now these queries can be canceled, plus several related test changes.  

There's also a couple of minor unrelated test changes which I rolled up into this, but can pull out if needed (combinatorial was missing `Union` for some reason, and had a leftover use of an old helper method).