### PR TITLE
Windows.UI.Color: Simplify Equals

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System/Windows/UI/Color.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Windows/UI/Color.cs
@@ -124,16 +124,7 @@ namespace Windows.UI
 
         public override bool Equals(object o)
         {
-            if (o is Color)
-            {
-                Color color = (Color)o;
-
-                return (this == color);
-            }
-            else
-            {
-                return false;
-            }
+            return o is Color && this == (Color)o;
         }
 
         public bool Equals(Color color)
@@ -143,26 +134,11 @@ namespace Windows.UI
 
         public static bool operator ==(Color color1, Color color2)
         {
-            if (color1.R != color2.R)
-            {
-                return false;
-            }
-
-            if (color1.G != color2.G)
-            {
-                return false;
-            }
-
-            if (color1.B != color2.B)
-            {
-                return false;
-            }
-
-            if (color1.A != color2.A)
-            {
-                return false;
-            }
-            return true;
+            return
+                color1.R == color2.R &&
+                color1.G == color2.G &&
+                color1.B == color2.B &&
+                color1.A == color2.A;
         }
 
         public static bool operator !=(Color color1, Color color2)


### PR DESCRIPTION
Simplify the code for `Equals(object)` and the equality operator.

Related to #5298 (this change is similar to the changes made to [`Point`](https://github.com/dotnet/corefx/pull/5298/files#diff-86d20b4ac1cd80ce94f0c691b2c0819b)/[`Rect`](https://github.com/dotnet/corefx/pull/5298/files#diff-bf47ad440a8bbbf9a14774aaaab12689)/[`Size`](https://github.com/dotnet/corefx/pull/5298/files#diff-5b87e0c17ee53b87f0043bd4cbb10114))

cc: @stephentoub, @mellinoe 