### PR TITLE
Avoid repeated virtual method calls in Stack.Contains

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -95,17 +95,17 @@ namespace System.Collections.Generic
         /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.Contains"]/*' />
         public bool Contains(T item)
         {
-            int count = _size;
+            // Compare items using the default equality comparer
 
-            EqualityComparer<T> c = EqualityComparer<T>.Default;
-            while (count-- > 0)
-            {
-                if (c.Equals(_array[count], item))
-                {
-                    return true;
-                }
-            }
-            return false;
+            // PERF: Internally Array.LastIndexOf calls
+            // EqualityComparer<T>.Default.LastIndexOf, which
+            // is specialized for different types. This
+            // boosts performance since instead of making a
+            // virtual method call each iteration of the loop,
+            // via EqualityComparer<T>.Default.Equals, we
+            // only make one virtual call to EqualityComparer.LastIndexOf.
+
+            return _size != 0 && Array.LastIndexOf(_array, item, _size - 1) != -1;
         }
 
         // Copies the stack into an array.


### PR DESCRIPTION
Currently the implementation of `Stack.Contains` calls `EqualityComparer.Default.Equals` in a loop, meaning that if a stack is N items in size, it will make N virtual method calls to `Equals`. A better way of doing this is to call `Array.LastIndexOf` on the stack's backing array. Internally `LastIndexOf` calls the internal virtual method [`EqualityComparer.LastIndexOf`](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Array.cs#L1532), which is specialized for all the default comparer types so instead of making N virtual calls we only make 1 (to `LastIndexOf`).

### Performance results

[old](https://gist.github.com/jamesqo/fbc16cc00105c28a0fa8b63441575969) / [new](https://gist.github.com/jamesqo/77f09c16797d23f934d65b19aa114aca) / [test source code](https://gist.github.com/jamesqo/b4c5e471ff840ef82b9f2ec73c6957a6)

There is a slowdown if the element is found at the 1st or 2nd position in the stack, presumably due to the overhead of argument validation from `LastIndexOf` and the fact that we only save 0/1 virtual method calls at those positions. However, by the 3rd position the timings are about the same; by the 10th position there is about a 2x speedup, and in an extreme case (1000th position) the speedup is about 4x.

Test coverage has already been added as part of #8876

cc @ianhays @stephentoub @omariom 