### PR TITLE
Added Close() methods to String IO

### DIFF
--- a/src/System.IO/ref/System.IO.cs
+++ b/src/System.IO/ref/System.IO.cs
@@ -169,6 +169,7 @@ namespace System.IO
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination) { return default(System.Threading.Tasks.Task); }
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
+        public virtual void Close() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public abstract void Flush();
@@ -198,6 +199,7 @@ namespace System.IO
         public virtual System.Text.Encoding CurrentEncoding { get { return default(System.Text.Encoding); } }
         public bool EndOfStream { get { return default(bool); } }
         public void DiscardBufferedData() { }
+        public override void Close() { }
         protected override void Dispose(bool disposing) { }
         public override int Peek() { return default(int); }
         public override int Read() { return default(int); }
@@ -220,6 +222,7 @@ namespace System.IO
         public virtual bool AutoFlush { get { return default(bool); } set { } }
         public virtual System.IO.Stream BaseStream { get { return default(System.IO.Stream); } }
         public override System.Text.Encoding Encoding { get { return default(System.Text.Encoding); } }
+        public override void Close() { }
         protected override void Dispose(bool disposing) { }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync() { return default(System.Threading.Tasks.Task); }
@@ -238,6 +241,7 @@ namespace System.IO
     public partial class StringReader : System.IO.TextReader
     {
         public StringReader(string s) { }
+        public override void Close() { }
         protected override void Dispose(bool disposing) { }
         public override int Peek() { return default(int); }
         public override int Read() { return default(int); }
@@ -256,6 +260,7 @@ namespace System.IO
         public StringWriter(System.Text.StringBuilder sb) { }
         public StringWriter(System.Text.StringBuilder sb, System.IFormatProvider formatProvider) { }
         public override System.Text.Encoding Encoding { get { return default(System.Text.Encoding); } }
+        public override void Close() { }
         protected override void Dispose(bool disposing) { }
         public override System.Threading.Tasks.Task FlushAsync() { return default(System.Threading.Tasks.Task); }
         public virtual System.Text.StringBuilder GetStringBuilder() { return default(System.Text.StringBuilder); }
@@ -274,6 +279,7 @@ namespace System.IO
     {
         public static readonly System.IO.TextReader Null;
         protected TextReader() { }
+        public virtual void Close() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public virtual int Peek() { return default(int); }
@@ -296,6 +302,7 @@ namespace System.IO
         public abstract System.Text.Encoding Encoding { get; }
         public virtual System.IFormatProvider FormatProvider { get { return default(System.IFormatProvider); } }
         public virtual string NewLine { get { return default(string); } set { } }
+        public virtual void Close() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public virtual void Flush() { }

--- a/src/System.IO/src/System/IO/Stream.cs
+++ b/src/System.IO/src/System/IO/Stream.cs
@@ -144,10 +144,15 @@ namespace System.IO
             }
         }
 
-        public void Dispose()
+        public virtual void Close()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
+        }
+
+        public void Dispose()
+        {
+            Close();
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/System.IO/src/System/IO/StreamReader.cs
+++ b/src/System.IO/src/System/IO/StreamReader.cs
@@ -197,6 +197,11 @@ namespace System.IO
             _closable = true;
         }
 
+        public override void Close()
+        {
+            Dispose(true);
+        }
+
         protected override void Dispose(bool disposing)
         {
             // Dispose of our resources if this StreamReader is closable.
@@ -207,7 +212,7 @@ namespace System.IO
                 // ensure cleaning up internal resources, inside the finally block.  
                 if (!LeaveOpen && disposing && (_stream != null))
                 {
-                    _stream.Dispose();
+                    _stream.Close();
                 }
             }
             finally

--- a/src/System.IO/src/System/IO/StreamWriter.cs
+++ b/src/System.IO/src/System/IO/StreamWriter.cs
@@ -148,6 +148,12 @@ namespace System.IO
             _closable = !shouldLeaveOpen;
         }
 
+        public override void Close()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
         protected override void Dispose(bool disposing)
         {
             try
@@ -181,7 +187,7 @@ namespace System.IO
                         // cleaning up internal resources, hence the finally block.  
                         if (disposing)
                         {
-                            _stream.Dispose();
+                            _stream.Close();
                         }
                     }
                     finally

