### PR TITLE
[TODO] Remove some boxing from IPv6AddressHelper.CreateCanonicalName

### DIFF
--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -15,8 +15,6 @@ namespace System
         // fields
 
         private const int NumberOfLabels = 8;
-        // Lower case hex, no leading zeros
-        private const string CanonicalNumberFormat = "{0:x}";
         private const char Separator = ':';
 
         // methods
@@ -43,12 +41,13 @@ namespace System
             bool ipv4Embedded = ShouldHaveIpv4Embedded(numbers);
 
             StringBuilder builder = new StringBuilder();
+	        var formatProvider = CultureInfo.InvariantCulture;
+
             for (int i = 0; i < NumberOfLabels; i++)
             {
                 if (ipv4Embedded && i == (NumberOfLabels - 2))
                 {
                     // Write the remaining digits as an IPv4 address
-                    var formatProvider = CultureInfo.InvariantCulture;
 
                     // Call all of this manually, instead of using AppendFormat,
                     // to avoid boxing
@@ -85,7 +84,7 @@ namespace System
                 {
                     builder.Append(Separator);
                 }
-                builder.AppendFormat(CultureInfo.InvariantCulture, CanonicalNumberFormat, numbers[i]);
+                builder.Append(numbers[i].ToString("x", formatProvider)); // Lower case hex, no leading zeros
             }
 
             return builder.ToString();

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -17,7 +17,6 @@ namespace System
         private const int NumberOfLabels = 8;
         // Lower case hex, no leading zeros
         private const string CanonicalNumberFormat = "{0:x}";
-        private const string EmbeddedIPv4Format = ":{0:d}.{1:d}.{2:d}.{3:d}";
         private const char Separator = ':';
 
         // methods
@@ -49,8 +48,21 @@ namespace System
                 if (ipv4Embedded && i == (NumberOfLabels - 2))
                 {
                     // Write the remaining digits as an IPv4 address
-                    builder.AppendFormat(CultureInfo.InvariantCulture, EmbeddedIPv4Format,
-                        numbers[i] >> 8, numbers[i] & 0xFF, numbers[i + 1] >> 8, numbers[i + 1] & 0xFF);
+                    var formatProvider = CultureInfo.InvariantCulture;
+
+                    // Call all of this manually, instead of using AppendFormat,
+                    // to avoid boxing
+                    // Equivalent to the format ":{0:d}.{1:d}.{2:d}.{3:d}"
+
+                    var first = (numbers[i] >> 8).ToString("d", formatProvider);
+                    var second = (numbers[i] & 0xFF).ToString("d", formatProvider);
+                    var third = (numbers[i + 1] >> 8).ToString("d", formatProvider);
+                    var fourth = (numbers[i + 1] & 0xFF).ToString("d", formatProvider);
+
+                    builder.Append(':').Append(first)
+                        .Append('.').Append(second)
+                        .Append('.').Append(third)
+                        .Append('.').Append(fourth);
                     break;
                 }
 


### PR DESCRIPTION
Don't use `StringBuilder.AppendFormat` which converts the rest of the arguments to objects, instead call the `ToString` overload accepting a format/format provider ourselves and `Append` it to the builder.

cc @stephentoub @davidsh