### PR TITLE
Remove ASCIIEncoding-specific workaround in tests

### DIFF
--- a/src/System.Text.Encoding/tests/NegativeEncodingTests.cs
+++ b/src/System.Text.Encoding/tests/NegativeEncodingTests.cs
@@ -38,7 +38,7 @@ namespace System.Text.Tests
         public static unsafe void GetByteCount_Invalid(Encoding encoding)
         {
             // Chars is null
-            Assert.Throws<ArgumentNullException>(encoding is ASCIIEncoding ? "chars" : "s", () => encoding.GetByteCount((string)null));
+            Assert.Throws<ArgumentNullException>("s", () => encoding.GetByteCount((string)null));
             Assert.Throws<ArgumentNullException>("chars", () => encoding.GetByteCount((char[])null));
             Assert.Throws<ArgumentNullException>("chars", () => encoding.GetByteCount(null, 0, 0));
 
@@ -66,13 +66,11 @@ namespace System.Text.Tests
         [MemberData(nameof(Encodings_TestData))]
         public static unsafe void GetBytes_Invalid(Encoding encoding)
         {
-            string expectedStringParamName = encoding is ASCIIEncoding ? "chars" : "s";
-
             // Source is null
             Assert.Throws<ArgumentNullException>("s", () => encoding.GetBytes((string)null));
             Assert.Throws<ArgumentNullException>("chars", () => encoding.GetBytes((char[])null));
             Assert.Throws<ArgumentNullException>("chars", () => encoding.GetBytes(null, 0, 0));
-            Assert.Throws<ArgumentNullException>(expectedStringParamName, () => encoding.GetBytes((string)null, 0, 0, new byte[1], 0));
+            Assert.Throws<ArgumentNullException>("s", () => encoding.GetBytes((string)null, 0, 0, new byte[1], 0));
             Assert.Throws<ArgumentNullException>("chars", () => encoding.GetBytes((char[])null, 0, 0, new byte[1], 0));
 
             // Bytes is null
@@ -91,15 +89,15 @@ namespace System.Text.Tests
 
             // Char index + count > source.Length
             Assert.Throws<ArgumentOutOfRangeException>("chars", () => encoding.GetBytes(new char[1], 2, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(expectedStringParamName, () => encoding.GetBytes("a", 2, 0, new byte[1], 0));
+            Assert.Throws<ArgumentOutOfRangeException>("s", () => encoding.GetBytes("a", 2, 0, new byte[1], 0));
             Assert.Throws<ArgumentOutOfRangeException>("chars", () => encoding.GetBytes(new char[1], 2, 0, new byte[1], 0));
 
             Assert.Throws<ArgumentOutOfRangeException>("chars", () => encoding.GetBytes(new char[1], 1, 1));
-            Assert.Throws<ArgumentOutOfRangeException>(expectedStringParamName, () => encoding.GetBytes("a", 1, 1, new byte[1], 0));
+            Assert.Throws<ArgumentOutOfRangeException>("s", () => encoding.GetBytes("a", 1, 1, new byte[1], 0));
             Assert.Throws<ArgumentOutOfRangeException>("chars", () => encoding.GetBytes(new char[1], 1, 1, new byte[1], 0));
 
             Assert.Throws<ArgumentOutOfRangeException>("chars", () => encoding.GetBytes(new char[1], 0, 2));
-            Assert.Throws<ArgumentOutOfRangeException>(expectedStringParamName, () => encoding.GetBytes("a", 0, 2, new byte[1], 0));
+            Assert.Throws<ArgumentOutOfRangeException>("s", () => encoding.GetBytes("a", 0, 2, new byte[1], 0));
             Assert.Throws<ArgumentOutOfRangeException>("chars", () => encoding.GetBytes(new char[1], 0, 2, new byte[1], 0));
 
             // Byte index < 0
@@ -284,8 +282,8 @@ namespace System.Text.Tests
             Assert.Throws<ArgumentNullException>("bytes", () => encoding.GetString(null, 0, 0));
 
             // Index or count < 0
-            Assert.Throws<ArgumentOutOfRangeException>(encoding is ASCIIEncoding ? "byteIndex" : "index", () => encoding.GetString(new byte[1], -1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(encoding is ASCIIEncoding ? "byteCount" : "count", () => encoding.GetString(new byte[1], 0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => encoding.GetString(new byte[1], -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => encoding.GetString(new byte[1], 0, -1));
 
             // Index + count > bytes.Length
             Assert.Throws<ArgumentOutOfRangeException>("bytes", () => encoding.GetString(new byte[1], 2, 0));


### PR DESCRIPTION
With the refactorization in dotnet/coreclr#6114 `ASCIIEncoding` now throws on the same parameter name as the other `Encodings`; e.g. it still has the signature

```cs
public int GetString(byte[] bytes, int byteIndex, int byteCount);
```

whereas `Encoding` has the signature

```cs
public int GetString(byte[] bytes, int index, int count);
```

in case someone uses named parameters, but will now throw on `"count"` instead of `"byteCount"`. We were using workarounds for this in our tests to determine which parameter name we should expect, so get rid of those.

This should be merged when the CoreCLR pull request is merged.

cc @hughbe @tarekgh @stephentoub 