--- a/src/System.IO/src/System/IO/StringReader.cs
+++ b/src/System.IO/src/System/IO/StringReader.cs
@@ -26,6 +26,10 @@ namespace System.IO
             _length = s == null ? 0 : s.Length;
         }
 
+        public override void Close()
+        {
+            Dispose(true);
+        }
 
         protected override void Dispose(bool disposing)
         {

--- a/src/System.IO/src/System/IO/StringWriter.cs
+++ b/src/System.IO/src/System/IO/StringWriter.cs
@@ -47,6 +47,11 @@ namespace System.IO
             _isOpen = true;
         }
 
+        public override void Close()
+        {
+            Dispose(true);
+        }
+
         protected override void Dispose(bool disposing)
         {
             // Do not destroy _sb, so that we can extract this after we are

--- a/src/System.IO/src/System/IO/TextReader.cs
+++ b/src/System.IO/src/System/IO/TextReader.cs
@@ -24,6 +24,12 @@ namespace System.IO
 
         protected TextReader() { }
 
+        public virtual void Close()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/src/System.IO/src/System/IO/TextWriter.cs
+++ b/src/System.IO/src/System/IO/TextWriter.cs
@@ -51,6 +51,12 @@ namespace System.IO
             }
         }
 
+        public virtual void Close()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
         protected virtual void Dispose(bool disposing)
         {
         }

--- a/src/System.IO/tests/Stream/Stream.TestLeaveOpen.cs
+++ b/src/System.IO/tests/Stream/Stream.TestLeaveOpen.cs
@@ -22,9 +22,14 @@ namespace System.IO.Tests
             ms.Position = 0;
             Assert.True(ms.CanRead, "ERROR: Before testing, MemoryStream's CanRead property was false!  What?");
 
-            // Test leaveOpen.
+            // Test leaveOpen with calling Dispose
             StreamReader sr = new StreamReader(ms, System.Text.Encoding.UTF8, true, 1000, true);
             sr.Dispose();
+            Assert.True(ms.CanRead, "ERROR: After disposing a StreamReader with leaveOpen bool set, MemoryStream's CanRead property was false!");
+
+            // Test leaveOpen with calling Close
+            sr = new StreamReader(ms, System.Text.Encoding.UTF8, true, 1000, true);
+            sr.Close();
             Assert.True(ms.CanRead, "ERROR: After closing a StreamReader with leaveOpen bool set, MemoryStream's CanRead property was false!");
 
             // Test not leaving open
@@ -32,10 +37,22 @@ namespace System.IO.Tests
             sr.Dispose();
             Assert.False(ms.CanRead, "ERROR: After closing a StreamReader with leaveOpen bool not set, MemoryStream's CanRead property was true!");
 
+            // Test not leaving open
+            ms = CreateStream();
+            sr = new StreamReader(ms, System.Text.Encoding.UTF8, true, 1000, false);
+            sr.Close();
+            Assert.False(ms.CanRead, "ERROR: After closing a StreamReader with leaveOpen bool not set, MemoryStream's CanRead property was true!");
+
             // Test default
             ms = CreateStream();
             sr = new StreamReader(ms);
             sr.Dispose();
+            Assert.False(ms.CanRead, "ERROR: After disposing a StreamReader with the default value for leaveOpen, MemoryStream's CanRead property was true!");
+
+            // Test default
+            ms = CreateStream();
+            sr = new StreamReader(ms);
+            sr.Close();
             Assert.False(ms.CanRead, "ERROR: After closing a StreamReader with the default value for leaveOpen, MemoryStream's CanRead property was true!");
         }
 
@@ -47,20 +64,37 @@ namespace System.IO.Tests
             ms.Position = 0;
             Assert.True(ms.CanRead, "ERROR: Before testing, MemoryStream's CanRead property was false!  What?");
 
-            // Test leaveOpen.
+            // Test leaveOpen with calling Dispose
             BinaryReader br = new BinaryReader(ms, System.Text.Encoding.UTF8, true);
             br.Dispose();
+            Assert.True(ms.CanRead, "ERROR: After disposing a BinaryReader with leaveOpen bool set, MemoryStream's CanRead property was false!");
+
+            // Test leaveOpen with calling Close
+            br = new BinaryReader(ms, System.Text.Encoding.UTF8, true);
+            br.Close();
             Assert.True(ms.CanRead, "ERROR: After closing a BinaryReader with leaveOpen bool set, MemoryStream's CanRead property was false!");
 
