### PR TITLE
Add back IHashCodeProvider/CaseInsensitiveHashCodeProvider to System.Collections.NonGeneric

### DIFF
--- a/src/System.Collections.NonGeneric/ref/System.Collections.NonGeneric.cs
+++ b/src/System.Collections.NonGeneric/ref/System.Collections.NonGeneric.cs
@@ -71,6 +71,15 @@ namespace System.Collections
         public static System.Collections.CaseInsensitiveComparer DefaultInvariant { get { return default(System.Collections.CaseInsensitiveComparer); } }
         public int Compare(object a, object b) { return default(int); }
     }
+    [System.ObsoleteAttribute("Please use StringComparer instead.")] 
+    public partial class CaseInsensitiveHashCodeProvider : System.Collections.IHashCodeProvider 
+    { 
+        public CaseInsensitiveHashCodeProvider() { } 
+        public CaseInsensitiveHashCodeProvider(System.Globalization.CultureInfo culture) { } 
+        public static System.Collections.CaseInsensitiveHashCodeProvider Default { get { return default(System.Collections.CaseInsensitiveHashCodeProvider); } } 
+        public static System.Collections.CaseInsensitiveHashCodeProvider DefaultInvariant { get { return default(System.Collections.CaseInsensitiveHashCodeProvider); } } 
+        public int GetHashCode(object obj) { return default(int); } 
+    }
     public abstract partial class CollectionBase : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
     {
         protected CollectionBase() { }
@@ -146,15 +155,29 @@ namespace System.Collections
         public Hashtable() { }
         public Hashtable(System.Collections.IDictionary d) { }
         public Hashtable(System.Collections.IDictionary d, System.Collections.IEqualityComparer equalityComparer) { }
+        [System.ObsoleteAttribute("Please use Hashtable(IDictionary, IEqualityComparer) instead.")]
+        public Hashtable(System.Collections.IDictionary d, System.Collections.IHashCodeProvider hcp, System.Collections.IComparer comparer) { }
         public Hashtable(System.Collections.IDictionary d, float loadFactor) { }
         public Hashtable(System.Collections.IDictionary d, float loadFactor, System.Collections.IEqualityComparer equalityComparer) { }
+        [System.ObsoleteAttribute("Please use Hashtable(IDictionary, float, IEqualityComparer) instead.")]
+        public Hashtable(System.Collections.IDictionary d, float loadFactor, System.Collections.IHashCodeProvider hcp, System.Collections.IComparer comparer) { }
         public Hashtable(System.Collections.IEqualityComparer equalityComparer) { }
+        [System.ObsoleteAttribute("Please use Hashtable(IEqualityComparer) instead.")]
+        public Hashtable(System.Collections.IHashCodeProvider hcp, System.Collections.IComparer comparer) { }
         public Hashtable(int capacity) { }
         public Hashtable(int capacity, System.Collections.IEqualityComparer equalityComparer) { }
+        [System.ObsoleteAttribute("Please use Hashtable(int, IEqualityComparer) instead.")]
+        public Hashtable(int capacity, System.Collections.IHashCodeProvider hcp, System.Collections.IComparer comparer) { }
         public Hashtable(int capacity, float loadFactor) { }
         public Hashtable(int capacity, float loadFactor, System.Collections.IEqualityComparer equalityComparer) { }
+        [System.ObsoleteAttribute("Please use Hashtable(int, float, IEqualityComparer) instead.")]
+        public Hashtable(int capacity, float loadFactor, System.Collections.IHashCodeProvider hcp, System.Collections.IComparer comparer) { }
+        [System.ObsoleteAttribute("Please use KeyComparer properties.")]
+        protected System.Collections.IComparer comparer { get { return default(System.Collections.IComparer); } set { } }
         public virtual int Count { get { return default(int); } }
         protected System.Collections.IEqualityComparer EqualityComparer { get { return default(System.Collections.IEqualityComparer); } }
+        [System.ObsoleteAttribute("Please use EqualityComparer property.")]
+        protected System.Collections.IHashCodeProvider hcp { get { return default(System.Collections.IHashCodeProvider); } set { } }
         public virtual bool IsFixedSize { get { return default(bool); } }
         public virtual bool IsReadOnly { get { return default(bool); } }
         public virtual bool IsSynchronized { get { return default(bool); } }
@@ -176,6 +199,11 @@ namespace System.Collections
         public static System.Collections.Hashtable Synchronized(System.Collections.Hashtable table) { return default(System.Collections.Hashtable); }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
     }
