### PR TITLE
Add System.Json

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -713,6 +713,16 @@
         ]
     },
     {
+        "Name": "System.Json",
+        "Description": "Provides standards-based support for the serialization of JavaScript Object Notation (JSON).",
+        "CommonTypes": [
+            "System.Json.JsonArray",
+            "System.Json.JsonObject",
+            "System.Json.JsonPrimitive",
+            "System.Json.JsonValue"
+        ]
+    },
+    {
         "Name": "System.Linq",
         "Description": "Provides classes and interfaces that supports queries that use Language-Integrated Query (LINQ).",
         "CommonTypes": [

--- a/src/System.Json/System.Json.sln
+++ b/src/System.Json/System.Json.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Json", "src\System.Json.csproj", "{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Json.Tests", "tests\System.Json.Tests.csproj", "{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Release|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Json/pkg/System.Json.builds
+++ b/src/System.Json/pkg/System.Json.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Json.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Json/pkg/System.Json.pkgproj
+++ b/src/System.Json/pkg/System.Json.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Json.builds">
+      <SupportedFramework>net46;netcore50;netcoreapp1.0</SupportedFramework>
+    </ProjectReference>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Json/pkg/System.Json.pkgproj
+++ b/src/System.Json/pkg/System.Json.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\src\System.Json.builds">
-      <SupportedFramework>net46;netcore50;netcoreapp1.0</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netcoreapp1.0;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />

--- a/src/System.Json/pkg/System.Json.pkgproj
+++ b/src/System.Json/pkg/System.Json.pkgproj
@@ -5,12 +5,26 @@
     <ProjectReference Include="..\src\System.Json.builds">
       <SupportedFramework>net45;netcore45;netcoreapp1.0;wp8;wpa81</SupportedFramework>
     </ProjectReference>
-    <InboxOnTargetFramework Include="MonoAndroid10" />
-    <InboxOnTargetFramework Include="MonoTouch10" />
-    <InboxOnTargetFramework Include="xamarinios10" />
-    <InboxOnTargetFramework Include="xamarinmac20" />
-    <InboxOnTargetFramework Include="xamarintvos10" />
-    <InboxOnTargetFramework Include="xamarinwatchos10" />
+    
+    <!-- System.Json is a classic reference assembly on Xamarin platforms -->
+    <InboxOnTargetFramework Include="monoandroid10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="monotouch10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarinios10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="Xamarinmac20">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarintvos10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarinwatchos10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Json/src/Resources/Strings.resx
+++ b/src/System.Json/src/Resources/Strings.resx
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ArgumentException_BufferNotFromPool" xml:space="preserve">
+    <value>The buffer is not associated with this pool and may not be returned to it.</value>
+  </data>
+</root>

--- a/src/System.Json/src/Resources/Strings.resx
+++ b/src/System.Json/src/Resources/Strings.resx
@@ -117,7 +117,58 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ArgumentException_BufferNotFromPool" xml:space="preserve">
-    <value>The buffer is not associated with this pool and may not be returned to it.</value>
+  <data name="ArgumentException_ExtraCharacters" xml:space="preserve">
+    <value>Extra characters in JSON input.</value>
+  </data>
+  <data name="ArgumentException_IncompleteInput" xml:space="preserve">
+    <value>Incomplete JSON input.</value>
+  </data>
+  <data name="ArgumentException_UnexpectedCharacter" xml:space="preserve">
+    <value>Unexpected character '{0}'.</value>
+  </data>
+  <data name="ArgumentException_ArrayMustEndWithBracket" xml:space="preserve">
+    <value>JSON array must end with ']'.</value>
+  </data>
+  <data name="ArgumentException_LeadingZeros" xml:space="preserve">
+    <value>Leading zeros are not allowed.</value>
+  </data>
+  <data name="ArgumentException_NoDigitFound" xml:space="preserve">
+    <value>Invalid JSON numeric literal; no digit found.</value>
+  </data>
+  <data name="ArgumentException_ExtraDot" xml:space="preserve">
+    <value>Invalid JSON numeric literal; extra dot.</value>
+  </data>
+  <data name="ArgumentException_IncompleteExponent" xml:space="preserve">
+    <value>Invalid JSON numeric literal; incomplete exponent.</value>
+  </data>
+  <data name="ArgumentException_InvalidLiteralFormat" xml:space="preserve">
+    <value>Invalid JSON string literal format.</value>
+  </data>
+  <data name="ArgumentException_StringNotClosed" xml:space="preserve">
+    <value>JSON string is not closed.</value>
+  </data>
+  <data name="ArgumentException_IncompleteEscapeSequence" xml:space="preserve">
+    <value>Invalid JSON string literal; incomplete escape sequence.</value>
+  </data>
+  <data name="ArgumentException_IncompleteEscapeLiteral" xml:space="preserve">
+    <value>Incomplete unicode character escape literal.</value>
+  </data>
+  <data name="ArgumentException_UnexpectedEscapeCharacter" xml:space="preserve">
+    <value>Invalid JSON string literal; unexpected escape character.</value>
+  </data>
+  <data name="ArgumentException_ExpectedXButGotY" xml:space="preserve">
+    <value>Expected '{0}', got '{1}'.</value>
+  </data>
+  <data name="ArgumentException_ExpectedXDiferedAtY" xml:space="preserve">
+    <value>Expected '{0}', differed at {1}.</value>
+  </data>
+  <data name="ArgumentException_MessageAt" xml:space="preserve">
+    <value>{0} At line {1}, column {2}.</value>
+  </data>
+  <data name="NotImplemented_GetFormattedString" xml:space="preserve">
+    <value>GetFormattedString from value type {0}.</value>
+  </data>
+  <data name="NotSupported_UnexpectedParserType" xml:space="preserve">
+    <value>Unexpected parser return type: {0}.</value>
   </data>
 </root>

--- a/src/System.Json/src/System.Json.builds
+++ b/src/System.Json/src/System.Json.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Json.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Json/src/System.Json.csproj
+++ b/src/System.Json/src/System.Json.csproj
@@ -4,10 +4,8 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <ProjectGuid>{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}</ProjectGuid>
-    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <UseOpenKey Condition="'$(UseOpenKey)'==''">true</UseOpenKey>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.0</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Json/src/System.Json.csproj
+++ b/src/System.Json/src/System.Json.csproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <ProjectGuid>{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}</ProjectGuid>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseOpenKey Condition="'$(UseOpenKey)'==''">true</UseOpenKey>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System\Json\JsonArray.cs" />
+    <Compile Include="System\Json\JsonObject.cs" />
+    <Compile Include="System\Json\JsonPrimitive.cs" />
+    <Compile Include="System\Json\JsonType.cs" />
+    <Compile Include="System\Json\JsonValue.cs" />
+    <Compile Include="System\Json\JavaScriptReader.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Json/src/System/Json/JavaScriptReader.cs
+++ b/src/System.Json/src/System/Json/JavaScriptReader.cs
@@ -18,7 +18,10 @@ namespace System.Runtime.Serialization.Json
         public JavaScriptReader(TextReader reader, bool raiseOnNumberError)
         {
             if (reader == null)
+            {
                 throw new ArgumentNullException(nameof(reader));
+            }
+
             _r = reader;
         }
 
@@ -27,7 +30,9 @@ namespace System.Runtime.Serialization.Json
             object v = ReadCore();
             SkipSpaces();
             if (ReadChar() >= 0)
-                throw JsonError(string.Format("extra characters in JSON input"));
+            {
+                throw JsonError(SR.ArgumentException_ExtraCharacters);
+            }
             return v;
         }
 
@@ -36,7 +41,7 @@ namespace System.Runtime.Serialization.Json
             SkipSpaces();
             int c = PeekChar();
             if (c < 0)
-                throw JsonError("Incomplete JSON input");
+                throw JsonError(SR.ArgumentException_IncompleteInput);
             switch (c)
             {
                 case '[':
@@ -59,7 +64,7 @@ namespace System.Runtime.Serialization.Json
                         continue;
                     }
                     if (ReadChar() != ']')
-                        throw JsonError("JSON array must end with ']'");
+                        throw JsonError(SR.ArgumentException_ArrayMustEndWithBracket);
                     return list.ToArray();
                 case '{':
                     ReadChar();
@@ -107,7 +112,7 @@ namespace System.Runtime.Serialization.Json
                     if ('0' <= c && c <= '9' || c == '-')
                         return ReadNumericLiteral();
                     else
-                        throw JsonError(string.Format("Unexpected character '{0}'", (char)c));
+                        throw JsonError(SR.Format(SR.ArgumentException_UnexpectedCharacter, (char)c));
             }
         }
 
@@ -183,10 +188,10 @@ namespace System.Runtime.Serialization.Json
                     break;
                 sb.Append((char)ReadChar());
                 if (zeroStart && x == 1)
-                    throw JsonError("leading zeros are not allowed");
+                    throw JsonError(SR.ArgumentException_LeadingZeros);
             }
             if (x == 0) // Reached e.g. for "- "
-                throw JsonError("Invalid JSON numeric literal; no digit found");
+                throw JsonError(SR.ArgumentException_NoDigitFound);
 
             // fraction
             bool hasFrac = false;
@@ -196,7 +201,7 @@ namespace System.Runtime.Serialization.Json
                 hasFrac = true;
                 sb.Append((char)ReadChar());
                 if (PeekChar() < 0)
-                    throw JsonError("Invalid JSON numeric literal; extra dot");
+                    throw JsonError(SR.ArgumentException_ExtraDot);
                 while (true)
                 {
                     c = PeekChar();
@@ -206,7 +211,7 @@ namespace System.Runtime.Serialization.Json
                     fdigits++;
                 }
                 if (fdigits == 0)
-                    throw JsonError("Invalid JSON numeric literal; extra dot");
+                    throw JsonError(SR.ArgumentException_ExtraDot);
             }
 
             c = PeekChar();
@@ -235,7 +240,7 @@ namespace System.Runtime.Serialization.Json
                 // exponent
                 sb.Append((char)ReadChar());
                 if (PeekChar() < 0)
-                    throw new ArgumentException("Invalid JSON numeric literal; incomplete exponent");
+                    throw JsonError(SR.ArgumentException_IncompleteExponent);
 
                 c = PeekChar();
                 if (c == '-')
@@ -246,7 +251,7 @@ namespace System.Runtime.Serialization.Json
                     sb.Append((char)ReadChar());
 
                 if (PeekChar() < 0)
-                    throw JsonError("Invalid JSON numeric literal; incomplete exponent");
+                    throw JsonError(SR.ArgumentException_IncompleteExponent);
                 while (true)
                 {
                     c = PeekChar();
@@ -264,7 +269,7 @@ namespace System.Runtime.Serialization.Json
         private string ReadStringLiteral()
         {
             if (PeekChar() != '"')
-                throw JsonError("Invalid JSON string literal format");
+                throw JsonError(SR.ArgumentException_InvalidLiteralFormat);
 
             ReadChar();
             _vb.Length = 0;
@@ -272,7 +277,7 @@ namespace System.Runtime.Serialization.Json
             {
                 int c = ReadChar();
                 if (c < 0)
-                    throw JsonError("JSON string is not closed");
+                    throw JsonError(SR.ArgumentException_StringNotClosed);
                 if (c == '"')
                     return _vb.ToString();
                 else if (c != '\\')
@@ -284,7 +289,7 @@ namespace System.Runtime.Serialization.Json
                 // escaped expression
                 c = ReadChar();
                 if (c < 0)
-                    throw JsonError("Invalid JSON string literal; incomplete escape sequence");
+                    throw JsonError(SR.ArgumentException_IncompleteEscapeSequence);
                 switch (c)
                 {
                     case '"':
@@ -313,7 +318,7 @@ namespace System.Runtime.Serialization.Json
                         {
                             cp <<= 4;
                             if ((c = ReadChar()) < 0)
-                                throw JsonError("Incomplete unicode character escape literal");
+                                throw JsonError(SR.ArgumentException_IncompleteEscapeLiteral);
                             if ('0' <= c && c <= '9')
                                 cp += (ushort)(c - '0');
                             if ('A' <= c && c <= 'F')
@@ -324,7 +329,7 @@ namespace System.Runtime.Serialization.Json
                         _vb.Append((char)cp);
                         break;
                     default:
-                        throw JsonError("Invalid JSON string literal; unexpected escape character");
+                        throw JsonError(SR.ArgumentException_UnexpectedEscapeCharacter);
                 }
             }
         }
@@ -333,19 +338,19 @@ namespace System.Runtime.Serialization.Json
         {
             int c;
             if ((c = ReadChar()) != expected)
-                throw JsonError(string.Format("Expected '{0}', got '{1}'", expected, (char)c));
+                throw JsonError(SR.Format(SR.ArgumentException_ExpectedXButGotY, expected, (char)c));
         }
 
         private void Expect(string expected)
         {
             for (int i = 0; i < expected.Length; i++)
                 if (ReadChar() != expected[i])
-                    throw JsonError(string.Format("Expected '{0}', differed at {1}", expected, i));
+                    throw JsonError(SR.Format(SR.ArgumentException_ExpectedXDiferedAtY, expected, i));
         }
 
         private Exception JsonError(string msg)
         {
-            return new ArgumentException(string.Format("{0}. At line {1}, column {2}", msg, _line, _column));
+            return new ArgumentException(SR.Format(SR.ArgumentException_MessageAt, msg, _line, _column));
         }
     }
 }

--- a/src/System.Json/src/System/Json/JavaScriptReader.cs
+++ b/src/System.Json/src/System/Json/JavaScriptReader.cs
@@ -1,0 +1,324 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace System.Runtime.Serialization.Json
+{
+	internal class JavaScriptReader
+	{
+		private readonly TextReader _r;
+		private int _line = 1, _column = 0;
+
+		public JavaScriptReader (TextReader reader, bool raiseOnNumberError)
+		{
+			if (reader == null)
+				throw new ArgumentNullException (nameof(reader));
+			this._r = reader;
+		}
+
+		public object Read ()
+		{
+			object v = ReadCore ();
+			SkipSpaces ();
+			if (ReadChar () >= 0)
+				throw JsonError (string.Format ("extra characters in JSON input"));
+			return v;
+		}
+
+		object ReadCore ()
+		{
+			SkipSpaces ();
+			int c = PeekChar ();
+			if (c < 0)
+				throw JsonError ("Incomplete JSON input");
+			switch (c) {
+			case '[':
+				ReadChar ();
+				var list = new List<object> ();
+				SkipSpaces ();
+				if (PeekChar () == ']') {
+					ReadChar ();
+					return list;
+				}
+				while (true) {
+					list.Add (ReadCore ());
+					SkipSpaces ();
+					c = PeekChar ();
+					if (c != ',')
+						break;
+					ReadChar ();
+					continue;
+				}
+				if (ReadChar () != ']')
+					throw JsonError ("JSON array must end with ']'");
+				return list.ToArray ();
+			case '{':
+				ReadChar ();
+				var obj = new Dictionary<string,object> ();
+				SkipSpaces ();
+				if (PeekChar () == '}') {
+					ReadChar ();
+					return obj;
+				}
+				while (true) {
+					SkipSpaces ();
+					if (PeekChar () == '}') {
+						ReadChar ();
+						break;
+					}
+					string name = ReadStringLiteral ();
+					SkipSpaces ();
+					Expect (':');
+					SkipSpaces ();
+					obj [name] = ReadCore (); // it does not reject duplicate names.
+					SkipSpaces ();
+					c = ReadChar ();
+					if (c == ',')
+						continue;
+					if (c == '}')
+						break;
+				}
+				return obj.ToArray ();
+			case 't':
+				Expect ("true");
+				return true;
+			case 'f':
+				Expect ("false");
+				return false;
+			case 'n':
+				Expect ("null");
+				// FIXME: what should we return?
+				return (string) null;
+			case '"':
+				return ReadStringLiteral ();
+			default:
+				if ('0' <= c && c <= '9' || c == '-')
+					return ReadNumericLiteral ();
+				else
+					throw JsonError (string.Format ("Unexpected character '{0}'", (char) c));
+			}
+		}
+
+		int peek;
+		bool has_peek;
+		bool prev_lf;
+
+		int PeekChar ()
+		{
+			if (!has_peek) {
+				peek = _r.Read ();
+				has_peek = true;
+			}
+			return peek;
+		}
+
+		int ReadChar ()
+		{
+			int v = has_peek ? peek : _r.Read ();
+
+			has_peek = false;
+
+			if (prev_lf) {
+				_line++;
+				_column = 0;
+				prev_lf = false;
+			}
+
+			if (v == '\n')
+				prev_lf = true;
+			_column++;
+
+			return v;
+		}
+
+		void SkipSpaces ()
+		{
+			while (true) {
+				switch (PeekChar ()) {
+				case ' ': case '\t': case '\r': case '\n':
+					ReadChar ();
+					continue;
+				default:
+					return;
+				}
+			}
+		}
+
+		// It could return either int, long or decimal, depending on the parsed value.
+		object ReadNumericLiteral ()
+		{
+			var sb = new StringBuilder ();
+			
+			if (PeekChar () == '-') {
+				sb.Append ((char) ReadChar ());
+			}
+
+			int c;
+			int x = 0;
+			bool zeroStart = PeekChar () == '0';
+			for (; ; x++) {
+				c = PeekChar ();
+				if (c < '0' || '9' < c)
+					break;
+				sb.Append ((char) ReadChar ());
+				if (zeroStart && x == 1)
+					throw JsonError ("leading zeros are not allowed");
+			}
+			if (x == 0) // Reached e.g. for "- "
+				throw JsonError ("Invalid JSON numeric literal; no digit found");
+
+			// fraction
+			bool hasFrac = false;
+			int fdigits = 0;
+			if (PeekChar () == '.') {
+				hasFrac = true;
+				sb.Append ((char) ReadChar ());
+				if (PeekChar () < 0)
+					throw JsonError ("Invalid JSON numeric literal; extra dot");
+				while (true) {
+					c = PeekChar ();
+					if (c < '0' || '9' < c)
+						break;
+					sb.Append ((char) ReadChar ());
+					fdigits++;
+				}
+				if (fdigits == 0)
+					throw JsonError ("Invalid JSON numeric literal; extra dot");
+			}
+
+			c = PeekChar ();
+			if (c != 'e' && c != 'E') {
+				if (!hasFrac) {
+					int valueInt;
+					if (int.TryParse (sb.ToString (), NumberStyles.Float, CultureInfo.InvariantCulture, out valueInt))
+						return valueInt;
+					
+					long valueLong;
+					if (long.TryParse (sb.ToString (), NumberStyles.Float, CultureInfo.InvariantCulture, out valueLong))
+						return valueLong;
+					
+					ulong valueUlong;
+					if (ulong.TryParse (sb.ToString (), NumberStyles.Float, CultureInfo.InvariantCulture, out valueUlong))
+						return valueUlong;
+				}
+				decimal valueDecimal;
+				if (decimal.TryParse (sb.ToString (), NumberStyles.Float, CultureInfo.InvariantCulture, out valueDecimal) && valueDecimal != 0)
+					return valueDecimal;
+			} else {
+				// exponent
+				sb.Append ((char) ReadChar ());
+				if (PeekChar () < 0)
+					throw new ArgumentException ("Invalid JSON numeric literal; incomplete exponent");
+			
+				c = PeekChar ();
+				if (c == '-') {
+					sb.Append ((char) ReadChar ());
+				}
+				else if (c == '+')
+					sb.Append ((char) ReadChar ());
+
+				if (PeekChar () < 0)
+					throw JsonError ("Invalid JSON numeric literal; incomplete exponent");
+				while (true) {
+					c = PeekChar ();
+					if (c < '0' || '9' < c)
+						break;
+					sb.Append ((char) ReadChar ());
+				}
+			}
+
+			return double.Parse (sb.ToString (), NumberStyles.Float, CultureInfo.InvariantCulture);
+		}
+
+		private readonly StringBuilder _vb = new StringBuilder ();
+
+		private string ReadStringLiteral ()
+		{
+			if (PeekChar () != '"')
+				throw JsonError ("Invalid JSON string literal format");
+
+			ReadChar ();
+			_vb.Length = 0;
+			while (true) {
+				int c = ReadChar ();
+				if (c < 0)
+					throw JsonError ("JSON string is not closed");
+				if (c == '"')
+					return _vb.ToString ();
+				else if (c != '\\') {
+					_vb.Append ((char) c);
+					continue;
+				}
+
+				// escaped expression
+				c = ReadChar ();
+				if (c < 0)
+					throw JsonError ("Invalid JSON string literal; incomplete escape sequence");
+				switch (c) {
+				case '"':
+				case '\\':
+				case '/':
+					_vb.Append ((char) c);
+					break;
+				case 'b':
+					_vb.Append ('\x8');
+					break;
+				case 'f':
+					_vb.Append ('\f');
+					break;
+				case 'n':
+					_vb.Append ('\n');
+					break;
+				case 'r':
+					_vb.Append ('\r');
+					break;
+				case 't':
+					_vb.Append ('\t');
+					break;
+				case 'u':
+					ushort cp = 0;
+					for (int i = 0; i < 4; i++) {
+						cp <<= 4;
+						if ((c = ReadChar ()) < 0)
+							throw JsonError ("Incomplete unicode character escape literal");
+						if ('0' <= c && c <= '9')
+							cp += (ushort) (c - '0');
+						if ('A' <= c && c <= 'F')
+							cp += (ushort) (c - 'A' + 10);
+						if ('a' <= c && c <= 'f')
+							cp += (ushort) (c - 'a' + 10);
+					}
+					_vb.Append ((char) cp);
+					break;
+				default:
+					throw JsonError ("Invalid JSON string literal; unexpected escape character");
+				}
+			}
+		}
+
+		private void Expect (char expected)
+		{
+			int c;
+			if ((c = ReadChar ()) != expected)
+				throw JsonError (string.Format ("Expected '{0}', got '{1}'", expected, (char) c));
+		}
+
+		private void Expect (string expected)
+		{
+			for (int i = 0; i < expected.Length; i++)
+				if (ReadChar () != expected [i])
+					throw JsonError (string.Format ("Expected '{0}', differed at {1}", expected, i));
+		}
+
+		private Exception JsonError (string msg)
+		{
+			return new ArgumentException (string.Format ("{0}. At line {1}, column {2}", msg, _line, _column));
+		}
+	}
+}

