### PR TITLE
Avoid wrapping async I/O in synchronous methods in the HTTP tests

### DIFF
--- a/src/Common/tests/System/IO/DelegateStream.cs
+++ b/src/Common/tests/System/IO/DelegateStream.cs
@@ -52,13 +52,17 @@ namespace System.IO
             _positionSetFunc = positionSetFunc ?? (_ => { throw new NotSupportedException(); });
             _positionGetFunc = positionGetFunc ?? (() => { throw new NotSupportedException(); });
 
-            _readFunc = readFunc ?? ((buffer, offset, count) => readAsyncFunc(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult());
+            if (readAsyncFunc != null && readFunc == null)
+                throw new InvalidOperationException("If reads are supported, must provide a synchronous read implementation");
+            _readFunc = readFunc;
             _readAsyncFunc = readAsyncFunc ?? ((buffer, offset, count, token) => base.ReadAsync(buffer, offset, count, token));
 
             _seekFunc = seekFunc ?? ((_, __) => { throw new NotSupportedException(); });
             _setLengthFunc = setLengthFunc ?? (_ => { throw new NotSupportedException(); });
 
-            _writeFunc = writeFunc ?? ((buffer, offset, count) => writeAsyncFunc(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult());
+            if (writeAsyncFunc != null && writeFunc == null)
+                throw new InvalidOperationException("If writes are supported, must provide a synchronous write implementation");
+            _writeFunc = writeFunc;
             _writeAsyncFunc = writeAsyncFunc ?? ((buffer, offset, count, token) => base.WriteAsync(buffer, offset, count, token));
         }
 


### PR DESCRIPTION
One theory I had about a potential cause of #9785 and #9270 was that it might be due to ThreadPool starvation; if not enough threads are available in the ThreadPool for long enough that a timeout fires, we might see the dreaded "a task was canceled" exception.  

To test this, I ran the System.Net.Http tests with the CoreCLR ThreadPool configured to limit itself to a single thread, and to trigger a breakpoint whenever that thread was tied up for a long time:

```
set COMPlus_ThreadPool_ForceMinWorkerThreads=1
set COMPlus_ThreadPool_ForceMaxWorkerThreads=1
set COMPlus_ThreadPool_DebugBreakOnWorkerStarvation=1
```

The breakpoint was triggered pretty consistently for the tests which use `DelegateStream`, due to that type's default of providing synchronous `Read` and `Write` methods in terms of the caller-supplied async methods; by blocking the current thread until the async I/O completes, we potentially require *another* ThreadPool thread, which may not be available soon, if ever.

This change forces callers to prove synchronous implementations if they've provided async methods, and updates the callers to do so.  After this, I have been unable to find any additional ThreadPool starvation issues in these tests.

Unfortunately this does not appear to have fixed the problem I was looking at, as I still saw occasional "a task was canceled" errors.  But maybe it's a good change to make anyway. :smile:

@stephentoub @CIPop @davidsh 