### PR TITLE
Make sure TcpClient properties do not throw when the underlying Socket is null

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
@@ -157,7 +157,7 @@ namespace System.Net.Sockets
             {
                 // If we have a client socket, return its available value.
                 // Otherwise, there isn't data available, so return 0.
-                return _clientSocket != null ? _clientSocket.Available : 0;
+                return _clientSocket?.Available ?? 0;
             }
         }
 
@@ -167,7 +167,7 @@ namespace System.Net.Sockets
             {
                 // If we have a client socket, return whether it's connected.
                 // Otherwise as we don't have a socket, by definition it's not.
-                return _clientSocket != null && _clientSocket.Connected;
+                return _clientSocket?.Connected ?? false;
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Windows.cs
@@ -20,19 +20,38 @@ namespace System.Net.Sockets
             set { _clientSocket = value; }
         }
 
-        private int AvailableCore { get { return _clientSocket.Available; } }
+        private int AvailableCore
+        {
+            get
+            {
+                // If we have a client socket, return its available value.
+                // Otherwise, there isn't data available, so return 0.
+                return _clientSocket?.Available ?? 0;
+            }
+        }
 
-        private bool ConnectedCore { get { return _clientSocket.Connected; } }
+        private bool ConnectedCore
+        {
+            get
+            {
+                // If we have a client socket, return whether it's connected.
+                // Otherwise as we don't have a socket, by definition it's not.
+                return _clientSocket?.Connected ?? false;
+            }
+        }
 
         private bool ExclusiveAddressUseCore
         {
             get
             {
-                return _clientSocket.ExclusiveAddressUse;
+                return _clientSocket?.ExclusiveAddressUse ?? false;
             }
             set
             {
-                _clientSocket.ExclusiveAddressUse = value;
+                if (_clientSocket != null)
+                {
+                    _clientSocket.ExclusiveAddressUse = value;
+                }
             }
         }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -69,6 +69,19 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        public void ConnectedAvailableExclusiveAddressUse_NullClient()
+        {
+            using (TcpClient client = new TcpClient())
+            {
+                client.Client = null;
+
+                Assert.False(client.Connected);
+                Assert.Equal(0, client.Available);
+                Assert.False(client.ExclusiveAddressUse);
+            }
+        }
+
+        [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public void Roundtrip_ExclusiveAddressUse_GetEqualsSet()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -69,7 +69,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        public void ConnectedAvailableExclusiveAddressUse_NullClient()
+        public void ConnectedAvailable_NullClient()
         {
             using (TcpClient client = new TcpClient())
             {
@@ -77,6 +77,17 @@ namespace System.Net.Sockets.Tests
 
                 Assert.False(client.Connected);
                 Assert.Equal(0, client.Available);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void ExclusiveAddressUse_NullClient()
+        {
+            using (TcpClient client = new TcpClient())
+            {
+                client.Client = null;
+
                 Assert.False(client.ExclusiveAddressUse);
             }
         }


### PR DESCRIPTION
Fixes #9762