+    [System.ObsoleteAttribute("Please use IEqualityComparer instead.")] 
+    public partial interface IHashCodeProvider 
+    { 
+        int GetHashCode(object obj); 
+    } 
     public partial class Queue : System.Collections.ICollection, System.Collections.IEnumerable
     {
         public Queue() { }

--- a/src/System.Collections.NonGeneric/src/Resources/Strings.resx
+++ b/src/System.Collections.NonGeneric/src/Resources/Strings.resx
@@ -216,4 +216,7 @@
   <data name="NotSupported_SortedListNestedWrite" xml:space="preserve">
     <value>This operation is not supported on SortedList nested types because they require modifying the original SortedList.</value>
   </data>
+  <data name="Arg_CannotMixComparisonInfrastructure" xml:space="preserve">
+    <value>The usage of IKeyComparer and IHashCodeProvider/IComparer interfaces cannot be mixed; use one or the other.</value>
+  </data>
 </root>

--- a/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
+++ b/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
@@ -18,10 +18,13 @@
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
     <Compile Include="System\Collections\ArrayList.cs" />
     <Compile Include="System\Collections\CaseInsensitiveComparer.cs" />
+    <Compile Include="System\Collections\CaseInsensitiveHashCodeProvider.cs" />
     <Compile Include="System\Collections\CollectionBase.cs" />
     <Compile Include="System\Collections\Comparer.cs" />
+    <Compile Include="System\Collections\CompatibleComparer.cs" />
     <Compile Include="System\Collections\DictionaryBase.cs" />
     <Compile Include="System\Collections\Hashtable.cs" />
+    <Compile Include="System\Collections\IHashCodeProvider.cs" />
     <Compile Include="System\Collections\KeyValuePairs.cs" />
     <Compile Include="System\Collections\Queue.cs" />
     <Compile Include="System\Collections\ReadOnlyCollectionBase.cs" />

--- a/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveHashCodeProvider.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveHashCodeProvider.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace System.Collections
+{
+    /// <summary>
+    /// Designed to support hashtables which require case-insensitive behavior while still maintaining case,
+    /// this provides an efficient mechanism for getting the hashcode of the string ignoring case.
+    /// </summary>
+    [Obsolete("Please use StringComparer instead.")]
+    public class CaseInsensitiveHashCodeProvider : IHashCodeProvider
+    {
+        private static volatile CaseInsensitiveHashCodeProvider s_invariantCaseInsensitiveHashCodeProvider = null;
+        private readonly CompareInfo _compareInfo;
+
+        public CaseInsensitiveHashCodeProvider()
+        {
+            _compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+        }
+
+        public CaseInsensitiveHashCodeProvider(CultureInfo culture)
+        {
+            if (culture == null)
+            {
+                throw new ArgumentNullException(nameof(culture));
+            }
+            _compareInfo = culture.CompareInfo;
+        }
+
+        public static CaseInsensitiveHashCodeProvider Default => new CaseInsensitiveHashCodeProvider();
+
+        public static CaseInsensitiveHashCodeProvider DefaultInvariant => s_invariantCaseInsensitiveHashCodeProvider ?? 
+            (s_invariantCaseInsensitiveHashCodeProvider = new CaseInsensitiveHashCodeProvider(CultureInfo.InvariantCulture));
+
+        public int GetHashCode(object obj)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            string s = obj as string;
+            return s != null ?
+                _compareInfo.GetHashCode(s, CompareOptions.IgnoreCase) :
+                obj.GetHashCode();
+        }
+    }
+}

--- a/src/System.Collections.NonGeneric/src/System/Collections/CompatibleComparer.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CompatibleComparer.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma warning disable 618 // obsolete types
+
+namespace System.Collections
+{
+    internal sealed class CompatibleComparer : IEqualityComparer
+    {
+        private readonly IHashCodeProvider _hcp;
+        private readonly IComparer _comparer;
+
+        internal CompatibleComparer(IHashCodeProvider hashCodeProvider, IComparer comparer)
+        {
+            _hcp = hashCodeProvider;
+            _comparer = comparer;
+        }
+
+        internal IHashCodeProvider HashCodeProvider => _hcp;
+
+        internal IComparer Comparer => _comparer;
+
+        public new bool Equals(object a, object b) => Compare(a, b) == 0;
+
+        public int Compare(object a, object b)
+        {
+            if (a == b) return 0;
+            if (a == null) return -1;
+            if (b == null) return 1;
+
+            if (_comparer != null)
+            {
+                return _comparer.Compare(a, b);
+            }
+
+            IComparable ia = a as IComparable;
+            if (ia != null)
+            {
+                return ia.CompareTo(b);
+            }
+            
+            throw new ArgumentException(SR.Argument_ImplementIComparable);
+        }
+
+        public int GetHashCode(object obj)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            return _hcp != null ? 
+                _hcp.GetHashCode(obj) :
+                obj.GetHashCode();
+        }
+    }
+}

--- a/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
@@ -141,6 +141,79 @@ namespace System.Collections
         private IEqualityComparer _keycomparer;
         private Object _syncRoot;
 
