### PR TITLE
Set default FilterToTestTFM to be netcoreapp1.0 in dir.props

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -511,6 +511,8 @@
   <!-- Default Test platform to deploy the netstandard compiled tests to -->
   <PropertyGroup>
     <TestTFM Condition="'$(TestTFM)'==''">netcoreapp1.0</TestTFM>
+    <!-- we default FilterToTestTFM to netcoreapp1.0 if it is not explicity defined -->
+    <FilterToTestTFM Condition="'$(FilterToTestTFM)'==''">netcoreapp1.0</FilterToTestTFM>        
   </PropertyGroup>
 
   <PropertyGroup>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -115,11 +115,6 @@
           BeforeTargets="TestAllProjects" 
           Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
 
-    <PropertyGroup>
-      <!-- we default FilterToTestTFM to netcoreapp1.0 if it is not explicity defined -->
-      <FilterToTestTFM Condition="'$(FilterToTestTFM)'==''">netcoreapp1.0</FilterToTestTFM>
-    </PropertyGroup>          
-
     <ItemGroup>
       <Project>
         <!-- make sure every defined TestTFM value are surrounded by semicolons for easier search, e.g. ";net46;"" -->


### PR DESCRIPTION
Moving the defaults for TestTFM filtering so that they are explicitly included in all targets that import dir.props (Build, CloudBuild)

/cc @MattGal @ChadNedzlek @tarekgh 