### PR TITLE
Fix HttpWebResponse.ContentType when response has invalid headers

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebResponseTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseTest.cs
@@ -12,13 +12,30 @@ namespace System.Net.Tests
 {
     public class HttpWebResponseTest
     {
-        [Fact]
-        public async Task ContentType_ServerResponseHasContentTypeHeader_ContentTypeIsNonEmptyString()
+        [Theory]
+        [InlineData("text/html")]
+        [InlineData("text/html; charset=utf-8")]
+        [InlineData("TypeAndNoSubType")]
+        public async Task ContentType_ServerResponseHasContentTypeHeader_ContentTypeReceivedCorrectly(string expectedContentType)
         {
-            HttpWebRequest request = WebRequest.CreateHttp(Configuration.Http.RemoteEchoServer);
-            request.Method = HttpMethod.Get.Method;
-            WebResponse response = await request.GetResponseAsync();
-            Assert.True(!string.IsNullOrEmpty(response.ContentType));
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                HttpWebRequest request = WebRequest.CreateHttp(url);
+                request.Method = HttpMethod.Get.Method;
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        $"HTTP/1.1 200 OK\r\n" +
+                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                        $"Content-Type: {expectedContentType}\r\n" +
+                        "Content-Length: 5\r\n" +
+                        "\r\n" +
+                        "12345");
+
+                using (WebResponse response = await getResponse)
+                {
+                    Assert.Equal(expectedContentType, response.ContentType);
+                }
+            });
         }
 
         [Fact]


### PR DESCRIPTION
The HttpWebResponse.ContentType property is supposed to return a string value with the response's `Content-Type` header value. Even if the response header is considered non-conformant with RFC7231, the value is returned as-is as received on the wire.

In .NET Core, HttpWebRequest/HttpWebResponse is implemented as a wrapper around HttpClient. HttpClient has a strongly-typed model for headers. The current implementation of HttpWebResponse.ContentType was trying to use the strongly typed header from HttpClient. In cases where the header was malformed, it was returning empty string. This was a difference in behavior from .NET Framework.

The fix is to use TryGetValues() to retrieve the raw response header value for the 'Content-Type' header. This will result in compatible behavior with .NET Framework.

Fixes #9433.