+        [Obsolete("Please use EqualityComparer property.")]
+        protected IHashCodeProvider hcp
+        {
+            get
+            {
+                if (_keycomparer is CompatibleComparer)
+                {
+                    return ((CompatibleComparer)_keycomparer).HashCodeProvider;
+                }
+                else if (_keycomparer == null)
+                {
+                    return null;
+                }
+                else
+                {
+                    throw new ArgumentException(SR.Arg_CannotMixComparisonInfrastructure);
+                }
+            }
+            set
+            {
+                if (_keycomparer is CompatibleComparer)
+                {
+                    CompatibleComparer keyComparer = (CompatibleComparer)_keycomparer;
+                    _keycomparer = new CompatibleComparer(value, keyComparer.Comparer);
+                }
+                else if (_keycomparer == null)
+                {
+                    _keycomparer = new CompatibleComparer(value, (IComparer)null);
+                }
+                else
+                {
+                    throw new ArgumentException(SR.Arg_CannotMixComparisonInfrastructure);
+                }
+            }
+        }
+
+        [Obsolete("Please use KeyComparer properties.")]
+        protected IComparer comparer
+        {
+            get
+            {
+                if (_keycomparer is CompatibleComparer)
+                {
+                    return ((CompatibleComparer)_keycomparer).Comparer;
+                }
+                else if (_keycomparer == null)
+                {
+                    return null;
+                }
+                else
+                {
+                    throw new ArgumentException(SR.Arg_CannotMixComparisonInfrastructure);
+                }
+            }
+            set
+            {
+                if (_keycomparer is CompatibleComparer)
+                {
+                    CompatibleComparer keyComparer = (CompatibleComparer)_keycomparer;
+                    _keycomparer = new CompatibleComparer(keyComparer.HashCodeProvider, value);
+                }
+                else if (_keycomparer == null)
+                {
+                    _keycomparer = new CompatibleComparer((IHashCodeProvider)null, value);
+                }
+                else
+                {
+                    throw new ArgumentException(SR.Arg_CannotMixComparisonInfrastructure);
+                }
+            }
+        }
+
+
         protected IEqualityComparer EqualityComparer
         {
             get
@@ -213,7 +286,19 @@ namespace System.Collections
             _keycomparer = equalityComparer;
         }
 
+        [Obsolete("Please use Hashtable(IEqualityComparer) instead.")]
+        public Hashtable(IHashCodeProvider hcp, IComparer comparer)
+            : this(0, 1.0f, hcp, comparer)
+        {
+        }
+
         public Hashtable(IEqualityComparer equalityComparer) : this(0, 1.0f, equalityComparer)
+        {
+        }
+
+        [Obsolete("Please use Hashtable(int, IEqualityComparer) instead.")]
+        public Hashtable(int capacity, IHashCodeProvider hcp, IComparer comparer)
+            : this(capacity, 1.0f, hcp, comparer)
         {
         }
 
@@ -237,9 +322,37 @@ namespace System.Collections
         {
         }
 
+        [Obsolete("Please use Hashtable(IDictionary, IEqualityComparer) instead.")]
+        public Hashtable(IDictionary d, IHashCodeProvider hcp, IComparer comparer)
+            : this(d, 1.0f, hcp, comparer)
+        {
+        }
+
         public Hashtable(IDictionary d, IEqualityComparer equalityComparer)
             : this(d, 1.0f, equalityComparer)
         {
+        }
+
+        [Obsolete("Please use Hashtable(int, float, IEqualityComparer) instead.")]
+        public Hashtable(int capacity, float loadFactor, IHashCodeProvider hcp, IComparer comparer)
+            : this(capacity, loadFactor)
+        {
+            if (hcp != null || comparer != null)
+            {
+                _keycomparer = new CompatibleComparer(hcp, comparer);
+            }
+        }
+
+        [Obsolete("Please use Hashtable(IDictionary, float, IEqualityComparer) instead.")]
+        public Hashtable(IDictionary d, float loadFactor, IHashCodeProvider hcp, IComparer comparer)
+            : this((d != null ? d.Count : 0), loadFactor, hcp, comparer)
+        {
+            if (d == null)
+                throw new ArgumentNullException(nameof(d), SR.ArgumentNull_Dictionary);
+            Contract.EndContractBlock();
+
+            IDictionaryEnumerator e = d.GetEnumerator();
+            while (e.MoveNext()) Add(e.Key, e.Value);
         }
 
         public Hashtable(IDictionary d, float loadFactor, IEqualityComparer equalityComparer)

--- a/src/System.Collections.NonGeneric/src/System/Collections/IHashCodeProvider.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/IHashCodeProvider.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Collections
+{
+    /// <summary>
+    /// Provides a mechanism for a <see cref="Hashtable"/> user to override the default
+    /// GetHashCode() function on Objects, providing their own hash function.
+    /// </summary>
+    [Obsolete("Please use IEqualityComparer instead.")]
+    public interface IHashCodeProvider
+    {
+        /// <summary>Returns a hash code for the given object.</summary>
+        int GetHashCode(object obj);
+    }
+}

--- a/src/System.Collections.NonGeneric/tests/CaseInsensitiveHashCodeProviderTests.cs
+++ b/src/System.Collections.NonGeneric/tests/CaseInsensitiveHashCodeProviderTests.cs
@@ -48,22 +48,28 @@ namespace System.Collections.Tests
 
             foreach (string cultureName in cultureNames)
             {
-                CultureInfo orig = CultureInfo.CurrentCulture;
+                CultureInfo newCulture;
                 try
                 {
-                    CultureInfo.CurrentCulture = new CultureInfo(cultureName);
-                    var provider = new CaseInsensitiveHashCodeProvider();
-                    Assert.Equal(provider.GetHashCode(a), provider.GetHashCode(a));
-                    Assert.Equal(provider.GetHashCode(b), provider.GetHashCode(b));
-                    Assert.Equal(expected, provider.GetHashCode(a) == provider.GetHashCode(b));
+                    newCulture = new CultureInfo(cultureName);
                 }
                 catch (CultureNotFoundException)
                 {
                     continue;
                 }
+
+                CultureInfo origCulture = CultureInfo.CurrentCulture;
+                try
+                {
+                    CultureInfo.CurrentCulture = newCulture;
+                    var provider = new CaseInsensitiveHashCodeProvider();
+                    Assert.Equal(provider.GetHashCode(a), provider.GetHashCode(a));
+                    Assert.Equal(provider.GetHashCode(b), provider.GetHashCode(b));
+                    Assert.Equal(expected, provider.GetHashCode(a) == provider.GetHashCode(b));
+                }
                 finally
                 {
-                    CultureInfo.CurrentCulture = orig;
+                    CultureInfo.CurrentCulture = origCulture;
                 }
             }
         }
