### PR TITLE
Added support for using certs with implicit skids in EnvelopedCms

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Cms.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Cms.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
 
 using Microsoft.Win32.SafeHandles;
 
@@ -88,7 +89,8 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsDecrypt")]
-        internal static extern int CmsDecrypt(SafeCmsHandle cms, SafeX509Handle recipientCert, SafeEvpPKeyHandle pKeyKandle, SafeBioHandle decryptedBuffered);
+        internal static extern int CmsDecrypt(
+            SafeCmsHandle cms, SafeX509Handle recipientCert, SafeEvpPKeyHandle pKeyKandle, SafeBioHandle decryptedBuffered, SubjectIdentifierType type);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsGetDerSize")]
         internal static extern int CmsGetDerSize(SafeCmsHandle cms);

--- a/src/Native/System.Security.Cryptography.Native/pal_cms.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_cms.h
@@ -7,14 +7,25 @@
 #include <openssl/cms.h>
 
 /*
+These values should be kept in sync with System.Security.Cryptography.Pkcs.SubjectIdentifierType.cs
+*/
+enum SubjectIdentifierType : int32_t
+{
+    Unknown = 0,
+    IssuerAndSerialNumber = 1,
+    SubjectKeyIdentifier = 2,
+    NoSignature = 3
+};
+
+/*
 Shims the d2i_CMS_ContentInfo method
 */
 extern "C" CMS_ContentInfo* CryptoNative_CmsDecode(const uint8_t* buf, int32_t len);
 
 /*
-Shims the CMS_decrypt method
+Shims the CMS_decrypt method and provides the implicit skid to the cert if necessary
 */
-extern "C" int CryptoNative_CmsDecrypt(CMS_ContentInfo* cms, X509* cert, EVP_PKEY* pkey, BIO* out);
+extern "C" int CryptoNative_CmsDecrypt(CMS_ContentInfo* cms, X509* cert, EVP_PKEY* pkey, BIO* out, SubjectIdentifierType type);
 
 /*
 Shim the CMS_ContentInfo_free method

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.h
@@ -293,3 +293,11 @@ Shims the i2d_X509_PUBKEY method, providing X509_get_X509_PUBKEY(x) as the input
 Returns the number of bytes written to buf.
 */
 extern "C" int32_t CryptoNative_EncodeX509SubjectPublicKeyInfo(X509* x, uint8_t* buf);
+
+/*
+This method calculates the implicit skid of an X509 certificate by calculating the SHA-1 hash of the
+publicKeyInfo binary blob of the DER representation of the certificate and stores it in pBuf.
+
+Returns -1 on input error, 0 on OpenSSL error, and 1 on success.
+*/
+extern "C" int32_t CryptoNative_X509GetImplicitSubjectKeyIdentifier(X509* x509, uint8_t* pBuf, int cBuf);

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/DecryptorPalOpenSsl.Decrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/DecryptorPalOpenSsl.Decrypt.cs
@@ -34,7 +34,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
             switch (type)
             {
                 case RecipientInfoType.KeyTransport:
-                    decryptedContent = TryDecryptTrans(cert, out exception);
+                    decryptedContent = TryDecryptTrans(cert, out exception, recipientInfo.RecipientIdentifier.Type);
                     break;
 
                 case RecipientInfoType.KeyAgreement:
@@ -59,7 +59,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
             return decryptedContent;
         }
 
-        private ContentInfo TryDecryptTrans(X509Certificate2 recipientCert, out Exception exception)
+        private ContentInfo TryDecryptTrans(X509Certificate2 recipientCert, out Exception exception, SubjectIdentifierType type)
         {
             // If there's no content OpenSSL will fail to decrypt, so do the check manually before
             // delegating to OpenSSL
@@ -91,7 +91,7 @@ namespace Internal.Cryptography.Pal.OpenSsl
                     Interop.Crypto.CheckValidOpenSslHandle(recipientCertHandle);
                     Interop.Crypto.CheckValidOpenSslHandle(pKey);
 
-                    int status = Interop.Crypto.CmsDecrypt(_decodedMessage, recipientCertHandle, pKey, decryptionBuffer);
+                    int status = Interop.Crypto.CmsDecrypt(_decodedMessage, recipientCertHandle, pKey, decryptionBuffer, type);
 
                     exception = status == 1 ?
                         null :

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/PkcsPalOpenSsl.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/PkcsPalOpenSsl.cs
@@ -164,7 +164,10 @@ namespace Internal.Cryptography.Pal.OpenSsl
             // as there might be a recipient for which we have a certificate which we can use to decrypt.
             // If all certificates don't match then TryDecrypt will throw a "recipient not found" cryptographic
             // exception which explains OpenSSL's behavior.
-            return Array.Empty<byte>();
+            using (SafeX509Handle certHandle = Interop.Crypto.X509Duplicate(certificate.Handle))
+            {
+                return Interop.Crypto.X509GetImplicitSubjectKeyIdentifier(certHandle);
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -23,7 +23,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_Ski()
         {
@@ -258,7 +257,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Fact]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestDecryptSimpleAes256_Ski()
         {
             // Message encrypted on framework for a recipient using the certificate returned by Certificates.RSAKeyTransfer1.GetCertificate()

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -56,7 +56,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Fact]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void ImportEdgeCaseSki()
         {
             byte[] encodedMessage =

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
@@ -86,7 +86,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeRecipientIdType_Ski_RoundTrip()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1(SubjectIdentifierType.SubjectKeyIdentifier);
@@ -103,7 +102,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyAgreeRecipientIdValue_Ski_RoundTrip()
         {
             KeyAgreeRecipientInfo recipient = FixedValueKeyAgree1(SubjectIdentifierType.SubjectKeyIdentifier);

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoTests.cs
@@ -90,7 +90,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransRecipientIdType_Ski_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl(SubjectIdentifierType.SubjectKeyIdentifier);
@@ -107,7 +106,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestKeyTransRecipientIdValue_Ski_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl(SubjectIdentifierType.SubjectKeyIdentifier);

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
@@ -99,7 +99,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void PostCtor_Decrypt()
         {
             EnvelopedCms ecms = new EnvelopedCms();

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslCertificateFinder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslCertificateFinder.cs
@@ -264,16 +264,7 @@ namespace Internal.Cryptography.Pal
                         // https://msdn.microsoft.com/en-us/library/windows/desktop/aa376079%28v=vs.85%29.aspx
 
                         OpenSslX509CertificateReader certPal = (OpenSslX509CertificateReader)cert.Pal;
-
-                        using (HashAlgorithm hash = SHA1.Create())
-                        {
-                            byte[] publicKeyInfoBytes = Interop.Crypto.OpenSslEncode(
-                                Interop.Crypto.GetX509SubjectPublicKeyInfoDerSize,
-                                Interop.Crypto.EncodeX509SubjectPublicKeyInfo,
-                                certPal.SafeHandle);
-
-                            certKeyId = hash.ComputeHash(publicKeyInfoBytes);
-                        }
+                        certKeyId = Interop.Crypto.X509GetImplicitSubjectKeyIdentifier(certPal.SafeHandle);
                     }
 
                     return keyIdentifier.ContentsEqual(certKeyId);


### PR DESCRIPTION
+ Added support for encryption for recipients that are identified with
SubjectKeyIdentifier but use a cert that doesn't have one explicitly.

+ Added support for decryption for recipients that are identified with
SubjectKeyIdentifier but use a cert that doesn't have one explicitly.

@weshaggard @bartonjs 