### PR TITLE
Fix handling of errors from Process.Start

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -240,14 +240,11 @@ namespace System.Diagnostics
             // is used to fork/execve as executing managed code in a forked process is not safe (only
             // the calling thread will transfer, thread IDs aren't stable across the fork, etc.)
             int childPid, stdinFd, stdoutFd, stderrFd;
-            if (Interop.Sys.ForkAndExecProcess(
+            Interop.Sys.ForkAndExecProcess(
                 filename, argv, envp, cwd,
                 startInfo.RedirectStandardInput, startInfo.RedirectStandardOutput, startInfo.RedirectStandardError,
-                out childPid, 
-                out stdinFd, out stdoutFd, out stderrFd) != 0)
-            {
-                throw new Win32Exception();
-            }
+                out childPid,
+                out stdinFd, out stdoutFd, out stderrFd);
 
             // Store the child's information into this Process object.
             Debug.Assert(childPid >= 0);


### PR DESCRIPTION
Two issues:
1. If the execve call fails (e.g. it can't find the target, or the target doesn't have proper permissions), we're already in the child process, so the Start call succeeds but the Process then ends in error, with the failure errno from execve as the exit code.  It'd be better (and closer to Windows) for Start to throw an exception with the error in such cases.
2. When ForkAndExecProcess does hit a failure in the parent process, Process.Start is properly throwing a Win32Exception, but configured with the wrong error code: it's getting an error code of 0 rather than the actual errno, causing the exception to contain a very confusing "Success" message.  The reason for this is that the errno value captured by the runtime as part of the P/Invoke is getting stomped on by the cleanup code performed in Interop.Sys.ForkAndExecProcess.

Fixes:
1. Add a call to access in ForkAndExecProcess to attempt to proactively validate (while still in the parent process) that the target path exists and is executable.  This will allow us to propagate the most common reasons for failure up to Start.  It won't catch everything, though, e.g. if the target file exists and is executable, but isn't actually in an executable format, execve will still fail.  In such cases we'll continue with the behavior we have today, using the execve errno result as the process' exit code. (I briefly explored an alternative, which is sending the errno value from execve over a pipe to the parent, but there doesn't appear to be a way to make that work without leaking file descriptors into the child.  If CLOEXEC is used on the pipe, then the pipe will be closed even if execve fails, such that we won't have an opportunity to write the execve errno to the pipe.  And if CLOEXEC isn't used, then if execve succeeds, the pipe's handles will be leaked into the child.)
2. Change Interop.Sys.ForkAndExecProcess to create/throw the relevant exception while the runtime's captured error value is still valid.

Fixes https://github.com/dotnet/corefx/issues/9910
cc: @ellismg, @ianhays, @Priya91, @DaveVdE