-            // Test not leaving open
+            // Test not leaving open with calling Dispose
             br = new BinaryReader(ms, System.Text.Encoding.UTF8, false);
             br.Dispose();
+            Assert.False(ms.CanRead, "ERROR: After disposing a BinaryReader with leaveOpen bool not set, MemoryStream's CanRead property was true!");
+
+            // Test not leaving open with calling Close
+            ms = CreateStream();
+            br = new BinaryReader(ms, System.Text.Encoding.UTF8, false);
+            br.Close();
             Assert.False(ms.CanRead, "ERROR: After closing a BinaryReader with leaveOpen bool not set, MemoryStream's CanRead property was true!");
 
-            // Test default
+            // Test default with calling Dispose
             ms = CreateStream();
             br = new BinaryReader(ms);
             br.Dispose();
+            Assert.False(ms.CanRead, "ERROR: After disposing a BinaryReader with the default value for leaveOpen, MemoryStream's CanRead property was true!");
+
+            // Test default with calling Close
+            ms = CreateStream();
+            br = new BinaryReader(ms);
+            br.Close();
             Assert.False(ms.CanRead, "ERROR: After closing a BinaryReader with the default value for leaveOpen, MemoryStream's CanRead property was true!");
         }
 
@@ -70,21 +104,38 @@ namespace System.IO.Tests
             Stream ms = CreateStream();
             Assert.True(ms.CanWrite, "ERROR: Before testing, MemoryStream's CanWrite property was false!  What?");
 
-            // Test leaveOpen.
+            // Test leaveOpen with calling Dispose
             StreamWriter sw = new StreamWriter(ms, System.Text.Encoding.UTF8, 1000, true);
             sw.Dispose();
+            Assert.True(ms.CanWrite, "ERROR: After disposing a StreamWriter with leaveOpen bool set, MemoryStream's CanWrite property was false!");
+
+            // Test leaveOpen with calling Close
+            sw = new StreamWriter(ms, System.Text.Encoding.UTF8, 1000, true);
+            sw.Close();
             Assert.True(ms.CanWrite, "ERROR: After closing a StreamWriter with leaveOpen bool set, MemoryStream's CanWrite property was false!");
 
-            // Test not leaving open
+            // Test not leaving open with calling Dispose
             sw = new StreamWriter(ms, System.Text.Encoding.UTF8, 1000, false);
             sw.Dispose();
+            Assert.False(ms.CanWrite, "ERROR: After disposing a StreamWriter with leaveOpen bool not set, MemoryStream's CanWrite property was true!");
+
+            // Test not leaving open with calling Close
+            ms = CreateStream();
+            sw = new StreamWriter(ms, System.Text.Encoding.UTF8, 1000, false);
+            sw.Close();
             Assert.False(ms.CanWrite, "ERROR: After closing a StreamWriter with leaveOpen bool not set, MemoryStream's CanWrite property was true!");
 
-            // Test default
+            // Test default with calling Dispose
             ms = CreateStream();
             sw = new StreamWriter(ms);
             sw.Dispose();
-            Assert.False( ms.CanWrite, "ERROR: After closing a StreamWriter with the default value for leaveOpen, MemoryStream's CanWrite property was true!");
+            Assert.False( ms.CanWrite, "ERROR: After disposing a StreamWriter with the default value for leaveOpen, MemoryStream's CanWrite property was true!");
+
+            // Test default with calling Close
+            ms = CreateStream();
+            sw = new StreamWriter(ms);
+            sw.Close();
+            Assert.False(ms.CanWrite, "ERROR: After closing a StreamWriter with the default value for leaveOpen, MemoryStream's CanWrite property was true!");
         }
 
         [Fact]
@@ -94,20 +145,37 @@ namespace System.IO.Tests
             Stream ms = CreateStream();
             Assert.True(ms.CanWrite, "ERROR: Before testing, MemoryStream's CanWrite property was false!  What?");
 
-            // Test leaveOpen.
+            // Test leaveOpen with calling Dispose
             BinaryWriter bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, true);
             bw.Dispose();
