### PR TITLE
Do a Debug.Assert in HttpContent.TryGetBuffer if we can't get it

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -142,7 +142,9 @@ namespace System.Net.Http
 
         internal bool TryGetBuffer(out ArraySegment<byte> buffer)
         {
-            return _bufferedContent != null && _bufferedContent.TryGetBuffer(out buffer);
+            bool result = _bufferedContent != null && _bufferedContent.TryGetBuffer(out buffer);
+            Debug.Assert(result, "Performance: TryGetBuffer failed, which means that reads from the content will copy the data!");
+            return result;
         }
 
         protected HttpContent()


### PR DESCRIPTION
This will cause debug builds that start going down this path to fail, so we're notified if we start copying the data.

cc @davidsh @stephentoub @CIPop 