### PR TITLE
Fix undefined ENODATA on FreeBSD.

### DIFF
--- a/src/Native/System.Native/pal_errno.cpp
+++ b/src/Native/System.Native/pal_errno.cpp
@@ -7,6 +7,12 @@
 #include "pal_utilities.h"
 
 #include <errno.h>
+
+// ENODATA is not defined on FreeBSD.
+#if defined(__FreeBSD__)
+#define ENODATA ENOATTR
+#endif
+
 #include <string.h>
 #include <assert.h>
 


### PR DESCRIPTION
When trying to build the native components on FreeBSD, the build fails, because ENODATA is not defined. 

````
$ ./build.sh native clang3.7
...
*** [System.Net.Security.Native/CMakeFiles/System.Net.Security.Native.dir/all] Error code 2

make[1]: stopped in /home/jostein/build/corefx/bin/obj/FreeBSD.x64.Debug/Native
/home/jostein/build/corefx/src/Native/System.Native/pal_errno.cpp:177:14: error: use of undeclared identifier 'ENODATA'
        case ENODATA:
             ^
/home/jostein/build/corefx/src/Native/System.Native/pal_errno.cpp:356:20: error: use of undeclared identifier 'ENODATA'
            return ENODATA;
                   ^
2 errors generated.
````

This is not due to a missing header-file, but because FreeBSD does not implement it.

[Discussions on the internet](http://freebsd.1045724.n5.nabble.com/Mising-ENODATA-td6084620.html) seems to agree that cases where Linux uses `ENODATA` are equivalent to where FreeBSD uses `ENOATTR`. In fact, on CentOS, `ENODATA` is directly defined as `ENOATTR`.

This PR does the same, but only as long as the build is run on FreeBSD.

This PR partially addresses issues reported in https://github.com/dotnet/coreclr/issues/6115.