### PR TITLE
[port from coreclr] Avoid repeated virtual method calls in List.Contains

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/List.cs
+++ b/src/System.Collections/src/System/Collections/Generic/List.cs
@@ -338,26 +338,19 @@ namespace System.Collections.Generic
 
         // Contains returns true if the specified element is in the List.
         // It does a linear, O(n) search.  Equality is determined by calling
-        // item.Equals().
-        //
+        // EqualityComparer<T>.Default.Equals().
+
         public bool Contains(T item)
         {
-            if ((Object)item == null)
-            {
-                for (int i = 0; i < _size; i++)
-                    if ((Object)_items[i] == null)
-                        return true;
-                return false;
-            }
-            else
-            {
-                EqualityComparer<T> c = EqualityComparer<T>.Default;
-                for (int i = 0; i < _size; i++)
-                {
-                    if (c.Equals(_items[i], item)) return true;
-                }
-                return false;
-            }
+            // PERF: IndexOf calls Array.IndexOf, which internally
+            // calls EqualityComparer<T>.Default.IndexOf, which
+            // is specialized for different types. This
+            // boosts performance since instead of making a
+            // virtual method call each iteration of the loop,
+            // via EqualityComparer<T>.Default.Equals, we
+            // only make one virtual call to EqualityComparer.IndexOf.
+
+            return _size != 0 && IndexOf(item) != -1;
         }
 
         bool System.Collections.IList.Contains(Object item)


### PR DESCRIPTION
Ported from dotnet/coreclr#6212. I'm not sure if the comment applies the same here as it does in CoreCLR, since looking at the [Array source code](https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/Array.cs#L1509) in corert it appears it does something a bit different. I can either change/remove the comment if you'd like, or keep it the way it is so things stay in sync.

cc @stephentoub, @ellismg 