### PR TITLE
Remove Mac OS minor version number from package filtering.

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -17,14 +17,14 @@ RuntimeOS=ubuntu.14.04
 OSName=$(uname -s)
 case $OSName in
     Darwin)
-        # Darwin version can be three sets of digits (e.g. 10.10.3), we want just the first two
-        DarwinVersion=$(sw_vers -productVersion | awk 'match($0, /[0-9]+\.[0-9]+/) { print substr($0, RSTART, RLENGTH) }')
+        # Darwin version can be three sets of digits (e.g. 10.10.3), we want just the first one
+        DarwinVersion=$(sw_vers -productVersion | awk 'match($0, /[0-9]+/) { print substr($0, RSTART, RLENGTH) }')
         RuntimeOS=osx.$DarwinVersion
         ;;
 
     FreeBSD|NetBSD)
         # TODO this doesn't seem correct
-        RuntimeOS=osx.10.10
+        RuntimeOS=osx.10
         ;;
 
     Linux)

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -24,7 +24,7 @@
       <Platform>amd64</Platform>
     </Project>
     <Project Include="osx\runtime.native.System.IO.Compression.pkgproj">
-      <OSGroup>osx.10.10</OSGroup>
+      <OSGroup>osx.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="opensuse\13.2\runtime.native.System.IO.Compression.pkgproj">

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
@@ -24,7 +24,7 @@
       <Platform>amd64</Platform>
     </Project>
     <Project Include="osx\runtime.native.System.Net.Http.pkgproj">
-      <OSGroup>osx.10.10</OSGroup>
+      <OSGroup>osx.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="opensuse\13.2\runtime.native.System.Net.Http.pkgproj">

--- a/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.builds
@@ -24,7 +24,7 @@
       <Platform>amd64</Platform>
     </Project>
     <Project Include="osx\runtime.native.System.Net.Security.pkgproj">
-      <OSGroup>osx.10.10</OSGroup>
+      <OSGroup>osx.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="opensuse\13.2\runtime.native.System.Net.Security.pkgproj">

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
@@ -24,7 +24,7 @@
       <Platform>amd64</Platform>
     </Project>
     <Project Include="osx\runtime.native.System.Security.Cryptography.pkgproj">
-      <OSGroup>osx.10.10</OSGroup>
+      <OSGroup>osx.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="opensuse\13.2\runtime.native.System.Security.Cryptography.pkgproj">

--- a/src/Native/pkg/runtime.native.System/runtime.native.System.builds
+++ b/src/Native/pkg/runtime.native.System/runtime.native.System.builds
@@ -24,7 +24,7 @@
       <Platform>amd64</Platform>
     </Project>
     <Project Include="osx\runtime.native.System.pkgproj">
-      <OSGroup>osx.10.10</OSGroup>
+      <OSGroup>osx.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="opensuse\13.2\runtime.native.System.pkgproj">


### PR DESCRIPTION
Building on Mac OS 10.11 produces binaries that are compatible with
version 10.10.  It order to build packages on Macs running 10.11 I have
removed the OS minor version number as part of the package filtering.