### PR TITLE
Add some more test coverage for the new string(char*) impl

### DIFF
--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -23,6 +23,8 @@ namespace System.Tests
         [InlineData(new char[] { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', '\0', 'i', 'j' }, "abcdefgh")]
         [InlineData(new char[] { 'a', '\0' }, "a")]
         [InlineData(new char[] { '\0' }, "")]
+        [InlineData(new char[] { '?', '@', ' ', '\0' }, "?@ ")] // ? and @ don't have overlapping bits
+        [InlineData(new char[] { '\u8001', '\u8002', '\ufffd', '\u1234', '\ud800', '\udfff', '\0' }, "\u8001\u8002\ufffd\u1234\ud800\udfff")] // chars with high bits set
         public static unsafe void Ctor_CharPtr(char[] valueArray, string expected)
         {
             fixed (char* value = valueArray)


### PR DESCRIPTION
This adds some more test coverage to the new `string(char*)` constructor, assuming dotnet/coreclr#6125 is merged.

cc @stephentoub 