### PR TITLE
Make sure TcpClient.ExclusiveAddressUse throws on Unix

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
@@ -379,8 +379,17 @@ namespace System.Net.Sockets
                 so._exclusiveAddressUse = value ? 1 : 0;
                 so._exclusiveAddressUseInitialized = true;
 
-                Socket s = _clientSocket ?? CreateSocket();
-                s.ExclusiveAddressUse = value; // Use setter explicitly as it does additional validation beyond that done by SetOption
+                if (_clientSocket == null)
+                {
+                    using (Socket s = CreateSocket())
+                    {
+                        s.ExclusiveAddressUse = value;
+                    }
+                }
+                else
+                {
+                    _clientSocket.ExclusiveAddressUse = value; // Use setter explicitly as it does additional validation beyond that done by SetOption
+                }
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
@@ -378,10 +378,9 @@ namespace System.Net.Sockets
                 ShadowOptions so = EnsureShadowValuesInitialized();
                 so._exclusiveAddressUse = value ? 1 : 0;
                 so._exclusiveAddressUseInitialized = true;
-                if (_clientSocket != null)
-                {
-                    _clientSocket.ExclusiveAddressUse = value; // Use setter explicitly as it does additional validation beyond that done by SetOption
-                }
+
+                Socket s = _clientSocket ?? CreateSocket();
+                s.ExclusiveAddressUse = value; // Use setter explicitly as it does additional validation beyond that done by SetOption
             }
         }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -69,6 +69,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Roundtrip_ExclusiveAddressUse_GetEqualsSet()
         {
             using (TcpClient client = new TcpClient())
@@ -77,6 +78,20 @@ namespace System.Net.Sockets.Tests
                 Assert.True(client.ExclusiveAddressUse);
                 client.ExclusiveAddressUse = false;
                 Assert.False(client.ExclusiveAddressUse);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void ExclusiveAddressUse_NotSupported()
+        {
+            using (TcpClient client = new TcpClient())
+            {
+                Assert.Throws<SocketException>(() => client.ExclusiveAddressUse);
+                Assert.Throws<SocketException>(() =>
+                {
+                    client.ExclusiveAddressUse = true;
+                });
             }
         }
 


### PR DESCRIPTION
This is related to the failure that happened in #9849.

cc: @stephentoub @ericeil 