### PR TITLE
Add tests for Delegate.DynamicInvoke with default parameters

### DIFF
--- a/src/System.Runtime/tests/System/DelegateTests.cs
+++ b/src/System.Runtime/tests/System/DelegateTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+using System.Text;
 using Xunit;
 
 namespace System.Tests
@@ -179,6 +181,184 @@ namespace System.Tests
             Assert.Throws<ArgumentException>(null, () => d.DynamicInvoke(IntEnum.Seven));
         }
 
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_AllPrimitiveParametersWithMissingValues()
+        {
+            object[] parameters = new object[13];
+            for (int i = 0; i < parameters.Length; i++) { parameters[i] = Type.Missing; }
+
+            Assert.Equal(
+                "True, test, c, 2, -1, -3, 4, -5, 6, -7, 8, 9.1, 11.12",
+                (string)(new AllPrimitivesWithDefaultValues(AllPrimitivesMethod)).DynamicInvoke(parameters));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_AllPrimitiveParametersWithAllExplicitValues()
+        {
+            Assert.Equal(
+                "False, value, d, 102, -101, -103, 104, -105, 106, -107, 108, 109.1, 111.12",
+                (string)(new AllPrimitivesWithDefaultValues(AllPrimitivesMethod)).DynamicInvoke(
+                    new object[13]
+                    {
+                        false,
+                        "value",
+                        'd',
+                        (byte)102,
+                        (sbyte)-101,
+                        (short)-103,
+                        (UInt16)104,
+                        (int)-105,
+                        (UInt32)106,
+                        (long)-107,
+                        (UInt64)108,
+                        (Single)109.1,
+                        (Double)111.12
+                    }
+                    ));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_AllPrimitiveParametersWithSomeExplicitValues()
+        {
+            Assert.Equal(
+                "False, test, d, 2, -101, -3, 104, -5, 106, -7, 108, 9.1, 111.12",
+                (string)(new AllPrimitivesWithDefaultValues(AllPrimitivesMethod)).DynamicInvoke(
+                    new object[13]
+                    {
+                        false,
+                        Type.Missing,
+                        'd',
+                        Type.Missing,
+                        (sbyte)-101,
+                        Type.Missing,
+                        (UInt16)104,
+                        Type.Missing,
+                        (UInt32)106,
+                        Type.Missing,
+                        (UInt64)108,
+                        Type.Missing,
+                        (Double)111.12
+                    }
+                    ));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_StringParameterWithMissingValue()
+        {
+            Assert.Equal
+                ("test",
+                (string)(new StringWithDefaultValue(StringMethod)).DynamicInvoke(new object[] { Type.Missing }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_StringParameterWithExplicitValue()
+        {
+            Assert.Equal(
+                "value",
+                (string)(new StringWithDefaultValue(StringMethod)).DynamicInvoke(new object[] { "value" }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_ReferenceTypeParameterWithMissingValue()
+        {
+            Assert.Null((new ReferenceWithDefaultValue(ReferenceMethod)).DynamicInvoke(new object[] { Type.Missing }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_ReferenceTypeParameterWithExplicitValue()
+        {
+            CustomReferenceType referenceInstance = new CustomReferenceType();
+            Assert.Same(
+                referenceInstance,
+                (new ReferenceWithDefaultValue(ReferenceMethod)).DynamicInvoke(new object[] { referenceInstance }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_ValueTypeParameterWithMissingValue()
+        {
+            Assert.Equal(
+                0,
+                ((CustomValueType)(new ValueTypeWithDefaultValue(ValueTypeMethod)).DynamicInvoke(new object[] { Type.Missing })).Id);
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_ValueTypeParameterWithExplicitValue()
+        {
+            Assert.Equal(
+                1,
+                ((CustomValueType)(new ValueTypeWithDefaultValue(ValueTypeMethod)).DynamicInvoke(new object[] { new CustomValueType { Id = 1 } })).Id);
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_DateTimeParameterWithMissingValue()
+        {
+            Assert.Equal(
+                new DateTime(42),
+                (DateTime)(new DateTimeWithDefaultValueAttribute(DateTimeMethod)).DynamicInvoke(new object[] { Type.Missing }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_DateTimeParameterWithExplicitValue()
+        {
+            Assert.Equal(
+                new DateTime(43),
+                (DateTime)(new DateTimeWithDefaultValueAttribute(DateTimeMethod)).DynamicInvoke(new object[] { new DateTime(43) }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_DecimalParameterWithAttributeAndMissingValue()
+        {
+            Assert.Equal(
+                new decimal(4, 3, 2, true, 1),
+                (decimal)(new DecimalWithDefaultValueAttribute(DecimalMethod)).DynamicInvoke(new object[] { Type.Missing }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_DecimalParameterWithAttributeAndExplicitValue()
+        {
+            Assert.Equal(
+                new decimal(12, 13, 14, true, 1),
+                (decimal)(new DecimalWithDefaultValueAttribute(DecimalMethod)).DynamicInvoke(new object[] { new decimal(12, 13, 14, true, 1) }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_DecimalParameterWithMissingValue()
+        {
+            Assert.Equal(
+                3.14m,
+                (decimal)(new DecimalWithDefaultValue(DecimalMethod)).DynamicInvoke(new object[] { Type.Missing }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_DecimalParameterWithExplicitValue()
+        {
+            Assert.Equal(
+                103.14m,
+                (decimal)(new DecimalWithDefaultValue(DecimalMethod)).DynamicInvoke(new object[] { 103.14m }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_NullableIntWithMissingValue()
+        {
+            Assert.Null((int?)(new NullableIntWithDefaultValue(NullableIntMethod)).DynamicInvoke(new object[] { Type.Missing }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_NullableIntWithExplicitValue()
+        {
+            Assert.Equal(
+                (int?)42,
+                (int?)(new NullableIntWithDefaultValue(NullableIntMethod)).DynamicInvoke(new object[] { (int?)42 }));
+        }
+
+        [Fact]
+        public static void DynamicInvoke_DefaultParameter_EnumParameterWithMissingValue()
+        {
+            Assert.Equal(
+                IntEnum.Seven,
+                (IntEnum)(new EnumWithDefaultValue(EnumMethod)).DynamicInvoke(new object[] { Type.Missing }));
+        }
+
         private static void IntIntMethod(int expected, int actual)
         {
             Assert.Equal(expected, actual);
@@ -244,6 +424,100 @@ namespace System.Tests
         {
             One = 1,
             Seven = 7,
+        }
+
+        private delegate string AllPrimitivesWithDefaultValues(
+            bool boolean = true,
+            string str = "test",
+            char character = 'c',
+            byte unsignedbyte = 2,
+            sbyte signedbyte = -1,
+            Int16 int16 = -3,
+            UInt16 uint16 = 4,
+            Int32 int32 = -5,
+            UInt32 uint32 = 6,
+            Int64 int64 = -7,
+            UInt64 uint64 = 8,
+            Single single = (Single)9.1,
+            Double dbl = 11.12);
+
+        private static string AllPrimitivesMethod(
+            bool boolean,
+            string str,
+            char character,
+            byte unsignedbyte,
+            sbyte signedbyte,
+            Int16 int16,
+            UInt16 uint16,
+            Int32 int32,
+            UInt32 uint32,
+            Int64 int64,
+            UInt64 uint64,
+            Single single,
+            Double dbl)
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append(boolean.ToString() + ", ");
+            builder.Append(str + ", ");
+            builder.Append(character.ToString() + ", ");
+            builder.Append(unsignedbyte.ToString() + ", ");
+            builder.Append(signedbyte.ToString() + ", ");
+            builder.Append(int16.ToString() + ", ");
+            builder.Append(uint16.ToString() + ", ");
+            builder.Append(int32.ToString() + ", ");
+            builder.Append(uint32.ToString() + ", ");
+            builder.Append(int64.ToString() + ", ");
+            builder.Append(uint64.ToString() + ", ");
+            builder.Append(single.ToString() + ", ");
+            builder.Append(dbl);
+            return builder.ToString();
+        }
+
+        private delegate string StringWithDefaultValue(string parameter = "test");
+        private static string StringMethod(string parameter)
+        {
+            return parameter;
+        }
+
+        private class CustomReferenceType { };
+
+        private delegate CustomReferenceType ReferenceWithDefaultValue(CustomReferenceType parameter = null);
+        private static CustomReferenceType ReferenceMethod(CustomReferenceType parameter)
+        {
+            return parameter;
+        }
+
+        private struct CustomValueType { public int Id; };
+
+        private delegate CustomValueType ValueTypeWithDefaultValue(CustomValueType parameter = default(CustomValueType));
+        private static CustomValueType ValueTypeMethod(CustomValueType parameter)
+        {
+            return parameter;
+        }
+
+        private delegate DateTime DateTimeWithDefaultValueAttribute([DateTimeConstant(42)] DateTime parameter);
+        private static DateTime DateTimeMethod(DateTime parameter)
+        {
+            return parameter;
+        }
+
+        private delegate decimal DecimalWithDefaultValueAttribute([DecimalConstant(1, 1, 2, 3, 4)] decimal parameter);
+        private delegate decimal DecimalWithDefaultValue(decimal parameter = 3.14m);
+        private static decimal DecimalMethod(decimal parameter)
+        {
+            return parameter;
+        }
+
+        private delegate int? NullableIntWithDefaultValue(int? parameter = null);
+        private static int? NullableIntMethod(int? parameter)
+        {
+            return parameter;
+        }
+
+        private delegate IntEnum EnumWithDefaultValue(IntEnum parameter = IntEnum.Seven);
+        private static IntEnum EnumMethod(IntEnum parameter = IntEnum.Seven)
+        {
+            return parameter;
         }
     }
 }


### PR DESCRIPTION
Add tests for various cases where Delegate.DynamicInvoke is used on a
delegate with default parameters. The tests were more or less copied
from the respective MethodInfo.Invoke tests since the default parameter
behavior should be the same between these two code paths.