### PR TITLE
ARM-CI: Enable build of managed components

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -373,6 +373,9 @@ def osShortName = ['Windows 10': 'win10',
                 steps {
                     // Call the arm32_ci_script.sh script to perform the cross build of native corefx
                     shell("./scripts/arm32_ci_script.sh --emulatorPath=${armemul_path} --mountPath=${armrootfs_mountpath} --buildConfig=${configurationGroup.toLowerCase()} --verbose")
+
+                    // Archive the native and managed binaries
+                    shell("tar -czf bin/build.tar.gz bin/*.${configurationGroup} bin/ref bin/packages --exclude=*.Tests")
                 }
             }
 
@@ -384,7 +387,7 @@ def osShortName = ['Windows 10': 'win10',
             Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
 
             // Add archival for the built binaries
-            def archiveContents = "bin/Linux.${arch}.${configurationGroup}/**"
+            def archiveContents = "bin/build.tar.gz"
             Utilities.addArchival(newJob, archiveContents)
 
             // Set up triggers

--- a/scripts/arm32_ci_script.sh
+++ b/scripts/arm32_ci_script.sh
@@ -146,7 +146,7 @@ function cross_build_corefx {
     git am < "$__ARMRootfsMountPath"/dotnet/setenv/corefx_cross.patch
 
     #Cross building for emulator rootfs
-    ROOTFS_DIR="$__ARMRootfsMountPath" CPLUS_INCLUDE_PATH=$LINUX_ARM_INCPATH CXXFLAGS=$LINUX_ARM_CXXFLAGS ./build.sh $__buildArch clean cross native $__verboseFlag $__buildConfig
+    ROOTFS_DIR="$__ARMRootfsMountPath" CPLUS_INCLUDE_PATH=$LINUX_ARM_INCPATH CXXFLAGS=$LINUX_ARM_CXXFLAGS ./build.sh $__buildArch clean cross $__verboseFlag $__buildConfig skiptests
 
     #Reset the code to the upstream version
     (set +x; echo 'Rewinding HEAD to master code')


### PR DESCRIPTION
To ensure that the native and managed components
are built on the same source code, enable managed
build as well. Tests are not needed

Signed-off-by: Prajwal A N <an.prajwal@samsung.com>