@@ -89,17 +95,20 @@ namespace System.Collections.Tests
 
             foreach (string cultureName in cultureNames)
             {
+                CultureInfo culture;
                 try
                 {
-                    var provider = new CaseInsensitiveHashCodeProvider(new CultureInfo(cultureName));
-                    Assert.Equal(provider.GetHashCode(a), provider.GetHashCode(a));
-                    Assert.Equal(provider.GetHashCode(b), provider.GetHashCode(b));
-                    Assert.Equal(expected, provider.GetHashCode(a) == provider.GetHashCode(b));
+                    culture = new CultureInfo(cultureName);
                 }
                 catch (CultureNotFoundException)
                 {
                     continue;
                 }
+
+                var provider = new CaseInsensitiveHashCodeProvider(culture);
+                Assert.Equal(provider.GetHashCode(a), provider.GetHashCode(a));
+                Assert.Equal(provider.GetHashCode(b), provider.GetHashCode(b));
+                Assert.Equal(expected, provider.GetHashCode(a) == provider.GetHashCode(b));
             }
         }
 
@@ -117,21 +126,23 @@ namespace System.Collections.Tests
 
             foreach (string cultureName in cultureNames)
             {
+                CultureInfo culture;
                 try
                 {
-                    var culture = new CultureInfo(cultureName);
-                    var provider = new CaseInsensitiveHashCodeProvider(culture);
-
-                    // Turkish has lower-case and upper-case version of the dotted "i", so the upper case of "i" (U+0069) isn't "I" (U+0049)
-                    // but rather "İ" (U+0130)
-                    Assert.Equal(
-                        culture.Name != "tr-TR",
-                        provider.GetHashCode("file") == provider.GetHashCode("FILE"));
+                    culture = new CultureInfo(cultureName);
                 }
                 catch (CultureNotFoundException)
                 {
                     continue;
                 }
+
+                var provider = new CaseInsensitiveHashCodeProvider(culture);
+
+                // Turkish has lower-case and upper-case version of the dotted "i", so the upper case of "i" (U+0069) isn't "I" (U+0049)
+                // but rather "İ" (U+0130)
+                Assert.Equal(
+                    culture.Name != "tr-TR",
+                    provider.GetHashCode("file") == provider.GetHashCode("FILE"));
             }
         }
 
@@ -168,7 +179,7 @@ namespace System.Collections.Tests
         {
             // Turkish has lower-case and upper-case version of the dotted "i", so the upper case of "i" (U+0069) isn't "I" (U+0049)
             // but rather "İ" (U+0130)
-            CultureInfo orig = CultureInfo.CurrentCulture;
+            CultureInfo origCulture = CultureInfo.CurrentCulture;
             try
             {
                 CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
@@ -180,7 +191,7 @@ namespace System.Collections.Tests
             }
             finally
             {
-                CultureInfo.CurrentCulture = orig;
+                CultureInfo.CurrentCulture = origCulture;
             }
         }
     }

