### PR TITLE
Add ARM64 build and packages

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -60,12 +60,6 @@ if "%__buildSpec%"=="managed"  goto :BuildManaged
 :BuildNative
 :: Run the Native Windows build
 echo [%time%] Building Native Libraries...
-:: Generate Native versioning assets
-set __binDir=%~dp0bin
-set __versionLog=%~dp0version.log
-if not exist "%__binDir%\obj\_version.h" (
-    msbuild "%~dp0build.proj" /nologo /t:GenerateVersionHeader /p:GenerateNativeVersionInfo=true > "%__versionLog%"
-)
 IF EXIST "%~dp0src\native\Windows\build-native.cmd" (
     call %~dp0src\native\Windows\build-native.cmd %__args% >nativebuild.log
     IF ERRORLEVEL 1 (

--- a/src/Native/Windows/CMakeLists.txt
+++ b/src/Native/Windows/CMakeLists.txt
@@ -93,7 +93,7 @@ set(__LinkArgs "${__LinkArgs} /PDBCOMPRESS")            #shrink pdb size
 set(__LinkArgs "${__LinkArgs} /DEBUG")
 set(__LinkArgs "${__LinkArgs} /IGNORE:4197,4013,4254,4070,4221")
 
-if (NOT $ENV{__BuildArch} STREQUAL "arm")
+if ($ENV{__BuildArch} STREQUAL "x86" OR $ENV{__BuildArch} STREQUAL "x86_64" )
     set(__LinkArgs "${__LinkArgs} /SUBSYSTEM:WINDOWS,6.00") #windows subsystem
 endif()
 

--- a/src/Native/Windows/clrcompression/CMakeLists.txt
+++ b/src/Native/Windows/clrcompression/CMakeLists.txt
@@ -34,7 +34,7 @@ set(NATIVECOMPRESSION_SOURCES
 )
 endif()
 
-if($ENV{__BuildArch} STREQUAL arm)
+if($ENV{__BuildArch} STREQUAL arm OR $ENV{__BuildArch} STREQUAL arm64)
 set(NATIVECOMPRESSION_SOURCES
     clrcompression.def
     zlib/adler32.c

--- a/src/Native/Windows/gen-buildsys-win.bat
+++ b/src/Native/Windows/gen-buildsys-win.bat
@@ -23,6 +23,7 @@ if /i "%2" == "vs2015" (set __VSString=14 2015)
 if /i "%3" == "x86"     (set __VSString=%__VSString%)
 if /i "%3" == "x64"     (set __VSString=%__VSString% Win64)
 if /i "%3" == "arm"     (set __VSString=%__VSString% ARM)
+if /i "%3" == "arm64"   (set __VSString=%__VSString% Win64)
 
 if defined CMakePath goto DoGen
 

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.builds
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.builds
@@ -11,6 +11,10 @@
       <OSGroup>Windows_NT</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="win\runtime.native.System.Data.SqlClient.sni.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>arm64</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -14,6 +14,9 @@
     <Dependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
       <Version>4.0.2-$(ExternalExpectedPrerelease)</Version>
     </Dependency>
+    <Dependency Include="runtime.win10-arm64.runtime.native.System.Data.SqlClient.sni">
+      <Version>4.0.2-$(ExternalExpectedPrerelease)</Version>
+    </Dependency>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/win/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/win/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -3,9 +3,11 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Version>4.0.2</Version>
+    <WinVersion Condition="'$(PackagePlatform)'=='arm64'">win10</WinVersion>
+    <WinVersion Condition="'$(PackagePlatform)'=='x86' OR '$(PackagePlatform)'=='x64'">win7</WinVersion>
     <!-- use the same naming convention as a runtime package, but don't treat as a runtime dependency -->
-    <IdPrefix>runtime.win7-$(PackagePlatform).</IdPrefix>
-    <PackagePlatforms>x64;x86;</PackagePlatforms>
+    <IdPrefix>runtime.$(WinVersion)-$(PackagePlatform).</IdPrefix>
+    <PackagePlatforms>x64;x86;arm64;</PackagePlatforms>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- don't package this as runtime specific -->
     <PackageTargetRuntime>
@@ -14,7 +16,7 @@
   <!-- These paths are not built in CoreFx, enable when fixing https://github.com/dotnet/corefx/issues/826 -->
   <ItemGroup>
     <NativeFile Include="$(WinNativePath)sni.dll">
-      <TargetPath>runtimes/win7-$(PackagePlatform)/native</TargetPath>
+      <TargetPath>runtimes/$(WinVersion)-$(PackagePlatform)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -43,6 +43,10 @@
       <OSGroup>Windows_NT</OSGroup>
       <Platform>arm</Platform>
     </Project>
+    <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>arm64</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -56,6 +56,9 @@
     <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
       <Platform>arm</Platform>
     </ProjectReference>
+    <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>arm64</Platform>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
@@ -4,7 +4,8 @@
   <PropertyGroup>
     <Version>4.1.1</Version>
     <WinVersion Condition="'$(PackagePlatform)'=='arm'">win8</WinVersion>
-    <WinVersion Condition="'$(PackagePlatform)'!='arm'">win7</WinVersion>
+    <WinVersion Condition="'$(PackagePlatform)'=='arm64'">win10</WinVersion>
+    <WinVersion Condition="'$(PackagePlatform)'=='x86' OR '$(PackagePlatform)'=='x64'">win7</WinVersion>
     <PackageTargetRuntime>$(WinVersion)-$(PackagePlatform)</PackageTargetRuntime>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
@@ -26,7 +26,7 @@
       <Name>System.ServiceProcess.ServiceController</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)'=='true'">
+  <ItemGroup Condition="'$(TargetsWindows)'=='true' AND '$(Platform)'!='arm64'">
     <ProjectReference Include="..\System.ServiceProcess.ServiceController.TestNativeService\System.ServiceProcess.ServiceController.TestNativeService.vcxproj">
       <Project>{ceb0775c-4273-4ac4-b50e-4492718051ae}</Project>
       <Name>System.ServiceProcess.ServiceController.TestNativeService</Name>


### PR DESCRIPTION
Adds the option to build an arm64 clrcompression using the build-native script and also adds packages for the ARM64 build of clrcompression and sni - the latter of which is still built internally.

Accompanying this PR is an internal Codeflow to fix the SNI build (which this PR depends on) as well as a soon-to-be-created checkin (which depends on this PR) to the build pipeline to add ARM64 clrcompression to be built in the open .

resolves #6891, #9627, #9632, #9630, #9629, and #9627

@stephentoub @gkhanna79 @ericstj @weshaggard 