--- a/src/System.Json/src/System/Json/JavaScriptReader.cs
+++ b/src/System.Json/src/System/Json/JavaScriptReader.cs
@@ -10,315 +10,342 @@ using System.Text;
 
 namespace System.Runtime.Serialization.Json
 {
-	internal class JavaScriptReader
-	{
-		private readonly TextReader _r;
-		private int _line = 1, _column = 0;
+    internal class JavaScriptReader
+    {
+        private readonly TextReader _r;
+        private int _line = 1, _column = 0;
 
-		public JavaScriptReader (TextReader reader, bool raiseOnNumberError)
-		{
-			if (reader == null)
-				throw new ArgumentNullException (nameof(reader));
-			this._r = reader;
-		}
+        public JavaScriptReader(TextReader reader, bool raiseOnNumberError)
+        {
+            if (reader == null)
+                throw new ArgumentNullException(nameof(reader));
+            _r = reader;
+        }
 
-		public object Read ()
-		{
-			object v = ReadCore ();
-			SkipSpaces ();
-			if (ReadChar () >= 0)
-				throw JsonError (string.Format ("extra characters in JSON input"));
-			return v;
-		}
+        public object Read()
+        {
+            object v = ReadCore();
+            SkipSpaces();
+            if (ReadChar() >= 0)
+                throw JsonError(string.Format("extra characters in JSON input"));
+            return v;
+        }
 
-		object ReadCore ()
-		{
-			SkipSpaces ();
-			int c = PeekChar ();
-			if (c < 0)
-				throw JsonError ("Incomplete JSON input");
-			switch (c) {
-			case '[':
-				ReadChar ();
-				var list = new List<object> ();
-				SkipSpaces ();
-				if (PeekChar () == ']') {
-					ReadChar ();
-					return list;
-				}
-				while (true) {
-					list.Add (ReadCore ());
-					SkipSpaces ();
-					c = PeekChar ();
-					if (c != ',')
-						break;
-					ReadChar ();
-					continue;
-				}
-				if (ReadChar () != ']')
-					throw JsonError ("JSON array must end with ']'");
-				return list.ToArray ();
-			case '{':
-				ReadChar ();
-				var obj = new Dictionary<string,object> ();
-				SkipSpaces ();
-				if (PeekChar () == '}') {
-					ReadChar ();
-					return obj;
-				}
-				while (true) {
-					SkipSpaces ();
-					if (PeekChar () == '}') {
-						ReadChar ();
-						break;
-					}
-					string name = ReadStringLiteral ();
-					SkipSpaces ();
-					Expect (':');
-					SkipSpaces ();
-					obj [name] = ReadCore (); // it does not reject duplicate names.
-					SkipSpaces ();
-					c = ReadChar ();
-					if (c == ',')
-						continue;
-					if (c == '}')
-						break;
-				}
-				return obj.ToArray ();
-			case 't':
-				Expect ("true");
-				return true;
-			case 'f':
-				Expect ("false");
-				return false;
-			case 'n':
-				Expect ("null");
-				// FIXME: what should we return?
-				return (string) null;
-			case '"':
-				return ReadStringLiteral ();
-			default:
-				if ('0' <= c && c <= '9' || c == '-')
-					return ReadNumericLiteral ();
-				else
-					throw JsonError (string.Format ("Unexpected character '{0}'", (char) c));
-			}
-		}
+        private object ReadCore()
+        {
+            SkipSpaces();
+            int c = PeekChar();
+            if (c < 0)
+                throw JsonError("Incomplete JSON input");
+            switch (c)
+            {
+                case '[':
+                    ReadChar();
+                    var list = new List<object>();
+                    SkipSpaces();
+                    if (PeekChar() == ']')
+                    {
+                        ReadChar();
+                        return list;
+                    }
+                    while (true)
+                    {
+                        list.Add(ReadCore());
+                        SkipSpaces();
+                        c = PeekChar();
+                        if (c != ',')
+                            break;
+                        ReadChar();
+                        continue;
+                    }
+                    if (ReadChar() != ']')
+                        throw JsonError("JSON array must end with ']'");
+                    return list.ToArray();
+                case '{':
+                    ReadChar();
+                    var obj = new Dictionary<string, object>();
+                    SkipSpaces();
+                    if (PeekChar() == '}')
+                    {
+                        ReadChar();
+                        return obj;
+                    }
+                    while (true)
+                    {
+                        SkipSpaces();
+                        if (PeekChar() == '}')
+                        {
+                            ReadChar();
+                            break;
+                        }
+                        string name = ReadStringLiteral();
+                        SkipSpaces();
+                        Expect(':');
+                        SkipSpaces();
+                        obj[name] = ReadCore(); // it does not reject duplicate names.
+                        SkipSpaces();
+                        c = ReadChar();
+                        if (c == ',')
+                            continue;
+                        if (c == '}')
+                            break;
+                    }
+                    return obj.ToArray();
+                case 't':
+                    Expect("true");
+                    return true;
+                case 'f':
+                    Expect("false");
+                    return false;
+                case 'n':
+                    Expect("null");
+                    // FIXME: what should we return?
+                    return (string)null;
+                case '"':
+                    return ReadStringLiteral();
+                default:
+                    if ('0' <= c && c <= '9' || c == '-')
+                        return ReadNumericLiteral();
+                    else
+                        throw JsonError(string.Format("Unexpected character '{0}'", (char)c));
+            }
+        }
 
-		int peek;
-		bool has_peek;
-		bool prev_lf;
+        private int _peek;
+        private bool _has_peek;
+        private bool _prev_lf;
 
-		int PeekChar ()
-		{
-			if (!has_peek) {
-				peek = _r.Read ();
-				has_peek = true;
-			}
-			return peek;
-		}
+        private int PeekChar()
+        {
+            if (!_has_peek)
+            {
+                _peek = _r.Read();
+                _has_peek = true;
+            }
+            return _peek;
+        }
 
-		int ReadChar ()
-		{
-			int v = has_peek ? peek : _r.Read ();
+        private int ReadChar()
+        {
+            int v = _has_peek ? _peek : _r.Read();
 
-			has_peek = false;
+            _has_peek = false;
 
-			if (prev_lf) {
-				_line++;
-				_column = 0;
-				prev_lf = false;
-			}
+            if (_prev_lf)
+            {
+                _line++;
+                _column = 0;
+                _prev_lf = false;
+            }
 
-			if (v == '\n')
-				prev_lf = true;
-			_column++;
+            if (v == '\n')
+                _prev_lf = true;
+            _column++;
 
-			return v;
-		}
+            return v;
+        }
 
-		void SkipSpaces ()
-		{
-			while (true) {
-				switch (PeekChar ()) {
-				case ' ': case '\t': case '\r': case '\n':
-					ReadChar ();
-					continue;
-				default:
-					return;
-				}
-			}
-		}
+        private void SkipSpaces()
+        {
+            while (true)
+            {
+                switch (PeekChar())
+                {
+                    case ' ':
+                    case '\t':
+                    case '\r':
+                    case '\n':
+                        ReadChar();
+                        continue;
+                    default:
+                        return;
+                }
+            }
+        }
 
-		// It could return either int, long or decimal, depending on the parsed value.
-		object ReadNumericLiteral ()
-		{
-			var sb = new StringBuilder ();
-			
-			if (PeekChar () == '-') {
-				sb.Append ((char) ReadChar ());
-			}
+        // It could return either int, long or decimal, depending on the parsed value.
+        private object ReadNumericLiteral()
+        {
+            var sb = new StringBuilder();
 
-			int c;
-			int x = 0;
-			bool zeroStart = PeekChar () == '0';
-			for (; ; x++) {
-				c = PeekChar ();
-				if (c < '0' || '9' < c)
-					break;
-				sb.Append ((char) ReadChar ());
-				if (zeroStart && x == 1)
-					throw JsonError ("leading zeros are not allowed");
-			}
-			if (x == 0) // Reached e.g. for "- "
-				throw JsonError ("Invalid JSON numeric literal; no digit found");
+            if (PeekChar() == '-')
+            {
+                sb.Append((char)ReadChar());
+            }
 
-			// fraction
-			bool hasFrac = false;
-			int fdigits = 0;
-			if (PeekChar () == '.') {
-				hasFrac = true;
-				sb.Append ((char) ReadChar ());
-				if (PeekChar () < 0)
-					throw JsonError ("Invalid JSON numeric literal; extra dot");
-				while (true) {
-					c = PeekChar ();
-					if (c < '0' || '9' < c)
-						break;
-					sb.Append ((char) ReadChar ());
-					fdigits++;
-				}
-				if (fdigits == 0)
-					throw JsonError ("Invalid JSON numeric literal; extra dot");
-			}
+            int c;
+            int x = 0;
+            bool zeroStart = PeekChar() == '0';
+            for (; ; x++)
+            {
+                c = PeekChar();
+                if (c < '0' || '9' < c)
+                    break;
+                sb.Append((char)ReadChar());
+                if (zeroStart && x == 1)
+                    throw JsonError("leading zeros are not allowed");
+            }
+            if (x == 0) // Reached e.g. for "- "
+                throw JsonError("Invalid JSON numeric literal; no digit found");
 
-			c = PeekChar ();
-			if (c != 'e' && c != 'E') {
-				if (!hasFrac) {
-					int valueInt;
-					if (int.TryParse (sb.ToString (), NumberStyles.Float, CultureInfo.InvariantCulture, out valueInt))
-						return valueInt;
-					
-					long valueLong;
-					if (long.TryParse (sb.ToString (), NumberStyles.Float, CultureInfo.InvariantCulture, out valueLong))
-						return valueLong;
-					
-					ulong valueUlong;
-					if (ulong.TryParse (sb.ToString (), NumberStyles.Float, CultureInfo.InvariantCulture, out valueUlong))
-						return valueUlong;
-				}
-				decimal valueDecimal;
-				if (decimal.TryParse (sb.ToString (), NumberStyles.Float, CultureInfo.InvariantCulture, out valueDecimal) && valueDecimal != 0)
-					return valueDecimal;
-			} else {
-				// exponent
-				sb.Append ((char) ReadChar ());
-				if (PeekChar () < 0)
-					throw new ArgumentException ("Invalid JSON numeric literal; incomplete exponent");
-			
-				c = PeekChar ();
-				if (c == '-') {
-					sb.Append ((char) ReadChar ());
-				}
-				else if (c == '+')
-					sb.Append ((char) ReadChar ());
+            // fraction
+            bool hasFrac = false;
+            int fdigits = 0;
+            if (PeekChar() == '.')
+            {
+                hasFrac = true;
+                sb.Append((char)ReadChar());
+                if (PeekChar() < 0)
+                    throw JsonError("Invalid JSON numeric literal; extra dot");
+                while (true)
+                {
+                    c = PeekChar();
+                    if (c < '0' || '9' < c)
+                        break;
+                    sb.Append((char)ReadChar());
+                    fdigits++;
+                }
+                if (fdigits == 0)
+                    throw JsonError("Invalid JSON numeric literal; extra dot");
+            }
 
-				if (PeekChar () < 0)
-					throw JsonError ("Invalid JSON numeric literal; incomplete exponent");
-				while (true) {
-					c = PeekChar ();
-					if (c < '0' || '9' < c)
-						break;
-					sb.Append ((char) ReadChar ());
-				}
-			}
+            c = PeekChar();
+            if (c != 'e' && c != 'E')
+            {
+                if (!hasFrac)
+                {
+                    int valueInt;
+                    if (int.TryParse(sb.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out valueInt))
+                        return valueInt;
 
-			return double.Parse (sb.ToString (), NumberStyles.Float, CultureInfo.InvariantCulture);
-		}
+                    long valueLong;
+                    if (long.TryParse(sb.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out valueLong))
+                        return valueLong;
 
-		private readonly StringBuilder _vb = new StringBuilder ();
+                    ulong valueUlong;
+                    if (ulong.TryParse(sb.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out valueUlong))
+                        return valueUlong;
+                }
+                decimal valueDecimal;
+                if (decimal.TryParse(sb.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out valueDecimal) && valueDecimal != 0)
+                    return valueDecimal;
+            }
+            else
+            {
+                // exponent
+                sb.Append((char)ReadChar());
+                if (PeekChar() < 0)
+                    throw new ArgumentException("Invalid JSON numeric literal; incomplete exponent");
 
-		private string ReadStringLiteral ()
-		{
-			if (PeekChar () != '"')
-				throw JsonError ("Invalid JSON string literal format");
+                c = PeekChar();
+                if (c == '-')
+                {
+                    sb.Append((char)ReadChar());
+                }
+                else if (c == '+')
+                    sb.Append((char)ReadChar());
 
-			ReadChar ();
-			_vb.Length = 0;
-			while (true) {
-				int c = ReadChar ();
-				if (c < 0)
-					throw JsonError ("JSON string is not closed");
-				if (c == '"')
-					return _vb.ToString ();
-				else if (c != '\\') {
-					_vb.Append ((char) c);
-					continue;
-				}
+                if (PeekChar() < 0)
+                    throw JsonError("Invalid JSON numeric literal; incomplete exponent");
+                while (true)
+                {
+                    c = PeekChar();
+                    if (c < '0' || '9' < c)
+                        break;
+                    sb.Append((char)ReadChar());
+                }
+            }
 
-				// escaped expression
-				c = ReadChar ();
-				if (c < 0)
-					throw JsonError ("Invalid JSON string literal; incomplete escape sequence");
-				switch (c) {
-				case '"':
-				case '\\':
-				case '/':
-					_vb.Append ((char) c);
-					break;
-				case 'b':
-					_vb.Append ('\x8');
-					break;
-				case 'f':
-					_vb.Append ('\f');
-					break;
-				case 'n':
-					_vb.Append ('\n');
-					break;
-				case 'r':
-					_vb.Append ('\r');
-					break;
-				case 't':
-					_vb.Append ('\t');
-					break;
-				case 'u':
-					ushort cp = 0;
-					for (int i = 0; i < 4; i++) {
-						cp <<= 4;
-						if ((c = ReadChar ()) < 0)
-							throw JsonError ("Incomplete unicode character escape literal");
-						if ('0' <= c && c <= '9')
-							cp += (ushort) (c - '0');
-						if ('A' <= c && c <= 'F')
-							cp += (ushort) (c - 'A' + 10);
-						if ('a' <= c && c <= 'f')
-							cp += (ushort) (c - 'a' + 10);
-					}
-					_vb.Append ((char) cp);
-					break;
-				default:
-					throw JsonError ("Invalid JSON string literal; unexpected escape character");
-				}
-			}
-		}
+            return double.Parse(sb.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture);
+        }
 
-		private void Expect (char expected)
-		{
-			int c;
-			if ((c = ReadChar ()) != expected)
-				throw JsonError (string.Format ("Expected '{0}', got '{1}'", expected, (char) c));
-		}
+        private readonly StringBuilder _vb = new StringBuilder();
 
-		private void Expect (string expected)
-		{
-			for (int i = 0; i < expected.Length; i++)
-				if (ReadChar () != expected [i])
-					throw JsonError (string.Format ("Expected '{0}', differed at {1}", expected, i));
-		}
+        private string ReadStringLiteral()
+        {
+            if (PeekChar() != '"')
+                throw JsonError("Invalid JSON string literal format");
 
-		private Exception JsonError (string msg)
-		{
-			return new ArgumentException (string.Format ("{0}. At line {1}, column {2}", msg, _line, _column));
-		}
-	}
+            ReadChar();
+            _vb.Length = 0;
+            while (true)
+            {
+                int c = ReadChar();
+                if (c < 0)
+                    throw JsonError("JSON string is not closed");
+                if (c == '"')
+                    return _vb.ToString();
+                else if (c != '\\')
+                {
+                    _vb.Append((char)c);
+                    continue;
+                }
+
+                // escaped expression
+                c = ReadChar();
+                if (c < 0)
+                    throw JsonError("Invalid JSON string literal; incomplete escape sequence");
+                switch (c)
+                {
+                    case '"':
+                    case '\\':
+                    case '/':
+                        _vb.Append((char)c);
+                        break;
+                    case 'b':
+                        _vb.Append('\x8');
+                        break;
+                    case 'f':
+                        _vb.Append('\f');
+                        break;
+                    case 'n':
+                        _vb.Append('\n');
+                        break;
+                    case 'r':
+                        _vb.Append('\r');
+                        break;
+                    case 't':
+                        _vb.Append('\t');
+                        break;
+                    case 'u':
+                        ushort cp = 0;
+                        for (int i = 0; i < 4; i++)
+                        {
+                            cp <<= 4;
+                            if ((c = ReadChar()) < 0)
+                                throw JsonError("Incomplete unicode character escape literal");
+                            if ('0' <= c && c <= '9')
+                                cp += (ushort)(c - '0');
+                            if ('A' <= c && c <= 'F')
+                                cp += (ushort)(c - 'A' + 10);
+                            if ('a' <= c && c <= 'f')
+                                cp += (ushort)(c - 'a' + 10);
+                        }
+                        _vb.Append((char)cp);
+                        break;
+                    default:
+                        throw JsonError("Invalid JSON string literal; unexpected escape character");
+                }
+            }
+        }
+
+        private void Expect(char expected)
+        {
+            int c;
+            if ((c = ReadChar()) != expected)
+                throw JsonError(string.Format("Expected '{0}', got '{1}'", expected, (char)c));
+        }
+
+        private void Expect(string expected)
+        {
+            for (int i = 0; i < expected.Length; i++)
+                if (ReadChar() != expected[i])
+                    throw JsonError(string.Format("Expected '{0}', differed at {1}", expected, i));
+        }
+
+        private Exception JsonError(string msg)
+        {
+            return new ArgumentException(string.Format("{0}. At line {1}, column {2}", msg, _line, _column));
+        }
+    }
 }