--- a/src/System.Collections.NonGeneric/tests/CaseInsensitiveHashCodeProviderTests.cs
+++ b/src/System.Collections.NonGeneric/tests/CaseInsensitiveHashCodeProviderTests.cs
@@ -1,0 +1,187 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Xunit;
+
+#pragma warning disable 618 // obsolete types
+
+namespace System.Collections.Tests
+{
+    public static class CaseInsensitiveHashCodeProviderTests
+    {
+        [Theory]
+        [InlineData("hello", "HELLO", true)]
+        [InlineData("hello", "hello", true)]
+        [InlineData("HELLO", "HELLO", true)]
+        [InlineData("hello", "goodbye", false)]
+        [InlineData(5, 5, true)]
+        [InlineData(10, 5, false)]
+        [InlineData(5, 10, false)]
+        public static void Ctor_Empty_GetHashCodeCompare(object a, object b, bool expected)
+        {
+            var provider = new CaseInsensitiveHashCodeProvider();
+            Assert.Equal(provider.GetHashCode(a), provider.GetHashCode(a));
+            Assert.Equal(provider.GetHashCode(b), provider.GetHashCode(b));
+            Assert.Equal(expected, provider.GetHashCode(a) == provider.GetHashCode(b));
+        }
+
+        [Theory]
+        [InlineData("hello", "HELLO", true)]
+        [InlineData("hello", "hello", true)]
+        [InlineData("HELLO", "HELLO", true)]
+        [InlineData("hello", "goodbye", false)]
+        [InlineData(5, 5, true)]
+        [InlineData(10, 5, false)]
+        [InlineData(5, 10, false)]
+        public static void Ctor_Empty_ChangeCurrentCulture_GetHashCodeCompare(object a, object b, bool expected)
+        {
+            var cultureNames = new string[]
+            {
+                "cs-CZ","da-DK","de-DE","el-GR","en-US",
+                "es-ES","fi-FI","fr-FR","hu-HU","it-IT",
+                "ja-JP","ko-KR","nb-NO","nl-NL","pl-PL",
+                "pt-BR","pt-PT","ru-RU","sv-SE","tr-TR",
+                "zh-CN","zh-HK","zh-TW"
+            };
+
+            foreach (string cultureName in cultureNames)
+            {
+                CultureInfo orig = CultureInfo.CurrentCulture;
+                try
+                {
+                    CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+                    var provider = new CaseInsensitiveHashCodeProvider();
+                    Assert.Equal(provider.GetHashCode(a), provider.GetHashCode(a));
+                    Assert.Equal(provider.GetHashCode(b), provider.GetHashCode(b));
+                    Assert.Equal(expected, provider.GetHashCode(a) == provider.GetHashCode(b));
+                }
+                catch (CultureNotFoundException)
+                {
+                    continue;
+                }
+                finally
+                {
+                    CultureInfo.CurrentCulture = orig;
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("hello", "HELLO", true)]
+        [InlineData("hello", "hello", true)]
+        [InlineData("HELLO", "HELLO", true)]
+        [InlineData("hello", "goodbye", false)]
+        [InlineData(5, 5, true)]
+        [InlineData(10, 5, false)]
+        [InlineData(5, 10, false)]
+        public static void Ctor_CultureInfo_ChangeCurrentCulture_GetHashCodeCompare(object a, object b, bool expected)
+        {
+            var cultureNames = new string[]
+            {
+                "cs-CZ","da-DK","de-DE","el-GR","en-US",
+                "es-ES","fi-FI","fr-FR","hu-HU","it-IT",
+                "ja-JP","ko-KR","nb-NO","nl-NL","pl-PL",
+                "pt-BR","pt-PT","ru-RU","sv-SE","tr-TR",
+                "zh-CN","zh-HK","zh-TW"
+            };
+
+            foreach (string cultureName in cultureNames)
+            {
+                try
+                {
+                    var provider = new CaseInsensitiveHashCodeProvider(new CultureInfo(cultureName));
+                    Assert.Equal(provider.GetHashCode(a), provider.GetHashCode(a));
+                    Assert.Equal(provider.GetHashCode(b), provider.GetHashCode(b));
+                    Assert.Equal(expected, provider.GetHashCode(a) == provider.GetHashCode(b));
+                }
+                catch (CultureNotFoundException)
+                {
+                    continue;
+                }
+            }
+        }
+
+        [Fact]
+        public static void Ctor_CultureInfo_GetHashCodeCompare_TurkishI()
+        {
+            var cultureNames = new string[]
+            {
+                "cs-CZ","da-DK","de-DE","el-GR","en-US",
+                "es-ES","fi-FI","fr-FR","hu-HU","it-IT",
+                "ja-JP","ko-KR","nb-NO","nl-NL","pl-PL",
+                "pt-BR","pt-PT","ru-RU","sv-SE","tr-TR",
+                "zh-CN","zh-HK","zh-TW"
+            };
+
+            foreach (string cultureName in cultureNames)
+            {
+                try
+                {
+                    var culture = new CultureInfo(cultureName);
+                    var provider = new CaseInsensitiveHashCodeProvider(culture);
+
+                    // Turkish has lower-case and upper-case version of the dotted "i", so the upper case of "i" (U+0069) isn't "I" (U+0049)
+                    // but rather "İ" (U+0130)
+                    Assert.Equal(
+                        culture.Name != "tr-TR",
+                        provider.GetHashCode("file") == provider.GetHashCode("FILE"));
+                }
+                catch (CultureNotFoundException)
+                {
+                    continue;
+                }
+            }
+        }
+
+        [Fact]
+        public static void Ctor_CultureInfo_NullCulture_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("culture", () => new CaseInsensitiveHashCodeProvider(null));
+        }
+
+        [Fact]
+        public static void GetHashCode_NullObj_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("obj", () => new CaseInsensitiveHashCodeProvider().GetHashCode(null));
+        }
+
+        [Theory]
+        [InlineData("hello", "HELLO", true)]
+        [InlineData("hello", "hello", true)]
+        [InlineData("HELLO", "HELLO", true)]
+        [InlineData("hello", "goodbye", false)]
+        [InlineData(5, 5, true)]
+        [InlineData(10, 5, false)]
+        [InlineData(5, 10, false)]
+        public static void Default_GetHashCodeCompare(object a, object b, bool expected)
+        {
+            Assert.Equal(expected,
+                CaseInsensitiveHashCodeProvider.Default.GetHashCode(a) == CaseInsensitiveHashCodeProvider.Default.GetHashCode(b));
+            Assert.Equal(expected,
+                CaseInsensitiveHashCodeProvider.DefaultInvariant.GetHashCode(a) == CaseInsensitiveHashCodeProvider.DefaultInvariant.GetHashCode(b));
+        }
+
+        [Fact]
+        public static void Default_Compare_TurkishI()
+        {
+            // Turkish has lower-case and upper-case version of the dotted "i", so the upper case of "i" (U+0069) isn't "I" (U+0049)
+            // but rather "İ" (U+0130)
+            CultureInfo orig = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+                Assert.False(CaseInsensitiveHashCodeProvider.Default.GetHashCode("file") == CaseInsensitiveHashCodeProvider.Default.GetHashCode("FILE"));
+                Assert.True(CaseInsensitiveHashCodeProvider.DefaultInvariant.GetHashCode("file") == CaseInsensitiveHashCodeProvider.DefaultInvariant.GetHashCode("FILE"));
+
+                CultureInfo.CurrentCulture = new CultureInfo("en-US");
+                Assert.True(CaseInsensitiveHashCodeProvider.Default.GetHashCode("file") == CaseInsensitiveHashCodeProvider.Default.GetHashCode("FILE"));
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = orig;
+            }
+        }
+    }
+}

