### PR TITLE
Clean up SymbolReader project

### DIFF
--- a/src/System.Diagnostics.Debug.SymbolReader/src/System.Diagnostics.Debug.SymbolReader.csproj
+++ b/src/System.Diagnostics.Debug.SymbolReader/src/System.Diagnostics.Debug.SymbolReader.csproj
@@ -7,41 +7,12 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
-    <!-- Disable 1685 (aka multiple type definitions) warning so it doesn't turn into an error -->
-    <NoWarn>$(NoWarn);1685</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <!-- Work around a bug that will be fixed by buildtools/#731 -->  
-  <PropertyGroup Condition="'$(TargetGroup)' == ''">  
-    <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>  
-  </PropertyGroup>  
-  <ItemGroup Condition="'$(TargetGroup)'!='netcore50aot'">
-    <TargetingPackReference Include="mscorlib" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netcore50aot'">
-    <TargetingPackReference Include="System.Private.CoreLib" />
-    <TargetingPackReference Include="System.Private.Reflection" />
-    <ProjectReference Include="..\..\System.Runtime\src\redist\System.Runtime.depproj" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="System/Diagnostics/Debug/SymbolReader/SymbolReader.cs" />
-    <ProjectReference Include="..\..\System.Collections\src\System.Collections.csproj" />  
-    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">  
-      <OSGroup>Windows_NT</OSGroup>  
-    </ProjectReference>    
-    <ProjectReference Include="..\..\System.IO\src\System.IO.csproj" />  
-    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />  
-    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj">  
-      <Aliases>SRE</Aliases>  
-      <OSGroup>Windows_NT</OSGroup>  
-    </ProjectReference>  
-    <ProjectReference Include="..\..\System.Runtime.InteropServices\src\System.Runtime.InteropServices.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Diagnostics.Debug.SymbolReader/src/System/Diagnostics/Debug/SymbolReader/SymbolReader.cs
+++ b/src/System.Diagnostics.Debug.SymbolReader/src/System/Diagnostics/Debug/SymbolReader/SymbolReader.cs
@@ -15,7 +15,7 @@ namespace System.Diagnostics.Debug.SymbolReader
 
     public class SymbolReader
     {
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public struct DebugInfo
         {
             public int lineNumber;
@@ -103,7 +103,7 @@ namespace System.Diagnostics.Debug.SymbolReader
                 return false;
             }
 
-            var structSize = Marshal.SizeOf(typeof(DebugInfo));
+            var structSize = Marshal.SizeOf<DebugInfo>();
 
             debugInfo.size = points.Count;
             var ptr = debugInfo.points;

--- a/src/System.Diagnostics.Debug.SymbolReader/src/project.json
+++ b/src/System.Diagnostics.Debug.SymbolReader/src/project.json
@@ -2,23 +2,8 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.2-beta-24329-03",
-        "System.IO.FileSystem": "4.0.2-beta-24327-03",
-        "System.Reflection.Metadata": "1.4.1-beta-24327-03",
-        "System.Collections.Immutable": "1.2.1-beta-24327-03"
-      },
-      "imports": [
-        "dotnet5.4"
-      ]
-    },
-    "netcore50": {
-      "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24329-00"
-      }
-    },
-    "net46": {
-      "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+        "System.IO.FileSystem": "4.0.1",
+        "System.Reflection.Metadata": "1.3.0"
       }
     }
   }


### PR DESCRIPTION
This library was unnecessarily building against mscorlib.  I've fixed it
to use contracts, which enables it to work even on platforms without
mscorlib (eg: .NET Native).

Additionally I cleaned up a bunch of unnecessary/unused cruft from the
csproj and project.json.

Please let me know if I'm missing any reason why this was compiling against MSCorlib.

/cc @stephentoub @mikem8361 @Dmitri-Botcharnikov