--- a/src/System.Json/src/System/Json/JsonArray.cs
+++ b/src/System.Json/src/System/Json/JsonArray.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+namespace System.Json
+{
+	public class JsonArray : JsonValue, IList<JsonValue>
+	{
+		private readonly List<JsonValue> _list;
+
+		public JsonArray (params JsonValue [] items)
+		{
+			_list = new List<JsonValue> ();
+			AddRange (items);
+		}
+
+		public JsonArray (IEnumerable<JsonValue> items)
+		{
+			if (items == null)
+				throw new ArgumentNullException (nameof(items));
+
+			_list = new List<JsonValue> (items);
+		}
+
+		public override int Count {
+			get { return _list.Count; }
+		}
+
+		public bool IsReadOnly {
+			get { return false; }
+		}
+
+		public override sealed JsonValue this [int index] {
+			get { return _list [index]; }
+			set { _list [index] = value; }
+		}
+
+		public override JsonType JsonType {
+			get { return JsonType.Array; }
+		}
+
+		public void Add (JsonValue item)
+		{
+			if (item == null)
+				throw new ArgumentNullException (nameof(item));
+
+			_list.Add (item);
+		}
+
+		public void AddRange (IEnumerable<JsonValue> items)
+		{
+            if (items == null)
+                throw new ArgumentNullException(nameof(items));
+
+			_list.AddRange (items);
+		}
+
+		public void AddRange (params JsonValue [] items)
+		{
+			if (items == null)
+				return;
+
+			_list.AddRange (items);
+		}
+
+		public void Clear ()
+		{
+			_list.Clear ();
+		}
+
+		public bool Contains (JsonValue item)
+		{
+			return _list.Contains (item);
+		}
+
+		public void CopyTo (JsonValue [] array, int arrayIndex)
+		{
+			_list.CopyTo (array, arrayIndex);
+		}
+
+		public int IndexOf (JsonValue item)
+		{
+			return _list.IndexOf (item);
+		}
+
+		public void Insert (int index, JsonValue item)
+		{
+			_list.Insert (index, item);
+		}
+
+		public bool Remove (JsonValue item)
+		{
+			return _list.Remove (item);
+		}
+
+		public void RemoveAt (int index)
+		{
+			_list.RemoveAt (index);
+		}
+
+		public override void Save (Stream stream)
+		{
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+			stream.WriteByte ((byte) '[');
+			for (int i = 0; i < _list.Count; i++) {
+				JsonValue v = _list [i];
+				if (v != null)
+					v.Save (stream);
+				else {
+					stream.WriteByte ((byte) 'n');
+					stream.WriteByte ((byte) 'u');
+					stream.WriteByte ((byte) 'l');
+					stream.WriteByte ((byte) 'l');
+				}
+
+				if (i < Count - 1) {
+					stream.WriteByte ((byte) ',');
+					stream.WriteByte ((byte) ' ');
+				}
+			}
+			stream.WriteByte ((byte) ']');
+		}
+
+		IEnumerator<JsonValue> IEnumerable<JsonValue>.GetEnumerator ()
+		{
+			return _list.GetEnumerator ();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+		{
+			return _list.GetEnumerator ();
+		}
+	}
+}

--- a/src/System.Json/src/System/Json/JsonArray.cs
+++ b/src/System.Json/src/System/Json/JsonArray.cs
@@ -21,20 +21,16 @@ namespace System.Json
         public JsonArray(IEnumerable<JsonValue> items)
         {
             if (items == null)
+            {
                 throw new ArgumentNullException(nameof(items));
+            }
 
             _list = new List<JsonValue>(items);
         }
 
-        public override int Count
-        {
-            get { return _list.Count; }
-        }
+        public override int Count => _list.Count;
 
-        public bool IsReadOnly
-        {
-            get { return false; }
-        }
+        public bool IsReadOnly => false;
 
         public override sealed JsonValue this[int index]
         {
@@ -42,15 +38,14 @@ namespace System.Json
             set { _list[index] = value; }
         }
 
-        public override JsonType JsonType
-        {
-            get { return JsonType.Array; }
-        }
+        public override JsonType JsonType => JsonType.Array;
 
         public void Add(JsonValue item)
         {
             if (item == null)
+            {
                 throw new ArgumentNullException(nameof(item));
+            }
 
             _list.Add(item);
         }
@@ -58,64 +53,51 @@ namespace System.Json
         public void AddRange(IEnumerable<JsonValue> items)
         {
             if (items == null)
+            {
                 throw new ArgumentNullException(nameof(items));
+            }
 
             _list.AddRange(items);
         }
 
         public void AddRange(params JsonValue[] items)
         {
-            if (items == null)
-                return;
-
-            _list.AddRange(items);
+            if (items != null)
+            {
+                _list.AddRange(items);
+            }
         }
 
-        public void Clear()
-        {
-            _list.Clear();
-        }
+        public void Clear() => _list.Clear();
 
-        public bool Contains(JsonValue item)
-        {
-            return _list.Contains(item);
-        }
+        public bool Contains(JsonValue item) => _list.Contains(item);
 
-        public void CopyTo(JsonValue[] array, int arrayIndex)
-        {
-            _list.CopyTo(array, arrayIndex);
-        }
+        public void CopyTo(JsonValue[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
 
-        public int IndexOf(JsonValue item)
-        {
-            return _list.IndexOf(item);
-        }
+        public int IndexOf(JsonValue item) => _list.IndexOf(item);
 
-        public void Insert(int index, JsonValue item)
-        {
-            _list.Insert(index, item);
-        }
+        public void Insert(int index, JsonValue item) => _list.Insert(index, item);
 
-        public bool Remove(JsonValue item)
-        {
-            return _list.Remove(item);
-        }
+        public bool Remove(JsonValue item) => _list.Remove(item);
 
-        public void RemoveAt(int index)
-        {
-            _list.RemoveAt(index);
-        }
+        public void RemoveAt(int index) => _list.RemoveAt(index);
 
         public override void Save(Stream stream)
         {
             if (stream == null)
+            {
                 throw new ArgumentNullException(nameof(stream));
+            }
+
             stream.WriteByte((byte)'[');
+
             for (int i = 0; i < _list.Count; i++)
             {
                 JsonValue v = _list[i];
                 if (v != null)
+                {
                     v.Save(stream);
+                }
                 else
                 {
                     stream.WriteByte((byte)'n');
@@ -130,17 +112,12 @@ namespace System.Json
                     stream.WriteByte((byte)' ');
                 }
             }
+
             stream.WriteByte((byte)']');
         }
 
-        IEnumerator<JsonValue> IEnumerable<JsonValue>.GetEnumerator()
-        {
-            return _list.GetEnumerator();
-        }
+        IEnumerator<JsonValue> IEnumerable<JsonValue>.GetEnumerator() => _list.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return _list.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
     }
 }

--- a/src/System.Json/src/System/Json/JsonArray.cs
+++ b/src/System.Json/src/System/Json/JsonArray.cs
@@ -8,132 +8,139 @@ using System.IO;
 
 namespace System.Json
 {
-	public class JsonArray : JsonValue, IList<JsonValue>
-	{
-		private readonly List<JsonValue> _list;
+    public class JsonArray : JsonValue, IList<JsonValue>
+    {
+        private readonly List<JsonValue> _list;
 
-		public JsonArray (params JsonValue [] items)
-		{
-			_list = new List<JsonValue> ();
-			AddRange (items);
-		}
+        public JsonArray(params JsonValue[] items)
+        {
+            _list = new List<JsonValue>();
+            AddRange(items);
+        }
 
-		public JsonArray (IEnumerable<JsonValue> items)
-		{
-			if (items == null)
-				throw new ArgumentNullException (nameof(items));
-
-			_list = new List<JsonValue> (items);
-		}
-
-		public override int Count {
-			get { return _list.Count; }
-		}
-
-		public bool IsReadOnly {
-			get { return false; }
-		}
-
-		public override sealed JsonValue this [int index] {
-			get { return _list [index]; }
-			set { _list [index] = value; }
-		}
-
-		public override JsonType JsonType {
-			get { return JsonType.Array; }
-		}
-
-		public void Add (JsonValue item)
-		{
-			if (item == null)
-				throw new ArgumentNullException (nameof(item));
-
-			_list.Add (item);
-		}
-
-		public void AddRange (IEnumerable<JsonValue> items)
-		{
+        public JsonArray(IEnumerable<JsonValue> items)
+        {
             if (items == null)
                 throw new ArgumentNullException(nameof(items));
 
-			_list.AddRange (items);
-		}
+            _list = new List<JsonValue>(items);
+        }
 
-		public void AddRange (params JsonValue [] items)
-		{
-			if (items == null)
-				return;
+        public override int Count
+        {
+            get { return _list.Count; }
+        }
 
-			_list.AddRange (items);
-		}
+        public bool IsReadOnly
+        {
+            get { return false; }
+        }
 
-		public void Clear ()
-		{
-			_list.Clear ();
-		}
+        public override sealed JsonValue this[int index]
+        {
+            get { return _list[index]; }
+            set { _list[index] = value; }
+        }
 
-		public bool Contains (JsonValue item)
-		{
-			return _list.Contains (item);
-		}
+        public override JsonType JsonType
+        {
+            get { return JsonType.Array; }
+        }
 
-		public void CopyTo (JsonValue [] array, int arrayIndex)
-		{
-			_list.CopyTo (array, arrayIndex);
-		}
+        public void Add(JsonValue item)
+        {
+            if (item == null)
+                throw new ArgumentNullException(nameof(item));
 
-		public int IndexOf (JsonValue item)
-		{
-			return _list.IndexOf (item);
-		}
+            _list.Add(item);
+        }
 
-		public void Insert (int index, JsonValue item)
-		{
-			_list.Insert (index, item);
-		}
+        public void AddRange(IEnumerable<JsonValue> items)
+        {
+            if (items == null)
+                throw new ArgumentNullException(nameof(items));
 
-		public bool Remove (JsonValue item)
-		{
-			return _list.Remove (item);
-		}
+            _list.AddRange(items);
+        }
 
-		public void RemoveAt (int index)
-		{
-			_list.RemoveAt (index);
-		}
+        public void AddRange(params JsonValue[] items)
+        {
+            if (items == null)
+                return;
 
-		public override void Save (Stream stream)
-		{
+            _list.AddRange(items);
+        }
+
+        public void Clear()
+        {
+            _list.Clear();
+        }
+
+        public bool Contains(JsonValue item)
+        {
+            return _list.Contains(item);
+        }
+
+        public void CopyTo(JsonValue[] array, int arrayIndex)
+        {
+            _list.CopyTo(array, arrayIndex);
+        }
+
+        public int IndexOf(JsonValue item)
+        {
+            return _list.IndexOf(item);
+        }
+
+        public void Insert(int index, JsonValue item)
+        {
+            _list.Insert(index, item);
+        }
+
+        public bool Remove(JsonValue item)
+        {
+            return _list.Remove(item);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _list.RemoveAt(index);
+        }
+
+        public override void Save(Stream stream)
+        {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
-			stream.WriteByte ((byte) '[');
-			for (int i = 0; i < _list.Count; i++) {
-				JsonValue v = _list [i];
-				if (v != null)
-					v.Save (stream);
-				else {
-					stream.WriteByte ((byte) 'n');
-					stream.WriteByte ((byte) 'u');
-					stream.WriteByte ((byte) 'l');
-					stream.WriteByte ((byte) 'l');
-				}
+            stream.WriteByte((byte)'[');
+            for (int i = 0; i < _list.Count; i++)
+            {
+                JsonValue v = _list[i];
+                if (v != null)
+                    v.Save(stream);
+                else
+                {
+                    stream.WriteByte((byte)'n');
+                    stream.WriteByte((byte)'u');
+                    stream.WriteByte((byte)'l');
+                    stream.WriteByte((byte)'l');
+                }
 
-				if (i < Count - 1) {
-					stream.WriteByte ((byte) ',');
-					stream.WriteByte ((byte) ' ');
-				}
-			}
-			stream.WriteByte ((byte) ']');
-		}
+                if (i < Count - 1)
+                {
+                    stream.WriteByte((byte)',');
+                    stream.WriteByte((byte)' ');
+                }
+            }
+            stream.WriteByte((byte)']');
+        }
 
-		IEnumerator<JsonValue> IEnumerable<JsonValue>.GetEnumerator ()
-		{
-			return _list.GetEnumerator ();
-		}
+        IEnumerator<JsonValue> IEnumerable<JsonValue>.GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
 
-		IEnumerator IEnumerable.GetEnumerator ()
-		{
-			return _list.GetEnumerator ();
-		}
-	}
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
+    }
 }

--- a/src/System.Json/src/System/Json/JsonObject.cs
+++ b/src/System.Json/src/System/Json/JsonObject.cs
@@ -86,7 +86,7 @@ namespace System.Json
         public void AddRange(JsonPairEnumerable items)
         {
             if (items == null)
-                throw new ArgumentNullException("items");
+                throw new ArgumentNullException(nameof(items));
 
             foreach (var pair in items)
                 _map.Add(pair.Key, pair.Value);
@@ -115,7 +115,7 @@ namespace System.Json
         public override bool ContainsKey(string key)
         {
             if (key == null)
-                throw new ArgumentNullException("key");
+                throw new ArgumentNullException(nameof(key));
 
             return _map.ContainsKey(key);
         }
@@ -128,7 +128,7 @@ namespace System.Json
         public bool Remove(string key)
         {
             if (key == null)
-                throw new ArgumentNullException("key");
+                throw new ArgumentNullException(nameof(key));
 
             return _map.Remove(key);
         }
@@ -141,7 +141,7 @@ namespace System.Json
         public override void Save(Stream stream)
         {
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
             stream.WriteByte((byte)'{');
             foreach (JsonPair pair in _map)
             {

--- a/src/System.Json/src/System/Json/JsonObject.cs
+++ b/src/System.Json/src/System/Json/JsonObject.cs
@@ -13,151 +13,160 @@ using JsonPairEnumerable = System.Collections.Generic.IEnumerable<System.Collect
 namespace System.Json
 {
     public class JsonObject : JsonValue, IDictionary<string, JsonValue>, ICollection<JsonPair>
-	{
-		// Use SortedDictionary to make result of ToString() deterministic
-		SortedDictionary<string, JsonValue> map;
+    {
+        // Use SortedDictionary to make result of ToString() deterministic
+        private SortedDictionary<string, JsonValue> _map;
 
-		public JsonObject (params JsonPair [] items)
-		{
-			map = new SortedDictionary<string, JsonValue> (StringComparer.Ordinal);
+        public JsonObject(params JsonPair[] items)
+        {
+            _map = new SortedDictionary<string, JsonValue>(StringComparer.Ordinal);
 
-			if (items != null)
-				AddRange (items);
-		}
+            if (items != null)
+                AddRange(items);
+        }
 
-		public JsonObject (JsonPairEnumerable items)
-		{
+        public JsonObject(JsonPairEnumerable items)
+        {
             if (items == null)
                 throw new ArgumentNullException(nameof(items));
 
-			map = new SortedDictionary<string, JsonValue> (StringComparer.Ordinal);
-			AddRange (items);
-		}
+            _map = new SortedDictionary<string, JsonValue>(StringComparer.Ordinal);
+            AddRange(items);
+        }
 
-		public override int Count {
-			get { return map.Count; }
-		}
+        public override int Count
+        {
+            get { return _map.Count; }
+        }
 
-		public IEnumerator<JsonPair> GetEnumerator ()
-		{
-			return map.GetEnumerator ();
-		}
+        public IEnumerator<JsonPair> GetEnumerator()
+        {
+            return _map.GetEnumerator();
+        }
 
-		IEnumerator IEnumerable.GetEnumerator ()
-		{
-			return map.GetEnumerator ();
-		}
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _map.GetEnumerator();
+        }
 
-		public override sealed JsonValue this [string key] {
-			get { return map [key]; }
-			set { map [key] = value; }
-		}
+        public override sealed JsonValue this[string key]
+        {
+            get { return _map[key]; }
+            set { _map[key] = value; }
+        }
 
-		public override JsonType JsonType {
-			get { return JsonType.Object; }
-		}
+        public override JsonType JsonType
+        {
+            get { return JsonType.Object; }
+        }
 
-		public ICollection<string> Keys {
-			get { return map.Keys; }
-		}
+        public ICollection<string> Keys
+        {
+            get { return _map.Keys; }
+        }
 
-		public ICollection<JsonValue> Values {
-			get { return map.Values; }
-		}
+        public ICollection<JsonValue> Values
+        {
+            get { return _map.Values; }
+        }
 
-		public void Add (string key, JsonValue value)
-		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+        public void Add(string key, JsonValue value)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
 
-			map.Add (key, value);
-		}
+            _map.Add(key, value);
+        }
 
-		public void Add (JsonPair pair)
-		{
-			Add (pair.Key, pair.Value);
-		}
+        public void Add(JsonPair pair)
+        {
+            Add(pair.Key, pair.Value);
+        }
 
-		public void AddRange (JsonPairEnumerable items)
-		{
-			if (items == null)
-				throw new ArgumentNullException ("items");
+        public void AddRange(JsonPairEnumerable items)
+        {
+            if (items == null)
+                throw new ArgumentNullException("items");
 
-			foreach (var pair in items)
-				map.Add (pair.Key, pair.Value);
-		}
+            foreach (var pair in items)
+                _map.Add(pair.Key, pair.Value);
+        }
 
-		public void AddRange (params JsonPair [] items)
-		{
-			AddRange ((JsonPairEnumerable) items);
-		}
+        public void AddRange(params JsonPair[] items)
+        {
+            AddRange((JsonPairEnumerable)items);
+        }
 
-		public void Clear ()
-		{
-			map.Clear ();
-		}
+        public void Clear()
+        {
+            _map.Clear();
+        }
 
-		bool ICollection<JsonPair>.Contains (JsonPair item)
-		{
-			return (map as ICollection<JsonPair>).Contains (item);
-		}
+        bool ICollection<JsonPair>.Contains(JsonPair item)
+        {
+            return (_map as ICollection<JsonPair>).Contains(item);
+        }
 
-		bool ICollection<JsonPair>.Remove (JsonPair item)
-		{
-			return (map as ICollection<JsonPair>).Remove (item);
-		}
+        bool ICollection<JsonPair>.Remove(JsonPair item)
+        {
+            return (_map as ICollection<JsonPair>).Remove(item);
+        }
 
-		public override bool ContainsKey (string key)
-		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+        public override bool ContainsKey(string key)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
 
-			return map.ContainsKey (key);
-		}
+            return _map.ContainsKey(key);
+        }
 
-		public void CopyTo (JsonPair [] array, int arrayIndex)
-		{
-			(map as ICollection<JsonPair>).CopyTo (array, arrayIndex);
-		}
+        public void CopyTo(JsonPair[] array, int arrayIndex)
+        {
+            (_map as ICollection<JsonPair>).CopyTo(array, arrayIndex);
+        }
 
-		public bool Remove (string key)
-		{
-			if (key == null)
-				throw new ArgumentNullException ("key");
+        public bool Remove(string key)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
 
-			return map.Remove (key);
-		}
+            return _map.Remove(key);
+        }
 
-		bool ICollection<JsonPair>.IsReadOnly {
-			get { return false; }
-		}
+        bool ICollection<JsonPair>.IsReadOnly
+        {
+            get { return false; }
+        }
 
-		public override void Save (Stream stream)
-		{
-			if (stream == null)
-				throw new ArgumentNullException ("stream");
-			stream.WriteByte ((byte) '{');
-			foreach (JsonPair pair in map) {
-				stream.WriteByte ((byte) '"');
-				byte [] bytes = Encoding.UTF8.GetBytes (EscapeString (pair.Key));
-				stream.Write (bytes, 0, bytes.Length);
-				stream.WriteByte ((byte) '"');
-				stream.WriteByte ((byte) ',');
-				stream.WriteByte ((byte) ' ');
-				if (pair.Value == null) {
-					stream.WriteByte ((byte) 'n');
-					stream.WriteByte ((byte) 'u');
-					stream.WriteByte ((byte) 'l');
-					stream.WriteByte ((byte) 'l');
-				} else
-					pair.Value.Save (stream);
-			}
-			stream.WriteByte ((byte) '}');
-		}
+        public override void Save(Stream stream)
+        {
+            if (stream == null)
+                throw new ArgumentNullException("stream");
+            stream.WriteByte((byte)'{');
+            foreach (JsonPair pair in _map)
+            {
+                stream.WriteByte((byte)'"');
+                byte[] bytes = Encoding.UTF8.GetBytes(EscapeString(pair.Key));
+                stream.Write(bytes, 0, bytes.Length);
+                stream.WriteByte((byte)'"');
+                stream.WriteByte((byte)',');
+                stream.WriteByte((byte)' ');
+                if (pair.Value == null)
+                {
+                    stream.WriteByte((byte)'n');
+                    stream.WriteByte((byte)'u');
+                    stream.WriteByte((byte)'l');
+                    stream.WriteByte((byte)'l');
+                }
+                else
+                    pair.Value.Save(stream);
+            }
+            stream.WriteByte((byte)'}');
+        }
 
-		public bool TryGetValue (string key, out JsonValue value)
-		{
-			return map.TryGetValue (key, out value);
-		}
-	}
+        public bool TryGetValue(string key, out JsonValue value)
+        {
+            return _map.TryGetValue(key, out value);
+        }
+    }
 }

