### PR TITLE
Added support for EnvelopedCms.Encrypt on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Cms.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Cms.cs
@@ -89,5 +89,26 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsDecrypt")]
         internal static extern int CmsDecrypt(SafeCmsHandle cms, SafeX509Handle recipientCert, SafeEvpPKeyHandle pKeyKandle, SafeBioHandle decryptedBuffered);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsGetDerSize")]
+        internal static extern int CmsGetDerSize(SafeCmsHandle cms);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsEncode")]
+        internal static extern int CmsEncode(SafeCmsHandle cms, byte[] buffer);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsInitializeEnvelope")]
+        internal static extern SafeCmsHandle CmsInitializeEnvelope(SafeAsn1ObjectHandle algoOid, out int status);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsAddSkidRecipient")]
+        internal static extern int CmsAddSkidRecipient(SafeCmsHandle cms, SafeX509Handle skidCert);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsAddIssuerAndSerialRecipient")]
+        internal static extern int CmsAddIssuerAndSerialRecipient(SafeCmsHandle cms, SafeX509Handle issuerAndSerialCert);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsCompleteMessage")]
+        internal static extern int CmsCompleteMessage(SafeCmsHandle cms, SafeBioHandle data, bool detached);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsAddOriginatorCert")]
+        internal static extern int CmsAddOriginatorCert(SafeCmsHandle cms, SafeX509Handle originatorCert);
     }
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_cms.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_cms.h
@@ -61,3 +61,55 @@ extern "C" int CryptoNative_CmsGetRecipientStackFieldCount(CmsRecipientStack* re
 Shims the CMS_RecipientInfo_free method
 */
 extern "C" void CryptoNative_CmsRecipientDestroy(CMS_RecipientInfo* recipient);
+
+/*
+Initializes a CMS_ContentInfo of type EnvelopedData with the cipher given by the oid in algorithmOid
+and returns a pointer to it. 
+
+Status is set to 1 on success, 0 on unsupported algorithm, and -1 on invalid input.
+*/
+extern "C" CMS_ContentInfo* CryptoNative_CmsInitializeEnvelope(ASN1_OBJECT* algorithmOid, int32_t* status);
+
+/*
+Adds an originator certificate to the CMS_ContentInfo structure. If the CMS_ContentInfo structure
+is of type EnvelopedData it will be added to OriginatorInfo, and for SignedData it will be added to
+the certificates.
+
+Returns 1 on success, 0 on OpenSSL failure, and -1 on invalid input.
+*/
+extern "C" int CryptoNative_CmsAddOriginatorCert(CMS_ContentInfo* cms, X509* cert);
+
+/*
+Creates a KeyTransportRecipientInfo using the IssuerAndSerial identification method for
+the provided certificate and adds it to the CMS_ContentInfo structure.
+
+Returns 1 on success, 0 on OpenSSL failure, and -1 on invalid input.
+*/
+extern "C" int CryptoNative_CmsAddIssuerAndSerialRecipient(CMS_ContentInfo* cms, X509* cert);
+
+/*
+Creates a KeyTransportRecipientInfo using the SubjectKeyIdentifier identification method for
+the provided certificate and adds it to the CMS_ContentInfo structure.
+
+Returns 1 on success, 0 on OpenSSL failure, and -1 on invalid input.
+*/
+extern "C" int CryptoNative_CmsAddSkidRecipient(CMS_ContentInfo* cms, X509* cert);
+
+/*
+Finalizes the message after all the recipients and certificates have been added. If detached is
+set to true, in the case of a CMS_ContentInfo of signed type, the signature will remain detached,
+in case of an enveloped type, the encrypted content will be detached.
+
+Returns 1 on success, 0 on OpenSSL failure, and -1 on invalid input.
+*/
+extern "C" int CryptoNative_CmsCompleteMessage(CMS_ContentInfo* cms, BIO* data, bool detached);
+
+/*
+Gets the byte length of the CMS_ContentInfo to encode.
+*/
+extern "C" int CryptoNative_CmsGetDerSize(CMS_ContentInfo* cms);
+
+/*
+Shims the i2d_CMS_ContentInfo method.
+*/
+extern "C" int CryptoNative_CmsEncode(CMS_ContentInfo* cms, uint8_t* buf);

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/PkcsPalOpenSsl.Encrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/PkcsPalOpenSsl.Encrypt.cs
@@ -1,0 +1,128 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+
+using Microsoft.Win32.SafeHandles;
+
+namespace Internal.Cryptography.Pal.OpenSsl
+{
+    internal sealed partial class PkcsPalOpenSsl : PkcsPal
+    {
+        public sealed override byte[] Encrypt(
+            CmsRecipientCollection recipients,
+            ContentInfo contentInfo,
+            AlgorithmIdentifier contentEncryptionAlgorithm,
+            X509Certificate2Collection originatorCerts,
+            CryptographicAttributeObjectCollection unprotectedAttributes)
+        {
+            int status;
+
+            using (SafeBioHandle contentBio = Interop.Crypto.CreateMemoryBio())
+            using (SafeAsn1ObjectHandle algoOid = Interop.Crypto.ObjTxt2Obj(contentEncryptionAlgorithm.Oid.Value))
+            {
+                Interop.Crypto.CheckValidOpenSslHandle(algoOid);
+                Interop.Crypto.CheckValidOpenSslHandle(contentBio);
+
+                using (SafeCmsHandle cms = Interop.Crypto.CmsInitializeEnvelope(algoOid, out status))
+                {
+                    if (status == 0)
+                        throw new CryptographicException(SR.Cryptography_Cms_UnknownAlgorithm);
+
+                    Interop.Crypto.CheckValidOpenSslHandle(cms);
+
+                    ClassifyAndAddRecipients(cms, recipients);
+
+                    foreach (X509Certificate2 cert in originatorCerts)
+                    {
+                        using (SafeX509Handle certHandle = Interop.Crypto.X509Duplicate(cert.Handle))
+                        {
+                            Interop.Crypto.CheckValidOpenSslHandle(certHandle);
+                            status = Interop.Crypto.CmsAddOriginatorCert(cms, certHandle);
+                            CheckStatus(status);
+                        }
+                    }
+                        
+                    Interop.Crypto.BioWrite(contentBio, contentInfo.Content, contentInfo.Content.Length);
+                    status = Interop.Crypto.CmsCompleteMessage(cms, contentBio, false);
+                    CheckStatus(status);
+
+                    byte[] encryptedMessage = Interop.Crypto.OpenSslEncode(
+                        handle => Interop.Crypto.CmsGetDerSize(handle),
+                        (handle, buf) => Interop.Crypto.CmsEncode(handle, buf),
+                        cms);
+
+                    // TODO(3334): Add support for unprotected attributes here.
+
+                    return encryptedMessage;
+                }
+            }
+        }
+
+        private void CheckStatus(int status)
+        {
+            switch(status)
+            {
+                case -1:
+                    // We should never reach this state. It checks for null inputs given to shim functions, but as we
+                    // always call CheckValidOpenSslHandle on a handle before using it there should never be such problem.
+                    System.Diagnostics.Debug.Fail("Call to the shim recieved unexpected invalid input.");
+                    throw new ArgumentNullException();
+
+                case 0:
+                    throw Interop.Crypto.CreateOpenSslCryptographicException();
+
+                case 1:
+                    // This is the expected state.
+                    return;
+            }
+            System.Diagnostics.Debug.Fail($"Unexpected status from shim ({status})");
+        }
+
+        private void ClassifyAndAddRecipients(SafeCmsHandle cms, CmsRecipientCollection recipients)
+        {
+            int status;
+
+            foreach (CmsRecipient recipient in recipients)
+            {
+                // This shouldn't happen as the CmsRecipient constructor throws an exception when a null recipient is passed,
+                // but for desktop compat in case someone manages to change the certificate, this is the exception Framework throws.
+                if (recipient.Certificate == null)
+                    throw new ArgumentNullException(SR.Cryptography_Cms_RecipientCertificate_Not_Found);
+
+                // We cannot encrypt KeyAgreement now as there is no native support for it in OpenSSL and it would require manual parsing
+                // of the data, so we have to make sure it's KeyTransport.
+                if (recipient.Certificate.GetKeyAlgorithm() != Oids.Rsa)
+                    throw new PlatformNotSupportedException(SR.Cryptography_Cms_KeyAgreementPlatformNotSupported);
+
+                using (SafeX509Handle certHandle = Interop.Crypto.X509Duplicate(recipient.Certificate.Handle))
+                {
+                    Interop.Crypto.CheckValidOpenSslHandle(certHandle);
+
+                    switch (recipient.RecipientIdentifierType)
+                    {
+                        case SubjectIdentifierType.SubjectKeyIdentifier:
+                            status = Interop.Crypto.CmsAddSkidRecipient(cms, certHandle);
+                            CheckStatus(status);
+                            break;
+
+                        case SubjectIdentifierType.Unknown:
+                        // For desktop compat, this needs to fall back to IssuerAndSerialNumber
+                        case SubjectIdentifierType.IssuerAndSerialNumber:
+                            status = Interop.Crypto.CmsAddIssuerAndSerialRecipient(cms, certHandle);
+                            CheckStatus(status);
+                            break;
+
+                        default:
+                            throw new CryptographicException(
+                                SR.Format(SR.Cryptography_Cms_Invalid_Subject_Identifier_Type, recipient.RecipientIdentifierType));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/PkcsPalOpenSsl.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/PkcsPalOpenSsl.cs
@@ -13,17 +13,6 @@ namespace Internal.Cryptography.Pal.OpenSsl
 {
     internal sealed partial class PkcsPalOpenSsl : PkcsPal
     {
-        public sealed override byte[] Encrypt(
-            CmsRecipientCollection recipients,
-            ContentInfo contentInfo,
-            AlgorithmIdentifier contentEncryptionAlgorithm,
-            X509Certificate2Collection originatorCerts,
-            CryptographicAttributeObjectCollection unprotectedAttributes)
-        {
-            // TODO(3334): see CMS_ContentInfo *CMS_encrypt(...) in cms.h
-            throw new NotImplementedException();
-        }
-
         public sealed override DecryptorPal Decode(byte[] encodedMessage,
             out int version,
             out ContentInfo contentInfo,

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -144,6 +144,9 @@
   <data name="Cryptography_Cms_Invalid_Subject_Identifier_Type" xml:space="preserve">
     <value>The subject identifier type {0} is not valid.</value>
   </data>
+  <data name="Cryptography_Cms_KeyAgreementPlatformNotSupported" xml:space="preserve">
+    <value>This platform does not support encrypting for KeyAgreement recipients.</value>
+  </data>
   <data name="Cryptography_Cms_Key_Agree_Date_Not_Available" xml:space="preserve">
     <value>The Date property is not available for none KID key agree recipient.</value>
   </data>
@@ -155,6 +158,12 @@
   </data>
   <data name="Cryptography_Cms_Recipient_Not_Found" xml:space="preserve">
     <value>The enveloped-data message does not contain the specified recipient.</value>
+  </data>
+  <data name="Cryptography_Cms_RecipientCertificate_Not_Found" xml:space="preserve">
+    <value>The recipient certificate is not specified.</value>
+  </data>
+  <data name="Cryptography_Cms_UnknownAlgorithm" xml:space="preserve">
+    <value>Unknown cryptographic algorithm.</value>
   </data>
   <data name="Cryptography_Cms_UnknownKeySpec" xml:space="preserve">
     <value>Unable to determine the type of key handle from this keyspec {0}.</value>

--- a/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Internal\Cryptography\Pal\Unix\KeyTransRecipientInfoPalOpenSsl.cs" />
     <Compile Include="Internal\Cryptography\Pal\Unix\PkcsPal.OpenSsl.cs" />
     <Compile Include="Internal\Cryptography\Pal\Unix\PkcsPalOpenSsl.cs" />
+    <Compile Include="Internal\Cryptography\Pal\Unix\PkcsPalOpenSsl.Encrypt.cs" />
   </ItemGroup>
   <!-- Common types (platform: Unix) -->
   <ItemGroup Condition="'$(TargetsUnix)' == 'true' AND '$(IsPartialFacadeAssembly)' != 'true' AND '$(GeneratePlatformNotSupportedAssembly)' != 'true'">
@@ -219,6 +220,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Encode.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Encode.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/CertificateTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/CertificateTests.cs
@@ -22,7 +22,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     public static partial class CertificateTests
     {
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void DecodeCertificates0_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/ContentEncryptionAlgorithmTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/ContentEncryptionAlgorithmTests.cs
@@ -22,7 +22,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     public static partial class ContentEncryptionAlgorithmTests
     {
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void DecodeAlgorithmRc2_128_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Rc2));
@@ -61,7 +60,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void DecodeAlgorithmDes_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Des));
@@ -100,7 +98,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void DecodeAlgorithm3Des_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.TripleDesCbc));
@@ -178,7 +175,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void DecodeAlgorithmAes128_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Aes128));
@@ -217,7 +213,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void DecodeAlgorithmAes192_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Aes192));
@@ -256,7 +251,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void DecodeAlgorithmAes256_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Aes256));

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -14,7 +14,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     public static partial class DecryptTests
     {
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_IssuerAndSerial()
         {
@@ -34,7 +33,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_Capi()
         {
@@ -44,7 +42,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_256()
         {
@@ -54,7 +51,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_384()
         {
@@ -64,7 +60,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_512()
         {
@@ -120,7 +115,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void DecryptMultipleRecipients()
         {

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -212,7 +212,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void ReuseEnvelopeCmsEncodeThenDecode()
         {
             // Test ability to encrypt, encode and decode all in one EnvelopedCms instance.
@@ -243,7 +242,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void ReuseEnvelopeCmsDecodeThenEncode()
         {
             byte[] encodedMessage =

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
@@ -15,7 +15,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     public static partial class GeneralTests
     {
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void DecodeVersion0_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -177,7 +176,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Fact]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void MultipleRecipientIdentifiers_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -213,7 +211,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Fact]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void RoundTrip_ExplicitSki()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoTests.cs
@@ -22,7 +22,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     public static partial class KeyTransRecipientInfoTests
     {
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransVersion_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();
@@ -37,7 +36,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransType_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();
@@ -52,7 +50,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransRecipientIdType_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();
@@ -69,7 +66,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransRecipientIdValue_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();
@@ -124,7 +120,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Fact]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransRecipientIdValue_ExplicitSki_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -164,7 +159,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransKeyEncryptionAlgorithm_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();
@@ -183,7 +177,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransEncryptedKey_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
@@ -123,7 +123,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         //
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void PostEncrypt_Version()
         {
             ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -139,7 +138,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void PostEncrypt_RecipientInfos()
         {
             ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -154,7 +152,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void PostEncrypt_Decrypt()
         {
             ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -167,7 +164,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void PostEncrypt_ContentInfo()
         {
             ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -252,7 +248,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         //
         [Fact]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void PostDecrypt_Encode()
         {
             byte[] expectedContent = { 6, 3, 128, 33, 44 };
@@ -286,7 +281,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Fact]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void PostDecrypt_RecipientInfos()
         {
             byte[] expectedContent = { 6, 3, 128, 33, 44 };
@@ -326,7 +320,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Fact]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void PostDecrypt_Decrypt()
         {
             byte[] expectedContent = { 6, 3, 128, 33, 44 };
@@ -372,7 +365,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void PostEncode_DifferentData()
         {
             // This ensures that the decoding and encoding output different values to make sure Encrypt changes the state of the data.


### PR DESCRIPTION
+ Added support for EnvelopedCms.Encrypt on Unix for recipients using
KeyTransport certificates using either IssuerAndSerialNumber of explicit
SubjectKeyIdentifier types for the recipients, except for UnprotectedAttributes.

+ Encryption of messages for recipients using KeyAgreement certificates
will throw a PlaformNotSupportedException due to lack of native support in
OpenSSL.

@weshaggard @bartonjs 