+            Assert.True(ms.CanWrite, "ERROR: After disposing a BinaryWriterwith leaveOpen bool set, MemoryStream's CanWrite property was false!");
+
+            // Test leaveOpen with calling Close
+            bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, true);
+            bw.Close();
             Assert.True(ms.CanWrite, "ERROR: After closing a BinaryWriterwith leaveOpen bool set, MemoryStream's CanWrite property was false!");
 
-            // Test not leaving open
+            // Test not leaving open with calling Dispose
             bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, false);
             bw.Dispose();
+            Assert.False(ms.CanWrite, "ERROR: After disposing a BinaryWriterwith leaveOpen bool not set, MemoryStream's CanWrite property was true!");
+
+            // Test not leaving open with calling Close
+            ms = CreateStream();
+            bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, false);
+            bw.Close();
             Assert.False(ms.CanWrite, "ERROR: After closing a BinaryWriterwith leaveOpen bool not set, MemoryStream's CanWrite property was true!");
 
-            // Test default
+            // Test default with calling Dispose
             ms = CreateStream();
             bw = new BinaryWriter(ms);
             bw.Dispose();
+            Assert.False(ms.CanWrite, "ERROR: After disposing a BinaryWriterwith the default value for leaveOpen, MemoryStream's CanWrite property was true!");
+
+            // Test default with calling Close
+            ms = CreateStream();
+            bw = new BinaryWriter(ms);
+            bw.Close();
             Assert.False(ms.CanWrite, "ERROR: After closing a BinaryWriterwith the default value for leaveOpen, MemoryStream's CanWrite property was true!");
         }
     }

--- a/src/System.IO/tests/StreamReader/StreamReaderTests.cs
+++ b/src/System.IO/tests/StreamReader/StreamReaderTests.cs
@@ -281,6 +281,16 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public void ObjectClosedReadLine()
+        {
+            var baseInfo = GetCharArrayStream();
+            var sr = baseInfo.Item2;
+
+            sr.Close();
+            Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
+        }
+
+        [Fact]
         public void ObjectDisposedReadLineBaseStream()
         {
             var ms = GetLargeStream();
@@ -289,7 +299,17 @@ namespace System.IO.Tests
             ms.Dispose();
             Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
         }
-       
+
+        [Fact]
+        public void ObjectClosedReadLineBaseStream()
+        {
+            var ms = GetLargeStream();
+            var sr = new StreamReader(ms);
+
+            ms.Close();
+            Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
+        }
+
         [Fact]
         public void VanillaReadLines()
         {

--- a/src/System.IO/tests/StreamWriter/StreamWriter.CloseTests.cs
+++ b/src/System.IO/tests/StreamWriter/StreamWriter.CloseTests.cs
@@ -20,17 +20,32 @@ namespace System.IO.Tests
         {
             StreamWriter sw2;
 
-            // [] Calling methods after closing the stream should throw
+            // [] Calling methods after disposing the stream should throw
             //-----------------------------------------------------------------
             sw2 = new StreamWriter(CreateStream());
             sw2.Dispose();
+            ValidateDisposedExceptions(sw2);
+        }
 
-            Assert.Throws<ObjectDisposedException>(() => sw2.Write('A'));
-            Assert.Throws<ObjectDisposedException>(() => sw2.Write("hello"));
-            Assert.Throws<ObjectDisposedException>(() => sw2.Flush());
-            Assert.Null(sw2.BaseStream);
+        [Fact]
+        public void AfterCloseThrows()
+        {
+            StreamWriter sw2;
 
-            Assert.Throws<ObjectDisposedException>(() => sw2.AutoFlush = true);
+            // [] Calling methods after closing the stream should throw
+            //-----------------------------------------------------------------
+            sw2 = new StreamWriter(CreateStream());
+            sw2.Close();
+            ValidateDisposedExceptions(sw2);
+        }
+
+        private void ValidateDisposedExceptions(StreamWriter sw)
+        {
+            Assert.Null(sw.BaseStream);
+            Assert.Throws<ObjectDisposedException>(() => sw.Write('A'));
+            Assert.Throws<ObjectDisposedException>(() => sw.Write("hello"));
+            Assert.Throws<ObjectDisposedException>(() => sw.Flush());
+            Assert.Throws<ObjectDisposedException>(() => sw.AutoFlush = true);
         }
 
         [Fact]
@@ -50,15 +65,29 @@ namespace System.IO.Tests
             sw2.Flush();
             Assert.Equal(strTemp.Length, memstr2.Length);
         }