--- a/src/System.Json/src/System/Json/JsonObject.cs
+++ b/src/System.Json/src/System/Json/JsonObject.cs
@@ -15,39 +15,34 @@ namespace System.Json
     public class JsonObject : JsonValue, IDictionary<string, JsonValue>, ICollection<JsonPair>
     {
         // Use SortedDictionary to make result of ToString() deterministic
-        private SortedDictionary<string, JsonValue> _map;
+        private readonly SortedDictionary<string, JsonValue> _map;
 
         public JsonObject(params JsonPair[] items)
         {
             _map = new SortedDictionary<string, JsonValue>(StringComparer.Ordinal);
 
             if (items != null)
+            {
                 AddRange(items);
+            }
         }
 
         public JsonObject(JsonPairEnumerable items)
         {
             if (items == null)
+            {
                 throw new ArgumentNullException(nameof(items));
+            }
 
             _map = new SortedDictionary<string, JsonValue>(StringComparer.Ordinal);
             AddRange(items);
         }
 
-        public override int Count
-        {
-            get { return _map.Count; }
-        }
+        public override int Count => _map.Count;
 
-        public IEnumerator<JsonPair> GetEnumerator()
-        {
-            return _map.GetEnumerator();
-        }
+        public IEnumerator<JsonPair> GetEnumerator() => _map.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return _map.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => _map.GetEnumerator();
 
         public override sealed JsonValue this[string key]
         {
@@ -55,94 +50,78 @@ namespace System.Json
             set { _map[key] = value; }
         }
 
-        public override JsonType JsonType
-        {
-            get { return JsonType.Object; }
-        }
+        public override JsonType JsonType => JsonType.Object;
 
-        public ICollection<string> Keys
-        {
-            get { return _map.Keys; }
-        }
+        public ICollection<string> Keys => _map.Keys;
 
-        public ICollection<JsonValue> Values
-        {
-            get { return _map.Values; }
-        }
+        public ICollection<JsonValue> Values => _map.Values;
 
         public void Add(string key, JsonValue value)
         {
             if (key == null)
-                throw new ArgumentNullException("key");
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
 
             _map.Add(key, value);
         }
 
-        public void Add(JsonPair pair)
-        {
-            Add(pair.Key, pair.Value);
-        }
+        public void Add(JsonPair pair) => Add(pair.Key, pair.Value);
 
         public void AddRange(JsonPairEnumerable items)
         {
             if (items == null)
+            {
                 throw new ArgumentNullException(nameof(items));
+            }
 
             foreach (var pair in items)
+            {
                 _map.Add(pair.Key, pair.Value);
+            }
         }
 
-        public void AddRange(params JsonPair[] items)
-        {
-            AddRange((JsonPairEnumerable)items);
-        }
+        public void AddRange(params JsonPair[] items) => AddRange((JsonPairEnumerable)items);
 
-        public void Clear()
-        {
-            _map.Clear();
-        }
+        public void Clear() => _map.Clear();
 
-        bool ICollection<JsonPair>.Contains(JsonPair item)
-        {
-            return (_map as ICollection<JsonPair>).Contains(item);
-        }
+        bool ICollection<JsonPair>.Contains(JsonPair item) => (_map as ICollection<JsonPair>).Contains(item);
 
-        bool ICollection<JsonPair>.Remove(JsonPair item)
-        {
-            return (_map as ICollection<JsonPair>).Remove(item);
-        }
+        bool ICollection<JsonPair>.Remove(JsonPair item) => (_map as ICollection<JsonPair>).Remove(item);
 
         public override bool ContainsKey(string key)
         {
             if (key == null)
+            {
                 throw new ArgumentNullException(nameof(key));
+            }
 
             return _map.ContainsKey(key);
         }
 
-        public void CopyTo(JsonPair[] array, int arrayIndex)
-        {
-            (_map as ICollection<JsonPair>).CopyTo(array, arrayIndex);
-        }
+        public void CopyTo(JsonPair[] array, int arrayIndex) => (_map as ICollection<JsonPair>).CopyTo(array, arrayIndex);
 
         public bool Remove(string key)
         {
             if (key == null)
+            {
                 throw new ArgumentNullException(nameof(key));
+            }
 
             return _map.Remove(key);
         }
 
-        bool ICollection<JsonPair>.IsReadOnly
-        {
-            get { return false; }
-        }
+        bool ICollection<JsonPair>.IsReadOnly => false;
 
         public override void Save(Stream stream)
         {
             if (stream == null)
+            {
                 throw new ArgumentNullException(nameof(stream));
+            }
+
             stream.WriteByte((byte)'{');
+
             foreach (JsonPair pair in _map)
             {
                 stream.WriteByte((byte)'"');
@@ -159,14 +138,14 @@ namespace System.Json
                     stream.WriteByte((byte)'l');
                 }
                 else
+                {
                     pair.Value.Save(stream);
+                }
             }
+
             stream.WriteByte((byte)'}');
         }
 
-        public bool TryGetValue(string key, out JsonValue value)
-        {
-            return _map.TryGetValue(key, out value);
-        }
+        public bool TryGetValue(string key, out JsonValue value) => _map.TryGetValue(key, out value);
     }
 }