--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#pragma warning disable 618 // obsolete types
+
 namespace System.Collections.Tests
 {
     public static class HashtableTests
@@ -17,6 +19,28 @@ namespace System.Collections.Tests
         {
             var hash = new ComparableHashtable();
             VerifyHashtable(hash, null, null);
+        }
+
+        [Fact]
+        public static void Ctor_HashCodeProvider_Comparer()
+        {
+            var hash = new ComparableHashtable(CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
+            VerifyHashtable(hash, null, hash.EqualityComparer);
+            Assert.Same(CaseInsensitiveHashCodeProvider.DefaultInvariant, hash.HashCodeProvider);
+            Assert.Same(StringComparer.OrdinalIgnoreCase, hash.Comparer);
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public static void Ctor_HashCodeProvider_Comparer_NullInputs(bool nullProvider, bool nullComparer)
+        {
+            var hash = new ComparableHashtable(
+                nullProvider ? null : CaseInsensitiveHashCodeProvider.DefaultInvariant,
+                nullComparer ? null : StringComparer.OrdinalIgnoreCase);
+            VerifyHashtable(hash, null, hash.EqualityComparer);
         }
 
         [Fact]
@@ -39,6 +63,28 @@ namespace System.Collections.Tests
         public static void Ctor_IDictionary_NullDictionary_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("d", () => new Hashtable((IDictionary)null)); // Dictionary is null
+        }
+
+        [Fact]
+        public static void Ctor_IDictionary_HashCodeProvider_Comparer()
+        {
+            // No exception
+            var hash1 = new ComparableHashtable(new Hashtable(), CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(0, hash1.Count);
+
+            hash1 = new ComparableHashtable(new Hashtable(new Hashtable(new Hashtable(new Hashtable(new Hashtable())))), CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(0, hash1.Count);
+
+            Hashtable hash2 = Helpers.CreateIntHashtable(100);
+            hash1 = new ComparableHashtable(hash2, CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
+
+            VerifyHashtable(hash1, hash2, hash1.EqualityComparer);
+        }
+
+        [Fact]
+        public static void Ctor_IDictionary_HashCodeProvider_Comparer_NullDictionary_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("d", () => new Hashtable(null, CaseInsensitiveHashCodeProvider.Default, StringComparer.OrdinalIgnoreCase)); // Dictionary is null
         }
 
         [Fact]
@@ -67,6 +113,16 @@ namespace System.Collections.Tests
             VerifyHashtable(hash, null, null);
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(100)]
+        public static void Ctor_Int_HashCodeProvider_Comparer(int capacity)
+        {
+            var hash = new ComparableHashtable(capacity, CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
+            VerifyHashtable(hash, null, hash.EqualityComparer);
+        }
+
         [Fact]
         public static void Ctor_Int_Invalid()
         {
@@ -78,16 +134,17 @@ namespace System.Collections.Tests
         public static void Ctor_IDictionary_Int()
         {
             // No exception
-            var hash1 = new ComparableHashtable(new Hashtable(), 1f);
+            var hash1 = new ComparableHashtable(new Hashtable(), 1f, CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
             Assert.Equal(0, hash1.Count);
 
-            hash1 = new ComparableHashtable(new Hashtable(new Hashtable(new Hashtable(new Hashtable(new Hashtable(), 1f), 1f), 1f), 1f), 1f);
+            hash1 = new ComparableHashtable(new Hashtable(new Hashtable(new Hashtable(new Hashtable(new Hashtable(), 1f), 1f), 1f), 1f), 1f,
+                CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
             Assert.Equal(0, hash1.Count);
 
             Hashtable hash2 = Helpers.CreateIntHashtable(100);
-            hash1 = new ComparableHashtable(hash2, 1f);
+            hash1 = new ComparableHashtable(hash2, 1f, CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
 
-            VerifyHashtable(hash1, hash2, null);
+            VerifyHashtable(hash1, hash2, hash1.EqualityComparer);
         }
 
         [Fact]
@@ -101,6 +158,22 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), float.NaN)); // Load factor is NaN
             Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), float.PositiveInfinity)); // Load factor is infinity
             Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), float.NegativeInfinity)); // Load factor is infinity