+
         [Fact]
         public void CantFlushAfterDispose() {
-            // [] Flushing closed writer should throw
+            // [] Flushing disposed writer should throw
             //-----------------------------------------------------------------
 
             Stream memstr2 = CreateStream();
             StreamWriter sw2 = new StreamWriter(memstr2);
             
             sw2.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => sw2.Flush());
+        }
+
+        [Fact]
+        public void CantFlushAfterClose()
+        {
+            // [] Flushing closed writer should throw
+            //-----------------------------------------------------------------
+
+            Stream memstr2 = CreateStream();
+            StreamWriter sw2 = new StreamWriter(memstr2);
+
+            sw2.Close();
             Assert.Throws<ObjectDisposedException>(() => sw2.Flush());
         }
     }

--- a/src/System.IO/tests/StringReader/StringReader.CtorTests.cs
+++ b/src/System.IO/tests/StringReader/StringReader.CtorTests.cs
@@ -36,7 +36,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public static void ReadEmtpyString() {
+        public static void ReadEmptyString() {
             StringReader sr = new StringReader(string.Empty);
             Assert.Equal(-1, sr.Read());
 
@@ -70,7 +70,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public static void ReadPsudoRandomString()
+        public static void ReadPseudoRandomString()
         {
             string str1 = string.Empty;
             Random r = new Random(-55);
@@ -84,12 +84,8 @@ namespace System.IO.Tests
             }
         }
 
-
-
-
-
         [Fact]
-        public static void PeedEmtpyString()
+        public static void PeekEmptyString()
         {
             StringReader sr = new StringReader(string.Empty);
             Assert.Equal(-1, sr.Peek());
@@ -111,7 +107,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public static void PeekPsudoRandomString()
+        public static void PeekPseudoRandomString()
         {
             string str1 = string.Empty;
             Random r = new Random(-55);
@@ -148,7 +144,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public static void ReadToEndPsuedoRandom() {
+        public static void ReadToEndPseudoRandom() {
             // [] Try with large random strings
             //-----------------------------------------------------------
             string str1 = string.Empty;
@@ -158,6 +154,29 @@ namespace System.IO.Tests
 
             StringReader sr = new StringReader(str1);
             Assert.Equal(str1, sr.ReadToEnd());
+        }
+
+        [Fact]
+        public static void Closed_DisposedExceptions()
+        {
+            StringReader sr = new StringReader("abcdefg");
+            sr.Close();
+            ValidateDisposedExceptions(sr);
+        }
+
+        [Fact]
+        public static void Disposed_DisposedExceptions()
+        {
+            StringReader sr = new StringReader("abcdefg");
+            sr.Dispose();
+            ValidateDisposedExceptions(sr);
+        }
+
+        private static void ValidateDisposedExceptions(StringReader sr)
+        {
+            Assert.Throws<ObjectDisposedException>(() => { sr.Peek(); });
+            Assert.Throws<ObjectDisposedException>(() => { sr.Read(); });
+            Assert.Throws<ObjectDisposedException>(() => { sr.Read(new char[10], 0 , 1); });
         }
     }
 }

--- a/src/System.IO/tests/StringWriter/StringWriterTests.cs
+++ b/src/System.IO/tests/StringWriter/StringWriterTests.cs
@@ -236,10 +236,26 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public static void Disposed()
+        public static void Closed_DisposedExceptions()
+        {
+            StringWriter sw = new StringWriter();
+            sw.Close();
+            ValidateDisposedExceptions(sw);
+        }
+
+        [Fact]
+        public static void Disposed_DisposedExceptions()
         {
             StringWriter sw = new StringWriter();
             sw.Dispose();
+            ValidateDisposedExceptions(sw);
+        }
+
+        private static void ValidateDisposedExceptions(StringWriter sw)
+        {
+            Assert.Throws<ObjectDisposedException>(() => { sw.Write('a'); });
+            Assert.Throws<ObjectDisposedException>(() => { sw.Write(new char[10], 0, 1); });
+            Assert.Throws<ObjectDisposedException>(() => { sw.Write("abc"); });
         }
 
         [Fact]


### PR DESCRIPTION
From #9870 - added Close() methods and corresponding tests
(`M:System.IO.BinaryReader.Close` and `M:System.IO.BinaryWriter.Close` have already been added in #9488, so I added the remaining ones)