### PR TITLE
Make Stack<T>.Enumerator.Current inlineable by the JIT

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -259,8 +259,8 @@ namespace System.Collections.Generic
             System.Collections.IEnumerator
         {
             private readonly Stack<T> _stack;
-            private int _index;
             private readonly int _version;
+            private int _index;
             private T _currentElement;
 
             internal Enumerator(Stack<T> stack)
@@ -309,7 +309,7 @@ namespace System.Collections.Generic
                 get
                 {
                     if (_index < 0)
-                        ThrowEnumerationNotStartedOrEnded(); // separated into a new method so the jit can inline this
+                        ThrowEnumerationNotStartedOrEnded();
                     return _currentElement;
                 }
             }

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -258,15 +258,15 @@ namespace System.Collections.Generic
         public struct Enumerator : IEnumerator<T>,
             System.Collections.IEnumerator
         {
-            private Stack<T> _stack;
+            private readonly Stack<T> _stack;
             private int _index;
-            private int _version;
+            private readonly int _version;
             private T _currentElement;
 
             internal Enumerator(Stack<T> stack)
             {
                 _stack = stack;
-                _version = _stack._version;
+                _version = stack._version;
                 _index = -2;
                 _currentElement = default(T);
             }
@@ -308,12 +308,18 @@ namespace System.Collections.Generic
             {
                 get
                 {
-                    if (_index == -2) throw new InvalidOperationException(SR.InvalidOperation_EnumNotStarted);
-                    if (_index == -1) throw new InvalidOperationException(SR.InvalidOperation_EnumEnded);
+                    if (_index < 0)
+                        ThrowEnumerationNotStartedOrEnded(); // separated into a new method so the jit can inline this
                     return _currentElement;
                 }
             }
-
+            
+            private void ThrowEnumerationNotStartedOrEnded()
+            {
+                Debug.Assert(_index == -1 || _index == -2);
+                throw new InvalidOperationException(_index == -2 ? SR.InvalidOperation_EnumNotStarted : SR.InvalidOperation_EnumEnded);
+            }
+            
             Object System.Collections.IEnumerator.Current
             {
                 get { return Current; }


### PR DESCRIPTION
Previously `Stack<T>.Enumerator.get_Current` wasn't being inlined by the JIT, due to some exception throwing logic in the method that shouldn't happen on the main codepath. I've trivially separated it out into a new method, so now it can be inlined.

### Performance data

- [Old assembly generated for foreach](https://gist.github.com/jamesqo/bc90b5ccf61e2556a6dec6722056023c)
- [New assembly generated for foreach](https://gist.github.com/jamesqo/83916949f86aaac9238701d3f321854c) (doing a Ctrl+F and searching for `get_Current` will turn up 0 matches)
- There is about a 10-20% speedup when iterating through the stack. (Less than I expected, probably due to the fact that it's a struct so `call` is emitted and no null checking is necessary)
  - [Old results](https://gist.github.com/jamesqo/193ff8246e4257574df6046ac0219203)
  - [New results](https://gist.github.com/jamesqo/bbe8e7282403c2b9d70647a4931cd702)
  - [Perf test source code](https://gist.github.com/jamesqo/078248988715fb85fa3e6b77982654c1)

cc @ianhays, @stephentoub, @omariom 

Contributes to #9843 