### PR TITLE
Add ICloneable back to System.Runtime contract

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -954,6 +954,10 @@ namespace System
         bool CompletedSynchronously { get; }
         bool IsCompleted { get; }
     }
+    public partial interface ICloneable
+    {
+        object Clone();
+    }
     public partial interface IComparable
     {
         int CompareTo(object obj);


### PR DESCRIPTION
We've got a bunch of types outside of mscorlib that implement this interface in desktop, and the lack of it is causing issues, e.g.  https://github.com/dotnet/corefx/issues/9884.  This commit adds the interface to the contract; when we subsequently update the packages, then we can start implementing this in types outside of System.Runtime (since System.Runtime is mostly a facade on System.Private.Corelib, the types it "contains" already implement the interface).

cc: @danmosemsft, @ericstj