+        }
+
+        [Fact]
+        public static void Ctor_IDictionary_Int_HashCodeProvider_Comparer()
+        {
+            // No exception
+            var hash1 = new ComparableHashtable(new Hashtable(), 1f);
+            Assert.Equal(0, hash1.Count);
+
+            hash1 = new ComparableHashtable(new Hashtable(new Hashtable(new Hashtable(new Hashtable(new Hashtable(), 1f), 1f), 1f), 1f), 1f);
+            Assert.Equal(0, hash1.Count);
+
+            Hashtable hash2 = Helpers.CreateIntHashtable(100);
+            hash1 = new ComparableHashtable(hash2, 1f);
+
+            VerifyHashtable(hash1, hash2, null);
         }
 
         [Fact]
@@ -131,7 +204,7 @@ namespace System.Collections.Tests
         [Fact]
         public static void Ctor_IDictionary_IEqualityComparer_NullDictionary_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("d", () => new Hashtable(null, null)); // Dictionary is null
+            Assert.Throws<ArgumentNullException>("d", () => new Hashtable((IDictionary)null, null)); // Dictionary is null
         }
 
         [Theory]
@@ -143,6 +216,17 @@ namespace System.Collections.Tests
         {
             var hash = new ComparableHashtable(capacity, loadFactor);
             VerifyHashtable(hash, null, null);
+        }
+
+        [Theory]
+        [InlineData(0, 0.1)]
+        [InlineData(10, 0.2)]
+        [InlineData(100, 0.3)]
+        [InlineData(1000, 1)]
+        public static void Ctor_Int_Int_HashCodeProvider_Comparer(int capacity, float loadFactor)
+        {
+            var hash = new ComparableHashtable(capacity, loadFactor, CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
+            VerifyHashtable(hash, null, hash.EqualityComparer);
         }
 
         [Fact]
@@ -710,6 +794,57 @@ namespace System.Collections.Tests
             }
         }
 
+        [Fact]
+        public static void HashCodeProvider_Set_ImpactsSearch()
+        {
+            var hash = new ComparableHashtable(CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
+            hash.Add("test", "test");
+
+            // Should be able to find with the same and different casing
+            Assert.True(hash.ContainsKey("test"));
+            Assert.True(hash.ContainsKey("TEST"));
+
+            // Changing the hash code provider, we shouldn't be able to find either
+            hash.HashCodeProvider = new FixedHashCodeProvider
+            {
+                FixedHashCode = CaseInsensitiveHashCodeProvider.DefaultInvariant.GetHashCode("test") + 1
+            };
+            Assert.False(hash.ContainsKey("test"));
+            Assert.False(hash.ContainsKey("TEST"));
+
+            // Changing it back, should be able to find both again
+            hash.HashCodeProvider = CaseInsensitiveHashCodeProvider.DefaultInvariant;
+            Assert.True(hash.ContainsKey("test"));
+            Assert.True(hash.ContainsKey("TEST"));
+        }
+
+        [Fact]
+        public static void Comparer_Set_ImpactsSearch()
+        {
+            var hash = new ComparableHashtable(CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
+            hash.Add("test", "test");
+
+            // Should be able to find with the same and different casing
+            Assert.True(hash.ContainsKey("test"));
+            Assert.True(hash.ContainsKey("TEST"));
+
+            // Changing the comparer, should only be able to find the matching case
+            hash.Comparer = StringComparer.Ordinal;
+            Assert.True(hash.ContainsKey("test"));
+            Assert.False(hash.ContainsKey("TEST"));
+
+            // Changing it back, should be able to find both again
+            hash.Comparer = StringComparer.OrdinalIgnoreCase;
+            Assert.True(hash.ContainsKey("test"));
+            Assert.True(hash.ContainsKey("TEST"));
+        }
+
+        private class FixedHashCodeProvider : IHashCodeProvider
+        {
+            public int FixedHashCode;
+            public int GetHashCode(object obj) => FixedHashCode;
+        }
+
         private static void VerifyHashtable(ComparableHashtable hash1, Hashtable hash2, IEqualityComparer ikc)
         {
             if (hash2 == null)
@@ -759,7 +894,11 @@ namespace System.Collections.Tests
 
             public ComparableHashtable(int capacity, float loadFactor) : base(capacity, loadFactor) { }
 
+            public ComparableHashtable(int capacity, IHashCodeProvider hcp, IComparer comparer) : base(capacity, hcp, comparer) { }
+
             public ComparableHashtable(int capacity, IEqualityComparer ikc) : base(capacity, ikc) { }
+
+            public ComparableHashtable(IHashCodeProvider hcp, IComparer comparer) : base(hcp, comparer) { }
 
             public ComparableHashtable(IEqualityComparer ikc) : base(ikc) { }
 
@@ -767,13 +906,21 @@ namespace System.Collections.Tests
 
             public ComparableHashtable(IDictionary d, float loadFactor) : base(d, loadFactor) { }
 
+            public ComparableHashtable(IDictionary d, IHashCodeProvider hcp, IComparer comparer) : base(d, hcp, comparer) { }
+
             public ComparableHashtable(IDictionary d, IEqualityComparer ikc) : base(d, ikc) { }
 
+            public ComparableHashtable(IDictionary d, float loadFactor, IHashCodeProvider hcp, IComparer comparer) : base(d, loadFactor, hcp, comparer) { }
+
             public ComparableHashtable(IDictionary d, float loadFactor, IEqualityComparer ikc) : base(d, loadFactor, ikc) { }
+
+            public ComparableHashtable(int capacity, float loadFactor, IHashCodeProvider hcp, IComparer comparer) : base(capacity, loadFactor, hcp, comparer) { }
 
             public ComparableHashtable(int capacity, float loadFactor, IEqualityComparer ikc) : base(capacity, loadFactor, ikc) { }
 
             public new IEqualityComparer EqualityComparer => base.EqualityComparer;
+            public IHashCodeProvider HashCodeProvider { get { return hcp; } set { hcp = value; } }
+            public IComparer Comparer { get { return comparer; } set { comparer = value; } }
         }
 
         private class BadHashCode
@@ -816,6 +963,34 @@ namespace System.Collections.Tests
             }
 
             public override int GetHashCode() => StringValue.GetHashCode();
+        }
+
+        private sealed class HashCodeProviderComparer : IEqualityComparer
+        {
+            private readonly IComparer _comparer;
+            private readonly IHashCodeProvider _hcp;
+
+            internal HashCodeProviderComparer(IHashCodeProvider hashCodeProvider, IComparer comparer)
+            {
+                _comparer = comparer;
+                _hcp = hashCodeProvider;
+            }
+
+            public new bool Equals(object a, object b)
+            {
+                if (a == b) return true;
+                if (a == null || b == null) return false;
+                return _comparer.Compare(a, b) == 0;
+            }
+
+            public int GetHashCode(object obj)
+            {
+                if (obj == null)
+                {
+                    throw new ArgumentNullException(nameof(obj));
+                }
+                return _hcp.GetHashCode(obj);
+            }
         }
     }
 

