### PR TITLE
Add a few more Environment.Exit* tests

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -51,20 +51,24 @@ namespace System.Tests
 
         [ActiveIssue("https://github.com/dotnet/coreclr/issues/6206")]
         [Theory]
-        [MemberData(nameof(ExitCodeValues))]
-        public static void ExitCode_VoidMainAppReturnsSetValue(int expectedExitCode)
+        [InlineData(1)] // setting ExitCode and exiting Main
+        [InlineData(2)] // setting ExitCode both from Main and from an Unloading event handler.
+        [InlineData(3)] // using Exit(exitCode)
+        public static void ExitCode_VoidMainAppReturnsSetValue(int mode)
         {
+            int expectedExitCode = 123;
+
             const string AppName = "VoidMainWithExitCodeApp.exe";
             var psi = new ProcessStartInfo();
             if (File.Exists(HostRunner))
             {
                 psi.FileName = HostRunner;
-                psi.Arguments = AppName + " " + expectedExitCode.ToString();
+                psi.Arguments = $"{AppName} {expectedExitCode} {mode}";
             }
             else
             {
                 psi.FileName = AppName;
-                psi.Arguments = expectedExitCode.ToString();
+                psi.Arguments = $"{expectedExitCode} {mode}";
             }
 
             using (Process p = Process.Start(psi))

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.Tests
 {
@@ -178,6 +179,8 @@ namespace System.Tests
             Assert.True(Environment.WorkingSet > 0, "Expected positive WorkingSet value");
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // fail fast crashes the process
+        [OuterLoop]
         [Fact]
         public void FailFast_ExpectFailureExitCode()
         {

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/project.json
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/project.json
@@ -3,7 +3,8 @@
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24222-03",
     "System.Runtime": "4.1.1-beta-24222-03",
     "System.Runtime.Extensions": "4.1.1-beta-24222-03",
-    "System.Reflection": "4.1.1-beta-24222-03"
+    "System.Reflection": "4.1.1-beta-24222-03",
+    "System.Threading.Thread": "4.0.1-beta-24222-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -12,6 +12,7 @@
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.1-beta-24222-03",
     "System.Text.RegularExpressions": "4.2.0-beta-24222-03",
     "System.Threading": "4.0.12-beta-24222-03",
+    "System.Threading.Thread": "4.0.1-beta-24222-03",
     "System.Threading.Tasks": "4.0.12-beta-24222-03",
     "test-runtime": {
       "target": "project",


### PR DESCRIPTION
- Verifies that Environment.Exit(exitCode) passes the code through
- Verifies that Environment.ExitCode passes the code through even after Main exits, e.g. from a foreground thread

Both of these currently fail due to a coreclr issue.

This also disables a test that appears to be causing some CI runs to hang due to popping up a dialog when the process crashes due to a (planned) fail fast.