### PR TITLE
Add a test for Environment.ExitCode

### DIFF
--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -126,6 +126,10 @@
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
+    <ProjectReference Include="VoidMainWithExitCodeApp\VoidMainWithExitCodeApp.csproj">
+      <Project>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</Project>
+      <Name>VoidMainWithExitCodeApp</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/AssemblyAttributes.cs
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/AssemblyAttributes.cs
@@ -1,0 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.cs
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+
+namespace VoidMainWithExitCodeApp
+{
+    internal static class Program
+    {
+        static void Main(string[] args)
+        {
+            int exitCode = args.Length > 0 ? int.Parse(args[0]) : 0;
+            typeof(Environment).GetTypeInfo().GetDeclaredProperty("ExitCode").SetValue(null, exitCode);
+            // Environment.ExitCode = exitCode; // TODO: Remove reflection when package updated with latest Environment exposing ExitCode
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>VoidMainWithExitCodeApp</RootNamespace>
+    <AssemblyName>VoidMainWithExitCodeApp</AssemblyName>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <CopyNuGetImplementations>false</CopyNuGetImplementations>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="VoidMainWithExitCodeApp.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+    <Compile Include="AssemblyAttributes.cs"/>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+    <TargetingPackReference Include="System" />
+    <TargetingPackReference Include="System.Core" />
+    <TargetingPackReference Include="System.Runtime" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/project.json
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/project.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.2-beta-24222-03",
+    "System.Runtime": "4.1.1-beta-24222-03",
+    "System.Runtime.Extensions": "4.1.1-beta-24222-03",
+    "System.Reflection": "4.1.1-beta-24222-03"
+  },
+  "frameworks": {
+    "netstandard1.3": {}
+  }
+}


### PR DESCRIPTION
We've consolidated almost all of our remote execution logic (testing code in another process) into a single shared console app that supports using reflection to invoke delegates, but to test ExitCode properly, we need a void-returning Main method.  This commit adds such a little helper app to the System.Runtime.Extensions tests suite and adds a test that uses it.  That test is disabled until https://github.com/dotnet/coreclr/issues/6206 is fixed.

cc: @jkotas, @danmosemsft 