--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -819,6 +819,37 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        public static void HashCodeProvider_Comparer_CompatibleGetSet_Success()
+        {
+            var hash = new ComparableHashtable();
+            Assert.Null(hash.HashCodeProvider);
+            Assert.Null(hash.Comparer);
+
+            hash = new ComparableHashtable();
+            hash.HashCodeProvider = null;
+            hash.Comparer = null;
+
+            hash = new ComparableHashtable();
+            hash.Comparer = null;
+            hash.HashCodeProvider = null;
+
+            hash.HashCodeProvider = CaseInsensitiveHashCodeProvider.DefaultInvariant;
+            hash.Comparer = StringComparer.OrdinalIgnoreCase;
+        }
+
+        [Fact]
+        public static void HashCodeProvider_Comparer_IncompatibleGetSet_Throws()
+        {
+            var hash = new ComparableHashtable(StringComparer.CurrentCulture);
+
+            Assert.Throws<ArgumentException>(() => hash.HashCodeProvider);
+            Assert.Throws<ArgumentException>(() => hash.Comparer);
+
+            Assert.Throws<ArgumentException>(() => hash.HashCodeProvider = CaseInsensitiveHashCodeProvider.DefaultInvariant);
+            Assert.Throws<ArgumentException>(() => hash.Comparer = StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public static void Comparer_Set_ImpactsSearch()
         {
             var hash = new ComparableHashtable(CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
@@ -963,34 +994,6 @@ namespace System.Collections.Tests
             }
 
             public override int GetHashCode() => StringValue.GetHashCode();
-        }
-
-        private sealed class HashCodeProviderComparer : IEqualityComparer
-        {
-            private readonly IComparer _comparer;
-            private readonly IHashCodeProvider _hcp;
-
-            internal HashCodeProviderComparer(IHashCodeProvider hashCodeProvider, IComparer comparer)
-            {
-                _comparer = comparer;
-                _hcp = hashCodeProvider;
-            }
-
-            public new bool Equals(object a, object b)
-            {
-                if (a == b) return true;
-                if (a == null || b == null) return false;
-                return _comparer.Compare(a, b) == 0;
-            }
-
-            public int GetHashCode(object obj)
-            {
-                if (obj == null)
-                {
-                    throw new ArgumentNullException(nameof(obj));
-                }
-                return _hcp.GetHashCode(obj);
-            }
         }
     }
 

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -37,6 +37,7 @@
     </Compile>
     <Compile Include="ArrayListTests.cs" />
     <Compile Include="ArrayList\ArrayList.IList.Tests.cs" />
+    <Compile Include="CaseInsensitiveHashCodeProviderTests.cs" />
     <Compile Include="Hashtable\Hashtable.Values.Tests.cs" />
     <Compile Include="Hashtable\Hashtable.Keys.Tests.cs" />
     <Compile Include="Hashtable\Hashtable.IDictionary.Tests.cs" />


### PR DESCRIPTION
This support is only for compatibility, but even though it's been obsoleted for a long time, it still shows up with a surprisingly high amount of usage.  I've ported them from desktop.

cc: @danmosemsft, @ellismg