--- a/src/System.Json/src/System/Json/JsonObject.cs
+++ b/src/System.Json/src/System/Json/JsonObject.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using JsonPair = System.Collections.Generic.KeyValuePair<string, System.Json.JsonValue>;
+using JsonPairEnumerable = System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, System.Json.JsonValue>>;
+
+namespace System.Json
+{
+    public class JsonObject : JsonValue, IDictionary<string, JsonValue>, ICollection<JsonPair>
+	{
+		// Use SortedDictionary to make result of ToString() deterministic
+		SortedDictionary<string, JsonValue> map;
+
+		public JsonObject (params JsonPair [] items)
+		{
+			map = new SortedDictionary<string, JsonValue> (StringComparer.Ordinal);
+
+			if (items != null)
+				AddRange (items);
+		}
+
+		public JsonObject (JsonPairEnumerable items)
+		{
+            if (items == null)
+                throw new ArgumentNullException(nameof(items));
+
+			map = new SortedDictionary<string, JsonValue> (StringComparer.Ordinal);
+			AddRange (items);
+		}
+
+		public override int Count {
+			get { return map.Count; }
+		}
+
+		public IEnumerator<JsonPair> GetEnumerator ()
+		{
+			return map.GetEnumerator ();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+		{
+			return map.GetEnumerator ();
+		}
+
+		public override sealed JsonValue this [string key] {
+			get { return map [key]; }
+			set { map [key] = value; }
+		}
+
+		public override JsonType JsonType {
+			get { return JsonType.Object; }
+		}
+
+		public ICollection<string> Keys {
+			get { return map.Keys; }
+		}
+
+		public ICollection<JsonValue> Values {
+			get { return map.Values; }
+		}
+
+		public void Add (string key, JsonValue value)
+		{
+			if (key == null)
+				throw new ArgumentNullException ("key");
+
+			map.Add (key, value);
+		}
+
+		public void Add (JsonPair pair)
+		{
+			Add (pair.Key, pair.Value);
+		}
+
+		public void AddRange (JsonPairEnumerable items)
+		{
+			if (items == null)
+				throw new ArgumentNullException ("items");
+
+			foreach (var pair in items)
+				map.Add (pair.Key, pair.Value);
+		}
+
+		public void AddRange (params JsonPair [] items)
+		{
+			AddRange ((JsonPairEnumerable) items);
+		}
+
+		public void Clear ()
+		{
+			map.Clear ();
+		}
+
+		bool ICollection<JsonPair>.Contains (JsonPair item)
+		{
+			return (map as ICollection<JsonPair>).Contains (item);
+		}
+
+		bool ICollection<JsonPair>.Remove (JsonPair item)
+		{
+			return (map as ICollection<JsonPair>).Remove (item);
+		}
+
+		public override bool ContainsKey (string key)
+		{
+			if (key == null)
+				throw new ArgumentNullException ("key");
+
+			return map.ContainsKey (key);
+		}
+
+		public void CopyTo (JsonPair [] array, int arrayIndex)
+		{
+			(map as ICollection<JsonPair>).CopyTo (array, arrayIndex);
+		}
+
+		public bool Remove (string key)
+		{
+			if (key == null)
+				throw new ArgumentNullException ("key");
+
+			return map.Remove (key);
+		}
+
+		bool ICollection<JsonPair>.IsReadOnly {
+			get { return false; }
+		}
+
+		public override void Save (Stream stream)
+		{
+			if (stream == null)
+				throw new ArgumentNullException ("stream");
+			stream.WriteByte ((byte) '{');
+			foreach (JsonPair pair in map) {
+				stream.WriteByte ((byte) '"');
+				byte [] bytes = Encoding.UTF8.GetBytes (EscapeString (pair.Key));
+				stream.Write (bytes, 0, bytes.Length);
+				stream.WriteByte ((byte) '"');
+				stream.WriteByte ((byte) ',');
+				stream.WriteByte ((byte) ' ');
+				if (pair.Value == null) {
+					stream.WriteByte ((byte) 'n');
+					stream.WriteByte ((byte) 'u');
+					stream.WriteByte ((byte) 'l');
+					stream.WriteByte ((byte) 'l');
+				} else
+					pair.Value.Save (stream);
+			}
+			stream.WriteByte ((byte) '}');
+		}
+
+		public bool TryGetValue (string key, out JsonValue value)
+		{
+			return map.TryGetValue (key, out value);
+		}
+	}
+}

--- a/src/System.Json/src/System/Json/JsonPrimitive.cs
+++ b/src/System.Json/src/System/Json/JsonPrimitive.cs
@@ -10,110 +10,110 @@ namespace System.Json
 {
     public class JsonPrimitive : JsonValue
     {
-        object value;
+        private object _value;
 
         public JsonPrimitive(bool value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(byte value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(char value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(decimal value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(double value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(float value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(int value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(long value)
         {
-            this.value = value;
+            _value = value;
         }
 
         [CLSCompliant(false)]
         public JsonPrimitive(sbyte value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(short value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(string value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(DateTime value)
         {
-            this.value = value;
+            _value = value;
         }
 
         [CLSCompliant(false)]
         public JsonPrimitive(uint value)
         {
-            this.value = value;
+            _value = value;
         }
 
         [CLSCompliant(false)]
         public JsonPrimitive(ulong value)
         {
-            this.value = value;
+            _value = value;
         }
 
         [CLSCompliant(false)]
         public JsonPrimitive(ushort value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(DateTimeOffset value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(Guid value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(TimeSpan value)
         {
-            this.value = value;
+            _value = value;
         }
 
         public JsonPrimitive(Uri value)
         {
-            this.value = value;
+            _value = value;
         }
 
         internal object Value
         {
-            get { return value; }
+            get { return _value; }
         }
 
         public override JsonType JsonType
@@ -121,8 +121,8 @@ namespace System.Json
             get
             {
                 return
-                    value == null || value.GetType() == typeof(char) || value.GetType() == typeof(string) || value.GetType() == typeof(DateTime) || value.GetType() == typeof(object) ? JsonType.String : // DateTimeOffset || Guid || TimeSpan || Uri
-                    value.GetType() == typeof(bool) ? JsonType.Boolean :
+                    _value == null || _value.GetType() == typeof(char) || _value.GetType() == typeof(string) || _value.GetType() == typeof(DateTime) || _value.GetType() == typeof(object) ? JsonType.String : // DateTimeOffset || Guid || TimeSpan || Uri
+                    _value.GetType() == typeof(bool) ? JsonType.Boolean :
                     JsonType.Number;
             }
         }
@@ -135,14 +135,14 @@ namespace System.Json
             switch (JsonType)
             {
                 case JsonType.Boolean:
-                    if ((bool)value)
+                    if ((bool)_value)
                         stream.Write(s_trueBytes, 0, 4);
                     else
                         stream.Write(s_falseBytes, 0, 5);
                     break;
                 case JsonType.String:
                     stream.WriteByte((byte)'\"');
-                    byte[] bytes = Encoding.UTF8.GetBytes(EscapeString(value.ToString()));
+                    byte[] bytes = Encoding.UTF8.GetBytes(EscapeString(_value.ToString()));
                     stream.Write(bytes, 0, bytes.Length);
                     stream.WriteByte((byte)'\"');
                     break;
@@ -158,18 +158,18 @@ namespace System.Json
             switch (JsonType)
             {
                 case JsonType.String:
-                    if (value is string || value == null)
-                        return (string)value;
-                    if (value is char)
-                        return value.ToString();
-                    throw new NotImplementedException("GetFormattedString from value type " + value.GetType());
+                    if (_value is string || _value == null)
+                        return (string)_value;
+                    if (_value is char)
+                        return _value.ToString();
+                    throw new NotImplementedException("GetFormattedString from value type " + _value.GetType());
                 case JsonType.Number:
                     string s;
-                    if (value is float || value is double)
+                    if (_value is float || _value is double)
                         // Use "round-trip" format
-                        s = ((IFormattable)value).ToString("R", NumberFormatInfo.InvariantInfo);
+                        s = ((IFormattable)_value).ToString("R", NumberFormatInfo.InvariantInfo);
                     else
-                        s = ((IFormattable)value).ToString("G", NumberFormatInfo.InvariantInfo);
+                        s = ((IFormattable)_value).ToString("G", NumberFormatInfo.InvariantInfo);
                     if (s == "NaN" || s == "Infinity" || s == "-Infinity")
                         return "\"" + s + "\"";
                     else

--- a/src/System.Json/src/System/Json/JsonPrimitive.cs
+++ b/src/System.Json/src/System/Json/JsonPrimitive.cs
@@ -1,0 +1,182 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace System.Json
+{
+    public class JsonPrimitive : JsonValue
+    {
+        object value;
+
+        public JsonPrimitive(bool value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(byte value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(char value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(decimal value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(double value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(float value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(int value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(long value)
+        {
+            this.value = value;
+        }
+
+        [CLSCompliant(false)]
+        public JsonPrimitive(sbyte value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(short value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(string value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(DateTime value)
+        {
+            this.value = value;
+        }
+
+        [CLSCompliant(false)]
+        public JsonPrimitive(uint value)
+        {
+            this.value = value;
+        }
+
+        [CLSCompliant(false)]
+        public JsonPrimitive(ulong value)
+        {
+            this.value = value;
+        }
+
+        [CLSCompliant(false)]
+        public JsonPrimitive(ushort value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(DateTimeOffset value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(Guid value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(TimeSpan value)
+        {
+            this.value = value;
+        }
+
+        public JsonPrimitive(Uri value)
+        {
+            this.value = value;
+        }
+
+        internal object Value
+        {
+            get { return value; }
+        }
+
+        public override JsonType JsonType
+        {
+            get
+            {
+                return
+                    value == null || value.GetType() == typeof(char) || value.GetType() == typeof(string) || value.GetType() == typeof(DateTime) || value.GetType() == typeof(object) ? JsonType.String : // DateTimeOffset || Guid || TimeSpan || Uri
+                    value.GetType() == typeof(bool) ? JsonType.Boolean :
+                    JsonType.Number;
+            }
+        }
+
+        private static readonly byte[] s_trueBytes = Encoding.UTF8.GetBytes("true");
+        private static readonly byte[] s_falseBytes = Encoding.UTF8.GetBytes("false");
+
+        public override void Save(Stream stream)
+        {
+            switch (JsonType)
+            {
+                case JsonType.Boolean:
+                    if ((bool)value)
+                        stream.Write(s_trueBytes, 0, 4);
+                    else
+                        stream.Write(s_falseBytes, 0, 5);
+                    break;
+                case JsonType.String:
+                    stream.WriteByte((byte)'\"');
+                    byte[] bytes = Encoding.UTF8.GetBytes(EscapeString(value.ToString()));
+                    stream.Write(bytes, 0, bytes.Length);
+                    stream.WriteByte((byte)'\"');
+                    break;
+                default:
+                    bytes = Encoding.UTF8.GetBytes(GetFormattedString());
+                    stream.Write(bytes, 0, bytes.Length);
+                    break;
+            }
+        }
+
+        internal string GetFormattedString()
+        {
+            switch (JsonType)
+            {
+                case JsonType.String:
+                    if (value is string || value == null)
+                        return (string)value;
+                    if (value is char)
+                        return value.ToString();
+                    throw new NotImplementedException("GetFormattedString from value type " + value.GetType());
+                case JsonType.Number:
+                    string s;
+                    if (value is float || value is double)
+                        // Use "round-trip" format
+                        s = ((IFormattable)value).ToString("R", NumberFormatInfo.InvariantInfo);
+                    else
+                        s = ((IFormattable)value).ToString("G", NumberFormatInfo.InvariantInfo);
+                    if (s == "NaN" || s == "Infinity" || s == "-Infinity")
+                        return "\"" + s + "\"";
+                    else
+                        return s;
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+    }
+}

--- a/src/System.Json/src/System/Json/JsonPrimitive.cs
+++ b/src/System.Json/src/System/Json/JsonPrimitive.cs
@@ -162,7 +162,7 @@ namespace System.Json
                         return (string)_value;
                     if (_value is char)
                         return _value.ToString();
-                    throw new NotImplementedException("GetFormattedString from value type " + _value.GetType());
+                    throw new NotImplementedException(SR.Format(SR.NotImplemented_GetFormattedString, _value.GetType()));
                 case JsonType.Number:
                     string s;
                     if (_value is float || _value is double)

--- a/src/System.Json/src/System/Json/JsonType.cs
+++ b/src/System.Json/src/System/Json/JsonType.cs
@@ -4,12 +4,12 @@
 
 namespace System.Json
 {
-	public enum JsonType
-	{
-		String,
-		Number,
-		Object,
-		Array,
-		Boolean,
-	}
+    public enum JsonType
+    {
+        String,
+        Number,
+        Object,
+        Array,
+        Boolean,
+    }
 }

--- a/src/System.Json/src/System/Json/JsonType.cs
+++ b/src/System.Json/src/System/Json/JsonType.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Json
+{
+	public enum JsonType
+	{
+		String,
+		Number,
+		Object,
+		Array,
+		Boolean,
+	}
+}

--- a/src/System.Json/src/System/Json/JsonValue.cs
+++ b/src/System.Json/src/System/Json/JsonValue.cs
@@ -93,7 +93,7 @@ namespace System.Json
                 return new JsonPrimitive((TimeSpan)ret);
             if (ret is Uri)
                 return new JsonPrimitive((Uri)ret);
-            throw new NotSupportedException(string.Format("Unexpected parser return type: {0}", ret.GetType()));
+            throw new NotSupportedException(SR.Format(SR.NotSupported_UnexpectedParserType, ret.GetType()));
         }
 
         public static JsonValue Parse(string jsonString)
@@ -130,14 +130,14 @@ namespace System.Json
         public virtual void Save(Stream stream)
         {
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
             Save(new StreamWriter(stream));
         }
 
         public virtual void Save(TextWriter textWriter)
         {
             if (textWriter == null)
-                throw new ArgumentNullException("textWriter");
+                throw new ArgumentNullException(nameof(textWriter));
             SaveInternal(textWriter);
         }
 

--- a/src/System.Json/src/System/Json/JsonValue.cs
+++ b/src/System.Json/src/System/Json/JsonValue.cs
@@ -14,493 +14,503 @@ using JsonPair = System.Collections.Generic.KeyValuePair<string, System.Json.Jso
 namespace System.Json
 {
     public abstract class JsonValue : IEnumerable
-	{
-		public static JsonValue Load (Stream stream)
-		{
+    {
+        public static JsonValue Load(Stream stream)
+        {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
-			return Load (new StreamReader (stream, true));
-		}
+            return Load(new StreamReader(stream, true));
+        }
 
-		public static JsonValue Load (TextReader textReader)
-		{
+        public static JsonValue Load(TextReader textReader)
+        {
             if (textReader == null)
                 throw new ArgumentNullException(nameof(textReader));
 
-			var ret = new JavaScriptReader (textReader, true).Read ();
+            var ret = new JavaScriptReader(textReader, true).Read();
 
-			return ToJsonValue (ret);
-		}
+            return ToJsonValue(ret);
+        }
 
-		static IEnumerable<KeyValuePair<string,JsonValue>> ToJsonPairEnumerable (IEnumerable<KeyValuePair<string,object>> kvpc)
-		{
-			foreach (var kvp in kvpc)
-				yield return new KeyValuePair<string,JsonValue> (kvp.Key, ToJsonValue (kvp.Value));
-		}
+        private static IEnumerable<KeyValuePair<string, JsonValue>> ToJsonPairEnumerable(IEnumerable<KeyValuePair<string, object>> kvpc)
+        {
+            foreach (var kvp in kvpc)
+                yield return new KeyValuePair<string, JsonValue>(kvp.Key, ToJsonValue(kvp.Value));
+        }
 
-		static IEnumerable<JsonValue> ToJsonValueEnumerable (IEnumerable<object> arr)
-		{
-			foreach (var obj in arr)
-				yield return ToJsonValue (obj);
-		}
+        private static IEnumerable<JsonValue> ToJsonValueEnumerable(IEnumerable<object> arr)
+        {
+            foreach (var obj in arr)
+                yield return ToJsonValue(obj);
+        }
 
-		static JsonValue ToJsonValue (object ret)
-		{
-			if (ret == null)
-				return null;
-			var kvpc = ret as IEnumerable<KeyValuePair<string,object>>;
-			if (kvpc != null)
-				return new JsonObject (ToJsonPairEnumerable (kvpc));
-			var arr = ret as IEnumerable<object>;
-			if (arr != null)
-				return new JsonArray (ToJsonValueEnumerable (arr));
+        private static JsonValue ToJsonValue(object ret)
+        {
+            if (ret == null)
+                return null;
+            var kvpc = ret as IEnumerable<KeyValuePair<string, object>>;
+            if (kvpc != null)
+                return new JsonObject(ToJsonPairEnumerable(kvpc));
+            var arr = ret as IEnumerable<object>;
+            if (arr != null)
+                return new JsonArray(ToJsonValueEnumerable(arr));
 
-			if (ret is bool)
-				return new JsonPrimitive ((bool) ret);
-			if (ret is byte)
-				return new JsonPrimitive ((byte) ret);
-			if (ret is char)
-				return new JsonPrimitive ((char) ret);
-			if (ret is decimal)
-				return new JsonPrimitive ((decimal) ret);
-			if (ret is double)
-				return new JsonPrimitive ((double) ret);
-			if (ret is float)
-				return new JsonPrimitive ((float) ret);
-			if (ret is int)
-				return new JsonPrimitive ((int) ret);
-			if (ret is long)
-				return new JsonPrimitive ((long) ret);
-			if (ret is sbyte)
-				return new JsonPrimitive ((sbyte) ret);
-			if (ret is short)
-				return new JsonPrimitive ((short) ret);
-			if (ret is string)
-				return new JsonPrimitive ((string) ret);
-			if (ret is uint)
-				return new JsonPrimitive ((uint) ret);
-			if (ret is ulong)
-				return new JsonPrimitive ((ulong) ret);
-			if (ret is ushort)
-				return new JsonPrimitive ((ushort) ret);
-			if (ret is DateTime)
-				return new JsonPrimitive ((DateTime) ret);
-			if (ret is DateTimeOffset)
-				return new JsonPrimitive ((DateTimeOffset) ret);
-			if (ret is Guid)
-				return new JsonPrimitive ((Guid) ret);
-			if (ret is TimeSpan)
-				return new JsonPrimitive ((TimeSpan) ret);
-			if (ret is Uri)
-				return new JsonPrimitive ((Uri) ret);
-			throw new NotSupportedException (string.Format ("Unexpected parser return type: {0}", ret.GetType ()));
-		}
+            if (ret is bool)
+                return new JsonPrimitive((bool)ret);
+            if (ret is byte)
+                return new JsonPrimitive((byte)ret);
+            if (ret is char)
+                return new JsonPrimitive((char)ret);
+            if (ret is decimal)
+                return new JsonPrimitive((decimal)ret);
+            if (ret is double)
+                return new JsonPrimitive((double)ret);
+            if (ret is float)
+                return new JsonPrimitive((float)ret);
+            if (ret is int)
+                return new JsonPrimitive((int)ret);
+            if (ret is long)
+                return new JsonPrimitive((long)ret);
+            if (ret is sbyte)
+                return new JsonPrimitive((sbyte)ret);
+            if (ret is short)
+                return new JsonPrimitive((short)ret);
+            if (ret is string)
+                return new JsonPrimitive((string)ret);
+            if (ret is uint)
+                return new JsonPrimitive((uint)ret);
+            if (ret is ulong)
+                return new JsonPrimitive((ulong)ret);
+            if (ret is ushort)
+                return new JsonPrimitive((ushort)ret);
+            if (ret is DateTime)
+                return new JsonPrimitive((DateTime)ret);
+            if (ret is DateTimeOffset)
+                return new JsonPrimitive((DateTimeOffset)ret);
+            if (ret is Guid)
+                return new JsonPrimitive((Guid)ret);
+            if (ret is TimeSpan)
+                return new JsonPrimitive((TimeSpan)ret);
+            if (ret is Uri)
+                return new JsonPrimitive((Uri)ret);
+            throw new NotSupportedException(string.Format("Unexpected parser return type: {0}", ret.GetType()));
+        }
 
-		public static JsonValue Parse (string jsonString)
-		{
+        public static JsonValue Parse(string jsonString)
+        {
             if (jsonString == null)
                 throw new ArgumentNullException(nameof(jsonString));
-			return Load (new StringReader (jsonString));
-		}
+            return Load(new StringReader(jsonString));
+        }
 
-		public virtual int Count {
-			get { throw new InvalidOperationException (); }
-		}
-
-		public abstract JsonType JsonType { get; }
-
-		public virtual JsonValue this [int index] {
-			get { throw new InvalidOperationException (); }
-			set { throw new InvalidOperationException (); }
-		}
-
-		public virtual JsonValue this [string key] {
-			get { throw new InvalidOperationException (); }
-			set { throw new InvalidOperationException (); }
-		}
-
-		public virtual bool ContainsKey (string key)
-		{
-			throw new InvalidOperationException ();
-		}
-
-		public virtual void Save (Stream stream)
-		{
-			if (stream == null)
-				throw new ArgumentNullException ("stream");
-			Save (new StreamWriter (stream));
-		}
-
-		public virtual void Save (TextWriter textWriter)
-		{
-			if (textWriter == null)
-				throw new ArgumentNullException ("textWriter");
-			SaveInternal (textWriter);
-		}
-		
-		void SaveInternal (TextWriter w)
-		{
-			switch (JsonType) {
-			case JsonType.Object:
-				w.Write ('{');
-				bool following = false;
-				foreach (JsonPair pair in ((JsonObject) this)) {
-					if (following)
-						w.Write (", ");
-					w.Write ('\"');
-					w.Write (EscapeString (pair.Key));
-					w.Write ("\": ");
-					if (pair.Value == null)
-						w.Write ("null");
-					else
-						pair.Value.SaveInternal (w);
-					following = true;
-				}
-				w.Write ('}');
-				break;
-			case JsonType.Array:
-				w.Write ('[');
-				following = false;
-				foreach (JsonValue v in ((JsonArray) this)) {
-					if (following)
-						w.Write (", ");
-					if (v != null) 
-						v.SaveInternal (w);
-					else
-						w.Write ("null");
-					following = true;
-				}
-				w.Write (']');
-				break;
-			case JsonType.Boolean:
-				w.Write ((bool) this ? "true" : "false");
-				break;
-			case JsonType.String:
-				w.Write ('"');
-				w.Write (EscapeString (((JsonPrimitive) this).GetFormattedString ()));
-				w.Write ('"');
-				break;
-			default:
-				w.Write (((JsonPrimitive) this).GetFormattedString ());
-				break;
-			}
-		}
-
-		public override string ToString ()
-		{
-			StringWriter sw = new StringWriter ();
-			Save (sw);
-			return sw.ToString ();
-		}
-
-		IEnumerator IEnumerable.GetEnumerator ()
-		{
-			throw new InvalidOperationException ();
-		}
-
-		// Characters which have to be escaped:
-		// - Required by JSON Spec: Control characters, '"' and '\\'
-		// - Broken surrogates to make sure the JSON string is valid Unicode
-		//   (and can be encoded as UTF8)
-		// - JSON does not require U+2028 and U+2029 to be escaped, but
-		//   JavaScript does require this:
-		//   http://stackoverflow.com/questions/2965293/javascript-parse-error-on-u2028-unicode-character/9168133#9168133
-		// - '/' also does not have to be escaped, but escaping it when
-		//   preceeded by a '<' avoids problems with JSON in HTML <script> tags
-		bool NeedEscape (string src, int i) {
-			char c = src [i];
-			return c < 32 || c == '"' || c == '\\'
-				// Broken lead surrogate
-				|| (c >= '\uD800' && c <= '\uDBFF' &&
-					(i == src.Length - 1 || src [i + 1] < '\uDC00' || src [i + 1] > '\uDFFF'))
-				// Broken tail surrogate
-				|| (c >= '\uDC00' && c <= '\uDFFF' &&
-					(i == 0 || src [i - 1] < '\uD800' || src [i - 1] > '\uDBFF'))
-				// To produce valid JavaScript
-				|| c == '\u2028' || c == '\u2029'
-				// Escape "</" for <script> tags
-				|| (c == '/' && i > 0 && src [i - 1] == '<');
-		}
-		
-		internal string EscapeString (string src)
-		{
-			if (src == null)
-				return null;
-
-			for (int i = 0; i < src.Length; i++)
-				if (NeedEscape (src, i)) {
-					var sb = new StringBuilder ();
-					if (i > 0)
-						sb.Append (src, 0, i);
-					return DoEscapeString (sb, src, i);
-				}
-			return src;
-		}
-
-		string DoEscapeString (StringBuilder sb, string src, int cur)
-		{
-			int start = cur;
-			for (int i = cur; i < src.Length; i++)
-				if (NeedEscape (src, i)) {
-					sb.Append (src, start, i - start);
-					switch (src [i]) {
-					case '\b': sb.Append ("\\b"); break;
-					case '\f': sb.Append ("\\f"); break;
-					case '\n': sb.Append ("\\n"); break;
-					case '\r': sb.Append ("\\r"); break;
-					case '\t': sb.Append ("\\t"); break;
-					case '\"': sb.Append ("\\\""); break;
-					case '\\': sb.Append ("\\\\"); break;
-					case '/': sb.Append ("\\/"); break;
-					default:
-						sb.Append ("\\u");
-						sb.Append (((int) src [i]).ToString ("x04"));
-						break;
-					}
-					start = i + 1;
-				}
-			sb.Append (src, start, src.Length - start);
-			return sb.ToString ();
-		}
-
-		// CLI -> JsonValue
-
-		public static implicit operator JsonValue (bool value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (byte value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (char value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (decimal value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (double value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (float value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (int value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (long value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-        [CLSCompliant(false)]
-		public static implicit operator JsonValue (sbyte value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (short value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (string value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-        [CLSCompliant(false)]
-		public static implicit operator JsonValue (uint value)
+        public virtual int Count
         {
-			return new JsonPrimitive (value);
-		}
+            get { throw new InvalidOperationException(); }
+        }
 
-        [CLSCompliant(false)]
-		public static implicit operator JsonValue (ulong value)
+        public abstract JsonType JsonType { get; }
+
+        public virtual JsonValue this[int index]
         {
-			return new JsonPrimitive (value);
-		}
+            get { throw new InvalidOperationException(); }
+            set { throw new InvalidOperationException(); }
+        }
 
-        [CLSCompliant(false)]
-		public static implicit operator JsonValue (ushort value)
+        public virtual JsonValue this[string key]
         {
-			return new JsonPrimitive (value);
-		}
+            get { throw new InvalidOperationException(); }
+            set { throw new InvalidOperationException(); }
+        }
 
-		public static implicit operator JsonValue (DateTime value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (DateTimeOffset value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (Guid value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (TimeSpan value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		public static implicit operator JsonValue (Uri value)
-		{
-			return new JsonPrimitive (value);
-		}
-
-		// JsonValue -> CLI
-
-		public static implicit operator bool (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToBoolean (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
-
-		public static implicit operator byte (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToByte (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
-
-		public static implicit operator char (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToChar (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
-
-		public static implicit operator decimal (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToDecimal (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
-
-		public static implicit operator double (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToDouble (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
-
-		public static implicit operator float (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToSingle (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
-
-		public static implicit operator int (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToInt32 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
-
-		public static implicit operator long (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToInt64 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
-
-        [CLSCompliant(false)]
-		public static implicit operator sbyte (JsonValue value)
+        public virtual bool ContainsKey(string key)
         {
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToSByte (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
+            throw new InvalidOperationException();
+        }
 
-		public static implicit operator short (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToInt16 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
-
-		public static implicit operator string (JsonValue value)
-		{
-			if (value == null)
-				return null;
-			return (string) ((JsonPrimitive) value).Value;
-		}
-
-        [CLSCompliant(false)]
-		public static implicit operator uint (JsonValue value)
+        public virtual void Save(Stream stream)
         {
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToUInt32 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
+            if (stream == null)
+                throw new ArgumentNullException("stream");
+            Save(new StreamWriter(stream));
+        }
 
-        [CLSCompliant(false)]
-		public static implicit operator ulong (JsonValue value)
+        public virtual void Save(TextWriter textWriter)
         {
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToUInt64(((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
+            if (textWriter == null)
+                throw new ArgumentNullException("textWriter");
+            SaveInternal(textWriter);
+        }
+
+        private void SaveInternal(TextWriter w)
+        {
+            switch (JsonType)
+            {
+                case JsonType.Object:
+                    w.Write('{');
+                    bool following = false;
+                    foreach (JsonPair pair in ((JsonObject)this))
+                    {
+                        if (following)
+                            w.Write(", ");
+                        w.Write('\"');
+                        w.Write(EscapeString(pair.Key));
+                        w.Write("\": ");
+                        if (pair.Value == null)
+                            w.Write("null");
+                        else
+                            pair.Value.SaveInternal(w);
+                        following = true;
+                    }
+                    w.Write('}');
+                    break;
+                case JsonType.Array:
+                    w.Write('[');
+                    following = false;
+                    foreach (JsonValue v in ((JsonArray)this))
+                    {
+                        if (following)
+                            w.Write(", ");
+                        if (v != null)
+                            v.SaveInternal(w);
+                        else
+                            w.Write("null");
+                        following = true;
+                    }
+                    w.Write(']');
+                    break;
+                case JsonType.Boolean:
+                    w.Write((bool)this ? "true" : "false");
+                    break;
+                case JsonType.String:
+                    w.Write('"');
+                    w.Write(EscapeString(((JsonPrimitive)this).GetFormattedString()));
+                    w.Write('"');
+                    break;
+                default:
+                    w.Write(((JsonPrimitive)this).GetFormattedString());
+                    break;
+            }
+        }
+
+        public override string ToString()
+        {
+            StringWriter sw = new StringWriter();
+            Save(sw);
+            return sw.ToString();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new InvalidOperationException();
+        }
+
+        // Characters which have to be escaped:
+        // - Required by JSON Spec: Control characters, '"' and '\\'
+        // - Broken surrogates to make sure the JSON string is valid Unicode
+        //   (and can be encoded as UTF8)
+        // - JSON does not require U+2028 and U+2029 to be escaped, but
+        //   JavaScript does require this:
+        //   http://stackoverflow.com/questions/2965293/javascript-parse-error-on-u2028-unicode-character/9168133#9168133
+        // - '/' also does not have to be escaped, but escaping it when
+        //   preceeded by a '<' avoids problems with JSON in HTML <script> tags
+        private bool NeedEscape(string src, int i)
+        {
+            char c = src[i];
+            return c < 32 || c == '"' || c == '\\'
+                // Broken lead surrogate
+                || (c >= '\uD800' && c <= '\uDBFF' &&
+                    (i == src.Length - 1 || src[i + 1] < '\uDC00' || src[i + 1] > '\uDFFF'))
+                // Broken tail surrogate
+                || (c >= '\uDC00' && c <= '\uDFFF' &&
+                    (i == 0 || src[i - 1] < '\uD800' || src[i - 1] > '\uDBFF'))
+                // To produce valid JavaScript
+                || c == '\u2028' || c == '\u2029'
+                // Escape "</" for <script> tags
+                || (c == '/' && i > 0 && src[i - 1] == '<');
+        }
+
+        internal string EscapeString(string src)
+        {
+            if (src == null)
+                return null;
+
+            for (int i = 0; i < src.Length; i++)
+                if (NeedEscape(src, i))
+                {
+                    var sb = new StringBuilder();
+                    if (i > 0)
+                        sb.Append(src, 0, i);
+                    return DoEscapeString(sb, src, i);
+                }
+            return src;
+        }
+
+        private string DoEscapeString(StringBuilder sb, string src, int cur)
+        {
+            int start = cur;
+            for (int i = cur; i < src.Length; i++)
+                if (NeedEscape(src, i))
+                {
+                    sb.Append(src, start, i - start);
+                    switch (src[i])
+                    {
+                        case '\b': sb.Append("\\b"); break;
+                        case '\f': sb.Append("\\f"); break;
+                        case '\n': sb.Append("\\n"); break;
+                        case '\r': sb.Append("\\r"); break;
+                        case '\t': sb.Append("\\t"); break;
+                        case '\"': sb.Append("\\\""); break;
+                        case '\\': sb.Append("\\\\"); break;
+                        case '/': sb.Append("\\/"); break;
+                        default:
+                            sb.Append("\\u");
+                            sb.Append(((int)src[i]).ToString("x04"));
+                            break;
+                    }
+                    start = i + 1;
+                }
+            sb.Append(src, start, src.Length - start);
+            return sb.ToString();
+        }
+
+        // CLI -> JsonValue
+
+        public static implicit operator JsonValue(bool value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(byte value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(char value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(decimal value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(double value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(float value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(int value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(long value)
+        {
+            return new JsonPrimitive(value);
+        }
 
         [CLSCompliant(false)]
-		public static implicit operator ushort (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return Convert.ToUInt16 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
-		}
+        public static implicit operator JsonValue(sbyte value)
+        {
+            return new JsonPrimitive(value);
+        }
 
-		public static implicit operator DateTime (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return (DateTime) ((JsonPrimitive) value).Value;
-		}
+        public static implicit operator JsonValue(short value)
+        {
+            return new JsonPrimitive(value);
+        }
 
-		public static implicit operator DateTimeOffset (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return (DateTimeOffset) ((JsonPrimitive) value).Value;
-		}
+        public static implicit operator JsonValue(string value)
+        {
+            return new JsonPrimitive(value);
+        }
 
-		public static implicit operator TimeSpan (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return (TimeSpan) ((JsonPrimitive) value).Value;
-		}
+        [CLSCompliant(false)]
+        public static implicit operator JsonValue(uint value)
+        {
+            return new JsonPrimitive(value);
+        }
 
-		public static implicit operator Guid (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return (Guid) ((JsonPrimitive) value).Value;
-		}
+        [CLSCompliant(false)]
+        public static implicit operator JsonValue(ulong value)
+        {
+            return new JsonPrimitive(value);
+        }
 
-		public static implicit operator Uri (JsonValue value)
-		{
-			if (value == null)
-				throw new ArgumentNullException (nameof(value));
-			return (Uri) ((JsonPrimitive) value).Value;
-		}
-	}
+        [CLSCompliant(false)]
+        public static implicit operator JsonValue(ushort value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(DateTime value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(DateTimeOffset value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(Guid value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(TimeSpan value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        public static implicit operator JsonValue(Uri value)
+        {
+            return new JsonPrimitive(value);
+        }
+
+        // JsonValue -> CLI
+
+        public static implicit operator bool (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToBoolean(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        public static implicit operator byte (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToByte(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        public static implicit operator char (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToChar(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        public static implicit operator decimal (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToDecimal(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        public static implicit operator double (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToDouble(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        public static implicit operator float (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToSingle(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        public static implicit operator int (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToInt32(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        public static implicit operator long (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToInt64(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        [CLSCompliant(false)]
+        public static implicit operator sbyte (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToSByte(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        public static implicit operator short (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToInt16(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        public static implicit operator string (JsonValue value)
+        {
+            if (value == null)
+                return null;
+            return (string)((JsonPrimitive)value).Value;
+        }
+
+        [CLSCompliant(false)]
+        public static implicit operator uint (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToUInt32(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        [CLSCompliant(false)]
+        public static implicit operator ulong (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToUInt64(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        [CLSCompliant(false)]
+        public static implicit operator ushort (JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return Convert.ToUInt16(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
+        }
+
+        public static implicit operator DateTime(JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return (DateTime)((JsonPrimitive)value).Value;
+        }
+
+        public static implicit operator DateTimeOffset(JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return (DateTimeOffset)((JsonPrimitive)value).Value;
+        }
+
+        public static implicit operator TimeSpan(JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return (TimeSpan)((JsonPrimitive)value).Value;
+        }
+
+        public static implicit operator Guid(JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return (Guid)((JsonPrimitive)value).Value;
+        }
+
+        public static implicit operator Uri(JsonValue value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            return (Uri)((JsonPrimitive)value).Value;
+        }
+    }
 }

--- a/src/System.Json/src/System/Json/JsonValue.cs
+++ b/src/System.Json/src/System/Json/JsonValue.cs
@@ -18,88 +18,88 @@ namespace System.Json
         public static JsonValue Load(Stream stream)
         {
             if (stream == null)
+            {
                 throw new ArgumentNullException(nameof(stream));
+            }
+
             return Load(new StreamReader(stream, true));
         }
 
         public static JsonValue Load(TextReader textReader)
         {
             if (textReader == null)
+            {
                 throw new ArgumentNullException(nameof(textReader));
+            }
 
-            var ret = new JavaScriptReader(textReader, true).Read();
-
-            return ToJsonValue(ret);
+            return ToJsonValue(new JavaScriptReader(textReader, true).Read());
         }
 
         private static IEnumerable<KeyValuePair<string, JsonValue>> ToJsonPairEnumerable(IEnumerable<KeyValuePair<string, object>> kvpc)
         {
-            foreach (var kvp in kvpc)
+            foreach (KeyValuePair<string, object> kvp in kvpc)
+            {
                 yield return new KeyValuePair<string, JsonValue>(kvp.Key, ToJsonValue(kvp.Value));
+            }
         }
 
         private static IEnumerable<JsonValue> ToJsonValueEnumerable(IEnumerable<object> arr)
         {
-            foreach (var obj in arr)
+            foreach (object obj in arr)
+            {
                 yield return ToJsonValue(obj);
+            }
         }
 
         private static JsonValue ToJsonValue(object ret)
         {
             if (ret == null)
+            {
                 return null;
+            }
+
             var kvpc = ret as IEnumerable<KeyValuePair<string, object>>;
             if (kvpc != null)
+            {
                 return new JsonObject(ToJsonPairEnumerable(kvpc));
+            }
+
             var arr = ret as IEnumerable<object>;
             if (arr != null)
+            {
                 return new JsonArray(ToJsonValueEnumerable(arr));
+            }
 
-            if (ret is bool)
-                return new JsonPrimitive((bool)ret);
-            if (ret is byte)
-                return new JsonPrimitive((byte)ret);
-            if (ret is char)
-                return new JsonPrimitive((char)ret);
-            if (ret is decimal)
-                return new JsonPrimitive((decimal)ret);
-            if (ret is double)
-                return new JsonPrimitive((double)ret);
-            if (ret is float)
-                return new JsonPrimitive((float)ret);
-            if (ret is int)
-                return new JsonPrimitive((int)ret);
-            if (ret is long)
-                return new JsonPrimitive((long)ret);
-            if (ret is sbyte)
-                return new JsonPrimitive((sbyte)ret);
-            if (ret is short)
-                return new JsonPrimitive((short)ret);
-            if (ret is string)
-                return new JsonPrimitive((string)ret);
-            if (ret is uint)
-                return new JsonPrimitive((uint)ret);
-            if (ret is ulong)
-                return new JsonPrimitive((ulong)ret);
-            if (ret is ushort)
-                return new JsonPrimitive((ushort)ret);
-            if (ret is DateTime)
-                return new JsonPrimitive((DateTime)ret);
-            if (ret is DateTimeOffset)
-                return new JsonPrimitive((DateTimeOffset)ret);
-            if (ret is Guid)
-                return new JsonPrimitive((Guid)ret);
-            if (ret is TimeSpan)
-                return new JsonPrimitive((TimeSpan)ret);
-            if (ret is Uri)
-                return new JsonPrimitive((Uri)ret);
+            if (ret is bool) return new JsonPrimitive((bool)ret);
+            if (ret is byte) return new JsonPrimitive((byte)ret);
+            if (ret is char) return new JsonPrimitive((char)ret);
+            if (ret is decimal) return new JsonPrimitive((decimal)ret);
+            if (ret is double) return new JsonPrimitive((double)ret);
+            if (ret is float) return new JsonPrimitive((float)ret);
+            if (ret is int) return new JsonPrimitive((int)ret);
+            if (ret is long) return new JsonPrimitive((long)ret);
+            if (ret is sbyte) return new JsonPrimitive((sbyte)ret);
+            if (ret is short) return new JsonPrimitive((short)ret);
+            if (ret is string) return new JsonPrimitive((string)ret);
+            if (ret is uint) return new JsonPrimitive((uint)ret);
+            if (ret is ulong) return new JsonPrimitive((ulong)ret);
+            if (ret is ushort) return new JsonPrimitive((ushort)ret);
+            if (ret is DateTime) return new JsonPrimitive((DateTime)ret);
+            if (ret is DateTimeOffset) return new JsonPrimitive((DateTimeOffset)ret);
+            if (ret is Guid) return new JsonPrimitive((Guid)ret);
+            if (ret is TimeSpan) return new JsonPrimitive((TimeSpan)ret);
+            if (ret is Uri) return new JsonPrimitive((Uri)ret);
+
             throw new NotSupportedException(SR.Format(SR.NotSupported_UnexpectedParserType, ret.GetType()));
         }
 
         public static JsonValue Parse(string jsonString)
         {
             if (jsonString == null)
+            {
                 throw new ArgumentNullException(nameof(jsonString));
+            }
+
             return Load(new StringReader(jsonString));
         }
 
@@ -130,14 +130,20 @@ namespace System.Json
         public virtual void Save(Stream stream)
         {
             if (stream == null)
+            {
                 throw new ArgumentNullException(nameof(stream));
+            }
+
             Save(new StreamWriter(stream));
         }
 
         public virtual void Save(TextWriter textWriter)
         {
             if (textWriter == null)
+            {
                 throw new ArgumentNullException(nameof(textWriter));
+            }
+
             SaveInternal(textWriter);
         }
 
@@ -151,41 +157,61 @@ namespace System.Json
                     foreach (JsonPair pair in ((JsonObject)this))
                     {
                         if (following)
+                        {
                             w.Write(", ");
+                        }
+
                         w.Write('\"');
                         w.Write(EscapeString(pair.Key));
                         w.Write("\": ");
                         if (pair.Value == null)
+                        {
                             w.Write("null");
+                        }
                         else
+                        {
                             pair.Value.SaveInternal(w);
+                        }
+
                         following = true;
                     }
                     w.Write('}');
                     break;
+
                 case JsonType.Array:
                     w.Write('[');
                     following = false;
                     foreach (JsonValue v in ((JsonArray)this))
                     {
                         if (following)
+                        {
                             w.Write(", ");
+                        }
+
                         if (v != null)
+                        {
                             v.SaveInternal(w);
+                        }
                         else
+                        {
                             w.Write("null");
+                        }
+
                         following = true;
                     }
                     w.Write(']');
                     break;
+
                 case JsonType.Boolean:
-                    w.Write((bool)this ? "true" : "false");
+                    w.Write(this ? "true" : "false");
                     break;
+
                 case JsonType.String:
                     w.Write('"');
                     w.Write(EscapeString(((JsonPrimitive)this).GetFormattedString()));
                     w.Write('"');
                     break;
+
                 default:
                     w.Write(((JsonPrimitive)this).GetFormattedString());
                     break;
@@ -194,7 +220,7 @@ namespace System.Json
 
         public override string ToString()
         {
-            StringWriter sw = new StringWriter();
+            var sw = new StringWriter();
             Save(sw);
             return sw.ToString();
         }
@@ -213,7 +239,7 @@ namespace System.Json
         //   http://stackoverflow.com/questions/2965293/javascript-parse-error-on-u2028-unicode-character/9168133#9168133
         // - '/' also does not have to be escaped, but escaping it when
         //   preceeded by a '<' avoids problems with JSON in HTML <script> tags
-        private bool NeedEscape(string src, int i)
+        private static bool NeedEscape(string src, int i)
         {
             char c = src[i];
             return c < 32 || c == '"' || c == '\\'
@@ -229,23 +255,28 @@ namespace System.Json
                 || (c == '/' && i > 0 && src[i - 1] == '<');
         }
 
-        internal string EscapeString(string src)
+        internal static string EscapeString(string src)
         {
-            if (src == null)
-                return null;
-
-            for (int i = 0; i < src.Length; i++)
-                if (NeedEscape(src, i))
+            if (src != null)
+            {
+                for (int i = 0; i < src.Length; i++)
                 {
-                    var sb = new StringBuilder();
-                    if (i > 0)
-                        sb.Append(src, 0, i);
-                    return DoEscapeString(sb, src, i);
+                    if (NeedEscape(src, i))
+                    {
+                        var sb = new StringBuilder();
+                        if (i > 0)
+                        {
+                            sb.Append(src, 0, i);
+                        }
+                        return DoEscapeString(sb, src, i);
+                    }
                 }
+            }
+
             return src;
         }
 
-        private string DoEscapeString(StringBuilder sb, string src, int cur)
+        private static string DoEscapeString(StringBuilder sb, string src, int cur)
         {
             int start = cur;
             for (int i = cur; i < src.Length; i++)
@@ -275,132 +306,87 @@ namespace System.Json
 
         // CLI -> JsonValue
 
-        public static implicit operator JsonValue(bool value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(bool value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(byte value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(byte value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(char value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(char value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(decimal value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(decimal value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(double value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(double value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(float value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(float value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(int value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(int value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(long value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(long value) => new JsonPrimitive(value);
 
         [CLSCompliant(false)]
-        public static implicit operator JsonValue(sbyte value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(sbyte value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(short value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(short value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(string value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(string value) => new JsonPrimitive(value);
 
         [CLSCompliant(false)]
-        public static implicit operator JsonValue(uint value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(uint value) => new JsonPrimitive(value);
 
         [CLSCompliant(false)]
-        public static implicit operator JsonValue(ulong value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(ulong value) => new JsonPrimitive(value);
 
         [CLSCompliant(false)]
-        public static implicit operator JsonValue(ushort value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(ushort value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(DateTime value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(DateTime value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(DateTimeOffset value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(DateTimeOffset value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(Guid value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(Guid value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(TimeSpan value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(TimeSpan value) => new JsonPrimitive(value);
 
-        public static implicit operator JsonValue(Uri value)
-        {
-            return new JsonPrimitive(value);
-        }
+        public static implicit operator JsonValue(Uri value) => new JsonPrimitive(value);
 
         // JsonValue -> CLI
 
         public static implicit operator bool (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToBoolean(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
         public static implicit operator byte (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToByte(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
         public static implicit operator char (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToChar(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
         public static implicit operator decimal (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToDecimal(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
@@ -414,21 +400,30 @@ namespace System.Json
         public static implicit operator float (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToSingle(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
         public static implicit operator int (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToInt32(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
         public static implicit operator long (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToInt64(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
@@ -436,29 +431,38 @@ namespace System.Json
         public static implicit operator sbyte (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToSByte(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
         public static implicit operator short (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToInt16(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
         public static implicit operator string (JsonValue value)
         {
-            if (value == null)
-                return null;
-            return (string)((JsonPrimitive)value).Value;
+            return value != null ?
+                (string)((JsonPrimitive)value).Value :
+                null;
         }
 
         [CLSCompliant(false)]
         public static implicit operator uint (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToUInt32(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
@@ -466,7 +470,10 @@ namespace System.Json
         public static implicit operator ulong (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToUInt64(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
@@ -474,42 +481,60 @@ namespace System.Json
         public static implicit operator ushort (JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return Convert.ToUInt16(((JsonPrimitive)value).Value, NumberFormatInfo.InvariantInfo);
         }
 
         public static implicit operator DateTime(JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+            
             return (DateTime)((JsonPrimitive)value).Value;
         }
 
         public static implicit operator DateTimeOffset(JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return (DateTimeOffset)((JsonPrimitive)value).Value;
         }
 
         public static implicit operator TimeSpan(JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return (TimeSpan)((JsonPrimitive)value).Value;
         }
 
         public static implicit operator Guid(JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return (Guid)((JsonPrimitive)value).Value;
         }
 
         public static implicit operator Uri(JsonValue value)
         {
             if (value == null)
+            {
                 throw new ArgumentNullException(nameof(value));
+            }
+
             return (Uri)((JsonPrimitive)value).Value;
         }
     }

--- a/src/System.Json/src/System/Json/JsonValue.cs
+++ b/src/System.Json/src/System/Json/JsonValue.cs
@@ -1,0 +1,506 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.Serialization.Json;
+using System.Text;
+
+using JsonPair = System.Collections.Generic.KeyValuePair<string, System.Json.JsonValue>;
+
+namespace System.Json
+{
+    public abstract class JsonValue : IEnumerable
+	{
+		public static JsonValue Load (Stream stream)
+		{
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+			return Load (new StreamReader (stream, true));
+		}
+
+		public static JsonValue Load (TextReader textReader)
+		{
+            if (textReader == null)
+                throw new ArgumentNullException(nameof(textReader));
+
+			var ret = new JavaScriptReader (textReader, true).Read ();
+
+			return ToJsonValue (ret);
+		}
+
+		static IEnumerable<KeyValuePair<string,JsonValue>> ToJsonPairEnumerable (IEnumerable<KeyValuePair<string,object>> kvpc)
+		{
+			foreach (var kvp in kvpc)
+				yield return new KeyValuePair<string,JsonValue> (kvp.Key, ToJsonValue (kvp.Value));
+		}
+
+		static IEnumerable<JsonValue> ToJsonValueEnumerable (IEnumerable<object> arr)
+		{
+			foreach (var obj in arr)
+				yield return ToJsonValue (obj);
+		}
+
+		static JsonValue ToJsonValue (object ret)
+		{
+			if (ret == null)
+				return null;
+			var kvpc = ret as IEnumerable<KeyValuePair<string,object>>;
+			if (kvpc != null)
+				return new JsonObject (ToJsonPairEnumerable (kvpc));
+			var arr = ret as IEnumerable<object>;
+			if (arr != null)
+				return new JsonArray (ToJsonValueEnumerable (arr));
+
+			if (ret is bool)
+				return new JsonPrimitive ((bool) ret);
+			if (ret is byte)
+				return new JsonPrimitive ((byte) ret);
+			if (ret is char)
+				return new JsonPrimitive ((char) ret);
+			if (ret is decimal)
+				return new JsonPrimitive ((decimal) ret);
+			if (ret is double)
+				return new JsonPrimitive ((double) ret);
+			if (ret is float)
+				return new JsonPrimitive ((float) ret);
+			if (ret is int)
+				return new JsonPrimitive ((int) ret);
+			if (ret is long)
+				return new JsonPrimitive ((long) ret);
+			if (ret is sbyte)
+				return new JsonPrimitive ((sbyte) ret);
+			if (ret is short)
+				return new JsonPrimitive ((short) ret);
+			if (ret is string)
+				return new JsonPrimitive ((string) ret);
+			if (ret is uint)
+				return new JsonPrimitive ((uint) ret);
+			if (ret is ulong)
+				return new JsonPrimitive ((ulong) ret);
+			if (ret is ushort)
+				return new JsonPrimitive ((ushort) ret);
+			if (ret is DateTime)
+				return new JsonPrimitive ((DateTime) ret);
+			if (ret is DateTimeOffset)
+				return new JsonPrimitive ((DateTimeOffset) ret);
+			if (ret is Guid)
+				return new JsonPrimitive ((Guid) ret);
+			if (ret is TimeSpan)
+				return new JsonPrimitive ((TimeSpan) ret);
+			if (ret is Uri)
+				return new JsonPrimitive ((Uri) ret);
+			throw new NotSupportedException (string.Format ("Unexpected parser return type: {0}", ret.GetType ()));
+		}
+
+		public static JsonValue Parse (string jsonString)
+		{
+            if (jsonString == null)
+                throw new ArgumentNullException(nameof(jsonString));
+			return Load (new StringReader (jsonString));
+		}
+
+		public virtual int Count {
+			get { throw new InvalidOperationException (); }
+		}
+
+		public abstract JsonType JsonType { get; }
+
+		public virtual JsonValue this [int index] {
+			get { throw new InvalidOperationException (); }
+			set { throw new InvalidOperationException (); }
+		}
+
+		public virtual JsonValue this [string key] {
+			get { throw new InvalidOperationException (); }
+			set { throw new InvalidOperationException (); }
+		}
+
+		public virtual bool ContainsKey (string key)
+		{
+			throw new InvalidOperationException ();
+		}
+
+		public virtual void Save (Stream stream)
+		{
+			if (stream == null)
+				throw new ArgumentNullException ("stream");
+			Save (new StreamWriter (stream));
+		}
+
+		public virtual void Save (TextWriter textWriter)
+		{
+			if (textWriter == null)
+				throw new ArgumentNullException ("textWriter");
+			SaveInternal (textWriter);
+		}
+		
+		void SaveInternal (TextWriter w)
+		{
+			switch (JsonType) {
+			case JsonType.Object:
+				w.Write ('{');
+				bool following = false;
+				foreach (JsonPair pair in ((JsonObject) this)) {
+					if (following)
+						w.Write (", ");
+					w.Write ('\"');
+					w.Write (EscapeString (pair.Key));
+					w.Write ("\": ");
+					if (pair.Value == null)
+						w.Write ("null");
+					else
+						pair.Value.SaveInternal (w);
+					following = true;
+				}
+				w.Write ('}');
+				break;
+			case JsonType.Array:
+				w.Write ('[');
+				following = false;
+				foreach (JsonValue v in ((JsonArray) this)) {
+					if (following)
+						w.Write (", ");
+					if (v != null) 
+						v.SaveInternal (w);
+					else
+						w.Write ("null");
+					following = true;
+				}
+				w.Write (']');
+				break;
+			case JsonType.Boolean:
+				w.Write ((bool) this ? "true" : "false");
+				break;
+			case JsonType.String:
+				w.Write ('"');
+				w.Write (EscapeString (((JsonPrimitive) this).GetFormattedString ()));
+				w.Write ('"');
+				break;
+			default:
+				w.Write (((JsonPrimitive) this).GetFormattedString ());
+				break;
+			}
+		}
+
+		public override string ToString ()
+		{
+			StringWriter sw = new StringWriter ();
+			Save (sw);
+			return sw.ToString ();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+		{
+			throw new InvalidOperationException ();
+		}
+
+		// Characters which have to be escaped:
+		// - Required by JSON Spec: Control characters, '"' and '\\'
+		// - Broken surrogates to make sure the JSON string is valid Unicode
+		//   (and can be encoded as UTF8)
+		// - JSON does not require U+2028 and U+2029 to be escaped, but
+		//   JavaScript does require this:
+		//   http://stackoverflow.com/questions/2965293/javascript-parse-error-on-u2028-unicode-character/9168133#9168133
+		// - '/' also does not have to be escaped, but escaping it when
+		//   preceeded by a '<' avoids problems with JSON in HTML <script> tags
+		bool NeedEscape (string src, int i) {
+			char c = src [i];
+			return c < 32 || c == '"' || c == '\\'
+				// Broken lead surrogate
+				|| (c >= '\uD800' && c <= '\uDBFF' &&
+					(i == src.Length - 1 || src [i + 1] < '\uDC00' || src [i + 1] > '\uDFFF'))
+				// Broken tail surrogate
+				|| (c >= '\uDC00' && c <= '\uDFFF' &&
+					(i == 0 || src [i - 1] < '\uD800' || src [i - 1] > '\uDBFF'))
+				// To produce valid JavaScript
+				|| c == '\u2028' || c == '\u2029'
+				// Escape "</" for <script> tags
+				|| (c == '/' && i > 0 && src [i - 1] == '<');
+		}
+		
+		internal string EscapeString (string src)
+		{
+			if (src == null)
+				return null;
+
+			for (int i = 0; i < src.Length; i++)
+				if (NeedEscape (src, i)) {
+					var sb = new StringBuilder ();
+					if (i > 0)
+						sb.Append (src, 0, i);
+					return DoEscapeString (sb, src, i);
+				}
+			return src;
+		}
+
+		string DoEscapeString (StringBuilder sb, string src, int cur)
+		{
+			int start = cur;
+			for (int i = cur; i < src.Length; i++)
+				if (NeedEscape (src, i)) {
+					sb.Append (src, start, i - start);
+					switch (src [i]) {
+					case '\b': sb.Append ("\\b"); break;
+					case '\f': sb.Append ("\\f"); break;
+					case '\n': sb.Append ("\\n"); break;
+					case '\r': sb.Append ("\\r"); break;
+					case '\t': sb.Append ("\\t"); break;
+					case '\"': sb.Append ("\\\""); break;
+					case '\\': sb.Append ("\\\\"); break;
+					case '/': sb.Append ("\\/"); break;
+					default:
+						sb.Append ("\\u");
+						sb.Append (((int) src [i]).ToString ("x04"));
+						break;
+					}
+					start = i + 1;
+				}
+			sb.Append (src, start, src.Length - start);
+			return sb.ToString ();
+		}
+
+		// CLI -> JsonValue
+
+		public static implicit operator JsonValue (bool value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (byte value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (char value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (decimal value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (double value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (float value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (int value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (long value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+        [CLSCompliant(false)]
+		public static implicit operator JsonValue (sbyte value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (short value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (string value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+        [CLSCompliant(false)]
+		public static implicit operator JsonValue (uint value)
+        {
+			return new JsonPrimitive (value);
+		}
+
+        [CLSCompliant(false)]
+		public static implicit operator JsonValue (ulong value)
+        {
+			return new JsonPrimitive (value);
+		}
+
+        [CLSCompliant(false)]
+		public static implicit operator JsonValue (ushort value)
+        {
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (DateTime value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (DateTimeOffset value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (Guid value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (TimeSpan value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		public static implicit operator JsonValue (Uri value)
+		{
+			return new JsonPrimitive (value);
+		}
+
+		// JsonValue -> CLI
+
+		public static implicit operator bool (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToBoolean (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+		public static implicit operator byte (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToByte (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+		public static implicit operator char (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToChar (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+		public static implicit operator decimal (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToDecimal (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+		public static implicit operator double (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToDouble (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+		public static implicit operator float (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToSingle (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+		public static implicit operator int (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToInt32 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+		public static implicit operator long (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToInt64 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+        [CLSCompliant(false)]
+		public static implicit operator sbyte (JsonValue value)
+        {
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToSByte (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+		public static implicit operator short (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToInt16 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+		public static implicit operator string (JsonValue value)
+		{
+			if (value == null)
+				return null;
+			return (string) ((JsonPrimitive) value).Value;
+		}
+
+        [CLSCompliant(false)]
+		public static implicit operator uint (JsonValue value)
+        {
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToUInt32 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+        [CLSCompliant(false)]
+		public static implicit operator ulong (JsonValue value)
+        {
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToUInt64(((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+        [CLSCompliant(false)]
+		public static implicit operator ushort (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return Convert.ToUInt16 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
+		}
+
+		public static implicit operator DateTime (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return (DateTime) ((JsonPrimitive) value).Value;
+		}
+
+		public static implicit operator DateTimeOffset (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return (DateTimeOffset) ((JsonPrimitive) value).Value;
+		}
+
+		public static implicit operator TimeSpan (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return (TimeSpan) ((JsonPrimitive) value).Value;
+		}
+
+		public static implicit operator Guid (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return (Guid) ((JsonPrimitive) value).Value;
+		}
+
+		public static implicit operator Uri (JsonValue value)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof(value));
+			return (Uri) ((JsonPrimitive) value).Value;
+		}
+	}
+}

--- a/src/System.Json/src/project.json
+++ b/src/System.Json/src/project.json
@@ -1,0 +1,30 @@
+{
+  "frameworks": {
+    "netstandard1.3": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Collections": "4.0.10",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.IO": "4.0.10",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Runtime.Handles": "4.0.0",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Text.Encoding": "4.0.10",
+        "System.Threading": "4.0.0",
+        "System.Threading.Tasks": "4.0.10"
+      },
+      "imports": [
+        "dotnet5.4"
+      ]
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    }
+  }
+}

--- a/src/System.Json/src/project.json
+++ b/src/System.Json/src/project.json
@@ -8,6 +8,7 @@
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
         "System.IO": "4.0.10",
+        "System.Linq": "4.0.0",
         "System.Resources.ResourceManager": "4.0.0",
         "System.Runtime": "4.0.20",
         "System.Runtime.Extensions": "4.0.10",

--- a/src/System.Json/src/project.json
+++ b/src/System.Json/src/project.json
@@ -1,30 +1,13 @@
 {
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.0": {
       "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1",
-        "System.Collections": "4.0.10",
-        "System.Diagnostics.Contracts": "4.0.0",
-        "System.Diagnostics.Debug": "4.0.10",
-        "System.Diagnostics.Tools": "4.0.0",
-        "System.IO": "4.0.10",
-        "System.Linq": "4.0.0",
-        "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.0.20",
-        "System.Runtime.Extensions": "4.0.10",
-        "System.Runtime.Handles": "4.0.0",
-        "System.Runtime.InteropServices": "4.0.20",
-        "System.Text.Encoding": "4.0.10",
-        "System.Threading": "4.0.0",
-        "System.Threading.Tasks": "4.0.10"
-      },
-      "imports": [
-        "dotnet5.4"
-      ]
-    },
-    "net46": {
-      "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+        "System.Collections": "4.0.11",
+        "System.IO": "4.1.0",
+        "System.Linq": "4.1.0",
+        "System.Runtime": "4.1.0",
+        "System.Runtime.Extensions": "4.1.0",
+        "System.Resources.ResourceManager": "4.0.1"
       }
     }
   }

--- a/src/System.Json/tests/JsonValueTests.cs
+++ b/src/System.Json/tests/JsonValueTests.cs
@@ -1,0 +1,278 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Json;
+using System.Globalization;
+using System.Threading;
+using Xunit;
+
+namespace System.Json.Tests
+{
+    public class JsonValueTests
+    {
+        // Facts that a trailing comma is allowed in dictionary definitions
+        [Fact]
+        public void LoadWithTrailingComma()
+        {
+            var j = JsonValue.Load(new StringReader("{ \"a\": \"b\",}"));
+            Assert.Equal(1, j.Count);
+            Assert.Equal(JsonType.String, j["a"].JsonType);
+            Assert.Equal("b", (string)j["a"]);
+
+            JsonValue.Parse("[{ \"a\": \"b\",}]");
+        }
+
+        [Fact]
+        public void LoadWithTrailingComma2()
+        {
+            JsonValue.Parse("[{ \"a\": \"b\",}]");
+        }
+
+        // Fact that we correctly serialize JsonArray with null elements.
+        [Fact]
+        public void ToStringOnJsonArrayWithNulls()
+        {
+            var j = JsonValue.Load(new StringReader("[1,2,3,null]"));
+            Assert.Equal(4, j.Count);
+            Assert.Equal(JsonType.Array, j.JsonType);
+            var str = j.ToString();
+            Assert.Equal(str, "[1, 2, 3, null]");
+        }
+
+        // Fact that we correctly serialize JsonObject with null elements.
+        [Fact]
+        public void ToStringOnJsonObjectWithNulls()
+        {
+            var j = JsonValue.Load(new StringReader("{\"a\":null,\"b\":2}"));
+            Assert.Equal(2, j.Count);
+            Assert.Equal(JsonType.Object, j.JsonType);
+            var str = j.ToString();
+            Assert.Equal(str, "{\"a\": null, \"b\": 2}");
+        }
+
+        [Fact]
+        public void JsonObjectOrder()
+        {
+            var obj = new JsonObject();
+            obj["a"] = 1;
+            obj["c"] = 3;
+            obj["b"] = 2;
+            var str = obj.ToString();
+            Assert.Equal(str, "{\"a\": 1, \"b\": 2, \"c\": 3}");
+        }
+
+        [Fact]
+        public void QuoteEscapeBug_20869()
+        {
+            Assert.Equal((new JsonPrimitive("\"\"")).ToString(), "\"\\\"\\\"\"");
+        }
+
+        // Fact whether an exception is thrown for invalid JSON
+        [Fact]
+        public void CheckErrors()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"-"));
+            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"- "));
+            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"1."));
+            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"1. "));
+            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"1e+"));
+            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"1 2"));
+            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"077"));
+            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"[1,]"));
+        }
+
+        // Parse a json string and compare to the expected value
+        void CheckDouble(double expected, string json)
+        {
+            double jvalue = (double)JsonValue.Parse(json);
+            Assert.Equal(expected, jvalue);
+        }
+
+        // Convert a number to json and parse the string, then compare the result to the original value
+        void CheckDouble(double number)
+        {
+            double jvalue = (double)JsonValue.Parse(new JsonPrimitive(number).ToString());
+            Assert.Equal(number, jvalue); // should be exactly the same
+        }
+
+        [Fact]
+        public void CheckIntegers()
+        {
+            Assert.Equal(sbyte.MinValue, (sbyte)JsonValue.Parse(new JsonPrimitive(sbyte.MinValue).ToString()));
+            Assert.Equal(sbyte.MaxValue, (sbyte)JsonValue.Parse(new JsonPrimitive(sbyte.MaxValue).ToString()));
+            Assert.Equal(byte.MinValue, (byte)JsonValue.Parse(new JsonPrimitive(byte.MinValue).ToString()));
+            Assert.Equal(byte.MaxValue, (byte)JsonValue.Parse(new JsonPrimitive(byte.MaxValue).ToString()));
+
+            Assert.Equal(short.MinValue, (short)JsonValue.Parse(new JsonPrimitive(short.MinValue).ToString()));
+            Assert.Equal(short.MaxValue, (short)JsonValue.Parse(new JsonPrimitive(short.MaxValue).ToString()));
+            Assert.Equal(ushort.MinValue, (ushort)JsonValue.Parse(new JsonPrimitive(ushort.MinValue).ToString()));
+            Assert.Equal(ushort.MaxValue, (ushort)JsonValue.Parse(new JsonPrimitive(ushort.MaxValue).ToString()));
+
+            Assert.Equal(int.MinValue, (int)JsonValue.Parse(new JsonPrimitive(int.MinValue).ToString()));
+            Assert.Equal(int.MaxValue, (int)JsonValue.Parse(new JsonPrimitive(int.MaxValue).ToString()));
+            Assert.Equal(uint.MinValue, (uint)JsonValue.Parse(new JsonPrimitive(uint.MinValue).ToString()));
+            Assert.Equal(uint.MaxValue, (uint)JsonValue.Parse(new JsonPrimitive(uint.MaxValue).ToString()));
+
+            Assert.Equal(long.MinValue, (long)JsonValue.Parse(new JsonPrimitive(long.MinValue).ToString()));
+            Assert.Equal(long.MaxValue, (long)JsonValue.Parse(new JsonPrimitive(long.MaxValue).ToString()));
+            Assert.Equal(ulong.MinValue, (ulong)JsonValue.Parse(new JsonPrimitive(ulong.MinValue).ToString()));
+            Assert.Equal(ulong.MaxValue, (ulong)JsonValue.Parse(new JsonPrimitive(ulong.MaxValue).ToString()));
+        }
+
+        [Fact]
+        public void CheckNumbers()
+        {
+            CheckDouble(0, "0");
+            CheckDouble(0, "-0");
+            CheckDouble(0, "0.00");
+            CheckDouble(0, "-0.00");
+            CheckDouble(1, "1");
+            CheckDouble(1.1, "1.1");
+            CheckDouble(-1, "-1");
+            CheckDouble(-1.1, "-1.1");
+            CheckDouble(1e-10, "1e-10");
+            CheckDouble(1e+10, "1e+10");
+            CheckDouble(1e-30, "1e-30");
+            CheckDouble(1e+30, "1e+30");
+
+            CheckDouble(1, "\"1\"");
+            CheckDouble(1.1, "\"1.1\"");
+            CheckDouble(-1, "\"-1\"");
+            CheckDouble(-1.1, "\"-1.1\"");
+
+            CheckDouble(double.NaN, "\"NaN\"");
+            CheckDouble(double.PositiveInfinity, "\"Infinity\"");
+            CheckDouble(double.NegativeInfinity, "\"-Infinity\"");
+
+            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse("NaN"));
+            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse("Infinity"));
+            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse("-Infinity"));
+
+            Assert.Equal("1.1", new JsonPrimitive(1.1).ToString());
+            Assert.Equal("-1.1", new JsonPrimitive(-1.1).ToString());
+            Assert.Equal("1E-20", new JsonPrimitive(1e-20).ToString());
+            Assert.Equal("1E+20", new JsonPrimitive(1e+20).ToString());
+            Assert.Equal("1E-30", new JsonPrimitive(1e-30).ToString());
+            Assert.Equal("1E+30", new JsonPrimitive(1e+30).ToString());
+            Assert.Equal("\"NaN\"", new JsonPrimitive(double.NaN).ToString());
+            Assert.Equal("\"Infinity\"", new JsonPrimitive(double.PositiveInfinity).ToString());
+            Assert.Equal("\"-Infinity\"", new JsonPrimitive(double.NegativeInfinity).ToString());
+
+            Assert.Equal("1E-30", JsonValue.Parse("1e-30").ToString());
+            Assert.Equal("1E+30", JsonValue.Parse("1e+30").ToString());
+
+            CheckDouble(1);
+            CheckDouble(1.1);
+            CheckDouble(1.25);
+            CheckDouble(-1);
+            CheckDouble(-1.1);
+            CheckDouble(-1.25);
+            CheckDouble(1e-20);
+            CheckDouble(1e+20);
+            CheckDouble(1e-30);
+            CheckDouble(1e+30);
+            CheckDouble(3.1415926535897932384626433);
+            CheckDouble(3.1415926535897932384626433e-20);
+            CheckDouble(3.1415926535897932384626433e+20);
+            CheckDouble(double.NaN);
+            CheckDouble(double.PositiveInfinity);
+            CheckDouble(double.NegativeInfinity);
+            CheckDouble(double.MinValue);
+            CheckDouble(double.MaxValue);
+
+            // A number which needs 17 digits (see http://stackoverflow.com/questions/6118231/why-do-i-need-17-significant-digits-and-not-16-to-represent-a-double)
+            CheckDouble(18014398509481982.0);
+
+            // Values around the smallest positive decimal value
+            CheckDouble(1.123456789e-29);
+            CheckDouble(1.123456789e-28);
+
+            CheckDouble(1.1E-29, "0.000000000000000000000000000011");
+            // This is being parsed as a decimal and rounded to 1e-28, even though it can be more accurately be represented by a double
+            //CheckDouble (1.1E-28, "0.00000000000000000000000000011");
+        }
+
+        // Retry the Fact with different locales
+        [Fact]
+        public void CheckNumbersCulture()
+        {
+            CultureInfo old = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("en");
+                CheckNumbers();
+                CultureInfo.CurrentCulture = new CultureInfo("fr");
+                CheckNumbers();
+                CultureInfo.CurrentCulture = new CultureInfo("de");
+                CheckNumbers();
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = old;
+            }
+        }
+
+        // Convert a string to json and parse the string, then compare the result to the original value
+        void CheckString(string str)
+        {
+            var json = new JsonPrimitive(str).ToString();
+            // Check whether the string is valid Unicode (will throw for broken surrogate pairs)
+            new UTF8Encoding(false, true).GetBytes(json);
+            string jvalue = (string)JsonValue.Parse(json);
+            Assert.Equal(str, jvalue);
+        }
+
+        // String handling: http://tools.ietf.org/html/rfc7159#section-7
+        [Fact]
+        public void CheckStrings()
+        {
+            Assert.Equal("\"Fact\"", new JsonPrimitive("Fact").ToString());
+            // Handling of characters
+            Assert.Equal("\"f\"", new JsonPrimitive('f').ToString());
+            Assert.Equal('f', (char)JsonValue.Parse("\"f\""));
+
+            // Control characters with special escape sequence
+            Assert.Equal("\"\\b\\f\\n\\r\\t\"", new JsonPrimitive("\b\f\n\r\t").ToString());
+            // Other characters which must be escaped
+            Assert.Equal(@"""\""\\""", new JsonPrimitive("\"\\").ToString());
+            // Control characters without special escape sequence
+            for (int i = 0; i < 32; i++)
+                if (i != '\b' && i != '\f' && i != '\n' && i != '\r' && i != '\t')
+                    Assert.Equal("\"\\u" + i.ToString("x04") + "\"", new JsonPrimitive("" + (char)i).ToString());
+
+            // JSON does not require U+2028 and U+2029 to be escaped, but
+            // JavaScript does require this:
+            // http://stackoverflow.com/questions/2965293/javascript-parse-error-on-u2028-unicode-character/9168133#9168133
+            Assert.Equal("\"\\u2028\\u2029\"", new JsonPrimitive("\u2028\u2029").ToString());
+
+            // '/' also does not have to be escaped, but escaping it when
+            // preceeded by a '<' avoids problems with JSON in HTML <script> tags
+            Assert.Equal("\"<\\/\"", new JsonPrimitive("</").ToString());
+            // Don't escape '/' in other cases as this makes the JSON hard to read
+            Assert.Equal("\"/bar\"", new JsonPrimitive("/bar").ToString());
+            Assert.Equal("\"foo/bar\"", new JsonPrimitive("foo/bar").ToString());
+
+            CheckString("Fact\b\f\n\r\t\"\\/</\0x");
+            for (int i = 0; i < 65536; i++)
+                CheckString("x" + ((char)i));
+
+            // Check broken surrogate pairs
+            CheckString("\ud800");
+            CheckString("x\ud800");
+            CheckString("\udfff\ud800");
+            CheckString("\ude03\ud912");
+            CheckString("\uc000\ubfff");
+            CheckString("\udfffx");
+            // Valid strings should not be escaped:
+            Assert.Equal("\"\ud7ff\"", new JsonPrimitive("\ud7ff").ToString());
+            Assert.Equal("\"\ue000\"", new JsonPrimitive("\ue000").ToString());
+            Assert.Equal("\"\ud800\udc00\"", new JsonPrimitive("\ud800\udc00").ToString());
+            Assert.Equal("\"\ud912\ude03\"", new JsonPrimitive("\ud912\ude03").ToString());
+            Assert.Equal("\"\udbff\udfff\"", new JsonPrimitive("\udbff\udfff").ToString());
+        }
+    }
+}

--- a/src/System.Json/tests/JsonValueTests.cs
+++ b/src/System.Json/tests/JsonValueTests.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 using System.Text;
-using System.Json;
 using System.Globalization;
-using System.Threading;
 using Xunit;
 
 namespace System.Json.Tests
@@ -16,233 +13,246 @@ namespace System.Json.Tests
     {
         // Facts that a trailing comma is allowed in dictionary definitions
         [Fact]
-        public void LoadWithTrailingComma()
+        public void JsonValue_Load_LoadWithTrailingComma()
         {
-            var j = JsonValue.Load(new StringReader("{ \"a\": \"b\",}"));
+            JsonValue j = JsonValue.Load(new StringReader("{ \"a\": \"b\",}"));
             Assert.Equal(1, j.Count);
             Assert.Equal(JsonType.String, j["a"].JsonType);
-            Assert.Equal("b", (string)j["a"]);
+            Assert.Equal("b", j["a"]);
 
-            JsonValue.Parse("[{ \"a\": \"b\",}]");
-        }
-
-        [Fact]
-        public void LoadWithTrailingComma2()
-        {
             JsonValue.Parse("[{ \"a\": \"b\",}]");
         }
 
         // Fact that we correctly serialize JsonArray with null elements.
         [Fact]
-        public void ToStringOnJsonArrayWithNulls()
+        public void JsonValue_Load_ToString_JsonArrayWithNulls()
         {
-            var j = JsonValue.Load(new StringReader("[1,2,3,null]"));
+            JsonValue j = JsonValue.Load(new StringReader("[1,2,3,null]"));
             Assert.Equal(4, j.Count);
             Assert.Equal(JsonType.Array, j.JsonType);
-            var str = j.ToString();
-            Assert.Equal(str, "[1, 2, 3, null]");
+            Assert.Equal("[1, 2, 3, null]", j.ToString());
         }
 
         // Fact that we correctly serialize JsonObject with null elements.
         [Fact]
-        public void ToStringOnJsonObjectWithNulls()
+        public void JsonValue_ToString_JsonObjectWithNulls()
         {
-            var j = JsonValue.Load(new StringReader("{\"a\":null,\"b\":2}"));
+            JsonValue j = JsonValue.Load(new StringReader("{\"a\":null,\"b\":2}"));
             Assert.Equal(2, j.Count);
             Assert.Equal(JsonType.Object, j.JsonType);
-            var str = j.ToString();
-            Assert.Equal(str, "{\"a\": null, \"b\": 2}");
+            Assert.Equal("{\"a\": null, \"b\": 2}", j.ToString());
         }
 
         [Fact]
-        public void JsonObjectOrder()
+        public void JsonObject_ToString_OrderingMaintained()
         {
             var obj = new JsonObject();
             obj["a"] = 1;
             obj["c"] = 3;
             obj["b"] = 2;
-            var str = obj.ToString();
-            Assert.Equal(str, "{\"a\": 1, \"b\": 2, \"c\": 3}");
+            Assert.Equal("{\"a\": 1, \"b\": 2, \"c\": 3}", obj.ToString());
         }
 
         [Fact]
-        public void QuoteEscapeBug_20869()
+        public void JsonPrimitive_QuoteEscape()
         {
             Assert.Equal((new JsonPrimitive("\"\"")).ToString(), "\"\\\"\\\"\"");
         }
 
         // Fact whether an exception is thrown for invalid JSON
-        [Fact]
-        public void CheckErrors()
+        [Theory]
+        [InlineData("-")]
+        [InlineData("- ")]
+        [InlineData("1.")]
+        [InlineData("1. ")]
+        [InlineData("1e+")]
+        [InlineData("1 2")]
+        [InlineData("077")]
+        [InlineData("[1,]")]
+        [InlineData("NaN")]
+        [InlineData("Infinity")]
+        [InlineData("-Infinity")]
+        public void JsonValue_Parse_InvalidInput_ThrowsArgumentException(string value)
         {
-            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"-"));
-            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"- "));
-            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"1."));
-            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"1. "));
-            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"1e+"));
-            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"1 2"));
-            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"077"));
-            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse(@"[1,]"));
+            Assert.Throws<ArgumentException>(() => JsonValue.Parse(value));
         }
 
         // Parse a json string and compare to the expected value
-        private void CheckDouble(double expected, string json)
+        [Theory]
+        [InlineData(0, "0")]
+        [InlineData(0, "-0")]
+        [InlineData(0, "0.00")]
+        [InlineData(0, "-0.00")]
+        [InlineData(1, "1")]
+        [InlineData(1.1, "1.1")]
+        [InlineData(-1, "-1")]
+        [InlineData(-1.1, "-1.1")]
+        [InlineData(1e-10, "1e-10")]
+        [InlineData(1e+10, "1e+10")]
+        [InlineData(1e-30, "1e-30")]
+        [InlineData(1e+30, "1e+30")]
+        [InlineData(1, "\"1\"")]
+        [InlineData(1.1, "\"1.1\"")]
+        [InlineData(-1, "\"-1\"")]
+        [InlineData(-1.1, "\"-1.1\"")]
+        [InlineData(double.NaN, "\"NaN\"")]
+        [InlineData(double.PositiveInfinity, "\"Infinity\"")]
+        [InlineData(double.NegativeInfinity, "\"-Infinity\"")]
+        [InlineData(1.1E-29, "0.000000000000000000000000000011")]
+        public void JsonValue_Parse_Double(double expected, string json)
         {
-            double jvalue = (double)JsonValue.Parse(json);
-            Assert.Equal(expected, jvalue);
+            foreach (string culture in new[] { "en", "fr", "de" })
+            {
+                CultureInfo old = CultureInfo.CurrentCulture;
+                try
+                {
+                    CultureInfo.CurrentCulture = new CultureInfo(culture);
+                    Assert.Equal(expected, (double)JsonValue.Parse(json));
+                }
+                finally
+                {
+                    CultureInfo.CurrentCulture = old;
+                }
+            }
         }
 
         // Convert a number to json and parse the string, then compare the result to the original value
-        private void CheckDouble(double number)
+        [Theory]
+        [InlineData(1)]
+        [InlineData(1.1)]
+        [InlineData(1.25)]
+        [InlineData(-1)]
+        [InlineData(-1.1)]
+        [InlineData(-1.25)]
+        [InlineData(1e-20)]
+        [InlineData(1e+20)]
+        [InlineData(1e-30)]
+        [InlineData(1e+30)]
+        [InlineData(3.1415926535897932384626433)]
+        [InlineData(3.1415926535897932384626433e-20)]
+        [InlineData(3.1415926535897932384626433e+20)]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity)]
+        [InlineData(double.MinValue)]
+        [InlineData(double.MaxValue)]
+        [InlineData(18014398509481982.0)] // A number which needs 17 digits (see http://stackoverflow.com/questions/6118231/why-do-i-need-17-significant-digits-and-not-16-to-represent-a-double)
+        [InlineData(1.123456789e-29)]
+        [InlineData(1.123456789e-28)] // Values around the smallest positive decimal value
+        public void JsonValue_Parse_Double_ViaJsonPrimitive(double number)
         {
-            double jvalue = (double)JsonValue.Parse(new JsonPrimitive(number).ToString());
-            Assert.Equal(number, jvalue); // should be exactly the same
+            foreach (string culture in new[] { "en", "fr", "de" })
+            {
+                CultureInfo old = CultureInfo.CurrentCulture;
+                try
+                {
+                    CultureInfo.CurrentCulture = new CultureInfo(culture);
+                    Assert.Equal(number, (double)JsonValue.Parse(new JsonPrimitive(number).ToString()));
+                }
+                finally
+                {
+                    CultureInfo.CurrentCulture = old;
+                }
+            }
         }
 
         [Fact]
-        public void CheckIntegers()
+        public void JsonValue_Parse_MinMax_Integers_ViaJsonPrimitive()
         {
             Assert.Equal(sbyte.MinValue, (sbyte)JsonValue.Parse(new JsonPrimitive(sbyte.MinValue).ToString()));
             Assert.Equal(sbyte.MaxValue, (sbyte)JsonValue.Parse(new JsonPrimitive(sbyte.MaxValue).ToString()));
+
             Assert.Equal(byte.MinValue, (byte)JsonValue.Parse(new JsonPrimitive(byte.MinValue).ToString()));
             Assert.Equal(byte.MaxValue, (byte)JsonValue.Parse(new JsonPrimitive(byte.MaxValue).ToString()));
 
             Assert.Equal(short.MinValue, (short)JsonValue.Parse(new JsonPrimitive(short.MinValue).ToString()));
             Assert.Equal(short.MaxValue, (short)JsonValue.Parse(new JsonPrimitive(short.MaxValue).ToString()));
+
             Assert.Equal(ushort.MinValue, (ushort)JsonValue.Parse(new JsonPrimitive(ushort.MinValue).ToString()));
             Assert.Equal(ushort.MaxValue, (ushort)JsonValue.Parse(new JsonPrimitive(ushort.MaxValue).ToString()));
 
             Assert.Equal(int.MinValue, (int)JsonValue.Parse(new JsonPrimitive(int.MinValue).ToString()));
             Assert.Equal(int.MaxValue, (int)JsonValue.Parse(new JsonPrimitive(int.MaxValue).ToString()));
+
             Assert.Equal(uint.MinValue, (uint)JsonValue.Parse(new JsonPrimitive(uint.MinValue).ToString()));
             Assert.Equal(uint.MaxValue, (uint)JsonValue.Parse(new JsonPrimitive(uint.MaxValue).ToString()));
 
             Assert.Equal(long.MinValue, (long)JsonValue.Parse(new JsonPrimitive(long.MinValue).ToString()));
             Assert.Equal(long.MaxValue, (long)JsonValue.Parse(new JsonPrimitive(long.MaxValue).ToString()));
+
             Assert.Equal(ulong.MinValue, (ulong)JsonValue.Parse(new JsonPrimitive(ulong.MinValue).ToString()));
             Assert.Equal(ulong.MaxValue, (ulong)JsonValue.Parse(new JsonPrimitive(ulong.MaxValue).ToString()));
         }
 
         [Fact]
-        public void CheckNumbers()
+        public void JsonPrimitive_ToString()
         {
-            CheckDouble(0, "0");
-            CheckDouble(0, "-0");
-            CheckDouble(0, "0.00");
-            CheckDouble(0, "-0.00");
-            CheckDouble(1, "1");
-            CheckDouble(1.1, "1.1");
-            CheckDouble(-1, "-1");
-            CheckDouble(-1.1, "-1.1");
-            CheckDouble(1e-10, "1e-10");
-            CheckDouble(1e+10, "1e+10");
-            CheckDouble(1e-30, "1e-30");
-            CheckDouble(1e+30, "1e+30");
-
-            CheckDouble(1, "\"1\"");
-            CheckDouble(1.1, "\"1.1\"");
-            CheckDouble(-1, "\"-1\"");
-            CheckDouble(-1.1, "\"-1.1\"");
-
-            CheckDouble(double.NaN, "\"NaN\"");
-            CheckDouble(double.PositiveInfinity, "\"Infinity\"");
-            CheckDouble(double.NegativeInfinity, "\"-Infinity\"");
-
-            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse("NaN"));
-            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse("Infinity"));
-            Assert.ThrowsAny<ArgumentException>(() => JsonValue.Parse("-Infinity"));
-
             Assert.Equal("1.1", new JsonPrimitive(1.1).ToString());
             Assert.Equal("-1.1", new JsonPrimitive(-1.1).ToString());
             Assert.Equal("1E-20", new JsonPrimitive(1e-20).ToString());
             Assert.Equal("1E+20", new JsonPrimitive(1e+20).ToString());
             Assert.Equal("1E-30", new JsonPrimitive(1e-30).ToString());
             Assert.Equal("1E+30", new JsonPrimitive(1e+30).ToString());
+
             Assert.Equal("\"NaN\"", new JsonPrimitive(double.NaN).ToString());
             Assert.Equal("\"Infinity\"", new JsonPrimitive(double.PositiveInfinity).ToString());
             Assert.Equal("\"-Infinity\"", new JsonPrimitive(double.NegativeInfinity).ToString());
 
             Assert.Equal("1E-30", JsonValue.Parse("1e-30").ToString());
             Assert.Equal("1E+30", JsonValue.Parse("1e+30").ToString());
-
-            CheckDouble(1);
-            CheckDouble(1.1);
-            CheckDouble(1.25);
-            CheckDouble(-1);
-            CheckDouble(-1.1);
-            CheckDouble(-1.25);
-            CheckDouble(1e-20);
-            CheckDouble(1e+20);
-            CheckDouble(1e-30);
-            CheckDouble(1e+30);
-            CheckDouble(3.1415926535897932384626433);
-            CheckDouble(3.1415926535897932384626433e-20);
-            CheckDouble(3.1415926535897932384626433e+20);
-            CheckDouble(double.NaN);
-            CheckDouble(double.PositiveInfinity);
-            CheckDouble(double.NegativeInfinity);
-            CheckDouble(double.MinValue);
-            CheckDouble(double.MaxValue);
-
-            // A number which needs 17 digits (see http://stackoverflow.com/questions/6118231/why-do-i-need-17-significant-digits-and-not-16-to-represent-a-double)
-            CheckDouble(18014398509481982.0);
-
-            // Values around the smallest positive decimal value
-            CheckDouble(1.123456789e-29);
-            CheckDouble(1.123456789e-28);
-
-            CheckDouble(1.1E-29, "0.000000000000000000000000000011");
-            // This is being parsed as a decimal and rounded to 1e-28, even though it can be more accurately be represented by a double
-            //CheckDouble (1.1E-28, "0.00000000000000000000000000011");
-        }
-
-        // Retry the Fact with different locales
-        [Fact]
-        public void CheckNumbersCulture()
-        {
-            CultureInfo old = CultureInfo.CurrentCulture;
-            try
-            {
-                CultureInfo.CurrentCulture = new CultureInfo("en");
-                CheckNumbers();
-                CultureInfo.CurrentCulture = new CultureInfo("fr");
-                CheckNumbers();
-                CultureInfo.CurrentCulture = new CultureInfo("de");
-                CheckNumbers();
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = old;
-            }
         }
 
         // Convert a string to json and parse the string, then compare the result to the original value
-        private void CheckString(string str)
+        [Theory]
+        [InlineData("Fact\b\f\n\r\t\"\\/</\0x")]
+        [InlineData("\ud800")]
+        [InlineData("x\ud800")]
+        [InlineData("\udfff\ud800")]
+        [InlineData("\ude03\ud912")]
+        [InlineData("\uc000\ubfff")]
+        [InlineData("\udfffx")]
+        public void JsonPrimitive_Roundtrip_ValidUnicode(string str)
         {
-            var json = new JsonPrimitive(str).ToString();
-            // Check whether the string is valid Unicode (will throw for broken surrogate pairs)
+            string json = new JsonPrimitive(str).ToString();
+
             new UTF8Encoding(false, true).GetBytes(json);
-            string jvalue = (string)JsonValue.Parse(json);
-            Assert.Equal(str, jvalue);
+
+            Assert.Equal(str, JsonValue.Parse(json));
+        }
+
+        [Fact]
+        public void JsonPrimitive_Roundtrip_ValidUnicode_AllChars()
+        {
+            for (int i = 0; i <= char.MaxValue; i++)
+            {
+                JsonPrimitive_Roundtrip_ValidUnicode("x" + (char)i);
+            }
         }
 
         // String handling: http://tools.ietf.org/html/rfc7159#section-7
         [Fact]
-        public void CheckStrings()
+        public void JsonPrimitive_StringHandling()
         {
             Assert.Equal("\"Fact\"", new JsonPrimitive("Fact").ToString());
+            
             // Handling of characters
             Assert.Equal("\"f\"", new JsonPrimitive('f').ToString());
             Assert.Equal('f', (char)JsonValue.Parse("\"f\""));
 
             // Control characters with special escape sequence
             Assert.Equal("\"\\b\\f\\n\\r\\t\"", new JsonPrimitive("\b\f\n\r\t").ToString());
+            
             // Other characters which must be escaped
             Assert.Equal(@"""\""\\""", new JsonPrimitive("\"\\").ToString());
+
             // Control characters without special escape sequence
             for (int i = 0; i < 32; i++)
+            {
                 if (i != '\b' && i != '\f' && i != '\n' && i != '\r' && i != '\t')
+                {
                     Assert.Equal("\"\\u" + i.ToString("x04") + "\"", new JsonPrimitive("" + (char)i).ToString());
+                }
+            }
 
             // JSON does not require U+2028 and U+2029 to be escaped, but
             // JavaScript does require this:
@@ -252,21 +262,11 @@ namespace System.Json.Tests
             // '/' also does not have to be escaped, but escaping it when
             // preceeded by a '<' avoids problems with JSON in HTML <script> tags
             Assert.Equal("\"<\\/\"", new JsonPrimitive("</").ToString());
+
             // Don't escape '/' in other cases as this makes the JSON hard to read
             Assert.Equal("\"/bar\"", new JsonPrimitive("/bar").ToString());
             Assert.Equal("\"foo/bar\"", new JsonPrimitive("foo/bar").ToString());
 
-            CheckString("Fact\b\f\n\r\t\"\\/</\0x");
-            for (int i = 0; i < 65536; i++)
-                CheckString("x" + ((char)i));
-
-            // Check broken surrogate pairs
-            CheckString("\ud800");
-            CheckString("x\ud800");
-            CheckString("\udfff\ud800");
-            CheckString("\ude03\ud912");
-            CheckString("\uc000\ubfff");
-            CheckString("\udfffx");
             // Valid strings should not be escaped:
             Assert.Equal("\"\ud7ff\"", new JsonPrimitive("\ud7ff").ToString());
             Assert.Equal("\"\ue000\"", new JsonPrimitive("\ue000").ToString());

--- a/src/System.Json/tests/JsonValueTests.cs
+++ b/src/System.Json/tests/JsonValueTests.cs
@@ -86,14 +86,14 @@ namespace System.Json.Tests
         }
 
         // Parse a json string and compare to the expected value
-        void CheckDouble(double expected, string json)
+        private void CheckDouble(double expected, string json)
         {
             double jvalue = (double)JsonValue.Parse(json);
             Assert.Equal(expected, jvalue);
         }
 
         // Convert a number to json and parse the string, then compare the result to the original value
-        void CheckDouble(double number)
+        private void CheckDouble(double number)
         {
             double jvalue = (double)JsonValue.Parse(new JsonPrimitive(number).ToString());
             Assert.Equal(number, jvalue); // should be exactly the same
@@ -217,7 +217,7 @@ namespace System.Json.Tests
         }
 
         // Convert a string to json and parse the string, then compare the result to the original value
-        void CheckString(string str)
+        private void CheckString(string str)
         {
             var json = new JsonPrimitive(str).ToString();
             // Check whether the string is valid Unicode (will throw for broken surrogate pairs)

--- a/src/System.Json/tests/System.Json.Tests.builds
+++ b/src/System.Json/tests/System.Json.Tests.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Json.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Json/tests/System.Json.Tests.csproj
+++ b/src/System.Json/tests/System.Json.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>System.Security.SecureString.Tests</RootNamespace>
+    <AssemblyName>System.Security.SecureString.Tests</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <Compile Include="JsonValueTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\pkg\System.Json.pkgproj">
+      <Project>{A958BBDD-3238-4E58-AB7F-390AB6D88233}</Project>
+      <Name>System.Json</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Json/tests/System.Json.Tests.csproj
+++ b/src/System.Json/tests/System.Json.Tests.csproj
@@ -9,8 +9,8 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>System.Security.SecureString.Tests</RootNamespace>
-    <AssemblyName>System.Security.SecureString.Tests</AssemblyName>
+    <RootNamespace>System.Json.Tests</RootNamespace>
+    <AssemblyName>System.Json.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Json/tests/project.json
+++ b/src/System.Json/tests/project.json
@@ -1,0 +1,40 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.2-beta-24222-03",
+    "System.Collections": "4.0.12-beta-24222-03",
+    "System.Console": "4.0.1-beta-24222-03",
+    "System.Diagnostics.Debug": "4.0.12-beta-24222-03",
+    "System.IO": "4.1.1-beta-24222-03",
+    "System.IO.Compression.TestData": "1.0.2-prerelease",
+    "System.IO.FileSystem": "4.0.2-beta-24222-03",
+    "System.Linq": "4.1.1-beta-24222-03",
+    "System.Linq.Expressions": "4.1.1-beta-24222-03",
+    "System.ObjectModel": "4.0.13-beta-24222-03",
+    "System.Runtime": "4.1.1-beta-24222-03",
+    "System.Runtime.Extensions": "4.1.1-beta-24222-03",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.1-beta-24222-03",
+    "System.Security.Cryptography.Algorithms": "4.2.1-beta-24222-03",
+    "System.Text.Encoding": "4.0.12-beta-24222-03",
+    "System.Text.Encoding.Extensions": "4.0.12-beta-24222-03",
+    "System.Text.RegularExpressions": "4.2.0-beta-24222-03",
+    "System.Threading.Tasks": "4.0.12-beta-24222-03",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
+  },
+  "frameworks": {
+    "netstandard1.3": {}
+  },
+  "supports": {
+    "coreFx.Test.netcore50": {},
+    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.net46": {},
+    "coreFx.Test.net461": {},
+    "coreFx.Test.net462": {},
+    "coreFx.Test.net463": {}
+  }
+}


### PR DESCRIPTION
System.Json.dll is part of Silverlight and doesn't ship in the .NET Framework, nor do we encourage its usage.  But, it's available and used with Mono, and in order to enable compatibility between Mono and .NET Core, we're adding it as an available assembly.

This PR ports the Mono implementation over to corefx.  This includes porting the tests, adding packaging, cleaning up the source, etc.  I've not done any performance work, increased code coverage of the tests, etc.  This is mainly about making the APIs available.  We can tweak is subsequently as is necessary.

cc: @danmosemsft, @KrzysztofCwalina, @ericstj, @ianhays 