### PR TITLE
Fix ValueTaskTests deadlocking on a single core machine

### DIFF
--- a/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using Xunit;
 
-namespace System.Threading.Tasks.Channels.Tests
+namespace System.Threading.Tasks.Tests
 {
     public class ValueTaskTests
     {
@@ -125,31 +124,31 @@ namespace System.Threading.Tasks.Channels.Tests
         }
 
         [Fact]
-        public void Awaiter_OnCompleted()
+        public async Task Awaiter_OnCompleted()
         {
             // Since ValueTask implements both OnCompleted and UnsafeOnCompleted,
             // OnCompleted typically won't be used by await, so we add an explicit test
             // for it here.
 
             ValueTask<int> t = new ValueTask<int>(42);
-            var mres = new ManualResetEventSlim();
-            t.GetAwaiter().OnCompleted(() => mres.Set());
-            Assert.True(mres.Wait(10000));
+            var tcs = new TaskCompletionSource<bool>();
+            t.GetAwaiter().OnCompleted(() => tcs.SetResult(true));
+            await tcs.Task;
         }
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void ConfiguredAwaiter_OnCompleted(bool continueOnCapturedContext)
+        public async Task ConfiguredAwaiter_OnCompleted(bool continueOnCapturedContext)
         {
             // Since ValueTask implements both OnCompleted and UnsafeOnCompleted,
             // OnCompleted typically won't be used by await, so we add an explicit test
             // for it here.
 
             ValueTask<int> t = new ValueTask<int>(42);
-            var mres = new ManualResetEventSlim();
-            t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().OnCompleted(() => mres.Set());
-            Assert.True(mres.Wait(10000));
+            var tcs = new TaskCompletionSource<bool>();
+            t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().OnCompleted(() => tcs.SetResult(true));
+            await tcs.Task;
         }
 
         [Fact]


### PR DESCRIPTION
cc: @svick, @mellinoe 
Fixes https://github.com/dotnet/corefx/issues/9887