### PR TITLE
ApiCompat - Add CAS Stubs

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -1405,6 +1405,11 @@
         ]
     },
     {
+        "Name": "System.Security.Permissions",
+        "Description": "Provides types supporting Code Access Security (CAS).",
+        "CommonTypes": [ ]
+    },
+    {
         "Name": "System.Security.Principal",
         "Description": "Provides the base interfaces for principal and identity objects that represents the security context under which code is running.",
         "CommonTypes": [

--- a/src/System.Security.Permissions/System.Security.Permissions.sln
+++ b/src/System.Security.Permissions/System.Security.Permissions.sln
@@ -1,0 +1,59 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Permissions", "src\System.Security.Permissions.csproj", "{07390899-C8F6-4E83-A3A9-6867B8CB46A0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A14C0271-4180-44DD-9241-908C97229CDC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{FEFA9BDE-0B1C-45E1-B46C-4997A473CC63}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{029F788F-D7DC-472C-9DC5-169EDFFA5DEB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Permissions.Tests", "tests\System.Security.Permissions.Tests.csproj", "{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Permissions", "ref\System.Security.Permissions.csproj", "{F82A69C2-3687-4A50-9C80-BC7005F40ADC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+		net46_Debug|Any CPU = net46_Debug|Any CPU
+		net46_Release|Any CPU = net46_Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
+		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.net46_Release|Any CPU.Build.0 = Release|Any CPU
+		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.net46_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.net46_Release|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0} = {A14C0271-4180-44DD-9241-908C97229CDC}
+		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02} = {FEFA9BDE-0B1C-45E1-B46C-4997A473CC63}
+		{F82A69C2-3687-4A50-9C80-BC7005F40ADC} = {029F788F-D7DC-472C-9DC5-169EDFFA5DEB}
+	EndGlobalSection
+EndGlobal

--- a/src/System.Security.Permissions/pkg/System.Security.Permissions.builds
+++ b/src/System.Security.Permissions/pkg/System.Security.Permissions.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Collections.NonGeneric.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Security.Permissions/pkg/System.Security.Permissions.pkgproj
+++ b/src/System.Security.Permissions/pkg/System.Security.Permissions.pkgproj
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Security.Permissions.csproj">
+      <SupportedFramework>net46;netcoreapp1.0;netcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Security.Permissions.builds" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Permissions/ref/DummyTypes.cs
+++ b/src/System.Security.Permissions/ref/DummyTypes.cs
@@ -1,0 +1,6 @@
+namespace System
+{
+    public class SystemException : Exception
+    { 
+    }
+}

--- a/src/System.Security.Permissions/ref/DummyTypes.cs
+++ b/src/System.Security.Permissions/ref/DummyTypes.cs
@@ -1,6 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// TODO remove when #9854 is resolved
+
 namespace System
 {
     public class SystemException : Exception
-    { 
+    {
     }
 }

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -1,0 +1,1108 @@
+namespace System.Security {
+  public abstract partial class CodeAccessPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.IStackWalk {
+    protected CodeAccessPermission() { }
+    public void Assert() { }
+    public abstract System.Security.IPermission Copy();
+    public void Demand() { }
+    public void Deny() { }
+    public override bool Equals(object obj) { return default(bool); }
+//    public abstract void FromXml(System.Security.SecurityElement elem);
+    public override int GetHashCode() { return default(int); }
+    public abstract System.Security.IPermission Intersect(System.Security.IPermission target);
+    public abstract bool IsSubsetOf(System.Security.IPermission target);
+    public void PermitOnly() { }
+    public override string ToString() { return default(string); }
+//    public abstract System.Security.SecurityElement ToXml();
+    public virtual System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+  }
+  public partial class HostProtectionException : System.SystemException {
+    public HostProtectionException() { }
+    // protected HostProtectionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    public HostProtectionException(string message) { }
+    public HostProtectionException(string message, System.Exception e) { }
+    public HostProtectionException(string message, System.Security.Permissions.HostProtectionResource protectedResources, System.Security.Permissions.HostProtectionResource demandedResources) { }
+    public System.Security.Permissions.HostProtectionResource DemandedResources { get { return default(System.Security.Permissions.HostProtectionResource); } }
+    public System.Security.Permissions.HostProtectionResource ProtectedResources { get { return default(System.Security.Permissions.HostProtectionResource); } }
+    // public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    public override string ToString() { return default(string); }
+  }
+  public partial class HostSecurityManager {
+    public HostSecurityManager() { }
+    public virtual System.Security.Policy.PolicyLevel DomainPolicy { get { return default(System.Security.Policy.PolicyLevel); } }
+    public virtual System.Security.HostSecurityManagerOptions Flags { get { return default(System.Security.HostSecurityManagerOptions); } }
+    public virtual System.Security.Policy.ApplicationTrust DetermineApplicationTrust(System.Security.Policy.Evidence applicationEvidence, System.Security.Policy.Evidence activatorEvidence, System.Security.Policy.TrustManagerContext context) { return default(System.Security.Policy.ApplicationTrust); }
+    public virtual System.Security.Policy.Evidence ProvideAppDomainEvidence(System.Security.Policy.Evidence inputEvidence) { return default(System.Security.Policy.Evidence); }
+    public virtual System.Security.Policy.Evidence ProvideAssemblyEvidence(System.Reflection.Assembly loadedAssembly, System.Security.Policy.Evidence inputEvidence) { return default(System.Security.Policy.Evidence); }
+    public virtual System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
+  }
+  [System.FlagsAttribute]
+  public enum HostSecurityManagerOptions {
+    AllFlags = 31,
+    HostAppDomainEvidence = 1,
+    HostAssemblyEvidence = 4,
+    HostDetermineApplicationTrust = 8,
+    HostPolicyLevel = 2,
+    HostResolvePolicy = 16,
+    None = 0,
+  }
+  public partial interface IEvidenceFactory {
+    System.Security.Policy.Evidence Evidence { get; }
+  }
+  public partial interface IPermission : System.Security.ISecurityEncodable {
+    System.Security.IPermission Copy();
+    void Demand();
+    System.Security.IPermission Intersect(System.Security.IPermission target);
+    bool IsSubsetOf(System.Security.IPermission target);
+    System.Security.IPermission Union(System.Security.IPermission target);
+  }
+  public partial interface ISecurityEncodable {
+//    void FromXml(System.Security.SecurityElement e);
+//    System.Security.SecurityElement ToXml();
+  }
+  public partial interface ISecurityPolicyEncodable {
+//    void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level);
+//    System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level);
+  }
+  public partial interface IStackWalk {
+    void Assert();
+    void Demand();
+    void Deny();
+    void PermitOnly();
+  }
+  public sealed partial class NamedPermissionSet : System.Security.PermissionSet {
+    public NamedPermissionSet(System.Security.NamedPermissionSet permSet) : base (default(System.Security.Permissions.PermissionState)) { }
+    public NamedPermissionSet(string name) : base (default(System.Security.Permissions.PermissionState)) { }
+    public NamedPermissionSet(string name, System.Security.Permissions.PermissionState state) : base (default(System.Security.Permissions.PermissionState)) { }
+    public NamedPermissionSet(string name, System.Security.PermissionSet permSet) : base (default(System.Security.Permissions.PermissionState)) { }
+    public string Description { get { return default(string); } set { } }
+    public string Name { get { return default(string); } set { } }
+    public override System.Security.PermissionSet Copy() { return default(System.Security.PermissionSet); }
+    public System.Security.NamedPermissionSet Copy(string name) { return default(System.Security.NamedPermissionSet); }
+    public override bool Equals(object obj) { return default(bool); }
+//    public override void FromXml(System.Security.SecurityElement et) { }
+    public override int GetHashCode() { return default(int); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+  }
+  public partial class PermissionSet : System.Collections.ICollection, System.Collections.IEnumerable, /* System.Runtime.Serialization.IDeserializationCallback, */ System.Security.ISecurityEncodable, System.Security.IStackWalk {
+    public PermissionSet(System.Security.Permissions.PermissionState state) { }
+    public PermissionSet(System.Security.PermissionSet permSet) { }
+    public virtual int Count { get { return default(int); } }
+    public virtual bool IsReadOnly { get { return default(bool); } }
+    public virtual bool IsSynchronized { get { return default(bool); } }
+    public virtual object SyncRoot { get { return default(object); } }
+    public System.Security.IPermission AddPermission(System.Security.IPermission perm) { return default(System.Security.IPermission); }
+    public void Assert() { }
+    public bool ContainsNonCodeAccessPermissions() { return default(bool); }
+    public static byte[] ConvertPermissionSet(string inFormat, byte[] inData, string outFormat) { return default(byte[]); }
+    public virtual System.Security.PermissionSet Copy() { return default(System.Security.PermissionSet); }
+    public virtual void CopyTo(System.Array array, int index) { }
+    public void Demand() { }
+    public void Deny() { }
+    public override bool Equals(object obj) { return default(bool); }
+//    public virtual void FromXml(System.Security.SecurityElement et) { }
+    public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
+    public override int GetHashCode() { return default(int); }
+    public System.Security.IPermission GetPermission(System.Type permClass) { return default(System.Security.IPermission); }
+    public System.Security.PermissionSet Intersect(System.Security.PermissionSet other) { return default(System.Security.PermissionSet); }
+    public bool IsEmpty() { return default(bool); }
+    public bool IsSubsetOf(System.Security.PermissionSet target) { return default(bool); }
+    public bool IsUnrestricted() { return default(bool); }
+    public void PermitOnly() { }
+    public System.Security.IPermission RemovePermission(System.Type permClass) { return default(System.Security.IPermission); }
+    public static void RevertAssert() { }
+    public System.Security.IPermission SetPermission(System.Security.IPermission perm) { return default(System.Security.IPermission); }
+//    void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
+    public override string ToString() { return default(string); }
+//    public virtual System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public System.Security.PermissionSet Union(System.Security.PermissionSet other) { return default(System.Security.PermissionSet); }
+  }
+  public enum PolicyLevelType {
+    AppDomain = 3,
+    Enterprise = 2,
+    Machine = 1,
+    User = 0,
+  }
+  public sealed partial class SecurityContext : System.IDisposable {
+    internal SecurityContext() { }
+    public static System.Security.SecurityContext Capture() { return default(System.Security.SecurityContext); }
+    public System.Security.SecurityContext CreateCopy() { return default(System.Security.SecurityContext); }
+    public void Dispose() { }
+    public static bool IsFlowSuppressed() { return default(bool); }
+    public static bool IsWindowsIdentityFlowSuppressed() { return default(bool); }
+    public static void RestoreFlow() { }
+    public static void Run(System.Security.SecurityContext securityContext, System.Threading.ContextCallback callback, object state) { }
+//    public static System.Threading.AsyncFlowControl SuppressFlow() { return default(System.Threading.AsyncFlowControl); }
+//    public static System.Threading.AsyncFlowControl SuppressFlowWindowsIdentity() { return default(System.Threading.AsyncFlowControl); }
+  }
+  public enum SecurityContextSource {
+    CurrentAppDomain = 0,
+    CurrentAssembly = 1,
+  }
+  [System.ObsoleteAttribute("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
+  public enum SecurityCriticalScope {
+    Everything = 1,
+    Explicit = 0,
+  }
+  public static partial class SecurityManager {
+    [System.ObsoleteAttribute]
+    public static bool CheckExecutionRights { get { return default(bool); } set { } }
+    [System.ObsoleteAttribute("The security manager cannot be turned off on MS runtime")]
+    public static bool SecurityEnabled { get { return default(bool); } set { } }
+    public static void GetZoneAndOrigin(out System.Collections.ArrayList zone, out System.Collections.ArrayList origin) { zone = default(System.Collections.ArrayList); origin = default(System.Collections.ArrayList); }
+    [System.ObsoleteAttribute]
+    public static bool IsGranted(System.Security.IPermission perm) { return default(bool); }
+    [System.ObsoleteAttribute]
+    public static System.Security.Policy.PolicyLevel LoadPolicyLevelFromFile(string path, System.Security.PolicyLevelType type) { return default(System.Security.Policy.PolicyLevel); }
+    [System.ObsoleteAttribute]
+    public static System.Security.Policy.PolicyLevel LoadPolicyLevelFromString(string str, System.Security.PolicyLevelType type) { return default(System.Security.Policy.PolicyLevel); }
+    [System.ObsoleteAttribute]
+    public static System.Collections.IEnumerator PolicyHierarchy() { return default(System.Collections.IEnumerator); }
+    [System.ObsoleteAttribute]
+    public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
+    [System.ObsoleteAttribute]
+    public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence, System.Security.PermissionSet reqdPset, System.Security.PermissionSet optPset, System.Security.PermissionSet denyPset, out System.Security.PermissionSet denied) { denied = default(System.Security.PermissionSet); return default(System.Security.PermissionSet); }
+    [System.ObsoleteAttribute]
+    public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence[] evidences) { return default(System.Security.PermissionSet); }
+    [System.ObsoleteAttribute]
+    public static System.Collections.IEnumerator ResolvePolicyGroups(System.Security.Policy.Evidence evidence) { return default(System.Collections.IEnumerator); }
+    [System.ObsoleteAttribute]
+    public static System.Security.PermissionSet ResolveSystemPolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
+    [System.ObsoleteAttribute]
+    public static void SavePolicy() { }
+    [System.ObsoleteAttribute]
+    public static void SavePolicyLevel(System.Security.Policy.PolicyLevel level) { }
+  }
+  public abstract partial class SecurityState {
+    protected SecurityState() { }
+    public abstract void EnsureState();
+    public bool IsStateAvailable() { return default(bool); }
+  }
+  public enum SecurityZone {
+    Internet = 3,
+    Intranet = 1,
+    MyComputer = 0,
+    NoZone = -1,
+    Trusted = 2,
+    Untrusted = 4,
+  }
+  public sealed partial class XmlSyntaxException : System.SystemException {
+    public XmlSyntaxException() { }
+    public XmlSyntaxException(int lineNumber) { }
+    public XmlSyntaxException(int lineNumber, string message) { }
+    public XmlSyntaxException(string message) { }
+    public XmlSyntaxException(string message, System.Exception inner) { }
+  }
+}
+namespace System.Security.Permissions {
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public abstract partial class CodeAccessSecurityAttribute : System.Security.Permissions.SecurityAttribute {
+    protected CodeAccessSecurityAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+  }
+  public sealed partial class EnvironmentPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
+    public EnvironmentPermission(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
+    public EnvironmentPermission(System.Security.Permissions.PermissionState state) { }
+    public void AddPathList(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement esd) { }
+    public string GetPathList(System.Security.Permissions.EnvironmentPermissionAccess flag) { return default(string); }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+    public bool IsUnrestricted() { return default(bool); }
+    public void SetPathList(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+  }
+  [System.FlagsAttribute]
+  public enum EnvironmentPermissionAccess {
+    AllAccess = 3,
+    NoAccess = 0,
+    Read = 1,
+    Write = 2,
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class EnvironmentPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public EnvironmentPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public string All { get { return default(string); } set { } }
+    public string Read { get { return default(string); } set { } }
+    public string Write { get { return default(string); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  public sealed partial class FileDialogPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
+    public FileDialogPermission(System.Security.Permissions.FileDialogPermissionAccess access) { }
+    public FileDialogPermission(System.Security.Permissions.PermissionState state) { }
+    public System.Security.Permissions.FileDialogPermissionAccess Access { get { return default(System.Security.Permissions.FileDialogPermissionAccess); } set { } }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement esd) { }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+    public bool IsUnrestricted() { return default(bool); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+  }
+  [System.FlagsAttribute]
+  public enum FileDialogPermissionAccess {
+    None = 0,
+    Open = 1,
+    OpenSave = 3,
+    Save = 2,
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class FileDialogPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public FileDialogPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public bool Open { get { return default(bool); } set { } }
+    public bool Save { get { return default(bool); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  public sealed partial class FileIOPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
+    public FileIOPermission(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
+    public FileIOPermission(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
+    public FileIOPermission(System.Security.Permissions.PermissionState state) { }
+    public System.Security.Permissions.FileIOPermissionAccess AllFiles { get { return default(System.Security.Permissions.FileIOPermissionAccess); } set { } }
+    public System.Security.Permissions.FileIOPermissionAccess AllLocalFiles { get { return default(System.Security.Permissions.FileIOPermissionAccess); } set { } }
+    public void AddPathList(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
+    public void AddPathList(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+    public override bool Equals(object obj) { return default(bool); }
+//    public override void FromXml(System.Security.SecurityElement esd) { }
+    public override int GetHashCode() { return default(int); }
+    public string[] GetPathList(System.Security.Permissions.FileIOPermissionAccess access) { return default(string[]); }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+    public bool IsUnrestricted() { return default(bool); }
+    public void SetPathList(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
+    public void SetPathList(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+  }
+  [System.FlagsAttribute]
+  public enum FileIOPermissionAccess {
+    AllAccess = 15,
+    Append = 4,
+    NoAccess = 0,
+    PathDiscovery = 8,
+    Read = 1,
+    Write = 2,
+  }
+  public sealed partial class GacIdentityPermission : System.Security.CodeAccessPermission {
+    public GacIdentityPermission() { }
+    public GacIdentityPermission(System.Security.Permissions.PermissionState state) { }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement securityElement) { }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class GacIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public GacIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(4205), AllowMultiple=true, Inherited=false)]
+  public sealed partial class HostProtectionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public HostProtectionAttribute() : base (default(System.Security.Permissions.SecurityAction)) { }
+    public HostProtectionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public bool ExternalProcessMgmt { get { return default(bool); } set { } }
+    public bool ExternalThreading { get { return default(bool); } set { } }
+    public bool MayLeakOnAbort { get { return default(bool); } set { } }
+    public System.Security.Permissions.HostProtectionResource Resources { get { return default(System.Security.Permissions.HostProtectionResource); } set { } }
+    public bool SecurityInfrastructure { get { return default(bool); } set { } }
+    public bool SelfAffectingProcessMgmt { get { return default(bool); } set { } }
+    public bool SelfAffectingThreading { get { return default(bool); } set { } }
+    public bool SharedState { get { return default(bool); } set { } }
+    public bool Synchronization { get { return default(bool); } set { } }
+    public bool UI { get { return default(bool); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  [System.FlagsAttribute]
+  public enum HostProtectionResource {
+    All = 511,
+    ExternalProcessMgmt = 4,
+    ExternalThreading = 16,
+    MayLeakOnAbort = 256,
+    None = 0,
+    SecurityInfrastructure = 64,
+    SelfAffectingProcessMgmt = 8,
+    SelfAffectingThreading = 32,
+    SharedState = 2,
+    Synchronization = 1,
+    UI = 128,
+  }
+  public partial interface IUnrestrictedPermission {
+    bool IsUnrestricted();
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class PermissionSetAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public PermissionSetAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public string File { get { return default(string); } set { } }
+    public string Hex { get { return default(string); } set { } }
+    public string Name { get { return default(string); } set { } }
+    public bool UnicodeEncoded { get { return default(bool); } set { } }
+    public string XML { get { return default(string); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    public System.Security.PermissionSet CreatePermissionSet() { return default(System.Security.PermissionSet); }
+  }
+  public enum PermissionState {
+    None = 0,
+    Unrestricted = 1,
+  }
+  public sealed partial class PrincipalPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.Permissions.IUnrestrictedPermission {
+    public PrincipalPermission(System.Security.Permissions.PermissionState state) { }
+    public PrincipalPermission(string name, string role) { }
+    public PrincipalPermission(string name, string role, bool isAuthenticated) { }
+    public System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+    public void Demand() { }
+    public override bool Equals(object obj) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement elem) { }
+    public override int GetHashCode() { return default(int); }
+    public System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+    public bool IsUnrestricted() { return default(bool); }
+    public override string ToString() { return default(string); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(68), AllowMultiple=true, Inherited=false)]
+  public sealed partial class PrincipalPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public PrincipalPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public bool Authenticated { get { return default(bool); } set { } }
+    public string Name { get { return default(string); } set { } }
+    public string Role { get { return default(string); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  public sealed partial class PublisherIdentityPermission : System.Security.CodeAccessPermission {
+    public PublisherIdentityPermission(System.Security.Cryptography.X509Certificates.X509Certificate certificate) { }
+    public PublisherIdentityPermission(System.Security.Permissions.PermissionState state) { }
+    public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } set { } }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement esd) { }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class PublisherIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public PublisherIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public string CertFile { get { return default(string); } set { } }
+    public string SignedFile { get { return default(string); } set { } }
+    public string X509Certificate { get { return default(string); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  public sealed partial class ReflectionPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
+    public ReflectionPermission(System.Security.Permissions.PermissionState state) { }
+    public ReflectionPermission(System.Security.Permissions.ReflectionPermissionFlag flag) { }
+    public System.Security.Permissions.ReflectionPermissionFlag Flags { get { return default(System.Security.Permissions.ReflectionPermissionFlag); } set { } }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement esd) { }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+    public bool IsUnrestricted() { return default(bool); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class ReflectionPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public ReflectionPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public System.Security.Permissions.ReflectionPermissionFlag Flags { get { return default(System.Security.Permissions.ReflectionPermissionFlag); } set { } }
+    public bool MemberAccess { get { return default(bool); } set { } }
+    [System.ObsoleteAttribute]
+    public bool ReflectionEmit { get { return default(bool); } set { } }
+    public bool RestrictedMemberAccess { get { return default(bool); } set { } }
+    [System.ObsoleteAttribute("not enforced in 2.0+")]
+    public bool TypeInformation { get { return default(bool); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  [System.FlagsAttribute]
+  public enum ReflectionPermissionFlag {
+    [System.ObsoleteAttribute]
+    AllFlags = 7,
+    MemberAccess = 2,
+    NoFlags = 0,
+    [System.ObsoleteAttribute]
+    ReflectionEmit = 4,
+    RestrictedMemberAccess = 8,
+    [System.ObsoleteAttribute("not used anymore")]
+    TypeInformation = 1,
+  }
+  public sealed partial class RegistryPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
+    public RegistryPermission(System.Security.Permissions.PermissionState state) { }
+    public RegistryPermission(System.Security.Permissions.RegistryPermissionAccess access, System.Security.AccessControl.AccessControlActions control, string pathList) { }
+    public RegistryPermission(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
+    public void AddPathList(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement esd) { }
+    public string GetPathList(System.Security.Permissions.RegistryPermissionAccess access) { return default(string); }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+    public bool IsUnrestricted() { return default(bool); }
+    public void SetPathList(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+  }
+  [System.FlagsAttribute]
+  public enum RegistryPermissionAccess {
+    AllAccess = 7,
+    Create = 4,
+    NoAccess = 0,
+    Read = 1,
+    Write = 2,
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class RegistryPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public RegistryPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    [System.ObsoleteAttribute("use newer properties")]
+    public string All { get { return default(string); } set { } }
+    public string ChangeAccessControl { get { return default(string); } set { } }
+    public string Create { get { return default(string); } set { } }
+    public string Read { get { return default(string); } set { } }
+    public string ViewAccessControl { get { return default(string); } set { } }
+    public string ViewAndModify { get { return default(string); } set { } }
+    public string Write { get { return default(string); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  public enum SecurityAction {
+    Assert = 3,
+    Demand = 2,
+    [System.ObsoleteAttribute("This requests should not be used")]
+    Deny = 4,
+    InheritanceDemand = 7,
+    LinkDemand = 6,
+    PermitOnly = 5,
+    [System.ObsoleteAttribute("This requests should not be used")]
+    RequestMinimum = 8,
+    [System.ObsoleteAttribute("This requests should not be used")]
+    RequestOptional = 9,
+    [System.ObsoleteAttribute("This requests should not be used")]
+    RequestRefuse = 10,
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public abstract partial class SecurityAttribute : System.Attribute {
+    protected SecurityAttribute(System.Security.Permissions.SecurityAction action) { }
+    public System.Security.Permissions.SecurityAction Action { get { return default(System.Security.Permissions.SecurityAction); } set { } }
+    public bool Unrestricted { get { return default(bool); } set { } }
+    public abstract System.Security.IPermission CreatePermission();
+  }
+  public sealed partial class SecurityPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
+    public SecurityPermission(System.Security.Permissions.PermissionState state) { }
+    public SecurityPermission(System.Security.Permissions.SecurityPermissionFlag flag) { }
+    public System.Security.Permissions.SecurityPermissionFlag Flags { get { return default(System.Security.Permissions.SecurityPermissionFlag); } set { } }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement esd) { }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+    public bool IsUnrestricted() { return default(bool); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class SecurityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public SecurityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public bool Assertion { get { return default(bool); } set { } }
+    public bool BindingRedirects { get { return default(bool); } set { } }
+    public bool ControlAppDomain { get { return default(bool); } set { } }
+    public bool ControlDomainPolicy { get { return default(bool); } set { } }
+    public bool ControlEvidence { get { return default(bool); } set { } }
+    public bool ControlPolicy { get { return default(bool); } set { } }
+    public bool ControlPrincipal { get { return default(bool); } set { } }
+    public bool ControlThread { get { return default(bool); } set { } }
+    public bool Execution { get { return default(bool); } set { } }
+    public System.Security.Permissions.SecurityPermissionFlag Flags { get { return default(System.Security.Permissions.SecurityPermissionFlag); } set { } }
+    public bool Infrastructure { get { return default(bool); } set { } }
+    public bool RemotingConfiguration { get { return default(bool); } set { } }
+    public bool SerializationFormatter { get { return default(bool); } set { } }
+    public bool SkipVerification { get { return default(bool); } set { } }
+    public bool UnmanagedCode { get { return default(bool); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  [System.FlagsAttribute]
+  public enum SecurityPermissionFlag {
+    AllFlags = 16383,
+    Assertion = 1,
+    BindingRedirects = 8192,
+    ControlAppDomain = 1024,
+    ControlDomainPolicy = 256,
+    ControlEvidence = 32,
+    ControlPolicy = 64,
+    ControlPrincipal = 512,
+    ControlThread = 16,
+    Execution = 8,
+    Infrastructure = 4096,
+    NoFlags = 0,
+    RemotingConfiguration = 2048,
+    SerializationFormatter = 128,
+    SkipVerification = 4,
+    UnmanagedCode = 2,
+  }
+  public sealed partial class SiteIdentityPermission : System.Security.CodeAccessPermission {
+    public SiteIdentityPermission(System.Security.Permissions.PermissionState state) { }
+    public SiteIdentityPermission(string site) { }
+    public string Site { get { return default(string); } set { } }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement esd) { }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class SiteIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public SiteIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public string Site { get { return default(string); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  public sealed partial class StrongNameIdentityPermission : System.Security.CodeAccessPermission {
+    public StrongNameIdentityPermission(System.Security.Permissions.PermissionState state) { }
+    public StrongNameIdentityPermission(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
+    public string Name { get { return default(string); } set { } }
+    public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } set { } }
+    public System.Version Version { get { return default(System.Version); } set { } }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement e) { }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class StrongNameIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public StrongNameIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public string Name { get { return default(string); } set { } }
+    public string PublicKey { get { return default(string); } set { } }
+    public string Version { get { return default(string); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  public sealed partial class StrongNamePublicKeyBlob {
+    public StrongNamePublicKeyBlob(byte[] publicKey) { }
+    public override bool Equals(object obj) { return default(bool); }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+  }
+  public sealed partial class TypeDescriptorPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
+    public TypeDescriptorPermission(System.Security.Permissions.PermissionState state) { }
+    public TypeDescriptorPermission(System.Security.Permissions.TypeDescriptorPermissionFlags flag) { }
+    public System.Security.Permissions.TypeDescriptorPermissionFlags Flags { get { return default(System.Security.Permissions.TypeDescriptorPermissionFlags); } set { } }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement securityElement) { }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+    public bool IsUnrestricted() { return default(bool); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+  }
+  [System.FlagsAttribute]
+  public enum TypeDescriptorPermissionFlags {
+    NoFlags = 0,
+    RestrictedRegistrationAccess = 1,
+  }
+  public sealed partial class UIPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
+    public UIPermission(System.Security.Permissions.PermissionState state) { }
+    public UIPermission(System.Security.Permissions.UIPermissionClipboard clipboardFlag) { }
+    public UIPermission(System.Security.Permissions.UIPermissionWindow windowFlag) { }
+    public UIPermission(System.Security.Permissions.UIPermissionWindow windowFlag, System.Security.Permissions.UIPermissionClipboard clipboardFlag) { }
+    public System.Security.Permissions.UIPermissionClipboard Clipboard { get { return default(System.Security.Permissions.UIPermissionClipboard); } set { } }
+    public System.Security.Permissions.UIPermissionWindow Window { get { return default(System.Security.Permissions.UIPermissionWindow); } set { } }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement esd) { }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+    public bool IsUnrestricted() { return default(bool); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class UIPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public UIPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public System.Security.Permissions.UIPermissionClipboard Clipboard { get { return default(System.Security.Permissions.UIPermissionClipboard); } set { } }
+    public System.Security.Permissions.UIPermissionWindow Window { get { return default(System.Security.Permissions.UIPermissionWindow); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  public enum UIPermissionClipboard {
+    AllClipboard = 2,
+    NoClipboard = 0,
+    OwnClipboard = 1,
+  }
+  public enum UIPermissionWindow {
+    AllWindows = 3,
+    NoWindows = 0,
+    SafeSubWindows = 1,
+    SafeTopLevelWindows = 2,
+  }
+  public sealed partial class UrlIdentityPermission : System.Security.CodeAccessPermission {
+    public UrlIdentityPermission(System.Security.Permissions.PermissionState state) { }
+    public UrlIdentityPermission(string site) { }
+    public string Url { get { return default(string); } set { } }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement esd) { }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class UrlIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public UrlIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public string Url { get { return default(string); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+  public sealed partial class ZoneIdentityPermission : System.Security.CodeAccessPermission {
+    public ZoneIdentityPermission(System.Security.Permissions.PermissionState state) { }
+    public ZoneIdentityPermission(System.Security.SecurityZone zone) { }
+    public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } set { } }
+    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+//    public override void FromXml(System.Security.SecurityElement esd) { }
+    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+  }
+  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
+  public sealed partial class ZoneIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
+    public ZoneIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
+    public System.Security.SecurityZone Zone { get { return default(System.Security.SecurityZone); } set { } }
+    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+  }
+}
+namespace System.Security.Policy {
+  public sealed partial class AllMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
+    public AllMembershipCondition() { }
+    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+    public override bool Equals(object o) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement e) { }
+//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+  }
+  public sealed partial class ApplicationDirectory : System.Security.Policy.EvidenceBase {
+    public ApplicationDirectory(string name) { }
+    public string Directory { get { return default(string); } }
+    public object Copy() { return default(object); }
+    public override bool Equals(object o) { return default(bool); }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+  }
+  public sealed partial class ApplicationDirectoryMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
+    public ApplicationDirectoryMembershipCondition() { }
+    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+    public override bool Equals(object o) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement e) { }
+//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+  }
+  public sealed partial class ApplicationTrust : System.Security.Policy.EvidenceBase, System.Security.ISecurityEncodable {
+    public ApplicationTrust() { }
+//    public ApplicationTrust(System.ApplicationIdentity applicationIdentity) { }
+    public ApplicationTrust(System.Security.PermissionSet defaultGrantSet, System.Collections.Generic.IEnumerable<System.Security.Policy.StrongName> fullTrustAssemblies) { }
+//    public System.ApplicationIdentity ApplicationIdentity { get { return default(System.ApplicationIdentity); } set { } }
+    public System.Security.Policy.PolicyStatement DefaultGrantSet { get { return default(System.Security.Policy.PolicyStatement); } set { } }
+    public object ExtraInfo { get { return default(object); } set { } }
+    public System.Collections.Generic.IList<System.Security.Policy.StrongName> FullTrustAssemblies { get { return default(System.Collections.Generic.IList<System.Security.Policy.StrongName>); } }
+    public bool IsApplicationTrustedToRun { get { return default(bool); } set { } }
+    public bool Persist { get { return default(bool); } set { } }
+//    public void FromXml(System.Security.SecurityElement element) { }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+  }
+  public sealed partial class ApplicationTrustCollection : System.Collections.ICollection, System.Collections.IEnumerable {
+    internal ApplicationTrustCollection() { }
+    public int Count { get { return default(int); } }
+    public bool IsSynchronized { get { return default(bool); } }
+    public System.Security.Policy.ApplicationTrust this[int index] { get { return default(System.Security.Policy.ApplicationTrust); } }
+    public System.Security.Policy.ApplicationTrust this[string appFullName] { get { return default(System.Security.Policy.ApplicationTrust); } }
+    public object SyncRoot { get { return default(object); } }
+    public int Add(System.Security.Policy.ApplicationTrust trust) { return default(int); }
+    public void AddRange(System.Security.Policy.ApplicationTrust[] trusts) { }
+    public void AddRange(System.Security.Policy.ApplicationTrustCollection trusts) { }
+    public void Clear() { }
+    public void CopyTo(System.Security.Policy.ApplicationTrust[] array, int index) { }
+//    public System.Security.Policy.ApplicationTrustCollection Find(System.ApplicationIdentity applicationIdentity, System.Security.Policy.ApplicationVersionMatch versionMatch) { return default(System.Security.Policy.ApplicationTrustCollection); }
+    public System.Security.Policy.ApplicationTrustEnumerator GetEnumerator() { return default(System.Security.Policy.ApplicationTrustEnumerator); }
+//    public void Remove(System.ApplicationIdentity applicationIdentity, System.Security.Policy.ApplicationVersionMatch versionMatch) { }
+    public void Remove(System.Security.Policy.ApplicationTrust trust) { }
+    public void RemoveRange(System.Security.Policy.ApplicationTrust[] trusts) { }
+    public void RemoveRange(System.Security.Policy.ApplicationTrustCollection trusts) { }
+    void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
+  }
+  public sealed partial class ApplicationTrustEnumerator : System.Collections.IEnumerator {
+    internal ApplicationTrustEnumerator() { }
+    public System.Security.Policy.ApplicationTrust Current { get { return default(System.Security.Policy.ApplicationTrust); } }
+    object System.Collections.IEnumerator.Current { get { return default(object); } }
+    public bool MoveNext() { return default(bool); }
+    public void Reset() { }
+  }
+  public enum ApplicationVersionMatch {
+    MatchAllVersions = 1,
+    MatchExactVersion = 0,
+  }
+  public partial class CodeConnectAccess {
+    public static readonly string AnyScheme;
+    public static readonly int DefaultPort;
+    public static readonly int OriginPort;
+    public static readonly string OriginScheme;
+    public CodeConnectAccess(string allowScheme, int allowPort) { }
+    public int Port { get { return default(int); } }
+    public string Scheme { get { return default(string); } }
+    public static System.Security.Policy.CodeConnectAccess CreateAnySchemeAccess(int allowPort) { return default(System.Security.Policy.CodeConnectAccess); }
+    public static System.Security.Policy.CodeConnectAccess CreateOriginSchemeAccess(int allowPort) { return default(System.Security.Policy.CodeConnectAccess); }
+    public override bool Equals(object o) { return default(bool); }
+    public override int GetHashCode() { return default(int); }
+  }
+  public abstract partial class CodeGroup {
+    protected CodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) { }
+    public virtual string AttributeString { get { return default(string); } }
+    public System.Collections.IList Children { get { return default(System.Collections.IList); } set { } }
+    public string Description { get { return default(string); } set { } }
+    public System.Security.Policy.IMembershipCondition MembershipCondition { get { return default(System.Security.Policy.IMembershipCondition); } set { } }
+    public abstract string MergeLogic { get; }
+    public string Name { get { return default(string); } set { } }
+    public virtual string PermissionSetName { get { return default(string); } }
+    public System.Security.Policy.PolicyStatement PolicyStatement { get { return default(System.Security.Policy.PolicyStatement); } set { } }
+    public void AddChild(System.Security.Policy.CodeGroup group) { }
+    public abstract System.Security.Policy.CodeGroup Copy();
+//    protected virtual void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
+    public override bool Equals(object o) { return default(bool); }
+    public bool Equals(System.Security.Policy.CodeGroup cg, bool compareChildren) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement e) { }
+//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public override int GetHashCode() { return default(int); }
+//    protected virtual void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public void RemoveChild(System.Security.Policy.CodeGroup group) { }
+    public abstract System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence);
+    public abstract System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence);
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+  }
+  public sealed partial class Evidence : System.Collections.ICollection, System.Collections.IEnumerable {
+    public Evidence() { }
+    [System.ObsoleteAttribute]
+    public Evidence(object[] hostEvidence, object[] assemblyEvidence) { }
+    public Evidence(System.Security.Policy.Evidence evidence) { }
+    [System.ObsoleteAttribute]
+    public int Count { get { return default(int); } }
+    public bool IsReadOnly { get { return default(bool); } }
+    public bool IsSynchronized { get { return default(bool); } }
+    public bool Locked { get { return default(bool); } set { } }
+    public object SyncRoot { get { return default(object); } }
+    [System.ObsoleteAttribute]
+    public void AddAssembly(object id) { }
+    [System.ObsoleteAttribute]
+    public void AddHost(object id) { }
+    public void Clear() { }
+    public System.Security.Policy.Evidence Clone() { return default(System.Security.Policy.Evidence); }
+    [System.ObsoleteAttribute]
+    public void CopyTo(System.Array array, int index) { }
+    public System.Collections.IEnumerator GetAssemblyEnumerator() { return default(System.Collections.IEnumerator); }
+    [System.ObsoleteAttribute]
+    public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
+    public System.Collections.IEnumerator GetHostEnumerator() { return default(System.Collections.IEnumerator); }
+    public void Merge(System.Security.Policy.Evidence evidence) { }
+    public void RemoveType(System.Type t) { }
+  }
+  public abstract partial class EvidenceBase {
+    protected EvidenceBase() { }
+    public virtual System.Security.Policy.EvidenceBase Clone() { return default(System.Security.Policy.EvidenceBase); }
+  }
+  public sealed partial class FileCodeGroup : System.Security.Policy.CodeGroup {
+    public FileCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Permissions.FileIOPermissionAccess access) : base (default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+    public override string AttributeString { get { return default(string); } }
+    public override string MergeLogic { get { return default(string); } }
+    public override string PermissionSetName { get { return default(string); } }
+    public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
+//    protected override void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
+    public override bool Equals(object o) { return default(bool); }
+    public override int GetHashCode() { return default(int); }
+//    protected override void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+    public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+  }
+  public sealed partial class FirstMatchCodeGroup : System.Security.Policy.CodeGroup {
+    public FirstMatchCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) : base (default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+    public override string MergeLogic { get { return default(string); } }
+    public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
+    public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+    public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+  }
+  public sealed partial class GacInstalled : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
+    public GacInstalled() { }
+    public object Copy() { return default(object); }
+    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+    public override bool Equals(object o) { return default(bool); }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+  }
+  public sealed partial class GacMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
+    public GacMembershipCondition() { }
+    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+    public override bool Equals(object o) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement e) { }
+//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+  }
+  public sealed partial class Hash : System.Security.Policy.EvidenceBase /*, System.Runtime.Serialization.ISerializable */ {
+    public Hash(System.Reflection.Assembly assembly) { }
+    public byte[] MD5 { get { return default(byte[]); } }
+    public byte[] SHA1 { get { return default(byte[]); } }
+    public static System.Security.Policy.Hash CreateMD5(byte[] md5) { return default(System.Security.Policy.Hash); }
+    public static System.Security.Policy.Hash CreateSHA1(byte[] sha1) { return default(System.Security.Policy.Hash); }
+    public byte[] GenerateHash(System.Security.Cryptography.HashAlgorithm hashAlg) { return default(byte[]); }
+    // public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    public override string ToString() { return default(string); }
+  }
+  public sealed partial class HashMembershipCondition : /* System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable, */ System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
+    public HashMembershipCondition(System.Security.Cryptography.HashAlgorithm hashAlg, byte[] value) { }
+    public System.Security.Cryptography.HashAlgorithm HashAlgorithm { get { return default(System.Security.Cryptography.HashAlgorithm); } set { } }
+    public byte[] HashValue { get { return default(byte[]); } set { } }
+    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+    public override bool Equals(object o) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement e) { }
+//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public override int GetHashCode() { return default(int); }
+//    void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
+//    void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    public override string ToString() { return default(string); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+  }
+  public partial interface IIdentityPermissionFactory {
+    System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence);
+  }
+  public partial interface IMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable {
+    bool Check(System.Security.Policy.Evidence evidence);
+    System.Security.Policy.IMembershipCondition Copy();
+    bool Equals(object obj);
+    string ToString();
+  }
+  public sealed partial class NetCodeGroup : System.Security.Policy.CodeGroup {
+    public static readonly string AbsentOriginScheme;
+    public static readonly string AnyOtherOriginScheme;
+    public NetCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition) : base (default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+    public override string AttributeString { get { return default(string); } }
+    public override string MergeLogic { get { return default(string); } }
+    public override string PermissionSetName { get { return default(string); } }
+    public void AddConnectAccess(string originScheme, System.Security.Policy.CodeConnectAccess connectAccess) { }
+    public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
+//    protected override void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
+    public override bool Equals(object o) { return default(bool); }
+    public System.Collections.DictionaryEntry[] GetConnectAccessRules() { return default(System.Collections.DictionaryEntry[]); }
+    public override int GetHashCode() { return default(int); }
+//    protected override void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public void ResetConnectAccess() { }
+    public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+    public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+  }
+  public sealed partial class PermissionRequestEvidence : System.Security.Policy.EvidenceBase {
+    public PermissionRequestEvidence(System.Security.PermissionSet request, System.Security.PermissionSet optional, System.Security.PermissionSet denied) { }
+    public System.Security.PermissionSet DeniedPermissions { get { return default(System.Security.PermissionSet); } }
+    public System.Security.PermissionSet OptionalPermissions { get { return default(System.Security.PermissionSet); } }
+    public System.Security.PermissionSet RequestedPermissions { get { return default(System.Security.PermissionSet); } }
+    public System.Security.Policy.PermissionRequestEvidence Copy() { return default(System.Security.Policy.PermissionRequestEvidence); }
+    public override string ToString() { return default(string); }
+  }
+  public partial class PolicyException : System.SystemException {
+    public PolicyException() { }
+//    protected PolicyException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    public PolicyException(string message) { }
+    public PolicyException(string message, System.Exception exception) { }
+  }
+  public sealed partial class PolicyLevel {
+    internal PolicyLevel() { }
+    [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+    public System.Collections.IList FullTrustAssemblies { get { return default(System.Collections.IList); } }
+    public string Label { get { return default(string); } }
+    public System.Collections.IList NamedPermissionSets { get { return default(System.Collections.IList); } }
+    public System.Security.Policy.CodeGroup RootCodeGroup { get { return default(System.Security.Policy.CodeGroup); } set { } }
+    public string StoreLocation { get { return default(string); } }
+    public System.Security.PolicyLevelType Type { get { return default(System.Security.PolicyLevelType); } }
+    [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+    public void AddFullTrustAssembly(System.Security.Policy.StrongName sn) { }
+    [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+    public void AddFullTrustAssembly(System.Security.Policy.StrongNameMembershipCondition snMC) { }
+    public void AddNamedPermissionSet(System.Security.NamedPermissionSet permSet) { }
+    public System.Security.NamedPermissionSet ChangeNamedPermissionSet(string name, System.Security.PermissionSet pSet) { return default(System.Security.NamedPermissionSet); }
+    public static System.Security.Policy.PolicyLevel CreateAppDomainLevel() { return default(System.Security.Policy.PolicyLevel); }
+//    public void FromXml(System.Security.SecurityElement e) { }
+    public System.Security.NamedPermissionSet GetNamedPermissionSet(string name) { return default(System.Security.NamedPermissionSet); }
+    public void Recover() { }
+    [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+    public void RemoveFullTrustAssembly(System.Security.Policy.StrongName sn) { }
+    [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+    public void RemoveFullTrustAssembly(System.Security.Policy.StrongNameMembershipCondition snMC) { }
+    public System.Security.NamedPermissionSet RemoveNamedPermissionSet(System.Security.NamedPermissionSet permSet) { return default(System.Security.NamedPermissionSet); }
+    public System.Security.NamedPermissionSet RemoveNamedPermissionSet(string name) { return default(System.Security.NamedPermissionSet); }
+    public void Reset() { }
+    public System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+    public System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+  }
+  public sealed partial class PolicyStatement : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable {
+    public PolicyStatement(System.Security.PermissionSet permSet) { }
+    public PolicyStatement(System.Security.PermissionSet permSet, System.Security.Policy.PolicyStatementAttribute attributes) { }
+    public System.Security.Policy.PolicyStatementAttribute Attributes { get { return default(System.Security.Policy.PolicyStatementAttribute); } set { } }
+    public string AttributeString { get { return default(string); } }
+    public System.Security.PermissionSet PermissionSet { get { return default(System.Security.PermissionSet); } set { } }
+    public System.Security.Policy.PolicyStatement Copy() { return default(System.Security.Policy.PolicyStatement); }
+    public override bool Equals(object obj) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement et) { }
+//    public void FromXml(System.Security.SecurityElement et, System.Security.Policy.PolicyLevel level) { }
+    public override int GetHashCode() { return default(int); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+  }
+  [System.FlagsAttribute]
+  public enum PolicyStatementAttribute {
+    All = 3,
+    Exclusive = 1,
+    LevelFinal = 2,
+    Nothing = 0,
+  }
+  public sealed partial class Publisher : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
+    public Publisher(System.Security.Cryptography.X509Certificates.X509Certificate cert) { }
+    public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } }
+    public object Copy() { return default(object); }
+    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+    public override bool Equals(object o) { return default(bool); }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+  }
+  public sealed partial class PublisherMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
+    public PublisherMembershipCondition(System.Security.Cryptography.X509Certificates.X509Certificate certificate) { }
+    public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } set { } }
+    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+    public override bool Equals(object o) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement e) { }
+//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+  }
+  public sealed partial class Site : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
+    public Site(string name) { }
+    public string Name { get { return default(string); } }
+    public object Copy() { return default(object); }
+    public static System.Security.Policy.Site CreateFromUrl(string url) { return default(System.Security.Policy.Site); }
+    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+    public override bool Equals(object o) { return default(bool); }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+  }
+  public sealed partial class SiteMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
+    public SiteMembershipCondition(string site) { }
+    public string Site { get { return default(string); } set { } }
+    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+    public override bool Equals(object o) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement e) { }
+//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+  }
+  public sealed partial class StrongName : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
+    public StrongName(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
+    public string Name { get { return default(string); } }
+    public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } }
+    public System.Version Version { get { return default(System.Version); } }
+    public object Copy() { return default(object); }
+    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+    public override bool Equals(object o) { return default(bool); }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+  }
+  public sealed partial class StrongNameMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
+    public StrongNameMembershipCondition(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
+    public string Name { get { return default(string); } set { } }
+    public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } set { } }
+    public System.Version Version { get { return default(System.Version); } set { } }
+    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+    public override bool Equals(object o) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement e) { }
+//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+  }
+  public partial class TrustManagerContext {
+    public TrustManagerContext() { }
+    public TrustManagerContext(System.Security.Policy.TrustManagerUIContext uiContext) { }
+    public virtual bool IgnorePersistedDecision { get { return default(bool); } set { } }
+    public virtual bool KeepAlive { get { return default(bool); } set { } }
+    public virtual bool NoPrompt { get { return default(bool); } set { } }
+    public virtual bool Persist { get { return default(bool); } set { } }
+//    public virtual System.ApplicationIdentity PreviousApplicationIdentity { get { return default(System.ApplicationIdentity); } set { } }
+    public virtual System.Security.Policy.TrustManagerUIContext UIContext { get { return default(System.Security.Policy.TrustManagerUIContext); } set { } }
+  }
+  public enum TrustManagerUIContext {
+    Install = 0,
+    Run = 2,
+    Upgrade = 1,
+  }
+  public sealed partial class UnionCodeGroup : System.Security.Policy.CodeGroup {
+    public UnionCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) : base (default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+    public override string MergeLogic { get { return default(string); } }
+    public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
+    public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+    public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+  }
+  public sealed partial class Url : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
+    public Url(string name) { }
+    public string Value { get { return default(string); } }
+    public object Copy() { return default(object); }
+    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+    public override bool Equals(object o) { return default(bool); }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+  }
+  public sealed partial class UrlMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
+    public UrlMembershipCondition(string url) { }
+    public string Url { get { return default(string); } set { } }
+    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+    public override bool Equals(object o) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement e) { }
+//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+  }
+  public sealed partial class Zone : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
+    public Zone(System.Security.SecurityZone zone) { }
+    public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } }
+    public object Copy() { return default(object); }
+    public static System.Security.Policy.Zone CreateFromUrl(string url) { return default(System.Security.Policy.Zone); }
+    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+    public override bool Equals(object o) { return default(bool); }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+  }
+  public sealed partial class ZoneMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
+    public ZoneMembershipCondition(System.Security.SecurityZone zone) { }
+    public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } set { } }
+    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+    public override bool Equals(object o) { return default(bool); }
+//    public void FromXml(System.Security.SecurityElement e) { }
+//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+    public override int GetHashCode() { return default(int); }
+    public override string ToString() { return default(string); }
+//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+  }
+}

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -1,1108 +1,1114 @@
-namespace System.Security {
-  public abstract partial class CodeAccessPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.IStackWalk {
-    protected CodeAccessPermission() { }
-    public void Assert() { }
-    public abstract System.Security.IPermission Copy();
-    public void Demand() { }
-    public void Deny() { }
-    public override bool Equals(object obj) { return default(bool); }
-//    public abstract void FromXml(System.Security.SecurityElement elem);
-    public override int GetHashCode() { return default(int); }
-    public abstract System.Security.IPermission Intersect(System.Security.IPermission target);
-    public abstract bool IsSubsetOf(System.Security.IPermission target);
-    public void PermitOnly() { }
-    public override string ToString() { return default(string); }
-//    public abstract System.Security.SecurityElement ToXml();
-    public virtual System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
-  }
-  public partial class HostProtectionException : System.SystemException {
-    public HostProtectionException() { }
-    // protected HostProtectionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    public HostProtectionException(string message) { }
-    public HostProtectionException(string message, System.Exception e) { }
-    public HostProtectionException(string message, System.Security.Permissions.HostProtectionResource protectedResources, System.Security.Permissions.HostProtectionResource demandedResources) { }
-    public System.Security.Permissions.HostProtectionResource DemandedResources { get { return default(System.Security.Permissions.HostProtectionResource); } }
-    public System.Security.Permissions.HostProtectionResource ProtectedResources { get { return default(System.Security.Permissions.HostProtectionResource); } }
-    // public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    public override string ToString() { return default(string); }
-  }
-  public partial class HostSecurityManager {
-    public HostSecurityManager() { }
-    public virtual System.Security.Policy.PolicyLevel DomainPolicy { get { return default(System.Security.Policy.PolicyLevel); } }
-    public virtual System.Security.HostSecurityManagerOptions Flags { get { return default(System.Security.HostSecurityManagerOptions); } }
-    public virtual System.Security.Policy.ApplicationTrust DetermineApplicationTrust(System.Security.Policy.Evidence applicationEvidence, System.Security.Policy.Evidence activatorEvidence, System.Security.Policy.TrustManagerContext context) { return default(System.Security.Policy.ApplicationTrust); }
-    public virtual System.Security.Policy.Evidence ProvideAppDomainEvidence(System.Security.Policy.Evidence inputEvidence) { return default(System.Security.Policy.Evidence); }
-    public virtual System.Security.Policy.Evidence ProvideAssemblyEvidence(System.Reflection.Assembly loadedAssembly, System.Security.Policy.Evidence inputEvidence) { return default(System.Security.Policy.Evidence); }
-    public virtual System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
-  }
-  [System.FlagsAttribute]
-  public enum HostSecurityManagerOptions {
-    AllFlags = 31,
-    HostAppDomainEvidence = 1,
-    HostAssemblyEvidence = 4,
-    HostDetermineApplicationTrust = 8,
-    HostPolicyLevel = 2,
-    HostResolvePolicy = 16,
-    None = 0,
-  }
-  public partial interface IEvidenceFactory {
-    System.Security.Policy.Evidence Evidence { get; }
-  }
-  public partial interface IPermission : System.Security.ISecurityEncodable {
-    System.Security.IPermission Copy();
-    void Demand();
-    System.Security.IPermission Intersect(System.Security.IPermission target);
-    bool IsSubsetOf(System.Security.IPermission target);
-    System.Security.IPermission Union(System.Security.IPermission target);
-  }
-  public partial interface ISecurityEncodable {
-//    void FromXml(System.Security.SecurityElement e);
-//    System.Security.SecurityElement ToXml();
-  }
-  public partial interface ISecurityPolicyEncodable {
-//    void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level);
-//    System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level);
-  }
-  public partial interface IStackWalk {
-    void Assert();
-    void Demand();
-    void Deny();
-    void PermitOnly();
-  }
-  public sealed partial class NamedPermissionSet : System.Security.PermissionSet {
-    public NamedPermissionSet(System.Security.NamedPermissionSet permSet) : base (default(System.Security.Permissions.PermissionState)) { }
-    public NamedPermissionSet(string name) : base (default(System.Security.Permissions.PermissionState)) { }
-    public NamedPermissionSet(string name, System.Security.Permissions.PermissionState state) : base (default(System.Security.Permissions.PermissionState)) { }
-    public NamedPermissionSet(string name, System.Security.PermissionSet permSet) : base (default(System.Security.Permissions.PermissionState)) { }
-    public string Description { get { return default(string); } set { } }
-    public string Name { get { return default(string); } set { } }
-    public override System.Security.PermissionSet Copy() { return default(System.Security.PermissionSet); }
-    public System.Security.NamedPermissionSet Copy(string name) { return default(System.Security.NamedPermissionSet); }
-    public override bool Equals(object obj) { return default(bool); }
-//    public override void FromXml(System.Security.SecurityElement et) { }
-    public override int GetHashCode() { return default(int); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-  }
-  public partial class PermissionSet : System.Collections.ICollection, System.Collections.IEnumerable, /* System.Runtime.Serialization.IDeserializationCallback, */ System.Security.ISecurityEncodable, System.Security.IStackWalk {
-    public PermissionSet(System.Security.Permissions.PermissionState state) { }
-    public PermissionSet(System.Security.PermissionSet permSet) { }
-    public virtual int Count { get { return default(int); } }
-    public virtual bool IsReadOnly { get { return default(bool); } }
-    public virtual bool IsSynchronized { get { return default(bool); } }
-    public virtual object SyncRoot { get { return default(object); } }
-    public System.Security.IPermission AddPermission(System.Security.IPermission perm) { return default(System.Security.IPermission); }
-    public void Assert() { }
-    public bool ContainsNonCodeAccessPermissions() { return default(bool); }
-    public static byte[] ConvertPermissionSet(string inFormat, byte[] inData, string outFormat) { return default(byte[]); }
-    public virtual System.Security.PermissionSet Copy() { return default(System.Security.PermissionSet); }
-    public virtual void CopyTo(System.Array array, int index) { }
-    public void Demand() { }
-    public void Deny() { }
-    public override bool Equals(object obj) { return default(bool); }
-//    public virtual void FromXml(System.Security.SecurityElement et) { }
-    public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
-    public override int GetHashCode() { return default(int); }
-    public System.Security.IPermission GetPermission(System.Type permClass) { return default(System.Security.IPermission); }
-    public System.Security.PermissionSet Intersect(System.Security.PermissionSet other) { return default(System.Security.PermissionSet); }
-    public bool IsEmpty() { return default(bool); }
-    public bool IsSubsetOf(System.Security.PermissionSet target) { return default(bool); }
-    public bool IsUnrestricted() { return default(bool); }
-    public void PermitOnly() { }
-    public System.Security.IPermission RemovePermission(System.Type permClass) { return default(System.Security.IPermission); }
-    public static void RevertAssert() { }
-    public System.Security.IPermission SetPermission(System.Security.IPermission perm) { return default(System.Security.IPermission); }
-//    void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-    public override string ToString() { return default(string); }
-//    public virtual System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public System.Security.PermissionSet Union(System.Security.PermissionSet other) { return default(System.Security.PermissionSet); }
-  }
-  public enum PolicyLevelType {
-    AppDomain = 3,
-    Enterprise = 2,
-    Machine = 1,
-    User = 0,
-  }
-  public sealed partial class SecurityContext : System.IDisposable {
-    internal SecurityContext() { }
-    public static System.Security.SecurityContext Capture() { return default(System.Security.SecurityContext); }
-    public System.Security.SecurityContext CreateCopy() { return default(System.Security.SecurityContext); }
-    public void Dispose() { }
-    public static bool IsFlowSuppressed() { return default(bool); }
-    public static bool IsWindowsIdentityFlowSuppressed() { return default(bool); }
-    public static void RestoreFlow() { }
-    public static void Run(System.Security.SecurityContext securityContext, System.Threading.ContextCallback callback, object state) { }
-//    public static System.Threading.AsyncFlowControl SuppressFlow() { return default(System.Threading.AsyncFlowControl); }
-//    public static System.Threading.AsyncFlowControl SuppressFlowWindowsIdentity() { return default(System.Threading.AsyncFlowControl); }
-  }
-  public enum SecurityContextSource {
-    CurrentAppDomain = 0,
-    CurrentAssembly = 1,
-  }
-  [System.ObsoleteAttribute("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
-  public enum SecurityCriticalScope {
-    Everything = 1,
-    Explicit = 0,
-  }
-  public static partial class SecurityManager {
-    [System.ObsoleteAttribute]
-    public static bool CheckExecutionRights { get { return default(bool); } set { } }
-    [System.ObsoleteAttribute("The security manager cannot be turned off on MS runtime")]
-    public static bool SecurityEnabled { get { return default(bool); } set { } }
-    public static void GetZoneAndOrigin(out System.Collections.ArrayList zone, out System.Collections.ArrayList origin) { zone = default(System.Collections.ArrayList); origin = default(System.Collections.ArrayList); }
-    [System.ObsoleteAttribute]
-    public static bool IsGranted(System.Security.IPermission perm) { return default(bool); }
-    [System.ObsoleteAttribute]
-    public static System.Security.Policy.PolicyLevel LoadPolicyLevelFromFile(string path, System.Security.PolicyLevelType type) { return default(System.Security.Policy.PolicyLevel); }
-    [System.ObsoleteAttribute]
-    public static System.Security.Policy.PolicyLevel LoadPolicyLevelFromString(string str, System.Security.PolicyLevelType type) { return default(System.Security.Policy.PolicyLevel); }
-    [System.ObsoleteAttribute]
-    public static System.Collections.IEnumerator PolicyHierarchy() { return default(System.Collections.IEnumerator); }
-    [System.ObsoleteAttribute]
-    public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
-    [System.ObsoleteAttribute]
-    public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence, System.Security.PermissionSet reqdPset, System.Security.PermissionSet optPset, System.Security.PermissionSet denyPset, out System.Security.PermissionSet denied) { denied = default(System.Security.PermissionSet); return default(System.Security.PermissionSet); }
-    [System.ObsoleteAttribute]
-    public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence[] evidences) { return default(System.Security.PermissionSet); }
-    [System.ObsoleteAttribute]
-    public static System.Collections.IEnumerator ResolvePolicyGroups(System.Security.Policy.Evidence evidence) { return default(System.Collections.IEnumerator); }
-    [System.ObsoleteAttribute]
-    public static System.Security.PermissionSet ResolveSystemPolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
-    [System.ObsoleteAttribute]
-    public static void SavePolicy() { }
-    [System.ObsoleteAttribute]
-    public static void SavePolicyLevel(System.Security.Policy.PolicyLevel level) { }
-  }
-  public abstract partial class SecurityState {
-    protected SecurityState() { }
-    public abstract void EnsureState();
-    public bool IsStateAvailable() { return default(bool); }
-  }
-  public enum SecurityZone {
-    Internet = 3,
-    Intranet = 1,
-    MyComputer = 0,
-    NoZone = -1,
-    Trusted = 2,
-    Untrusted = 4,
-  }
-  public sealed partial class XmlSyntaxException : System.SystemException {
-    public XmlSyntaxException() { }
-    public XmlSyntaxException(int lineNumber) { }
-    public XmlSyntaxException(int lineNumber, string message) { }
-    public XmlSyntaxException(string message) { }
-    public XmlSyntaxException(string message, System.Exception inner) { }
-  }
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
+{
+    public abstract partial class CodeAccessPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.IStackWalk
+    {
+        protected CodeAccessPermission() { }
+        public void Assert() { }
+        public abstract System.Security.IPermission Copy();
+        public void Demand() { }
+        [System.ObsoleteAttribute]
+        public void Deny() { }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public abstract System.Security.IPermission Intersect(System.Security.IPermission target);
+        public abstract bool IsSubsetOf(System.Security.IPermission target);
+        public void PermitOnly() { }
+        public override string ToString() => base.ToString();
+        public virtual System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+    public partial class HostProtectionException : System.SystemException
+    {
+        public HostProtectionException() { }
+        public HostProtectionException(string message) { }
+        public HostProtectionException(string message, System.Exception e) { }
+        public HostProtectionException(string message, System.Security.Permissions.HostProtectionResource protectedResources, System.Security.Permissions.HostProtectionResource demandedResources) { }
+        public System.Security.Permissions.HostProtectionResource DemandedResources { get { return default(System.Security.Permissions.HostProtectionResource); } }
+        public System.Security.Permissions.HostProtectionResource ProtectedResources { get { return default(System.Security.Permissions.HostProtectionResource); } }
+        public override string ToString() => base.ToString();
+    }
+    public partial class HostSecurityManager
+    {
+        public HostSecurityManager() { }
+        public virtual System.Security.Policy.PolicyLevel DomainPolicy { get { return default(System.Security.Policy.PolicyLevel); } }
+        public virtual System.Security.HostSecurityManagerOptions Flags { get { return default(System.Security.HostSecurityManagerOptions); } }
+        public virtual System.Security.Policy.ApplicationTrust DetermineApplicationTrust(System.Security.Policy.Evidence applicationEvidence, System.Security.Policy.Evidence activatorEvidence, System.Security.Policy.TrustManagerContext context) { return default(System.Security.Policy.ApplicationTrust); }
+        public virtual System.Security.Policy.Evidence ProvideAppDomainEvidence(System.Security.Policy.Evidence inputEvidence) { return default(System.Security.Policy.Evidence); }
+        public virtual System.Security.Policy.Evidence ProvideAssemblyEvidence(System.Reflection.Assembly loadedAssembly, System.Security.Policy.Evidence inputEvidence) { return default(System.Security.Policy.Evidence); }
+        [System.ObsoleteAttribute]
+        public virtual System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
+    }
+    [System.FlagsAttribute]
+    public enum HostSecurityManagerOptions
+    {
+        AllFlags = 31,
+        HostAppDomainEvidence = 1,
+        HostAssemblyEvidence = 4,
+        HostDetermineApplicationTrust = 8,
+        HostPolicyLevel = 2,
+        HostResolvePolicy = 16,
+        None = 0,
+    }
+    public partial interface IEvidenceFactory
+    {
+        System.Security.Policy.Evidence Evidence { get; }
+    }
+    public partial interface IPermission : System.Security.ISecurityEncodable
+    {
+        System.Security.IPermission Copy();
+        void Demand();
+        System.Security.IPermission Intersect(System.Security.IPermission target);
+        bool IsSubsetOf(System.Security.IPermission target);
+        System.Security.IPermission Union(System.Security.IPermission target);
+    }
+    public partial interface ISecurityEncodable
+    {
+    }
+    public partial interface ISecurityPolicyEncodable
+    {
+    }
+    public partial interface IStackWalk
+    {
+        void Assert();
+        void Demand();
+        void Deny();
+        void PermitOnly();
+    }
+    public sealed partial class NamedPermissionSet : System.Security.PermissionSet
+    {
+        public NamedPermissionSet(System.Security.NamedPermissionSet permSet) : base(default(System.Security.Permissions.PermissionState)) { }
+        public NamedPermissionSet(string name) : base(default(System.Security.Permissions.PermissionState)) { }
+        public NamedPermissionSet(string name, System.Security.Permissions.PermissionState state) : base(default(System.Security.Permissions.PermissionState)) { }
+        public NamedPermissionSet(string name, System.Security.PermissionSet permSet) : base(default(System.Security.Permissions.PermissionState)) { }
+        public string Description { get; set; }
+        public string Name { get; set; }
+        public override System.Security.PermissionSet Copy() { return this; }
+        public System.Security.NamedPermissionSet Copy(string name) { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+    }
+    public partial class PermissionSet : System.Collections.ICollection, System.Collections.IEnumerable, System.Security.ISecurityEncodable, System.Security.IStackWalk
+    {
+        public PermissionSet(System.Security.Permissions.PermissionState state) { }
+        public PermissionSet(System.Security.PermissionSet permSet) { }
+        public virtual int Count { get { return default(int); } }
+        public virtual bool IsReadOnly { get { return default(bool); } }
+        public virtual bool IsSynchronized { get { return default(bool); } }
+        public virtual object SyncRoot { get { return default(object); } }
+        public System.Security.IPermission AddPermission(System.Security.IPermission perm) { return default(System.Security.IPermission); }
+        public void Assert() { }
+        public bool ContainsNonCodeAccessPermissions() { return default(bool); }
+        [System.ObsoleteAttribute]
+        public static byte[] ConvertPermissionSet(string inFormat, byte[] inData, string outFormat) { return default(byte[]); }
+        public virtual System.Security.PermissionSet Copy() { return this; }
+        public virtual void CopyTo(System.Array array, int index) { }
+        public void Demand() { }
+        [System.ObsoleteAttribute]
+        public void Deny() { }
+        public override bool Equals(object o) => base.Equals(o);
+        public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
+        public override int GetHashCode() => base.GetHashCode();
+        public System.Security.IPermission GetPermission(System.Type permClass) { return default(System.Security.IPermission); }
+        public System.Security.PermissionSet Intersect(System.Security.PermissionSet other) { return default(System.Security.PermissionSet); }
+        public bool IsEmpty() { return default(bool); }
+        public bool IsSubsetOf(System.Security.PermissionSet target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public void PermitOnly() { }
+        public System.Security.IPermission RemovePermission(System.Type permClass) { return default(System.Security.IPermission); }
+        public static void RevertAssert() { }
+        public System.Security.IPermission SetPermission(System.Security.IPermission perm) { return default(System.Security.IPermission); }
+        public override string ToString() => base.ToString();
+        public System.Security.PermissionSet Union(System.Security.PermissionSet other) { return default(System.Security.PermissionSet); }
+    }
+    public enum PolicyLevelType
+    {
+        AppDomain = 3,
+        Enterprise = 2,
+        Machine = 1,
+        User = 0,
+    }
+    public sealed partial class SecurityContext : System.IDisposable
+    {
+        internal SecurityContext() { }
+        public static System.Security.SecurityContext Capture() { return default(System.Security.SecurityContext); }
+        public System.Security.SecurityContext CreateCopy() { return default(System.Security.SecurityContext); }
+        public void Dispose() { }
+        public static bool IsFlowSuppressed() { return default(bool); }
+        public static bool IsWindowsIdentityFlowSuppressed() { return default(bool); }
+        public static void RestoreFlow() { }
+        public static void Run(System.Security.SecurityContext securityContext, System.Threading.ContextCallback callback, object state) { }
+    }
+    public enum SecurityContextSource
+    {
+        CurrentAppDomain = 0,
+        CurrentAssembly = 1,
+    }
+    [System.ObsoleteAttribute("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
+    public enum SecurityCriticalScope
+    {
+        Everything = 1,
+        Explicit = 0,
+    }
+    public static partial class SecurityManager
+    {
+        [System.ObsoleteAttribute]
+        public static bool CheckExecutionRights { get; set; }
+        [System.ObsoleteAttribute("The security manager cannot be turned off on MS runtime")]
+        public static bool SecurityEnabled { get; set; }
+        public static void GetZoneAndOrigin(out System.Collections.ArrayList zone, out System.Collections.ArrayList origin) { zone = default(System.Collections.ArrayList); origin = default(System.Collections.ArrayList); }
+        [System.ObsoleteAttribute]
+        public static bool IsGranted(System.Security.IPermission perm) { return default(bool); }
+        [System.ObsoleteAttribute]
+        public static System.Security.Policy.PolicyLevel LoadPolicyLevelFromFile(string path, System.Security.PolicyLevelType type) { return default(System.Security.Policy.PolicyLevel); }
+        [System.ObsoleteAttribute]
+        public static System.Security.Policy.PolicyLevel LoadPolicyLevelFromString(string str, System.Security.PolicyLevelType type) { return default(System.Security.Policy.PolicyLevel); }
+        [System.ObsoleteAttribute]
+        public static System.Collections.IEnumerator PolicyHierarchy() { return default(System.Collections.IEnumerator); }
+        [System.ObsoleteAttribute]
+        public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
+        [System.ObsoleteAttribute]
+        public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence, System.Security.PermissionSet reqdPset, System.Security.PermissionSet optPset, System.Security.PermissionSet denyPset, out System.Security.PermissionSet denied) { denied = default(System.Security.PermissionSet); return default(System.Security.PermissionSet); }
+        [System.ObsoleteAttribute]
+        public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence[] evidences) { return default(System.Security.PermissionSet); }
+        [System.ObsoleteAttribute]
+        public static System.Collections.IEnumerator ResolvePolicyGroups(System.Security.Policy.Evidence evidence) { return default(System.Collections.IEnumerator); }
+        [System.ObsoleteAttribute]
+        public static System.Security.PermissionSet ResolveSystemPolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
+        [System.ObsoleteAttribute]
+        public static void SavePolicy() { }
+        [System.ObsoleteAttribute]
+        public static void SavePolicyLevel(System.Security.Policy.PolicyLevel level) { }
+    }
+    public abstract partial class SecurityState
+    {
+        protected SecurityState() { }
+        public abstract void EnsureState();
+        public bool IsStateAvailable() { return default(bool); }
+    }
+    public enum SecurityZone
+    {
+        Internet = 3,
+        Intranet = 1,
+        MyComputer = 0,
+        NoZone = -1,
+        Trusted = 2,
+        Untrusted = 4,
+    }
+    public sealed partial class XmlSyntaxException : System.SystemException
+    {
+        public XmlSyntaxException() { }
+        public XmlSyntaxException(int lineNumber) { }
+        public XmlSyntaxException(int lineNumber, string message) { }
+        public XmlSyntaxException(string message) { }
+        public XmlSyntaxException(string message, System.Exception inner) { }
+    }
 }
-namespace System.Security.Permissions {
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public abstract partial class CodeAccessSecurityAttribute : System.Security.Permissions.SecurityAttribute {
-    protected CodeAccessSecurityAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-  }
-  public sealed partial class EnvironmentPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
-    public EnvironmentPermission(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
-    public EnvironmentPermission(System.Security.Permissions.PermissionState state) { }
-    public void AddPathList(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement esd) { }
-    public string GetPathList(System.Security.Permissions.EnvironmentPermissionAccess flag) { return default(string); }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-    public bool IsUnrestricted() { return default(bool); }
-    public void SetPathList(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
-  }
-  [System.FlagsAttribute]
-  public enum EnvironmentPermissionAccess {
-    AllAccess = 3,
-    NoAccess = 0,
-    Read = 1,
-    Write = 2,
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class EnvironmentPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public EnvironmentPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public string All { get { return default(string); } set { } }
-    public string Read { get { return default(string); } set { } }
-    public string Write { get { return default(string); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  public sealed partial class FileDialogPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
-    public FileDialogPermission(System.Security.Permissions.FileDialogPermissionAccess access) { }
-    public FileDialogPermission(System.Security.Permissions.PermissionState state) { }
-    public System.Security.Permissions.FileDialogPermissionAccess Access { get { return default(System.Security.Permissions.FileDialogPermissionAccess); } set { } }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement esd) { }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-    public bool IsUnrestricted() { return default(bool); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
-  }
-  [System.FlagsAttribute]
-  public enum FileDialogPermissionAccess {
-    None = 0,
-    Open = 1,
-    OpenSave = 3,
-    Save = 2,
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class FileDialogPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public FileDialogPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public bool Open { get { return default(bool); } set { } }
-    public bool Save { get { return default(bool); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  public sealed partial class FileIOPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
-    public FileIOPermission(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
-    public FileIOPermission(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
-    public FileIOPermission(System.Security.Permissions.PermissionState state) { }
-    public System.Security.Permissions.FileIOPermissionAccess AllFiles { get { return default(System.Security.Permissions.FileIOPermissionAccess); } set { } }
-    public System.Security.Permissions.FileIOPermissionAccess AllLocalFiles { get { return default(System.Security.Permissions.FileIOPermissionAccess); } set { } }
-    public void AddPathList(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
-    public void AddPathList(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-    public override bool Equals(object obj) { return default(bool); }
-//    public override void FromXml(System.Security.SecurityElement esd) { }
-    public override int GetHashCode() { return default(int); }
-    public string[] GetPathList(System.Security.Permissions.FileIOPermissionAccess access) { return default(string[]); }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-    public bool IsUnrestricted() { return default(bool); }
-    public void SetPathList(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
-    public void SetPathList(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
-  }
-  [System.FlagsAttribute]
-  public enum FileIOPermissionAccess {
-    AllAccess = 15,
-    Append = 4,
-    NoAccess = 0,
-    PathDiscovery = 8,
-    Read = 1,
-    Write = 2,
-  }
-  public sealed partial class GacIdentityPermission : System.Security.CodeAccessPermission {
-    public GacIdentityPermission() { }
-    public GacIdentityPermission(System.Security.Permissions.PermissionState state) { }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement securityElement) { }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class GacIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public GacIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(4205), AllowMultiple=true, Inherited=false)]
-  public sealed partial class HostProtectionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public HostProtectionAttribute() : base (default(System.Security.Permissions.SecurityAction)) { }
-    public HostProtectionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public bool ExternalProcessMgmt { get { return default(bool); } set { } }
-    public bool ExternalThreading { get { return default(bool); } set { } }
-    public bool MayLeakOnAbort { get { return default(bool); } set { } }
-    public System.Security.Permissions.HostProtectionResource Resources { get { return default(System.Security.Permissions.HostProtectionResource); } set { } }
-    public bool SecurityInfrastructure { get { return default(bool); } set { } }
-    public bool SelfAffectingProcessMgmt { get { return default(bool); } set { } }
-    public bool SelfAffectingThreading { get { return default(bool); } set { } }
-    public bool SharedState { get { return default(bool); } set { } }
-    public bool Synchronization { get { return default(bool); } set { } }
-    public bool UI { get { return default(bool); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  [System.FlagsAttribute]
-  public enum HostProtectionResource {
-    All = 511,
-    ExternalProcessMgmt = 4,
-    ExternalThreading = 16,
-    MayLeakOnAbort = 256,
-    None = 0,
-    SecurityInfrastructure = 64,
-    SelfAffectingProcessMgmt = 8,
-    SelfAffectingThreading = 32,
-    SharedState = 2,
-    Synchronization = 1,
-    UI = 128,
-  }
-  public partial interface IUnrestrictedPermission {
-    bool IsUnrestricted();
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class PermissionSetAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public PermissionSetAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public string File { get { return default(string); } set { } }
-    public string Hex { get { return default(string); } set { } }
-    public string Name { get { return default(string); } set { } }
-    public bool UnicodeEncoded { get { return default(bool); } set { } }
-    public string XML { get { return default(string); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-    public System.Security.PermissionSet CreatePermissionSet() { return default(System.Security.PermissionSet); }
-  }
-  public enum PermissionState {
-    None = 0,
-    Unrestricted = 1,
-  }
-  public sealed partial class PrincipalPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.Permissions.IUnrestrictedPermission {
-    public PrincipalPermission(System.Security.Permissions.PermissionState state) { }
-    public PrincipalPermission(string name, string role) { }
-    public PrincipalPermission(string name, string role, bool isAuthenticated) { }
-    public System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-    public void Demand() { }
-    public override bool Equals(object obj) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement elem) { }
-    public override int GetHashCode() { return default(int); }
-    public System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-    public bool IsUnrestricted() { return default(bool); }
-    public override string ToString() { return default(string); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(68), AllowMultiple=true, Inherited=false)]
-  public sealed partial class PrincipalPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public PrincipalPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public bool Authenticated { get { return default(bool); } set { } }
-    public string Name { get { return default(string); } set { } }
-    public string Role { get { return default(string); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  public sealed partial class PublisherIdentityPermission : System.Security.CodeAccessPermission {
-    public PublisherIdentityPermission(System.Security.Cryptography.X509Certificates.X509Certificate certificate) { }
-    public PublisherIdentityPermission(System.Security.Permissions.PermissionState state) { }
-    public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } set { } }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement esd) { }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class PublisherIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public PublisherIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public string CertFile { get { return default(string); } set { } }
-    public string SignedFile { get { return default(string); } set { } }
-    public string X509Certificate { get { return default(string); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  public sealed partial class ReflectionPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
-    public ReflectionPermission(System.Security.Permissions.PermissionState state) { }
-    public ReflectionPermission(System.Security.Permissions.ReflectionPermissionFlag flag) { }
-    public System.Security.Permissions.ReflectionPermissionFlag Flags { get { return default(System.Security.Permissions.ReflectionPermissionFlag); } set { } }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement esd) { }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-    public bool IsUnrestricted() { return default(bool); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class ReflectionPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public ReflectionPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public System.Security.Permissions.ReflectionPermissionFlag Flags { get { return default(System.Security.Permissions.ReflectionPermissionFlag); } set { } }
-    public bool MemberAccess { get { return default(bool); } set { } }
-    [System.ObsoleteAttribute]
-    public bool ReflectionEmit { get { return default(bool); } set { } }
-    public bool RestrictedMemberAccess { get { return default(bool); } set { } }
-    [System.ObsoleteAttribute("not enforced in 2.0+")]
-    public bool TypeInformation { get { return default(bool); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  [System.FlagsAttribute]
-  public enum ReflectionPermissionFlag {
-    [System.ObsoleteAttribute]
-    AllFlags = 7,
-    MemberAccess = 2,
-    NoFlags = 0,
-    [System.ObsoleteAttribute]
-    ReflectionEmit = 4,
-    RestrictedMemberAccess = 8,
-    [System.ObsoleteAttribute("not used anymore")]
-    TypeInformation = 1,
-  }
-  public sealed partial class RegistryPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
-    public RegistryPermission(System.Security.Permissions.PermissionState state) { }
-    public RegistryPermission(System.Security.Permissions.RegistryPermissionAccess access, System.Security.AccessControl.AccessControlActions control, string pathList) { }
-    public RegistryPermission(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
-    public void AddPathList(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement esd) { }
-    public string GetPathList(System.Security.Permissions.RegistryPermissionAccess access) { return default(string); }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-    public bool IsUnrestricted() { return default(bool); }
-    public void SetPathList(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
-  }
-  [System.FlagsAttribute]
-  public enum RegistryPermissionAccess {
-    AllAccess = 7,
-    Create = 4,
-    NoAccess = 0,
-    Read = 1,
-    Write = 2,
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class RegistryPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public RegistryPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    [System.ObsoleteAttribute("use newer properties")]
-    public string All { get { return default(string); } set { } }
-    public string ChangeAccessControl { get { return default(string); } set { } }
-    public string Create { get { return default(string); } set { } }
-    public string Read { get { return default(string); } set { } }
-    public string ViewAccessControl { get { return default(string); } set { } }
-    public string ViewAndModify { get { return default(string); } set { } }
-    public string Write { get { return default(string); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  public enum SecurityAction {
-    Assert = 3,
-    Demand = 2,
-    [System.ObsoleteAttribute("This requests should not be used")]
-    Deny = 4,
-    InheritanceDemand = 7,
-    LinkDemand = 6,
-    PermitOnly = 5,
-    [System.ObsoleteAttribute("This requests should not be used")]
-    RequestMinimum = 8,
-    [System.ObsoleteAttribute("This requests should not be used")]
-    RequestOptional = 9,
-    [System.ObsoleteAttribute("This requests should not be used")]
-    RequestRefuse = 10,
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public abstract partial class SecurityAttribute : System.Attribute {
-    protected SecurityAttribute(System.Security.Permissions.SecurityAction action) { }
-    public System.Security.Permissions.SecurityAction Action { get { return default(System.Security.Permissions.SecurityAction); } set { } }
-    public bool Unrestricted { get { return default(bool); } set { } }
-    public abstract System.Security.IPermission CreatePermission();
-  }
-  public sealed partial class SecurityPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
-    public SecurityPermission(System.Security.Permissions.PermissionState state) { }
-    public SecurityPermission(System.Security.Permissions.SecurityPermissionFlag flag) { }
-    public System.Security.Permissions.SecurityPermissionFlag Flags { get { return default(System.Security.Permissions.SecurityPermissionFlag); } set { } }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement esd) { }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-    public bool IsUnrestricted() { return default(bool); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class SecurityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public SecurityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public bool Assertion { get { return default(bool); } set { } }
-    public bool BindingRedirects { get { return default(bool); } set { } }
-    public bool ControlAppDomain { get { return default(bool); } set { } }
-    public bool ControlDomainPolicy { get { return default(bool); } set { } }
-    public bool ControlEvidence { get { return default(bool); } set { } }
-    public bool ControlPolicy { get { return default(bool); } set { } }
-    public bool ControlPrincipal { get { return default(bool); } set { } }
-    public bool ControlThread { get { return default(bool); } set { } }
-    public bool Execution { get { return default(bool); } set { } }
-    public System.Security.Permissions.SecurityPermissionFlag Flags { get { return default(System.Security.Permissions.SecurityPermissionFlag); } set { } }
-    public bool Infrastructure { get { return default(bool); } set { } }
-    public bool RemotingConfiguration { get { return default(bool); } set { } }
-    public bool SerializationFormatter { get { return default(bool); } set { } }
-    public bool SkipVerification { get { return default(bool); } set { } }
-    public bool UnmanagedCode { get { return default(bool); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  [System.FlagsAttribute]
-  public enum SecurityPermissionFlag {
-    AllFlags = 16383,
-    Assertion = 1,
-    BindingRedirects = 8192,
-    ControlAppDomain = 1024,
-    ControlDomainPolicy = 256,
-    ControlEvidence = 32,
-    ControlPolicy = 64,
-    ControlPrincipal = 512,
-    ControlThread = 16,
-    Execution = 8,
-    Infrastructure = 4096,
-    NoFlags = 0,
-    RemotingConfiguration = 2048,
-    SerializationFormatter = 128,
-    SkipVerification = 4,
-    UnmanagedCode = 2,
-  }
-  public sealed partial class SiteIdentityPermission : System.Security.CodeAccessPermission {
-    public SiteIdentityPermission(System.Security.Permissions.PermissionState state) { }
-    public SiteIdentityPermission(string site) { }
-    public string Site { get { return default(string); } set { } }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement esd) { }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class SiteIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public SiteIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public string Site { get { return default(string); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  public sealed partial class StrongNameIdentityPermission : System.Security.CodeAccessPermission {
-    public StrongNameIdentityPermission(System.Security.Permissions.PermissionState state) { }
-    public StrongNameIdentityPermission(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
-    public string Name { get { return default(string); } set { } }
-    public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } set { } }
-    public System.Version Version { get { return default(System.Version); } set { } }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement e) { }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class StrongNameIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public StrongNameIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public string Name { get { return default(string); } set { } }
-    public string PublicKey { get { return default(string); } set { } }
-    public string Version { get { return default(string); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  public sealed partial class StrongNamePublicKeyBlob {
-    public StrongNamePublicKeyBlob(byte[] publicKey) { }
-    public override bool Equals(object obj) { return default(bool); }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-  }
-  public sealed partial class TypeDescriptorPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
-    public TypeDescriptorPermission(System.Security.Permissions.PermissionState state) { }
-    public TypeDescriptorPermission(System.Security.Permissions.TypeDescriptorPermissionFlags flag) { }
-    public System.Security.Permissions.TypeDescriptorPermissionFlags Flags { get { return default(System.Security.Permissions.TypeDescriptorPermissionFlags); } set { } }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement securityElement) { }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-    public bool IsUnrestricted() { return default(bool); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
-  }
-  [System.FlagsAttribute]
-  public enum TypeDescriptorPermissionFlags {
-    NoFlags = 0,
-    RestrictedRegistrationAccess = 1,
-  }
-  public sealed partial class UIPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission {
-    public UIPermission(System.Security.Permissions.PermissionState state) { }
-    public UIPermission(System.Security.Permissions.UIPermissionClipboard clipboardFlag) { }
-    public UIPermission(System.Security.Permissions.UIPermissionWindow windowFlag) { }
-    public UIPermission(System.Security.Permissions.UIPermissionWindow windowFlag, System.Security.Permissions.UIPermissionClipboard clipboardFlag) { }
-    public System.Security.Permissions.UIPermissionClipboard Clipboard { get { return default(System.Security.Permissions.UIPermissionClipboard); } set { } }
-    public System.Security.Permissions.UIPermissionWindow Window { get { return default(System.Security.Permissions.UIPermissionWindow); } set { } }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement esd) { }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-    public bool IsUnrestricted() { return default(bool); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class UIPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public UIPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public System.Security.Permissions.UIPermissionClipboard Clipboard { get { return default(System.Security.Permissions.UIPermissionClipboard); } set { } }
-    public System.Security.Permissions.UIPermissionWindow Window { get { return default(System.Security.Permissions.UIPermissionWindow); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  public enum UIPermissionClipboard {
-    AllClipboard = 2,
-    NoClipboard = 0,
-    OwnClipboard = 1,
-  }
-  public enum UIPermissionWindow {
-    AllWindows = 3,
-    NoWindows = 0,
-    SafeSubWindows = 1,
-    SafeTopLevelWindows = 2,
-  }
-  public sealed partial class UrlIdentityPermission : System.Security.CodeAccessPermission {
-    public UrlIdentityPermission(System.Security.Permissions.PermissionState state) { }
-    public UrlIdentityPermission(string site) { }
-    public string Url { get { return default(string); } set { } }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement esd) { }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class UrlIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public UrlIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public string Url { get { return default(string); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
-  public sealed partial class ZoneIdentityPermission : System.Security.CodeAccessPermission {
-    public ZoneIdentityPermission(System.Security.Permissions.PermissionState state) { }
-    public ZoneIdentityPermission(System.Security.SecurityZone zone) { }
-    public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } set { } }
-    public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-//    public override void FromXml(System.Security.SecurityElement esd) { }
-    public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
-    public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-//    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
-  }
-  [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple=true, Inherited=false)]
-  public sealed partial class ZoneIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute {
-    public ZoneIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
-    public System.Security.SecurityZone Zone { get { return default(System.Security.SecurityZone); } set { } }
-    public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
-  }
+namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public abstract partial class CodeAccessSecurityAttribute : System.Security.Permissions.SecurityAttribute
+    {
+        protected CodeAccessSecurityAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+    }
+    public sealed partial class EnvironmentPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public EnvironmentPermission(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
+        public EnvironmentPermission(System.Security.Permissions.PermissionState state) { }
+        public void AddPathList(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
+        public override System.Security.IPermission Copy() { return this; }
+        public string GetPathList(System.Security.Permissions.EnvironmentPermissionAccess flag) { return default(string); }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public void SetPathList(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
+        public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+    [System.FlagsAttribute]
+    public enum EnvironmentPermissionAccess
+    {
+        AllAccess = 3,
+        NoAccess = 0,
+        Read = 1,
+        Write = 2,
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class EnvironmentPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public EnvironmentPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string All { get; set; }
+        public string Read { get; set; }
+        public string Write { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    public sealed partial class FileDialogPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public FileDialogPermission(System.Security.Permissions.FileDialogPermissionAccess access) { }
+        public FileDialogPermission(System.Security.Permissions.PermissionState state) { }
+        public System.Security.Permissions.FileDialogPermissionAccess Access { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+    [System.FlagsAttribute]
+    public enum FileDialogPermissionAccess
+    {
+        None = 0,
+        Open = 1,
+        OpenSave = 3,
+        Save = 2,
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class FileDialogPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public FileDialogPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public bool Open { get; set; }
+        public bool Save { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    public sealed partial class FileIOPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public FileIOPermission(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
+        public FileIOPermission(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
+        public FileIOPermission(System.Security.Permissions.PermissionState state) { }
+        public System.Security.Permissions.FileIOPermissionAccess AllFiles { get; set; }
+        public System.Security.Permissions.FileIOPermissionAccess AllLocalFiles { get; set; }
+        public void AddPathList(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
+        public void AddPathList(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
+        public override System.Security.IPermission Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public string[] GetPathList(System.Security.Permissions.FileIOPermissionAccess access) { return default(string[]); }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public void SetPathList(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
+        public void SetPathList(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
+        public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+    [System.FlagsAttribute]
+    public enum FileIOPermissionAccess
+    {
+        AllAccess = 15,
+        Append = 4,
+        NoAccess = 0,
+        PathDiscovery = 8,
+        Read = 1,
+        Write = 2,
+    }
+    public sealed partial class GacIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public GacIdentityPermission() { }
+        public GacIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public override System.Security.IPermission Copy() { return this; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class GacIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public GacIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4205), AllowMultiple = true, Inherited = false)]
+    public sealed partial class HostProtectionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public HostProtectionAttribute() : base(default(System.Security.Permissions.SecurityAction)) { }
+        public HostProtectionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public bool ExternalProcessMgmt { get; set; }
+        public bool ExternalThreading { get; set; }
+        public bool MayLeakOnAbort { get; set; }
+        public System.Security.Permissions.HostProtectionResource Resources { get; set; }
+        public bool SecurityInfrastructure { get; set; }
+        public bool SelfAffectingProcessMgmt { get; set; }
+        public bool SelfAffectingThreading { get; set; }
+        public bool SharedState { get; set; }
+        public bool Synchronization { get; set; }
+        public bool UI { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    [System.FlagsAttribute]
+    public enum HostProtectionResource
+    {
+        All = 511,
+        ExternalProcessMgmt = 4,
+        ExternalThreading = 16,
+        MayLeakOnAbort = 256,
+        None = 0,
+        SecurityInfrastructure = 64,
+        SelfAffectingProcessMgmt = 8,
+        SelfAffectingThreading = 32,
+        SharedState = 2,
+        Synchronization = 1,
+        UI = 128,
+    }
+    public partial interface IUnrestrictedPermission
+    {
+        bool IsUnrestricted();
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class PermissionSetAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public PermissionSetAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string File { get; set; }
+        public string Hex { get; set; }
+        public string Name { get; set; }
+        public bool UnicodeEncoded { get; set; }
+        public string XML { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+        public System.Security.PermissionSet CreatePermissionSet() { return default(System.Security.PermissionSet); }
+    }
+    public enum PermissionState
+    {
+        None = 0,
+        Unrestricted = 1,
+    }
+    public sealed partial class PrincipalPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public PrincipalPermission(System.Security.Permissions.PermissionState state) { }
+        public PrincipalPermission(string name, string role) { }
+        public PrincipalPermission(string name, string role, bool isAuthenticated) { }
+        public System.Security.IPermission Copy() { return this; }
+        public void Demand() { }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public override string ToString() => base.ToString();
+        public System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(68), AllowMultiple = true, Inherited = false)]
+    public sealed partial class PrincipalPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public PrincipalPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public bool Authenticated { get; set; }
+        public string Name { get; set; }
+        public string Role { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    public sealed partial class PublisherIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public PublisherIdentityPermission(System.Security.Cryptography.X509Certificates.X509Certificate certificate) { }
+        public PublisherIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class PublisherIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public PublisherIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string CertFile { get; set; }
+        public string SignedFile { get; set; }
+        public string X509Certificate { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    public sealed partial class ReflectionPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public ReflectionPermission(System.Security.Permissions.PermissionState state) { }
+        public ReflectionPermission(System.Security.Permissions.ReflectionPermissionFlag flag) { }
+        public System.Security.Permissions.ReflectionPermissionFlag Flags { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class ReflectionPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public ReflectionPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public System.Security.Permissions.ReflectionPermissionFlag Flags { get; set; }
+        public bool MemberAccess { get; set; }
+        [System.ObsoleteAttribute]
+        public bool ReflectionEmit { get; set; }
+        public bool RestrictedMemberAccess { get; set; }
+        [System.ObsoleteAttribute("not enforced in 2.0+")]
+        public bool TypeInformation { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    [System.FlagsAttribute]
+    public enum ReflectionPermissionFlag
+    {
+        [System.ObsoleteAttribute]
+        AllFlags = 7,
+        MemberAccess = 2,
+        NoFlags = 0,
+        [System.ObsoleteAttribute]
+        ReflectionEmit = 4,
+        RestrictedMemberAccess = 8,
+        [System.ObsoleteAttribute("not used anymore")]
+        TypeInformation = 1,
+    }
+    public sealed partial class RegistryPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public RegistryPermission(System.Security.Permissions.PermissionState state) { }
+        public RegistryPermission(System.Security.Permissions.RegistryPermissionAccess access, System.Security.AccessControl.AccessControlActions control, string pathList) { }
+        public RegistryPermission(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
+        public void AddPathList(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
+        public override System.Security.IPermission Copy() { return this; }
+        public string GetPathList(System.Security.Permissions.RegistryPermissionAccess access) { return default(string); }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public void SetPathList(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
+        public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+    [System.FlagsAttribute]
+    public enum RegistryPermissionAccess
+    {
+        AllAccess = 7,
+        Create = 4,
+        NoAccess = 0,
+        Read = 1,
+        Write = 2,
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class RegistryPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public RegistryPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        [System.ObsoleteAttribute("use newer properties")]
+        public string All { get; set; }
+        public string ChangeAccessControl { get; set; }
+        public string Create { get; set; }
+        public string Read { get; set; }
+        public string ViewAccessControl { get; set; }
+        public string ViewAndModify { get; set; }
+        public string Write { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    public enum SecurityAction
+    {
+        Assert = 3,
+        Demand = 2,
+        [System.ObsoleteAttribute("This requests should not be used")]
+        Deny = 4,
+        InheritanceDemand = 7,
+        LinkDemand = 6,
+        PermitOnly = 5,
+        [System.ObsoleteAttribute("This requests should not be used")]
+        RequestMinimum = 8,
+        [System.ObsoleteAttribute("This requests should not be used")]
+        RequestOptional = 9,
+        [System.ObsoleteAttribute("This requests should not be used")]
+        RequestRefuse = 10,
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public abstract partial class SecurityAttribute : System.Attribute
+    {
+        protected SecurityAttribute(System.Security.Permissions.SecurityAction action) { }
+        public System.Security.Permissions.SecurityAction Action { get; set; }
+        public bool Unrestricted { get; set; }
+        public abstract System.Security.IPermission CreatePermission();
+    }
+    public sealed partial class SecurityPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public SecurityPermission(System.Security.Permissions.PermissionState state) { }
+        public SecurityPermission(System.Security.Permissions.SecurityPermissionFlag flag) { }
+        public System.Security.Permissions.SecurityPermissionFlag Flags { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class SecurityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public SecurityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public bool Assertion { get; set; }
+        public bool BindingRedirects { get; set; }
+        public bool ControlAppDomain { get; set; }
+        public bool ControlDomainPolicy { get; set; }
+        public bool ControlEvidence { get; set; }
+        public bool ControlPolicy { get; set; }
+        public bool ControlPrincipal { get; set; }
+        public bool ControlThread { get; set; }
+        public bool Execution { get; set; }
+        public System.Security.Permissions.SecurityPermissionFlag Flags { get; set; }
+        public bool Infrastructure { get; set; }
+        public bool RemotingConfiguration { get; set; }
+        public bool SerializationFormatter { get; set; }
+        public bool SkipVerification { get; set; }
+        public bool UnmanagedCode { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    [System.FlagsAttribute]
+    public enum SecurityPermissionFlag
+    {
+        AllFlags = 16383,
+        Assertion = 1,
+        BindingRedirects = 8192,
+        ControlAppDomain = 1024,
+        ControlDomainPolicy = 256,
+        ControlEvidence = 32,
+        ControlPolicy = 64,
+        ControlPrincipal = 512,
+        ControlThread = 16,
+        Execution = 8,
+        Infrastructure = 4096,
+        NoFlags = 0,
+        RemotingConfiguration = 2048,
+        SerializationFormatter = 128,
+        SkipVerification = 4,
+        UnmanagedCode = 2,
+    }
+    public sealed partial class SiteIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public SiteIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public SiteIdentityPermission(string site) { }
+        public string Site { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class SiteIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public SiteIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string Site { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    public sealed partial class StrongNameIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public StrongNameIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public StrongNameIdentityPermission(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
+        public string Name { get; set; }
+        public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get; set; }
+        public System.Version Version { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class StrongNameIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public StrongNameIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string Name { get; set; }
+        public string PublicKey { get; set; }
+        public string Version { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    public sealed partial class StrongNamePublicKeyBlob
+    {
+        public StrongNamePublicKeyBlob(byte[] publicKey) { }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class TypeDescriptorPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public TypeDescriptorPermission(System.Security.Permissions.PermissionState state) { }
+        public TypeDescriptorPermission(System.Security.Permissions.TypeDescriptorPermissionFlags flag) { }
+        public System.Security.Permissions.TypeDescriptorPermissionFlags Flags { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+    [System.FlagsAttribute]
+    public enum TypeDescriptorPermissionFlags
+    {
+        NoFlags = 0,
+        RestrictedRegistrationAccess = 1,
+    }
+    public sealed partial class UIPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public UIPermission(System.Security.Permissions.PermissionState state) { }
+        public UIPermission(System.Security.Permissions.UIPermissionClipboard clipboardFlag) { }
+        public UIPermission(System.Security.Permissions.UIPermissionWindow windowFlag) { }
+        public UIPermission(System.Security.Permissions.UIPermissionWindow windowFlag, System.Security.Permissions.UIPermissionClipboard clipboardFlag) { }
+        public System.Security.Permissions.UIPermissionClipboard Clipboard { get; set; }
+        public System.Security.Permissions.UIPermissionWindow Window { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class UIPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public UIPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public System.Security.Permissions.UIPermissionClipboard Clipboard { get; set; }
+        public System.Security.Permissions.UIPermissionWindow Window { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    public enum UIPermissionClipboard
+    {
+        AllClipboard = 2,
+        NoClipboard = 0,
+        OwnClipboard = 1,
+    }
+    public enum UIPermissionWindow
+    {
+        AllWindows = 3,
+        NoWindows = 0,
+        SafeSubWindows = 1,
+        SafeTopLevelWindows = 2,
+    }
+    public sealed partial class UrlIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public UrlIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public UrlIdentityPermission(string site) { }
+        public string Url { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class UrlIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public UrlIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string Url { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+    public sealed partial class ZoneIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public ZoneIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public ZoneIdentityPermission(System.Security.SecurityZone zone) { }
+        public System.Security.SecurityZone SecurityZone { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class ZoneIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public ZoneIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public System.Security.SecurityZone Zone { get; set; }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
 }
-namespace System.Security.Policy {
-  public sealed partial class AllMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
-    public AllMembershipCondition() { }
-    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-    public override bool Equals(object o) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement e) { }
-//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
-  }
-  public sealed partial class ApplicationDirectory : System.Security.Policy.EvidenceBase {
-    public ApplicationDirectory(string name) { }
-    public string Directory { get { return default(string); } }
-    public object Copy() { return default(object); }
-    public override bool Equals(object o) { return default(bool); }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-  }
-  public sealed partial class ApplicationDirectoryMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
-    public ApplicationDirectoryMembershipCondition() { }
-    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-    public override bool Equals(object o) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement e) { }
-//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
-  }
-  public sealed partial class ApplicationTrust : System.Security.Policy.EvidenceBase, System.Security.ISecurityEncodable {
-    public ApplicationTrust() { }
-//    public ApplicationTrust(System.ApplicationIdentity applicationIdentity) { }
-    public ApplicationTrust(System.Security.PermissionSet defaultGrantSet, System.Collections.Generic.IEnumerable<System.Security.Policy.StrongName> fullTrustAssemblies) { }
-//    public System.ApplicationIdentity ApplicationIdentity { get { return default(System.ApplicationIdentity); } set { } }
-    public System.Security.Policy.PolicyStatement DefaultGrantSet { get { return default(System.Security.Policy.PolicyStatement); } set { } }
-    public object ExtraInfo { get { return default(object); } set { } }
-    public System.Collections.Generic.IList<System.Security.Policy.StrongName> FullTrustAssemblies { get { return default(System.Collections.Generic.IList<System.Security.Policy.StrongName>); } }
-    public bool IsApplicationTrustedToRun { get { return default(bool); } set { } }
-    public bool Persist { get { return default(bool); } set { } }
-//    public void FromXml(System.Security.SecurityElement element) { }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-  }
-  public sealed partial class ApplicationTrustCollection : System.Collections.ICollection, System.Collections.IEnumerable {
-    internal ApplicationTrustCollection() { }
-    public int Count { get { return default(int); } }
-    public bool IsSynchronized { get { return default(bool); } }
-    public System.Security.Policy.ApplicationTrust this[int index] { get { return default(System.Security.Policy.ApplicationTrust); } }
-    public System.Security.Policy.ApplicationTrust this[string appFullName] { get { return default(System.Security.Policy.ApplicationTrust); } }
-    public object SyncRoot { get { return default(object); } }
-    public int Add(System.Security.Policy.ApplicationTrust trust) { return default(int); }
-    public void AddRange(System.Security.Policy.ApplicationTrust[] trusts) { }
-    public void AddRange(System.Security.Policy.ApplicationTrustCollection trusts) { }
-    public void Clear() { }
-    public void CopyTo(System.Security.Policy.ApplicationTrust[] array, int index) { }
-//    public System.Security.Policy.ApplicationTrustCollection Find(System.ApplicationIdentity applicationIdentity, System.Security.Policy.ApplicationVersionMatch versionMatch) { return default(System.Security.Policy.ApplicationTrustCollection); }
-    public System.Security.Policy.ApplicationTrustEnumerator GetEnumerator() { return default(System.Security.Policy.ApplicationTrustEnumerator); }
-//    public void Remove(System.ApplicationIdentity applicationIdentity, System.Security.Policy.ApplicationVersionMatch versionMatch) { }
-    public void Remove(System.Security.Policy.ApplicationTrust trust) { }
-    public void RemoveRange(System.Security.Policy.ApplicationTrust[] trusts) { }
-    public void RemoveRange(System.Security.Policy.ApplicationTrustCollection trusts) { }
-    void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
-  }
-  public sealed partial class ApplicationTrustEnumerator : System.Collections.IEnumerator {
-    internal ApplicationTrustEnumerator() { }
-    public System.Security.Policy.ApplicationTrust Current { get { return default(System.Security.Policy.ApplicationTrust); } }
-    object System.Collections.IEnumerator.Current { get { return default(object); } }
-    public bool MoveNext() { return default(bool); }
-    public void Reset() { }
-  }
-  public enum ApplicationVersionMatch {
-    MatchAllVersions = 1,
-    MatchExactVersion = 0,
-  }
-  public partial class CodeConnectAccess {
-    public static readonly string AnyScheme;
-    public static readonly int DefaultPort;
-    public static readonly int OriginPort;
-    public static readonly string OriginScheme;
-    public CodeConnectAccess(string allowScheme, int allowPort) { }
-    public int Port { get { return default(int); } }
-    public string Scheme { get { return default(string); } }
-    public static System.Security.Policy.CodeConnectAccess CreateAnySchemeAccess(int allowPort) { return default(System.Security.Policy.CodeConnectAccess); }
-    public static System.Security.Policy.CodeConnectAccess CreateOriginSchemeAccess(int allowPort) { return default(System.Security.Policy.CodeConnectAccess); }
-    public override bool Equals(object o) { return default(bool); }
-    public override int GetHashCode() { return default(int); }
-  }
-  public abstract partial class CodeGroup {
-    protected CodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) { }
-    public virtual string AttributeString { get { return default(string); } }
-    public System.Collections.IList Children { get { return default(System.Collections.IList); } set { } }
-    public string Description { get { return default(string); } set { } }
-    public System.Security.Policy.IMembershipCondition MembershipCondition { get { return default(System.Security.Policy.IMembershipCondition); } set { } }
-    public abstract string MergeLogic { get; }
-    public string Name { get { return default(string); } set { } }
-    public virtual string PermissionSetName { get { return default(string); } }
-    public System.Security.Policy.PolicyStatement PolicyStatement { get { return default(System.Security.Policy.PolicyStatement); } set { } }
-    public void AddChild(System.Security.Policy.CodeGroup group) { }
-    public abstract System.Security.Policy.CodeGroup Copy();
-//    protected virtual void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
-    public override bool Equals(object o) { return default(bool); }
-    public bool Equals(System.Security.Policy.CodeGroup cg, bool compareChildren) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement e) { }
-//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public override int GetHashCode() { return default(int); }
-//    protected virtual void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public void RemoveChild(System.Security.Policy.CodeGroup group) { }
-    public abstract System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence);
-    public abstract System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence);
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
-  }
-  public sealed partial class Evidence : System.Collections.ICollection, System.Collections.IEnumerable {
-    public Evidence() { }
-    [System.ObsoleteAttribute]
-    public Evidence(object[] hostEvidence, object[] assemblyEvidence) { }
-    public Evidence(System.Security.Policy.Evidence evidence) { }
-    [System.ObsoleteAttribute]
-    public int Count { get { return default(int); } }
-    public bool IsReadOnly { get { return default(bool); } }
-    public bool IsSynchronized { get { return default(bool); } }
-    public bool Locked { get { return default(bool); } set { } }
-    public object SyncRoot { get { return default(object); } }
-    [System.ObsoleteAttribute]
-    public void AddAssembly(object id) { }
-    [System.ObsoleteAttribute]
-    public void AddHost(object id) { }
-    public void Clear() { }
-    public System.Security.Policy.Evidence Clone() { return default(System.Security.Policy.Evidence); }
-    [System.ObsoleteAttribute]
-    public void CopyTo(System.Array array, int index) { }
-    public System.Collections.IEnumerator GetAssemblyEnumerator() { return default(System.Collections.IEnumerator); }
-    [System.ObsoleteAttribute]
-    public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
-    public System.Collections.IEnumerator GetHostEnumerator() { return default(System.Collections.IEnumerator); }
-    public void Merge(System.Security.Policy.Evidence evidence) { }
-    public void RemoveType(System.Type t) { }
-  }
-  public abstract partial class EvidenceBase {
-    protected EvidenceBase() { }
-    public virtual System.Security.Policy.EvidenceBase Clone() { return default(System.Security.Policy.EvidenceBase); }
-  }
-  public sealed partial class FileCodeGroup : System.Security.Policy.CodeGroup {
-    public FileCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Permissions.FileIOPermissionAccess access) : base (default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
-    public override string AttributeString { get { return default(string); } }
-    public override string MergeLogic { get { return default(string); } }
-    public override string PermissionSetName { get { return default(string); } }
-    public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
-//    protected override void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
-    public override bool Equals(object o) { return default(bool); }
-    public override int GetHashCode() { return default(int); }
-//    protected override void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
-    public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
-  }
-  public sealed partial class FirstMatchCodeGroup : System.Security.Policy.CodeGroup {
-    public FirstMatchCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) : base (default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
-    public override string MergeLogic { get { return default(string); } }
-    public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
-    public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
-    public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
-  }
-  public sealed partial class GacInstalled : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
-    public GacInstalled() { }
-    public object Copy() { return default(object); }
-    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-    public override bool Equals(object o) { return default(bool); }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-  }
-  public sealed partial class GacMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
-    public GacMembershipCondition() { }
-    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-    public override bool Equals(object o) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement e) { }
-//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
-  }
-  public sealed partial class Hash : System.Security.Policy.EvidenceBase /*, System.Runtime.Serialization.ISerializable */ {
-    public Hash(System.Reflection.Assembly assembly) { }
-    public byte[] MD5 { get { return default(byte[]); } }
-    public byte[] SHA1 { get { return default(byte[]); } }
-    public static System.Security.Policy.Hash CreateMD5(byte[] md5) { return default(System.Security.Policy.Hash); }
-    public static System.Security.Policy.Hash CreateSHA1(byte[] sha1) { return default(System.Security.Policy.Hash); }
-    public byte[] GenerateHash(System.Security.Cryptography.HashAlgorithm hashAlg) { return default(byte[]); }
-    // public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    public override string ToString() { return default(string); }
-  }
-  public sealed partial class HashMembershipCondition : /* System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable, */ System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
-    public HashMembershipCondition(System.Security.Cryptography.HashAlgorithm hashAlg, byte[] value) { }
-    public System.Security.Cryptography.HashAlgorithm HashAlgorithm { get { return default(System.Security.Cryptography.HashAlgorithm); } set { } }
-    public byte[] HashValue { get { return default(byte[]); } set { } }
-    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-    public override bool Equals(object o) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement e) { }
-//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public override int GetHashCode() { return default(int); }
-//    void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-//    void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    public override string ToString() { return default(string); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
-  }
-  public partial interface IIdentityPermissionFactory {
-    System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence);
-  }
-  public partial interface IMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable {
-    bool Check(System.Security.Policy.Evidence evidence);
-    System.Security.Policy.IMembershipCondition Copy();
-    bool Equals(object obj);
-    string ToString();
-  }
-  public sealed partial class NetCodeGroup : System.Security.Policy.CodeGroup {
-    public static readonly string AbsentOriginScheme;
-    public static readonly string AnyOtherOriginScheme;
-    public NetCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition) : base (default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
-    public override string AttributeString { get { return default(string); } }
-    public override string MergeLogic { get { return default(string); } }
-    public override string PermissionSetName { get { return default(string); } }
-    public void AddConnectAccess(string originScheme, System.Security.Policy.CodeConnectAccess connectAccess) { }
-    public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
-//    protected override void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
-    public override bool Equals(object o) { return default(bool); }
-    public System.Collections.DictionaryEntry[] GetConnectAccessRules() { return default(System.Collections.DictionaryEntry[]); }
-    public override int GetHashCode() { return default(int); }
-//    protected override void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public void ResetConnectAccess() { }
-    public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
-    public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
-  }
-  public sealed partial class PermissionRequestEvidence : System.Security.Policy.EvidenceBase {
-    public PermissionRequestEvidence(System.Security.PermissionSet request, System.Security.PermissionSet optional, System.Security.PermissionSet denied) { }
-    public System.Security.PermissionSet DeniedPermissions { get { return default(System.Security.PermissionSet); } }
-    public System.Security.PermissionSet OptionalPermissions { get { return default(System.Security.PermissionSet); } }
-    public System.Security.PermissionSet RequestedPermissions { get { return default(System.Security.PermissionSet); } }
-    public System.Security.Policy.PermissionRequestEvidence Copy() { return default(System.Security.Policy.PermissionRequestEvidence); }
-    public override string ToString() { return default(string); }
-  }
-  public partial class PolicyException : System.SystemException {
-    public PolicyException() { }
-//    protected PolicyException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    public PolicyException(string message) { }
-    public PolicyException(string message, System.Exception exception) { }
-  }
-  public sealed partial class PolicyLevel {
-    internal PolicyLevel() { }
-    [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
-    public System.Collections.IList FullTrustAssemblies { get { return default(System.Collections.IList); } }
-    public string Label { get { return default(string); } }
-    public System.Collections.IList NamedPermissionSets { get { return default(System.Collections.IList); } }
-    public System.Security.Policy.CodeGroup RootCodeGroup { get { return default(System.Security.Policy.CodeGroup); } set { } }
-    public string StoreLocation { get { return default(string); } }
-    public System.Security.PolicyLevelType Type { get { return default(System.Security.PolicyLevelType); } }
-    [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
-    public void AddFullTrustAssembly(System.Security.Policy.StrongName sn) { }
-    [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
-    public void AddFullTrustAssembly(System.Security.Policy.StrongNameMembershipCondition snMC) { }
-    public void AddNamedPermissionSet(System.Security.NamedPermissionSet permSet) { }
-    public System.Security.NamedPermissionSet ChangeNamedPermissionSet(string name, System.Security.PermissionSet pSet) { return default(System.Security.NamedPermissionSet); }
-    public static System.Security.Policy.PolicyLevel CreateAppDomainLevel() { return default(System.Security.Policy.PolicyLevel); }
-//    public void FromXml(System.Security.SecurityElement e) { }
-    public System.Security.NamedPermissionSet GetNamedPermissionSet(string name) { return default(System.Security.NamedPermissionSet); }
-    public void Recover() { }
-    [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
-    public void RemoveFullTrustAssembly(System.Security.Policy.StrongName sn) { }
-    [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
-    public void RemoveFullTrustAssembly(System.Security.Policy.StrongNameMembershipCondition snMC) { }
-    public System.Security.NamedPermissionSet RemoveNamedPermissionSet(System.Security.NamedPermissionSet permSet) { return default(System.Security.NamedPermissionSet); }
-    public System.Security.NamedPermissionSet RemoveNamedPermissionSet(string name) { return default(System.Security.NamedPermissionSet); }
-    public void Reset() { }
-    public System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
-    public System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-  }
-  public sealed partial class PolicyStatement : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable {
-    public PolicyStatement(System.Security.PermissionSet permSet) { }
-    public PolicyStatement(System.Security.PermissionSet permSet, System.Security.Policy.PolicyStatementAttribute attributes) { }
-    public System.Security.Policy.PolicyStatementAttribute Attributes { get { return default(System.Security.Policy.PolicyStatementAttribute); } set { } }
-    public string AttributeString { get { return default(string); } }
-    public System.Security.PermissionSet PermissionSet { get { return default(System.Security.PermissionSet); } set { } }
-    public System.Security.Policy.PolicyStatement Copy() { return default(System.Security.Policy.PolicyStatement); }
-    public override bool Equals(object obj) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement et) { }
-//    public void FromXml(System.Security.SecurityElement et, System.Security.Policy.PolicyLevel level) { }
-    public override int GetHashCode() { return default(int); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
-  }
-  [System.FlagsAttribute]
-  public enum PolicyStatementAttribute {
-    All = 3,
-    Exclusive = 1,
-    LevelFinal = 2,
-    Nothing = 0,
-  }
-  public sealed partial class Publisher : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
-    public Publisher(System.Security.Cryptography.X509Certificates.X509Certificate cert) { }
-    public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } }
-    public object Copy() { return default(object); }
-    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-    public override bool Equals(object o) { return default(bool); }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-  }
-  public sealed partial class PublisherMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
-    public PublisherMembershipCondition(System.Security.Cryptography.X509Certificates.X509Certificate certificate) { }
-    public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } set { } }
-    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-    public override bool Equals(object o) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement e) { }
-//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
-  }
-  public sealed partial class Site : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
-    public Site(string name) { }
-    public string Name { get { return default(string); } }
-    public object Copy() { return default(object); }
-    public static System.Security.Policy.Site CreateFromUrl(string url) { return default(System.Security.Policy.Site); }
-    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-    public override bool Equals(object o) { return default(bool); }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-  }
-  public sealed partial class SiteMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
-    public SiteMembershipCondition(string site) { }
-    public string Site { get { return default(string); } set { } }
-    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-    public override bool Equals(object o) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement e) { }
-//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
-  }
-  public sealed partial class StrongName : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
-    public StrongName(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
-    public string Name { get { return default(string); } }
-    public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } }
-    public System.Version Version { get { return default(System.Version); } }
-    public object Copy() { return default(object); }
-    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-    public override bool Equals(object o) { return default(bool); }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-  }
-  public sealed partial class StrongNameMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
-    public StrongNameMembershipCondition(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
-    public string Name { get { return default(string); } set { } }
-    public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } set { } }
-    public System.Version Version { get { return default(System.Version); } set { } }
-    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-    public override bool Equals(object o) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement e) { }
-//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
-  }
-  public partial class TrustManagerContext {
-    public TrustManagerContext() { }
-    public TrustManagerContext(System.Security.Policy.TrustManagerUIContext uiContext) { }
-    public virtual bool IgnorePersistedDecision { get { return default(bool); } set { } }
-    public virtual bool KeepAlive { get { return default(bool); } set { } }
-    public virtual bool NoPrompt { get { return default(bool); } set { } }
-    public virtual bool Persist { get { return default(bool); } set { } }
-//    public virtual System.ApplicationIdentity PreviousApplicationIdentity { get { return default(System.ApplicationIdentity); } set { } }
-    public virtual System.Security.Policy.TrustManagerUIContext UIContext { get { return default(System.Security.Policy.TrustManagerUIContext); } set { } }
-  }
-  public enum TrustManagerUIContext {
-    Install = 0,
-    Run = 2,
-    Upgrade = 1,
-  }
-  public sealed partial class UnionCodeGroup : System.Security.Policy.CodeGroup {
-    public UnionCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) : base (default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
-    public override string MergeLogic { get { return default(string); } }
-    public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
-    public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
-    public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
-  }
-  public sealed partial class Url : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
-    public Url(string name) { }
-    public string Value { get { return default(string); } }
-    public object Copy() { return default(object); }
-    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-    public override bool Equals(object o) { return default(bool); }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-  }
-  public sealed partial class UrlMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
-    public UrlMembershipCondition(string url) { }
-    public string Url { get { return default(string); } set { } }
-    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-    public override bool Equals(object o) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement e) { }
-//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
-  }
-  public sealed partial class Zone : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory {
-    public Zone(System.Security.SecurityZone zone) { }
-    public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } }
-    public object Copy() { return default(object); }
-    public static System.Security.Policy.Zone CreateFromUrl(string url) { return default(System.Security.Policy.Zone); }
-    public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-    public override bool Equals(object o) { return default(bool); }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-  }
-  public sealed partial class ZoneMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition {
-    public ZoneMembershipCondition(System.Security.SecurityZone zone) { }
-    public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } set { } }
-    public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-    public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-    public override bool Equals(object o) { return default(bool); }
-//    public void FromXml(System.Security.SecurityElement e) { }
-//    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-    public override int GetHashCode() { return default(int); }
-    public override string ToString() { return default(string); }
-//    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-//    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
-  }
+namespace System.Security.Policy
+{
+    public sealed partial class AllMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public AllMembershipCondition() { }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class ApplicationDirectory : System.Security.Policy.EvidenceBase
+    {
+        public ApplicationDirectory(string name) { }
+        public string Directory { get { return default(string); } }
+        public object Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class ApplicationDirectoryMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public ApplicationDirectoryMembershipCondition() { }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class ApplicationTrust : System.Security.Policy.EvidenceBase, System.Security.ISecurityEncodable
+    {
+        public ApplicationTrust() { }
+        public ApplicationTrust(System.Security.PermissionSet defaultGrantSet, System.Collections.Generic.IEnumerable<System.Security.Policy.StrongName> fullTrustAssemblies) { }
+        public System.Security.Policy.PolicyStatement DefaultGrantSet { get; set; }
+        public object ExtraInfo { get; set; }
+        public System.Collections.Generic.IList<System.Security.Policy.StrongName> FullTrustAssemblies { get { return default(System.Collections.Generic.IList<System.Security.Policy.StrongName>); } }
+        public bool IsApplicationTrustedToRun { get; set; }
+        public bool Persist { get; set; }
+    }
+    public sealed partial class ApplicationTrustCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal ApplicationTrustCollection() { }
+        public int Count { get { return default(int); } }
+        public bool IsSynchronized { get { return default(bool); } }
+        public System.Security.Policy.ApplicationTrust this[int index] { get { return default(System.Security.Policy.ApplicationTrust); } }
+        public System.Security.Policy.ApplicationTrust this[string appFullName] { get { return default(System.Security.Policy.ApplicationTrust); } }
+        public object SyncRoot { get { return default(object); } }
+        public int Add(System.Security.Policy.ApplicationTrust trust) { return default(int); }
+        public void AddRange(System.Security.Policy.ApplicationTrust[] trusts) { }
+        public void AddRange(System.Security.Policy.ApplicationTrustCollection trusts) { }
+        public void Clear() { }
+        public void CopyTo(System.Security.Policy.ApplicationTrust[] array, int index) { }
+        public System.Security.Policy.ApplicationTrustEnumerator GetEnumerator() { return default(System.Security.Policy.ApplicationTrustEnumerator); }
+        public void Remove(System.Security.Policy.ApplicationTrust trust) { }
+        public void RemoveRange(System.Security.Policy.ApplicationTrust[] trusts) { }
+        public void RemoveRange(System.Security.Policy.ApplicationTrustCollection trusts) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
+    }
+    public sealed partial class ApplicationTrustEnumerator : System.Collections.IEnumerator
+    {
+        internal ApplicationTrustEnumerator() { }
+        public System.Security.Policy.ApplicationTrust Current { get { return default(System.Security.Policy.ApplicationTrust); } }
+        object System.Collections.IEnumerator.Current { get { return default(object); } }
+        public bool MoveNext() { return default(bool); }
+        public void Reset() { }
+    }
+    public enum ApplicationVersionMatch
+    {
+        MatchAllVersions = 1,
+        MatchExactVersion = 0,
+    }
+    public partial class CodeConnectAccess
+    {
+        public static readonly string AnyScheme;
+        public static readonly int DefaultPort;
+        public static readonly int OriginPort;
+        public static readonly string OriginScheme;
+        public CodeConnectAccess(string allowScheme, int allowPort) { }
+        public int Port { get { return default(int); } }
+        public string Scheme { get { return default(string); } }
+        public static System.Security.Policy.CodeConnectAccess CreateAnySchemeAccess(int allowPort) { return default(System.Security.Policy.CodeConnectAccess); }
+        public static System.Security.Policy.CodeConnectAccess CreateOriginSchemeAccess(int allowPort) { return default(System.Security.Policy.CodeConnectAccess); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+    }
+    public abstract partial class CodeGroup
+    {
+        protected CodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) { }
+        public virtual string AttributeString { get { return default(string); } }
+        public System.Collections.IList Children { get; set; }
+        public string Description { get; set; }
+        public System.Security.Policy.IMembershipCondition MembershipCondition { get; set; }
+        public abstract string MergeLogic { get; }
+        public string Name { get; set; }
+        public virtual string PermissionSetName { get { return default(string); } }
+        public System.Security.Policy.PolicyStatement PolicyStatement { get; set; }
+        public void AddChild(System.Security.Policy.CodeGroup group) { }
+        public abstract System.Security.Policy.CodeGroup Copy();
+        public override bool Equals(object o) => base.Equals(o);
+        public bool Equals(System.Security.Policy.CodeGroup cg, bool compareChildren) { return default(bool); }
+        public override int GetHashCode() => base.GetHashCode();
+        public void RemoveChild(System.Security.Policy.CodeGroup group) { }
+        public abstract System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence);
+        public abstract System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence);
+    }
+    public sealed partial class Evidence : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public Evidence() { }
+        [System.ObsoleteAttribute]
+        public Evidence(object[] hostEvidence, object[] assemblyEvidence) { }
+        public Evidence(System.Security.Policy.Evidence evidence) { }
+        [System.ObsoleteAttribute]
+        public int Count { get { return default(int); } }
+        public bool IsReadOnly { get { return default(bool); } }
+        public bool IsSynchronized { get { return default(bool); } }
+        public bool Locked { get; set; }
+        public object SyncRoot { get { return default(object); } }
+        [System.ObsoleteAttribute]
+        public void AddAssembly(object id) { }
+        [System.ObsoleteAttribute]
+        public void AddHost(object id) { }
+        public void Clear() { }
+        public System.Security.Policy.Evidence Clone() { return default(System.Security.Policy.Evidence); }
+        [System.ObsoleteAttribute]
+        public void CopyTo(System.Array array, int index) { }
+        public System.Collections.IEnumerator GetAssemblyEnumerator() { return default(System.Collections.IEnumerator); }
+        [System.ObsoleteAttribute]
+        public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
+        public System.Collections.IEnumerator GetHostEnumerator() { return default(System.Collections.IEnumerator); }
+        public void Merge(System.Security.Policy.Evidence evidence) { }
+        public void RemoveType(System.Type t) { }
+    }
+    public abstract partial class EvidenceBase
+    {
+        protected EvidenceBase() { }
+        public virtual System.Security.Policy.EvidenceBase Clone() { return default(System.Security.Policy.EvidenceBase); }
+    }
+    public sealed partial class FileCodeGroup : System.Security.Policy.CodeGroup
+    {
+        public FileCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Permissions.FileIOPermissionAccess access) : base(default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+        public override string AttributeString { get { return default(string); } }
+        public override string MergeLogic { get { return default(string); } }
+        public override string PermissionSetName { get { return default(string); } }
+        public override System.Security.Policy.CodeGroup Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+        public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+    }
+    public sealed partial class FirstMatchCodeGroup : System.Security.Policy.CodeGroup
+    {
+        public FirstMatchCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) : base(default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+        public override string MergeLogic { get { return default(string); } }
+        public override System.Security.Policy.CodeGroup Copy() { return this; }
+        public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+        public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+    }
+    public sealed partial class GacInstalled : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public GacInstalled() { }
+        public object Copy() { return this; }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class GacMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public GacMembershipCondition() { }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class Hash : System.Security.Policy.EvidenceBase
+    {
+        public Hash(System.Reflection.Assembly assembly) { }
+        public byte[] MD5 { get { return default(byte[]); } }
+        public byte[] SHA1 { get { return default(byte[]); } }
+        public static System.Security.Policy.Hash CreateMD5(byte[] md5) { return default(System.Security.Policy.Hash); }
+        public static System.Security.Policy.Hash CreateSHA1(byte[] sha1) { return default(System.Security.Policy.Hash); }
+        public byte[] GenerateHash(System.Security.Cryptography.HashAlgorithm hashAlg) { return default(byte[]); }
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class HashMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public HashMembershipCondition(System.Security.Cryptography.HashAlgorithm hashAlg, byte[] value) { }
+        public System.Security.Cryptography.HashAlgorithm HashAlgorithm { get; set; }
+        public byte[] HashValue { get; set; }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public partial interface IIdentityPermissionFactory
+    {
+        System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence);
+    }
+    public partial interface IMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable
+    {
+        bool Check(System.Security.Policy.Evidence evidence);
+        System.Security.Policy.IMembershipCondition Copy();
+        bool Equals(object obj);
+        string ToString();
+    }
+    public sealed partial class NetCodeGroup : System.Security.Policy.CodeGroup
+    {
+        public static readonly string AbsentOriginScheme;
+        public static readonly string AnyOtherOriginScheme;
+        public NetCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition) : base(default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+        public override string AttributeString { get { return default(string); } }
+        public override string MergeLogic { get { return default(string); } }
+        public override string PermissionSetName { get { return default(string); } }
+        public void AddConnectAccess(string originScheme, System.Security.Policy.CodeConnectAccess connectAccess) { }
+        public override System.Security.Policy.CodeGroup Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public System.Collections.DictionaryEntry[] GetConnectAccessRules() { return default(System.Collections.DictionaryEntry[]); }
+        public override int GetHashCode() => base.GetHashCode();
+        public void ResetConnectAccess() { }
+        public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+        public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+    }
+    public sealed partial class PermissionRequestEvidence : System.Security.Policy.EvidenceBase
+    {
+        public PermissionRequestEvidence(System.Security.PermissionSet request, System.Security.PermissionSet optional, System.Security.PermissionSet denied) { }
+        public System.Security.PermissionSet DeniedPermissions { get { return default(System.Security.PermissionSet); } }
+        public System.Security.PermissionSet OptionalPermissions { get { return default(System.Security.PermissionSet); } }
+        public System.Security.PermissionSet RequestedPermissions { get { return default(System.Security.PermissionSet); } }
+        public System.Security.Policy.PermissionRequestEvidence Copy() { return this; }
+        public override string ToString() => base.ToString();
+    }
+    public partial class PolicyException : System.SystemException
+    {
+        public PolicyException() { }
+        public PolicyException(string message) { }
+        public PolicyException(string message, System.Exception exception) { }
+    }
+    public sealed partial class PolicyLevel
+    {
+        internal PolicyLevel() { }
+        [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+        public System.Collections.IList FullTrustAssemblies { get { return default(System.Collections.IList); } }
+        public string Label { get { return default(string); } }
+        public System.Collections.IList NamedPermissionSets { get { return default(System.Collections.IList); } }
+        public System.Security.Policy.CodeGroup RootCodeGroup { get; set; }
+        public string StoreLocation { get { return default(string); } }
+        public System.Security.PolicyLevelType Type { get { return default(System.Security.PolicyLevelType); } }
+        [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+        public void AddFullTrustAssembly(System.Security.Policy.StrongName sn) { }
+        [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+        public void AddFullTrustAssembly(System.Security.Policy.StrongNameMembershipCondition snMC) { }
+        public void AddNamedPermissionSet(System.Security.NamedPermissionSet permSet) { }
+        public System.Security.NamedPermissionSet ChangeNamedPermissionSet(string name, System.Security.PermissionSet pSet) { return default(System.Security.NamedPermissionSet); }
+        public static System.Security.Policy.PolicyLevel CreateAppDomainLevel() { return default(System.Security.Policy.PolicyLevel); }
+        public System.Security.NamedPermissionSet GetNamedPermissionSet(string name) { return default(System.Security.NamedPermissionSet); }
+        public void Recover() { }
+        [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+        public void RemoveFullTrustAssembly(System.Security.Policy.StrongName sn) { }
+        [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+        public void RemoveFullTrustAssembly(System.Security.Policy.StrongNameMembershipCondition snMC) { }
+        public System.Security.NamedPermissionSet RemoveNamedPermissionSet(System.Security.NamedPermissionSet permSet) { return default(System.Security.NamedPermissionSet); }
+        public System.Security.NamedPermissionSet RemoveNamedPermissionSet(string name) { return default(System.Security.NamedPermissionSet); }
+        public void Reset() { }
+        public System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+        public System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+    }
+    public sealed partial class PolicyStatement : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable
+    {
+        public PolicyStatement(System.Security.PermissionSet permSet) { }
+        public PolicyStatement(System.Security.PermissionSet permSet, System.Security.Policy.PolicyStatementAttribute attributes) { }
+        public System.Security.Policy.PolicyStatementAttribute Attributes { get; set; }
+        public string AttributeString { get { return default(string); } }
+        public System.Security.PermissionSet PermissionSet { get; set; }
+        public System.Security.Policy.PolicyStatement Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+    }
+    [System.FlagsAttribute]
+    public enum PolicyStatementAttribute
+    {
+        All = 3,
+        Exclusive = 1,
+        LevelFinal = 2,
+        Nothing = 0,
+    }
+    public sealed partial class Publisher : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public Publisher(System.Security.Cryptography.X509Certificates.X509Certificate cert) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } }
+        public object Copy() { return this; }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class PublisherMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public PublisherMembershipCondition(System.Security.Cryptography.X509Certificates.X509Certificate certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get; set; }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class Site : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public Site(string name) { }
+        public string Name { get { return default(string); } }
+        public object Copy() { return this; }
+        public static System.Security.Policy.Site CreateFromUrl(string url) { return default(System.Security.Policy.Site); }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class SiteMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public SiteMembershipCondition(string site) { }
+        public string Site { get; set; }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class StrongName : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public StrongName(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
+        public string Name { get { return default(string); } }
+        public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } }
+        public System.Version Version { get { return default(System.Version); } }
+        public object Copy() { return this; }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class StrongNameMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public StrongNameMembershipCondition(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
+        public string Name { get; set; }
+        public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get; set; }
+        public System.Version Version { get; set; }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public partial class TrustManagerContext
+    {
+        public TrustManagerContext() { }
+        public TrustManagerContext(System.Security.Policy.TrustManagerUIContext uiContext) { }
+        public virtual bool IgnorePersistedDecision { get; set; }
+        public virtual bool KeepAlive { get; set; }
+        public virtual bool NoPrompt { get; set; }
+        public virtual bool Persist { get; set; }
+        public virtual System.Security.Policy.TrustManagerUIContext UIContext { get; set; }
+    }
+    public enum TrustManagerUIContext
+    {
+        Install = 0,
+        Run = 2,
+        Upgrade = 1,
+    }
+    public sealed partial class UnionCodeGroup : System.Security.Policy.CodeGroup
+    {
+        public UnionCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) : base(default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+        public override string MergeLogic { get { return default(string); } }
+        public override System.Security.Policy.CodeGroup Copy() { return this; }
+        public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+        public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+    }
+    public sealed partial class Url : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public Url(string name) { }
+        public string Value { get { return default(string); } }
+        public object Copy() { return this; }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class UrlMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public UrlMembershipCondition(string url) { }
+        public string Url { get; set; }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class Zone : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public Zone(System.Security.SecurityZone zone) { }
+        public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } }
+        public object Copy() { return this; }
+        public static System.Security.Policy.Zone CreateFromUrl(string url) { return default(System.Security.Policy.Zone); }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
+    public sealed partial class ZoneMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public ZoneMembershipCondition(System.Security.SecurityZone zone) { }
+        public System.Security.SecurityZone SecurityZone { get; set; }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
+    }
 }

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System.Security.Permissions.cs" />
+    <Compile Include="DummyTypes.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Permissions/ref/project.json
+++ b/src/System.Security.Permissions/ref/project.json
@@ -1,0 +1,20 @@
+{
+  "dependencies": {
+    "System.Collections.NonGeneric": "4.0.0",
+    "System.Reflection": "4.1.0",
+    "System.Runtime.Extensions": "4.1.0",
+    "System.Runtime": "4.1.0",
+    "System.Security.AccessControl": "4.0.0",
+    "System.Security.Cryptography.Primitives": "4.0.0",
+    "System.Security.Cryptography.X509Certificates": "4.1.0",
+    "System.Security.Principal": "4.0.0",
+    "System.Threading": "4.0.10"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4"
+      ]
+    }
+  }
+}

--- a/src/System.Security.Permissions/src/ApiCompatBaseline.net46.txt
+++ b/src/System.Security.Permissions/src/ApiCompatBaseline.net46.txt
@@ -1,0 +1,6 @@
+CannotAddAbstractMembers : Member 'System.Security.CodeAccessPermission.FromXml(System.Security.SecurityElement)' is abstract in the implementation but is missing in the contract.
+CannotAddAbstractMembers : Member 'System.Security.CodeAccessPermission.ToXml()' is abstract in the implementation but is missing in the contract.
+InterfacesShouldHaveSameMembers : Implementation interface member 'System.Security.ISecurityEncodable.FromXml(System.Security.SecurityElement)' is not in the contract.
+InterfacesShouldHaveSameMembers : Implementation interface member 'System.Security.ISecurityEncodable.ToXml()' is not in the contract.
+InterfacesShouldHaveSameMembers : Implementation interface member 'System.Security.ISecurityPolicyEncodable.FromXml(System.Security.SecurityElement, System.Security.Policy.PolicyLevel)' is not in the contract.
+InterfacesShouldHaveSameMembers : Implementation interface member 'System.Security.ISecurityPolicyEncodable.ToXml(System.Security.Policy.PolicyLevel)' is not in the contract.

--- a/src/System.Security.Permissions/src/Properties/InternalsVisibleTo.cs
+++ b/src/System.Security.Permissions/src/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("System.Security.Permissions.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]

--- a/src/System.Security.Permissions/src/Properties/InternalsVisibleTo.cs
+++ b/src/System.Security.Permissions/src/Properties/InternalsVisibleTo.cs
@@ -1,9 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-//------------------------------------------------------------
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("System.Security.Permissions.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]

--- a/src/System.Security.Permissions/src/System.Security.Permissions.builds
+++ b/src/System.Security.Permissions/src/System.Security.Permissions.builds
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Security.Permissions.csproj" />
+    <Project Include="System.Security.Permissions.csproj">
+      <TargetGroup>net46</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -1,0 +1,131 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{07390899-C8F6-4E83-A3A9-6867B8CB46A0}</ProjectGuid>
+    <RootNamespace>System.Security.Permissions</RootNamespace>
+    <AssemblyName>System.Security.Permissions</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.3</PackageTargetFramework>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+    <Compile Include="System\SystemException.cs" />
+    <Compile Include="System\Security\CodeAccessPermission.cs" />
+    <Compile Include="System\Security\ISecurityPolicyEncodable.cs" />
+    <Compile Include="System\Security\IStackWalk.cs" />
+    <Compile Include="System\Security\Permissions\TypeDescriptorPermission.cs" />
+    <Compile Include="System\Security\Permissions\TypeDescriptorPermissionFlags.cs" />
+    <Compile Include="System\Security\Permissions\UIPermission.cs" />
+    <Compile Include="System\Security\Permissions\UIPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\UIPermissionClipboard.cs" />
+    <Compile Include="System\Security\Permissions\UIPermissionWindow.cs" />
+    <Compile Include="System\Security\Permissions\UrlIdentityPermission.cs" />
+    <Compile Include="System\Security\Permissions\UrlIdentityPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\ZoneIdentityPermission.cs" />
+    <Compile Include="System\Security\Permissions\PrincipalPermission.cs" />
+    <Compile Include="System\Security\Permissions\PrincipalPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\PublisherIdentityPermission.cs" />
+    <Compile Include="System\Security\Permissions\PublisherIdentityPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\ReflectionPermission.cs" />
+    <Compile Include="System\Security\Permissions\ReflectionPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\ReflectionPermissionFlag.cs" />
+    <Compile Include="System\Security\Permissions\RegistryPermission.cs" />
+    <Compile Include="System\Security\Permissions\RegistryPermissionAccess.cs" />
+    <Compile Include="System\Security\Permissions\RegistryPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\SecurityAction.cs" />
+    <Compile Include="System\Security\Permissions\SecurityAttribute.cs" />
+    <Compile Include="System\Security\Permissions\SecurityPermission.cs" />
+    <Compile Include="System\Security\Permissions\SecurityPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\SecurityPermissionFlag.cs" />
+    <Compile Include="System\Security\Permissions\SiteIdentityPermission.cs" />
+    <Compile Include="System\Security\Permissions\SiteIdentityPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\StrongNameIdentityPermission.cs" />
+    <Compile Include="System\Security\Permissions\StrongNameIdentityPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\StrongNamePublicKeyBlob.cs" />
+    <Compile Include="System\Security\Permissions\ZoneIdentityPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\CodeAccessSecurityAttribute.cs" />
+    <Compile Include="System\Security\Permissions\EnvironmentPermission.cs" />
+    <Compile Include="System\Security\Permissions\EnvironmentPermissionAccess.cs" />
+    <Compile Include="System\Security\Permissions\EnvironmentPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\FileDialogPermission.cs" />
+    <Compile Include="System\Security\Permissions\FileDialogPermissionAccess.cs" />
+    <Compile Include="System\Security\Permissions\FileDialogPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\FileIOPermission.cs" />
+    <Compile Include="System\Security\Permissions\FileIOPermissionAccess.cs" />
+    <Compile Include="System\Security\Permissions\GacIdentityPermission.cs" />
+    <Compile Include="System\Security\Permissions\GacIdentityPermissionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\HostProtectionAttribute.cs" />
+    <Compile Include="System\Security\Permissions\HostProtectionResource.cs" />
+    <Compile Include="System\Security\Permissions\IUnrestrictedPermission.cs" />
+    <Compile Include="System\Security\Permissions\PermissionSetAttribute.cs" />
+    <Compile Include="System\Security\Permissions\PermissionState.cs" />
+    <Compile Include="System\Security\Policy\AllMembershipCondition.cs" />
+    <Compile Include="System\Security\Policy\ApplicationDirectory.cs" />
+    <Compile Include="System\Security\Policy\ApplicationDirectoryMembershipCondition.cs" />
+    <Compile Include="System\Security\Policy\ApplicationTrust.cs" />
+    <Compile Include="System\Security\Policy\ApplicationTrustCollection.cs" />
+    <Compile Include="System\Security\Policy\ApplicationTrustEnumerator.cs" />
+    <Compile Include="System\Security\Policy\ApplicationVersionMatch.cs" />
+    <Compile Include="System\Security\Policy\PolicyException.cs" />
+    <Compile Include="System\Security\Policy\PolicyLevel.cs" />
+    <Compile Include="System\Security\Policy\PolicyStatement.cs" />
+    <Compile Include="System\Security\Policy\PolicyStatementAttribute.cs" />
+    <Compile Include="System\Security\Policy\Publisher.cs" />
+    <Compile Include="System\Security\Policy\PublisherMembershipCondition.cs" />
+    <Compile Include="System\Security\Policy\Site.cs" />
+    <Compile Include="System\Security\Policy\SiteMembershipCondition.cs" />
+    <Compile Include="System\Security\Policy\StrongName.cs" />
+    <Compile Include="System\Security\Policy\StrongNameMembershipCondition.cs" />
+    <Compile Include="System\Security\Policy\TrustManagerContext.cs" />
+    <Compile Include="System\Security\Policy\UnionCodeGroup.cs" />
+    <Compile Include="System\Security\Policy\Url.cs" />
+    <Compile Include="System\Security\Policy\UrlMembershipCondition.cs" />
+    <Compile Include="System\Security\Policy\Zone.cs" />
+    <Compile Include="System\Security\Policy\ZoneMembershipCondition.cs" />
+    <Compile Include="System\Security\Policy\CodeConnectAccess.cs" />
+    <Compile Include="System\Security\Policy\CodeGroup.cs" />
+    <Compile Include="System\Security\Policy\Evidence.cs" />
+    <Compile Include="System\Security\Policy\EvidenceBase.cs" />
+    <Compile Include="System\Security\Policy\FileCodeGroup.cs" />
+    <Compile Include="System\Security\Policy\FirstMatchCodeGroup.cs" />
+    <Compile Include="System\Security\Policy\GacInstalled.cs" />
+    <Compile Include="System\Security\Policy\GacMembershipCondition.cs" />
+    <Compile Include="System\Security\Policy\Hash.cs" />
+    <Compile Include="System\Security\Policy\HashMembershipCondition.cs" />
+    <Compile Include="System\Security\Policy\IIdentityPermissionFactory.cs" />
+    <Compile Include="System\Security\Policy\IMembershipCondition.cs" />
+    <Compile Include="System\Security\Policy\NetCodeGroup.cs" />
+    <Compile Include="System\Security\Policy\PermissionRequestEvidence.cs" />
+    <Compile Include="System\Security\SecurityCriticalScope.cs" />
+    <Compile Include="System\Security\SecurityManager.cs" />
+    <Compile Include="System\Security\SecurityState.cs" />
+    <Compile Include="System\Security\SecurityZone.cs" />
+    <Compile Include="System\Security\XmlSyntaxException.cs" />
+    <Compile Include="System\Security\PolicyLevelType.cs" />
+    <Compile Include="System\Security\SecurityContext.cs" />
+    <Compile Include="System\Security\SecurityContextSource.cs" />
+    <Compile Include="System\Security\PermissionSet.cs" />
+    <Compile Include="System\Security\NamedPermissionSet.cs" />
+    <Compile Include="System\Security\ISecurityEncodable.cs" />
+    <Compile Include="System\Security\IPermission.cs" />
+    <Compile Include="System\Security\IEvidenceFactory.cs" />
+    <Compile Include="System\Security\HostSecurityManagerOptions.cs" />
+    <Compile Include="System\Security\HostSecurityManager.cs" />
+    <Compile Include="System\Security\HostProtectionException.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+    <TargetingPackReference Include="mscorlib" />
+    <TargetingPackReference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Permissions/src/System/Security/CodeAccessPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/CodeAccessPermission.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace System.Security
 {
     public abstract partial class CodeAccessPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.IStackWalk
@@ -6,15 +10,14 @@ namespace System.Security
         public void Assert() { }
         public abstract System.Security.IPermission Copy();
         public void Demand() { }
-        public void Deny() { }
-        public override bool Equals(object obj) { return default(bool); }
-        //    public abstract void FromXml(System.Security.SecurityElement elem);
-        public override int GetHashCode() { return default(int); }
+        [System.ObsoleteAttribute]
+        public void Deny() { throw new System.NotSupportedException(); }
+        public override bool Equals(object obj) => base.Equals(obj);
+        public override int GetHashCode() => base.GetHashCode();
         public abstract System.Security.IPermission Intersect(System.Security.IPermission target);
         public abstract bool IsSubsetOf(System.Security.IPermission target);
-        public void PermitOnly() { }
-        public override string ToString() { return default(string); }
-        //    public abstract System.Security.SecurityElement ToXml();
+        public void PermitOnly() { throw new System.PlatformNotSupportedException(); }
+        public override string ToString() => base.ToString();
         public virtual System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/CodeAccessPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/CodeAccessPermission.cs
@@ -1,0 +1,20 @@
+namespace System.Security
+{
+    public abstract partial class CodeAccessPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.IStackWalk
+    {
+        protected CodeAccessPermission() { }
+        public void Assert() { }
+        public abstract System.Security.IPermission Copy();
+        public void Demand() { }
+        public void Deny() { }
+        public override bool Equals(object obj) { return default(bool); }
+        //    public abstract void FromXml(System.Security.SecurityElement elem);
+        public override int GetHashCode() { return default(int); }
+        public abstract System.Security.IPermission Intersect(System.Security.IPermission target);
+        public abstract bool IsSubsetOf(System.Security.IPermission target);
+        public void PermitOnly() { }
+        public override string ToString() { return default(string); }
+        //    public abstract System.Security.SecurityElement ToXml();
+        public virtual System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/HostProtectionException.cs
+++ b/src/System.Security.Permissions/src/System/Security/HostProtectionException.cs
@@ -1,0 +1,15 @@
+﻿namespace System.Security
+{
+    public partial class HostProtectionException : System.SystemException
+    {
+        public HostProtectionException() { }
+        // protected HostProtectionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public HostProtectionException(string message) { }
+        public HostProtectionException(string message, System.Exception e) { }
+        public HostProtectionException(string message, System.Security.Permissions.HostProtectionResource protectedResources, System.Security.Permissions.HostProtectionResource demandedResources) { }
+        public System.Security.Permissions.HostProtectionResource DemandedResources { get { return default(System.Security.Permissions.HostProtectionResource); } }
+        public System.Security.Permissions.HostProtectionResource ProtectedResources { get { return default(System.Security.Permissions.HostProtectionResource); } }
+        // public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public override string ToString() { return default(string); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/HostProtectionException.cs
+++ b/src/System.Security.Permissions/src/System/Security/HostProtectionException.cs
@@ -1,15 +1,17 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public partial class HostProtectionException : System.SystemException
     {
         public HostProtectionException() { }
-        // protected HostProtectionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public HostProtectionException(string message) { }
         public HostProtectionException(string message, System.Exception e) { }
         public HostProtectionException(string message, System.Security.Permissions.HostProtectionResource protectedResources, System.Security.Permissions.HostProtectionResource demandedResources) { }
         public System.Security.Permissions.HostProtectionResource DemandedResources { get { return default(System.Security.Permissions.HostProtectionResource); } }
         public System.Security.Permissions.HostProtectionResource ProtectedResources { get { return default(System.Security.Permissions.HostProtectionResource); } }
-        // public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public override string ToString() { return default(string); }
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/HostSecurityManager.cs
+++ b/src/System.Security.Permissions/src/System/Security/HostSecurityManager.cs
@@ -1,0 +1,13 @@
+﻿namespace System.Security
+{
+    public partial class HostSecurityManager
+    {
+        public HostSecurityManager() { }
+        public virtual System.Security.Policy.PolicyLevel DomainPolicy { get { return default(System.Security.Policy.PolicyLevel); } }
+        public virtual System.Security.HostSecurityManagerOptions Flags { get { return default(System.Security.HostSecurityManagerOptions); } }
+        public virtual System.Security.Policy.ApplicationTrust DetermineApplicationTrust(System.Security.Policy.Evidence applicationEvidence, System.Security.Policy.Evidence activatorEvidence, System.Security.Policy.TrustManagerContext context) { return default(System.Security.Policy.ApplicationTrust); }
+        public virtual System.Security.Policy.Evidence ProvideAppDomainEvidence(System.Security.Policy.Evidence inputEvidence) { return default(System.Security.Policy.Evidence); }
+        public virtual System.Security.Policy.Evidence ProvideAssemblyEvidence(System.Reflection.Assembly loadedAssembly, System.Security.Policy.Evidence inputEvidence) { return default(System.Security.Policy.Evidence); }
+        public virtual System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/HostSecurityManager.cs
+++ b/src/System.Security.Permissions/src/System/Security/HostSecurityManager.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public partial class HostSecurityManager
     {
@@ -8,6 +12,7 @@
         public virtual System.Security.Policy.ApplicationTrust DetermineApplicationTrust(System.Security.Policy.Evidence applicationEvidence, System.Security.Policy.Evidence activatorEvidence, System.Security.Policy.TrustManagerContext context) { return default(System.Security.Policy.ApplicationTrust); }
         public virtual System.Security.Policy.Evidence ProvideAppDomainEvidence(System.Security.Policy.Evidence inputEvidence) { return default(System.Security.Policy.Evidence); }
         public virtual System.Security.Policy.Evidence ProvideAssemblyEvidence(System.Reflection.Assembly loadedAssembly, System.Security.Policy.Evidence inputEvidence) { return default(System.Security.Policy.Evidence); }
+        [System.ObsoleteAttribute]
         public virtual System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/HostSecurityManagerOptions.cs
+++ b/src/System.Security.Permissions/src/System/Security/HostSecurityManagerOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace System.Security
+{
+    [System.FlagsAttribute]
+    public enum HostSecurityManagerOptions
+    {
+        AllFlags = 31,
+        HostAppDomainEvidence = 1,
+        HostAssemblyEvidence = 4,
+        HostDetermineApplicationTrust = 8,
+        HostPolicyLevel = 2,
+        HostResolvePolicy = 16,
+        None = 0,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/HostSecurityManagerOptions.cs
+++ b/src/System.Security.Permissions/src/System/Security/HostSecurityManagerOptions.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     [System.FlagsAttribute]
     public enum HostSecurityManagerOptions

--- a/src/System.Security.Permissions/src/System/Security/IEvidenceFactory.cs
+++ b/src/System.Security.Permissions/src/System/Security/IEvidenceFactory.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public partial interface IEvidenceFactory
     {

--- a/src/System.Security.Permissions/src/System/Security/IEvidenceFactory.cs
+++ b/src/System.Security.Permissions/src/System/Security/IEvidenceFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace System.Security
+{
+    public partial interface IEvidenceFactory
+    {
+        System.Security.Policy.Evidence Evidence { get; }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/IPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/IPermission.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Security
+{
+    public partial interface IPermission : System.Security.ISecurityEncodable
+    {
+        System.Security.IPermission Copy();
+        void Demand();
+        System.Security.IPermission Intersect(System.Security.IPermission target);
+        bool IsSubsetOf(System.Security.IPermission target);
+        System.Security.IPermission Union(System.Security.IPermission target);
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/IPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/IPermission.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public partial interface IPermission : System.Security.ISecurityEncodable
     {

--- a/src/System.Security.Permissions/src/System/Security/ISecurityEncodable.cs
+++ b/src/System.Security.Permissions/src/System/Security/ISecurityEncodable.cs
@@ -1,0 +1,8 @@
+﻿namespace System.Security
+{
+    public partial interface ISecurityEncodable
+    {
+        //    void FromXml(System.Security.SecurityElement e);
+        //    System.Security.SecurityElement ToXml();
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/ISecurityEncodable.cs
+++ b/src/System.Security.Permissions/src/System/Security/ISecurityEncodable.cs
@@ -1,8 +1,10 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public partial interface ISecurityEncodable
     {
-        //    void FromXml(System.Security.SecurityElement e);
-        //    System.Security.SecurityElement ToXml();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/ISecurityPolicyEncodable.cs
+++ b/src/System.Security.Permissions/src/System/Security/ISecurityPolicyEncodable.cs
@@ -1,8 +1,10 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public partial interface ISecurityPolicyEncodable
     {
-        //    void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level);
-        //    System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level);
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/ISecurityPolicyEncodable.cs
+++ b/src/System.Security.Permissions/src/System/Security/ISecurityPolicyEncodable.cs
@@ -1,0 +1,8 @@
+﻿namespace System.Security
+{
+    public partial interface ISecurityPolicyEncodable
+    {
+        //    void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level);
+        //    System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level);
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/IStackWalk.cs
+++ b/src/System.Security.Permissions/src/System/Security/IStackWalk.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Security
+{
+    public partial interface IStackWalk
+    {
+        void Assert();
+        void Demand();
+        void Deny();
+        void PermitOnly();
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/IStackWalk.cs
+++ b/src/System.Security.Permissions/src/System/Security/IStackWalk.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public partial interface IStackWalk
     {

--- a/src/System.Security.Permissions/src/System/Security/NamedPermissionSet.cs
+++ b/src/System.Security.Permissions/src/System/Security/NamedPermissionSet.cs
@@ -1,0 +1,18 @@
+﻿namespace System.Security
+{
+    public sealed partial class NamedPermissionSet : System.Security.PermissionSet
+    {
+        public NamedPermissionSet(System.Security.NamedPermissionSet permSet) : base(default(System.Security.Permissions.PermissionState)) { }
+        public NamedPermissionSet(string name) : base(default(System.Security.Permissions.PermissionState)) { }
+        public NamedPermissionSet(string name, System.Security.Permissions.PermissionState state) : base(default(System.Security.Permissions.PermissionState)) { }
+        public NamedPermissionSet(string name, System.Security.PermissionSet permSet) : base(default(System.Security.Permissions.PermissionState)) { }
+        public string Description { get { return default(string); } set { } }
+        public string Name { get { return default(string); } set { } }
+        public override System.Security.PermissionSet Copy() { return default(System.Security.PermissionSet); }
+        public System.Security.NamedPermissionSet Copy(string name) { return default(System.Security.NamedPermissionSet); }
+        public override bool Equals(object obj) { return default(bool); }
+        //    public override void FromXml(System.Security.SecurityElement et) { }
+        public override int GetHashCode() { return default(int); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/NamedPermissionSet.cs
+++ b/src/System.Security.Permissions/src/System/Security/NamedPermissionSet.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public sealed partial class NamedPermissionSet : System.Security.PermissionSet
     {
@@ -6,13 +10,11 @@
         public NamedPermissionSet(string name) : base(default(System.Security.Permissions.PermissionState)) { }
         public NamedPermissionSet(string name, System.Security.Permissions.PermissionState state) : base(default(System.Security.Permissions.PermissionState)) { }
         public NamedPermissionSet(string name, System.Security.PermissionSet permSet) : base(default(System.Security.Permissions.PermissionState)) { }
-        public string Description { get { return default(string); } set { } }
-        public string Name { get { return default(string); } set { } }
+        public string Description { get; set; }
+        public string Name { get; set; }
         public override System.Security.PermissionSet Copy() { return default(System.Security.PermissionSet); }
         public System.Security.NamedPermissionSet Copy(string name) { return default(System.Security.NamedPermissionSet); }
-        public override bool Equals(object obj) { return default(bool); }
-        //    public override void FromXml(System.Security.SecurityElement et) { }
-        public override int GetHashCode() { return default(int); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/PermissionSet.cs
+++ b/src/System.Security.Permissions/src/System/Security/PermissionSet.cs
@@ -1,0 +1,37 @@
+﻿namespace System.Security
+{
+    public partial class PermissionSet : System.Collections.ICollection, System.Collections.IEnumerable, /* System.Runtime.Serialization.IDeserializationCallback, */ System.Security.ISecurityEncodable, System.Security.IStackWalk
+    {
+        public PermissionSet(System.Security.Permissions.PermissionState state) { }
+        public PermissionSet(System.Security.PermissionSet permSet) { }
+        public virtual int Count { get { return default(int); } }
+        public virtual bool IsReadOnly { get { return default(bool); } }
+        public virtual bool IsSynchronized { get { return default(bool); } }
+        public virtual object SyncRoot { get { return default(object); } }
+        public System.Security.IPermission AddPermission(System.Security.IPermission perm) { return default(System.Security.IPermission); }
+        public void Assert() { }
+        public bool ContainsNonCodeAccessPermissions() { return default(bool); }
+        public static byte[] ConvertPermissionSet(string inFormat, byte[] inData, string outFormat) { return default(byte[]); }
+        public virtual System.Security.PermissionSet Copy() { return default(System.Security.PermissionSet); }
+        public virtual void CopyTo(System.Array array, int index) { }
+        public void Demand() { }
+        public void Deny() { }
+        public override bool Equals(object obj) { return default(bool); }
+        //    public virtual void FromXml(System.Security.SecurityElement et) { }
+        public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
+        public override int GetHashCode() { return default(int); }
+        public System.Security.IPermission GetPermission(System.Type permClass) { return default(System.Security.IPermission); }
+        public System.Security.PermissionSet Intersect(System.Security.PermissionSet other) { return default(System.Security.PermissionSet); }
+        public bool IsEmpty() { return default(bool); }
+        public bool IsSubsetOf(System.Security.PermissionSet target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public void PermitOnly() { }
+        public System.Security.IPermission RemovePermission(System.Type permClass) { return default(System.Security.IPermission); }
+        public static void RevertAssert() { }
+        public System.Security.IPermission SetPermission(System.Security.IPermission perm) { return default(System.Security.IPermission); }
+        //    void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
+        public override string ToString() { return default(string); }
+        //    public virtual System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public System.Security.PermissionSet Union(System.Security.PermissionSet other) { return default(System.Security.PermissionSet); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/PermissionSet.cs
+++ b/src/System.Security.Permissions/src/System/Security/PermissionSet.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public partial class PermissionSet : System.Collections.ICollection, System.Collections.IEnumerable, /* System.Runtime.Serialization.IDeserializationCallback, */ System.Security.ISecurityEncodable, System.Security.IStackWalk
     {
@@ -11,27 +15,26 @@
         public System.Security.IPermission AddPermission(System.Security.IPermission perm) { return default(System.Security.IPermission); }
         public void Assert() { }
         public bool ContainsNonCodeAccessPermissions() { return default(bool); }
+        [System.ObsoleteAttribute]
         public static byte[] ConvertPermissionSet(string inFormat, byte[] inData, string outFormat) { return default(byte[]); }
         public virtual System.Security.PermissionSet Copy() { return default(System.Security.PermissionSet); }
         public virtual void CopyTo(System.Array array, int index) { }
         public void Demand() { }
-        public void Deny() { }
-        public override bool Equals(object obj) { return default(bool); }
-        //    public virtual void FromXml(System.Security.SecurityElement et) { }
+        [System.ObsoleteAttribute]
+        public void Deny() { throw new System.NotSupportedException(); }
+        public override bool Equals(object o) => base.Equals(o);
         public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
-        public override int GetHashCode() { return default(int); }
+        public override int GetHashCode() => base.GetHashCode();
         public System.Security.IPermission GetPermission(System.Type permClass) { return default(System.Security.IPermission); }
         public System.Security.PermissionSet Intersect(System.Security.PermissionSet other) { return default(System.Security.PermissionSet); }
         public bool IsEmpty() { return default(bool); }
         public bool IsSubsetOf(System.Security.PermissionSet target) { return default(bool); }
         public bool IsUnrestricted() { return default(bool); }
-        public void PermitOnly() { }
+        public void PermitOnly() { throw new System.PlatformNotSupportedException(); }
         public System.Security.IPermission RemovePermission(System.Type permClass) { return default(System.Security.IPermission); }
         public static void RevertAssert() { }
         public System.Security.IPermission SetPermission(System.Security.IPermission perm) { return default(System.Security.IPermission); }
-        //    void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-        public override string ToString() { return default(string); }
-        //    public virtual System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override string ToString() => base.ToString();
         public System.Security.PermissionSet Union(System.Security.PermissionSet other) { return default(System.Security.PermissionSet); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/CodeAccessSecurityAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/CodeAccessSecurityAttribute.cs
@@ -1,0 +1,8 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public abstract partial class CodeAccessSecurityAttribute : System.Security.Permissions.SecurityAttribute
+    {
+        protected CodeAccessSecurityAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/CodeAccessSecurityAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/CodeAccessSecurityAttribute.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public abstract partial class CodeAccessSecurityAttribute : System.Security.Permissions.SecurityAttribute

--- a/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermission.cs
@@ -1,0 +1,18 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class EnvironmentPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public EnvironmentPermission(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
+        public EnvironmentPermission(System.Security.Permissions.PermissionState state) { }
+        public void AddPathList(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public string GetPathList(System.Security.Permissions.EnvironmentPermissionAccess flag) { return default(string); }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public void SetPathList(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermission.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class EnvironmentPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
     {
@@ -6,13 +10,11 @@
         public EnvironmentPermission(System.Security.Permissions.PermissionState state) { }
         public void AddPathList(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
         public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement esd) { }
         public string GetPathList(System.Security.Permissions.EnvironmentPermissionAccess flag) { return default(string); }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
         public bool IsUnrestricted() { return default(bool); }
         public void SetPathList(System.Security.Permissions.EnvironmentPermissionAccess flag, string pathList) { }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAccess.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Security.Permissions
+{
+    [System.FlagsAttribute]
+    public enum EnvironmentPermissionAccess
+    {
+        AllAccess = 3,
+        NoAccess = 0,
+        Read = 1,
+        Write = 2,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAccess.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.FlagsAttribute]
     public enum EnvironmentPermissionAccess

--- a/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class EnvironmentPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public EnvironmentPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string All { get { return default(string); } set { } }
+        public string Read { get { return default(string); } set { } }
+        public string Write { get { return default(string); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAttribute.cs
@@ -1,12 +1,16 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class EnvironmentPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public EnvironmentPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public string All { get { return default(string); } set { } }
-        public string Read { get { return default(string); } set { } }
-        public string Write { get { return default(string); } set { } }
+        public string All { get; set; }
+        public string Read { get; set; }
+        public string Write { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermission.cs
@@ -1,0 +1,16 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class FileDialogPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public FileDialogPermission(System.Security.Permissions.FileDialogPermissionAccess access) { }
+        public FileDialogPermission(System.Security.Permissions.PermissionState state) { }
+        public System.Security.Permissions.FileDialogPermissionAccess Access { get { return default(System.Security.Permissions.FileDialogPermissionAccess); } set { } }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermission.cs
@@ -1,16 +1,18 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class FileDialogPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
     {
         public FileDialogPermission(System.Security.Permissions.FileDialogPermissionAccess access) { }
         public FileDialogPermission(System.Security.Permissions.PermissionState state) { }
-        public System.Security.Permissions.FileDialogPermissionAccess Access { get { return default(System.Security.Permissions.FileDialogPermissionAccess); } set { } }
-        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public System.Security.Permissions.FileDialogPermissionAccess Access { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
         public bool IsUnrestricted() { return default(bool); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAccess.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Security.Permissions
+{
+    [System.FlagsAttribute]
+    public enum FileDialogPermissionAccess
+    {
+        None = 0,
+        Open = 1,
+        OpenSave = 3,
+        Save = 2,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAccess.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.FlagsAttribute]
     public enum FileDialogPermissionAccess

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class FileDialogPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public FileDialogPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public bool Open { get { return default(bool); } set { } }
+        public bool Save { get { return default(bool); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAttribute.cs
@@ -1,11 +1,15 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class FileDialogPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public FileDialogPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public bool Open { get { return default(bool); } set { } }
-        public bool Save { get { return default(bool); } set { } }
+        public bool Open { get; set; }
+        public bool Save { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileIOPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileIOPermission.cs
@@ -1,0 +1,25 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class FileIOPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public FileIOPermission(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
+        public FileIOPermission(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
+        public FileIOPermission(System.Security.Permissions.PermissionState state) { }
+        public System.Security.Permissions.FileIOPermissionAccess AllFiles { get { return default(System.Security.Permissions.FileIOPermissionAccess); } set { } }
+        public System.Security.Permissions.FileIOPermissionAccess AllLocalFiles { get { return default(System.Security.Permissions.FileIOPermissionAccess); } set { } }
+        public void AddPathList(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
+        public void AddPathList(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        public override bool Equals(object obj) { return default(bool); }
+        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public override int GetHashCode() { return default(int); }
+        public string[] GetPathList(System.Security.Permissions.FileIOPermissionAccess access) { return default(string[]); }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public void SetPathList(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
+        public void SetPathList(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileIOPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileIOPermission.cs
@@ -1,25 +1,27 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class FileIOPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
     {
         public FileIOPermission(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
         public FileIOPermission(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
         public FileIOPermission(System.Security.Permissions.PermissionState state) { }
-        public System.Security.Permissions.FileIOPermissionAccess AllFiles { get { return default(System.Security.Permissions.FileIOPermissionAccess); } set { } }
-        public System.Security.Permissions.FileIOPermissionAccess AllLocalFiles { get { return default(System.Security.Permissions.FileIOPermissionAccess); } set { } }
+        public System.Security.Permissions.FileIOPermissionAccess AllFiles { get; set; }
+        public System.Security.Permissions.FileIOPermissionAccess AllLocalFiles { get; set; }
         public void AddPathList(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
         public void AddPathList(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
-        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        public override bool Equals(object obj) { return default(bool); }
-        //    public override void FromXml(System.Security.SecurityElement esd) { }
-        public override int GetHashCode() { return default(int); }
+        public override System.Security.IPermission Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
         public string[] GetPathList(System.Security.Permissions.FileIOPermissionAccess access) { return default(string[]); }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
         public bool IsUnrestricted() { return default(bool); }
         public void SetPathList(System.Security.Permissions.FileIOPermissionAccess access, string path) { }
         public void SetPathList(System.Security.Permissions.FileIOPermissionAccess access, string[] pathList) { }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileIOPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileIOPermissionAccess.cs
@@ -1,0 +1,13 @@
+﻿namespace System.Security.Permissions
+{
+    [System.FlagsAttribute]
+    public enum FileIOPermissionAccess
+    {
+        AllAccess = 15,
+        Append = 4,
+        NoAccess = 0,
+        PathDiscovery = 8,
+        Read = 1,
+        Write = 2,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileIOPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileIOPermissionAccess.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.FlagsAttribute]
     public enum FileIOPermissionAccess

--- a/src/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermission.cs
@@ -1,14 +1,16 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class GacIdentityPermission : System.Security.CodeAccessPermission
     {
         public GacIdentityPermission() { }
         public GacIdentityPermission(System.Security.Permissions.PermissionState state) { }
         public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement securityElement) { }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermission.cs
@@ -1,0 +1,14 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class GacIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public GacIdentityPermission() { }
+        public GacIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement securityElement) { }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermissionAttribute.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class GacIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute

--- a/src/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermissionAttribute.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class GacIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public GacIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/HostProtectionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/HostProtectionAttribute.cs
@@ -1,0 +1,20 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4205), AllowMultiple = true, Inherited = false)]
+    public sealed partial class HostProtectionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public HostProtectionAttribute() : base(default(System.Security.Permissions.SecurityAction)) { }
+        public HostProtectionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public bool ExternalProcessMgmt { get { return default(bool); } set { } }
+        public bool ExternalThreading { get { return default(bool); } set { } }
+        public bool MayLeakOnAbort { get { return default(bool); } set { } }
+        public System.Security.Permissions.HostProtectionResource Resources { get { return default(System.Security.Permissions.HostProtectionResource); } set { } }
+        public bool SecurityInfrastructure { get { return default(bool); } set { } }
+        public bool SelfAffectingProcessMgmt { get { return default(bool); } set { } }
+        public bool SelfAffectingThreading { get { return default(bool); } set { } }
+        public bool SharedState { get { return default(bool); } set { } }
+        public bool Synchronization { get { return default(bool); } set { } }
+        public bool UI { get { return default(bool); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/HostProtectionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/HostProtectionAttribute.cs
@@ -1,20 +1,24 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(4205), AllowMultiple = true, Inherited = false)]
     public sealed partial class HostProtectionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public HostProtectionAttribute() : base(default(System.Security.Permissions.SecurityAction)) { }
         public HostProtectionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public bool ExternalProcessMgmt { get { return default(bool); } set { } }
-        public bool ExternalThreading { get { return default(bool); } set { } }
-        public bool MayLeakOnAbort { get { return default(bool); } set { } }
-        public System.Security.Permissions.HostProtectionResource Resources { get { return default(System.Security.Permissions.HostProtectionResource); } set { } }
-        public bool SecurityInfrastructure { get { return default(bool); } set { } }
-        public bool SelfAffectingProcessMgmt { get { return default(bool); } set { } }
-        public bool SelfAffectingThreading { get { return default(bool); } set { } }
-        public bool SharedState { get { return default(bool); } set { } }
-        public bool Synchronization { get { return default(bool); } set { } }
-        public bool UI { get { return default(bool); } set { } }
+        public bool ExternalProcessMgmt { get; set; }
+        public bool ExternalThreading { get; set; }
+        public bool MayLeakOnAbort { get; set; }
+        public System.Security.Permissions.HostProtectionResource Resources { get; set; }
+        public bool SecurityInfrastructure { get; set; }
+        public bool SelfAffectingProcessMgmt { get; set; }
+        public bool SelfAffectingThreading { get; set; }
+        public bool SharedState { get; set; }
+        public bool Synchronization { get; set; }
+        public bool UI { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/HostProtectionResource.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/HostProtectionResource.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.FlagsAttribute]
     public enum HostProtectionResource

--- a/src/System.Security.Permissions/src/System/Security/Permissions/HostProtectionResource.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/HostProtectionResource.cs
@@ -1,0 +1,18 @@
+﻿namespace System.Security.Permissions
+{
+    [System.FlagsAttribute]
+    public enum HostProtectionResource
+    {
+        All = 511,
+        ExternalProcessMgmt = 4,
+        ExternalThreading = 16,
+        MayLeakOnAbort = 256,
+        None = 0,
+        SecurityInfrastructure = 64,
+        SelfAffectingProcessMgmt = 8,
+        SelfAffectingThreading = 32,
+        SharedState = 2,
+        Synchronization = 1,
+        UI = 128,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/IUnrestrictedPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/IUnrestrictedPermission.cs
@@ -1,0 +1,7 @@
+﻿namespace System.Security.Permissions
+{
+    public partial interface IUnrestrictedPermission
+    {
+        bool IsUnrestricted();
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/IUnrestrictedPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/IUnrestrictedPermission.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public partial interface IUnrestrictedPermission
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PermissionSetAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PermissionSetAttribute.cs
@@ -1,0 +1,15 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class PermissionSetAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public PermissionSetAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string File { get { return default(string); } set { } }
+        public string Hex { get { return default(string); } set { } }
+        public string Name { get { return default(string); } set { } }
+        public bool UnicodeEncoded { get { return default(bool); } set { } }
+        public string XML { get { return default(string); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+        public System.Security.PermissionSet CreatePermissionSet() { return default(System.Security.PermissionSet); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PermissionSetAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PermissionSetAttribute.cs
@@ -1,14 +1,18 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class PermissionSetAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public PermissionSetAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public string File { get { return default(string); } set { } }
-        public string Hex { get { return default(string); } set { } }
-        public string Name { get { return default(string); } set { } }
-        public bool UnicodeEncoded { get { return default(bool); } set { } }
-        public string XML { get { return default(string); } set { } }
+        public string File { get; set; }
+        public string Hex { get; set; }
+        public string Name { get; set; }
+        public bool UnicodeEncoded { get; set; }
+        public string XML { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
         public System.Security.PermissionSet CreatePermissionSet() { return default(System.Security.PermissionSet); }
     }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PermissionState.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PermissionState.cs
@@ -1,0 +1,8 @@
+﻿namespace System.Security.Permissions
+{
+    public enum PermissionState
+    {
+        None = 0,
+        Unrestricted = 1,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PermissionState.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PermissionState.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public enum PermissionState
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
@@ -1,20 +1,23 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
+    //TODO implement PrincipalPermission
     public sealed partial class PrincipalPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.Permissions.IUnrestrictedPermission
     {
         public PrincipalPermission(System.Security.Permissions.PermissionState state) { }
         public PrincipalPermission(string name, string role) { }
         public PrincipalPermission(string name, string role, bool isAuthenticated) { }
         public System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        public void Demand() { }
-        public override bool Equals(object obj) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement elem) { }
-        public override int GetHashCode() { return default(int); }
+        public void Demand() { throw new System.Security.SecurityException(); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
         public System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
         public bool IsUnrestricted() { return default(bool); }
-        public override string ToString() { return default(string); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override string ToString() => base.ToString();
         public System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
@@ -1,0 +1,20 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class PrincipalPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public PrincipalPermission(System.Security.Permissions.PermissionState state) { }
+        public PrincipalPermission(string name, string role) { }
+        public PrincipalPermission(string name, string role, bool isAuthenticated) { }
+        public System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        public void Demand() { }
+        public override bool Equals(object obj) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement elem) { }
+        public override int GetHashCode() { return default(int); }
+        public System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public override string ToString() { return default(string); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermissionAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(68), AllowMultiple = true, Inherited = false)]
+    public sealed partial class PrincipalPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public PrincipalPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public bool Authenticated { get { return default(bool); } set { } }
+        public string Name { get { return default(string); } set { } }
+        public string Role { get { return default(string); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermissionAttribute.cs
@@ -1,12 +1,16 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(68), AllowMultiple = true, Inherited = false)]
     public sealed partial class PrincipalPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public PrincipalPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public bool Authenticated { get { return default(bool); } set { } }
-        public string Name { get { return default(string); } set { } }
-        public string Role { get { return default(string); } set { } }
+        public bool Authenticated { get; set; }
+        public string Name { get; set; }
+        public string Role { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermission.cs
@@ -1,0 +1,15 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class PublisherIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public PublisherIdentityPermission(System.Security.Cryptography.X509Certificates.X509Certificate certificate) { }
+        public PublisherIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } set { } }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermission.cs
@@ -1,15 +1,17 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class PublisherIdentityPermission : System.Security.CodeAccessPermission
     {
         public PublisherIdentityPermission(System.Security.Cryptography.X509Certificates.X509Certificate certificate) { }
         public PublisherIdentityPermission(System.Security.Permissions.PermissionState state) { }
-        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } set { } }
-        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermissionAttribute.cs
@@ -1,12 +1,16 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class PublisherIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public PublisherIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public string CertFile { get { return default(string); } set { } }
-        public string SignedFile { get { return default(string); } set { } }
-        public string X509Certificate { get { return default(string); } set { } }
+        public string CertFile { get; set; }
+        public string SignedFile { get; set; }
+        public string X509Certificate { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermissionAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class PublisherIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public PublisherIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string CertFile { get { return default(string); } set { } }
+        public string SignedFile { get { return default(string); } set { } }
+        public string X509Certificate { get { return default(string); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermission.cs
@@ -1,16 +1,18 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class ReflectionPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
     {
         public ReflectionPermission(System.Security.Permissions.PermissionState state) { }
         public ReflectionPermission(System.Security.Permissions.ReflectionPermissionFlag flag) { }
-        public System.Security.Permissions.ReflectionPermissionFlag Flags { get { return default(System.Security.Permissions.ReflectionPermissionFlag); } set { } }
-        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public System.Security.Permissions.ReflectionPermissionFlag Flags { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
         public bool IsUnrestricted() { return default(bool); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermission.cs
@@ -1,0 +1,16 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class ReflectionPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public ReflectionPermission(System.Security.Permissions.PermissionState state) { }
+        public ReflectionPermission(System.Security.Permissions.ReflectionPermissionFlag flag) { }
+        public System.Security.Permissions.ReflectionPermissionFlag Flags { get { return default(System.Security.Permissions.ReflectionPermissionFlag); } set { } }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionAttribute.cs
@@ -1,0 +1,16 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class ReflectionPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public ReflectionPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public System.Security.Permissions.ReflectionPermissionFlag Flags { get { return default(System.Security.Permissions.ReflectionPermissionFlag); } set { } }
+        public bool MemberAccess { get { return default(bool); } set { } }
+        [System.ObsoleteAttribute]
+        public bool ReflectionEmit { get { return default(bool); } set { } }
+        public bool RestrictedMemberAccess { get { return default(bool); } set { } }
+        [System.ObsoleteAttribute("not enforced in 2.0+")]
+        public bool TypeInformation { get { return default(bool); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionAttribute.cs
@@ -1,16 +1,20 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class ReflectionPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public ReflectionPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public System.Security.Permissions.ReflectionPermissionFlag Flags { get { return default(System.Security.Permissions.ReflectionPermissionFlag); } set { } }
-        public bool MemberAccess { get { return default(bool); } set { } }
+        public System.Security.Permissions.ReflectionPermissionFlag Flags { get; set; }
+        public bool MemberAccess { get; set; }
         [System.ObsoleteAttribute]
-        public bool ReflectionEmit { get { return default(bool); } set { } }
-        public bool RestrictedMemberAccess { get { return default(bool); } set { } }
+        public bool ReflectionEmit { get; set; }
+        public bool RestrictedMemberAccess { get; set; }
         [System.ObsoleteAttribute("not enforced in 2.0+")]
-        public bool TypeInformation { get { return default(bool); } set { } }
+        public bool TypeInformation { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
@@ -1,0 +1,16 @@
+﻿namespace System.Security.Permissions
+{
+    [System.FlagsAttribute]
+    public enum ReflectionPermissionFlag
+    {
+        [System.ObsoleteAttribute]
+        AllFlags = 7,
+        MemberAccess = 2,
+        NoFlags = 0,
+        [System.ObsoleteAttribute]
+        ReflectionEmit = 4,
+        RestrictedMemberAccess = 8,
+        [System.ObsoleteAttribute("not used anymore")]
+        TypeInformation = 1,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.FlagsAttribute]
     public enum ReflectionPermissionFlag

--- a/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermission.cs
@@ -1,0 +1,19 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class RegistryPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public RegistryPermission(System.Security.Permissions.PermissionState state) { }
+        public RegistryPermission(System.Security.Permissions.RegistryPermissionAccess access, System.Security.AccessControl.AccessControlActions control, string pathList) { }
+        public RegistryPermission(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
+        public void AddPathList(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public string GetPathList(System.Security.Permissions.RegistryPermissionAccess access) { return default(string); }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        public void SetPathList(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermission.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class RegistryPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
     {
@@ -7,13 +11,11 @@
         public RegistryPermission(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
         public void AddPathList(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
         public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement esd) { }
         public string GetPathList(System.Security.Permissions.RegistryPermissionAccess access) { return default(string); }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
         public bool IsUnrestricted() { return default(bool); }
         public void SetPathList(System.Security.Permissions.RegistryPermissionAccess access, string pathList) { }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission other) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAccess.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Security.Permissions
+{
+    [System.FlagsAttribute]
+    public enum RegistryPermissionAccess
+    {
+        AllAccess = 7,
+        Create = 4,
+        NoAccess = 0,
+        Read = 1,
+        Write = 2,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAccess.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.FlagsAttribute]
     public enum RegistryPermissionAccess

--- a/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAttribute.cs
@@ -1,17 +1,21 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class RegistryPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public RegistryPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
         [System.ObsoleteAttribute("use newer properties")]
-        public string All { get { return default(string); } set { } }
-        public string ChangeAccessControl { get { return default(string); } set { } }
-        public string Create { get { return default(string); } set { } }
-        public string Read { get { return default(string); } set { } }
-        public string ViewAccessControl { get { return default(string); } set { } }
-        public string ViewAndModify { get { return default(string); } set { } }
-        public string Write { get { return default(string); } set { } }
+        public string All { get; set; }
+        public string ChangeAccessControl { get; set; }
+        public string Create { get; set; }
+        public string Read { get; set; }
+        public string ViewAccessControl { get; set; }
+        public string ViewAndModify { get; set; }
+        public string Write { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAttribute.cs
@@ -1,0 +1,17 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class RegistryPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public RegistryPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        [System.ObsoleteAttribute("use newer properties")]
+        public string All { get { return default(string); } set { } }
+        public string ChangeAccessControl { get { return default(string); } set { } }
+        public string Create { get { return default(string); } set { } }
+        public string Read { get { return default(string); } set { } }
+        public string ViewAccessControl { get { return default(string); } set { } }
+        public string ViewAndModify { get { return default(string); } set { } }
+        public string Write { get { return default(string); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SecurityAction.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SecurityAction.cs
@@ -1,0 +1,19 @@
+﻿namespace System.Security.Permissions
+{
+    public enum SecurityAction
+    {
+        Assert = 3,
+        Demand = 2,
+        [System.ObsoleteAttribute("This requests should not be used")]
+        Deny = 4,
+        InheritanceDemand = 7,
+        LinkDemand = 6,
+        PermitOnly = 5,
+        [System.ObsoleteAttribute("This requests should not be used")]
+        RequestMinimum = 8,
+        [System.ObsoleteAttribute("This requests should not be used")]
+        RequestOptional = 9,
+        [System.ObsoleteAttribute("This requests should not be used")]
+        RequestRefuse = 10,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SecurityAction.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SecurityAction.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public enum SecurityAction
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SecurityAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SecurityAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public abstract partial class SecurityAttribute : System.Attribute
+    {
+        protected SecurityAttribute(System.Security.Permissions.SecurityAction action) { }
+        public System.Security.Permissions.SecurityAction Action { get { return default(System.Security.Permissions.SecurityAction); } set { } }
+        public bool Unrestricted { get { return default(bool); } set { } }
+        public abstract System.Security.IPermission CreatePermission();
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SecurityAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SecurityAttribute.cs
@@ -1,11 +1,15 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public abstract partial class SecurityAttribute : System.Attribute
     {
         protected SecurityAttribute(System.Security.Permissions.SecurityAction action) { }
-        public System.Security.Permissions.SecurityAction Action { get { return default(System.Security.Permissions.SecurityAction); } set { } }
-        public bool Unrestricted { get { return default(bool); } set { } }
+        public System.Security.Permissions.SecurityAction Action { get; set; }
+        public bool Unrestricted { get; set; }
         public abstract System.Security.IPermission CreatePermission();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermission.cs
@@ -1,16 +1,18 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class SecurityPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
     {
         public SecurityPermission(System.Security.Permissions.PermissionState state) { }
         public SecurityPermission(System.Security.Permissions.SecurityPermissionFlag flag) { }
-        public System.Security.Permissions.SecurityPermissionFlag Flags { get { return default(System.Security.Permissions.SecurityPermissionFlag); } set { } }
-        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public System.Security.Permissions.SecurityPermissionFlag Flags { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
         public bool IsUnrestricted() { return default(bool); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermission.cs
@@ -1,0 +1,16 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class SecurityPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public SecurityPermission(System.Security.Permissions.PermissionState state) { }
+        public SecurityPermission(System.Security.Permissions.SecurityPermissionFlag flag) { }
+        public System.Security.Permissions.SecurityPermissionFlag Flags { get { return default(System.Security.Permissions.SecurityPermissionFlag); } set { } }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermissionAttribute.cs
@@ -1,24 +1,28 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class SecurityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public SecurityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public bool Assertion { get { return default(bool); } set { } }
-        public bool BindingRedirects { get { return default(bool); } set { } }
-        public bool ControlAppDomain { get { return default(bool); } set { } }
-        public bool ControlDomainPolicy { get { return default(bool); } set { } }
-        public bool ControlEvidence { get { return default(bool); } set { } }
-        public bool ControlPolicy { get { return default(bool); } set { } }
-        public bool ControlPrincipal { get { return default(bool); } set { } }
-        public bool ControlThread { get { return default(bool); } set { } }
-        public bool Execution { get { return default(bool); } set { } }
-        public System.Security.Permissions.SecurityPermissionFlag Flags { get { return default(System.Security.Permissions.SecurityPermissionFlag); } set { } }
-        public bool Infrastructure { get { return default(bool); } set { } }
-        public bool RemotingConfiguration { get { return default(bool); } set { } }
-        public bool SerializationFormatter { get { return default(bool); } set { } }
-        public bool SkipVerification { get { return default(bool); } set { } }
-        public bool UnmanagedCode { get { return default(bool); } set { } }
+        public bool Assertion { get; set; }
+        public bool BindingRedirects { get; set; }
+        public bool ControlAppDomain { get; set; }
+        public bool ControlDomainPolicy { get; set; }
+        public bool ControlEvidence { get; set; }
+        public bool ControlPolicy { get; set; }
+        public bool ControlPrincipal { get; set; }
+        public bool ControlThread { get; set; }
+        public bool Execution { get; set; }
+        public System.Security.Permissions.SecurityPermissionFlag Flags { get; set; }
+        public bool Infrastructure { get; set; }
+        public bool RemotingConfiguration { get; set; }
+        public bool SerializationFormatter { get; set; }
+        public bool SkipVerification { get; set; }
+        public bool UnmanagedCode { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermissionAttribute.cs
@@ -1,0 +1,24 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class SecurityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public SecurityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public bool Assertion { get { return default(bool); } set { } }
+        public bool BindingRedirects { get { return default(bool); } set { } }
+        public bool ControlAppDomain { get { return default(bool); } set { } }
+        public bool ControlDomainPolicy { get { return default(bool); } set { } }
+        public bool ControlEvidence { get { return default(bool); } set { } }
+        public bool ControlPolicy { get { return default(bool); } set { } }
+        public bool ControlPrincipal { get { return default(bool); } set { } }
+        public bool ControlThread { get { return default(bool); } set { } }
+        public bool Execution { get { return default(bool); } set { } }
+        public System.Security.Permissions.SecurityPermissionFlag Flags { get { return default(System.Security.Permissions.SecurityPermissionFlag); } set { } }
+        public bool Infrastructure { get { return default(bool); } set { } }
+        public bool RemotingConfiguration { get { return default(bool); } set { } }
+        public bool SerializationFormatter { get { return default(bool); } set { } }
+        public bool SkipVerification { get { return default(bool); } set { } }
+        public bool UnmanagedCode { get { return default(bool); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermissionFlag.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermissionFlag.cs
@@ -1,0 +1,23 @@
+﻿namespace System.Security.Permissions
+{
+    [System.FlagsAttribute]
+    public enum SecurityPermissionFlag
+    {
+        AllFlags = 16383,
+        Assertion = 1,
+        BindingRedirects = 8192,
+        ControlAppDomain = 1024,
+        ControlDomainPolicy = 256,
+        ControlEvidence = 32,
+        ControlPolicy = 64,
+        ControlPrincipal = 512,
+        ControlThread = 16,
+        Execution = 8,
+        Infrastructure = 4096,
+        NoFlags = 0,
+        RemotingConfiguration = 2048,
+        SerializationFormatter = 128,
+        SkipVerification = 4,
+        UnmanagedCode = 2,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermissionFlag.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SecurityPermissionFlag.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.FlagsAttribute]
     public enum SecurityPermissionFlag

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermission.cs
@@ -1,0 +1,15 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class SiteIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public SiteIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public SiteIdentityPermission(string site) { }
+        public string Site { get { return default(string); } set { } }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermission.cs
@@ -1,15 +1,17 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class SiteIdentityPermission : System.Security.CodeAccessPermission
     {
         public SiteIdentityPermission(System.Security.Permissions.PermissionState state) { }
         public SiteIdentityPermission(string site) { }
-        public string Site { get { return default(string); } set { } }
+        public string Site { get; set; }
         public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement esd) { }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermissionAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class SiteIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public SiteIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string Site { get { return default(string); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermissionAttribute.cs
@@ -1,10 +1,14 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class SiteIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public SiteIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public string Site { get { return default(string); } set { } }
+        public string Site { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermission.cs
@@ -1,0 +1,17 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class StrongNameIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public StrongNameIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public StrongNameIdentityPermission(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
+        public string Name { get { return default(string); } set { } }
+        public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } set { } }
+        public System.Version Version { get { return default(System.Version); } set { } }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement e) { }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermission.cs
@@ -1,17 +1,19 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class StrongNameIdentityPermission : System.Security.CodeAccessPermission
     {
         public StrongNameIdentityPermission(System.Security.Permissions.PermissionState state) { }
         public StrongNameIdentityPermission(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
-        public string Name { get { return default(string); } set { } }
-        public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } set { } }
-        public System.Version Version { get { return default(System.Version); } set { } }
-        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement e) { }
+        public string Name { get; set; }
+        public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get; set; }
+        public System.Version Version { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermissionAttribute.cs
@@ -1,12 +1,16 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class StrongNameIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public StrongNameIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public string Name { get { return default(string); } set { } }
-        public string PublicKey { get { return default(string); } set { } }
-        public string Version { get { return default(string); } set { } }
+        public string Name { get; set; }
+        public string PublicKey { get; set; }
+        public string Version { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermissionAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class StrongNameIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public StrongNameIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string Name { get { return default(string); } set { } }
+        public string PublicKey { get { return default(string); } set { } }
+        public string Version { get { return default(string); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/StrongNamePublicKeyBlob.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/StrongNamePublicKeyBlob.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class StrongNamePublicKeyBlob
+    {
+        public StrongNamePublicKeyBlob(byte[] publicKey) { }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/StrongNamePublicKeyBlob.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/StrongNamePublicKeyBlob.cs
@@ -1,10 +1,14 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class StrongNamePublicKeyBlob
     {
         public StrongNamePublicKeyBlob(byte[] publicKey) { }
-        public override bool Equals(object obj) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermission.cs
@@ -1,16 +1,18 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class TypeDescriptorPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
     {
         public TypeDescriptorPermission(System.Security.Permissions.PermissionState state) { }
         public TypeDescriptorPermission(System.Security.Permissions.TypeDescriptorPermissionFlags flag) { }
-        public System.Security.Permissions.TypeDescriptorPermissionFlags Flags { get { return default(System.Security.Permissions.TypeDescriptorPermissionFlags); } set { } }
-        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement securityElement) { }
+        public System.Security.Permissions.TypeDescriptorPermissionFlags Flags { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
         public bool IsUnrestricted() { return default(bool); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermission.cs
@@ -1,0 +1,16 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class TypeDescriptorPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public TypeDescriptorPermission(System.Security.Permissions.PermissionState state) { }
+        public TypeDescriptorPermission(System.Security.Permissions.TypeDescriptorPermissionFlags flag) { }
+        public System.Security.Permissions.TypeDescriptorPermissionFlags Flags { get { return default(System.Security.Permissions.TypeDescriptorPermissionFlags); } set { } }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement securityElement) { }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermissionFlags.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermissionFlags.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Security.Permissions
+{
+    [System.FlagsAttribute]
+    public enum TypeDescriptorPermissionFlags
+    {
+        NoFlags = 0,
+        RestrictedRegistrationAccess = 1,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermissionFlags.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermissionFlags.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.FlagsAttribute]
     public enum TypeDescriptorPermissionFlags

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UIPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UIPermission.cs
@@ -1,0 +1,19 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class UIPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public UIPermission(System.Security.Permissions.PermissionState state) { }
+        public UIPermission(System.Security.Permissions.UIPermissionClipboard clipboardFlag) { }
+        public UIPermission(System.Security.Permissions.UIPermissionWindow windowFlag) { }
+        public UIPermission(System.Security.Permissions.UIPermissionWindow windowFlag, System.Security.Permissions.UIPermissionClipboard clipboardFlag) { }
+        public System.Security.Permissions.UIPermissionClipboard Clipboard { get { return default(System.Security.Permissions.UIPermissionClipboard); } set { } }
+        public System.Security.Permissions.UIPermissionWindow Window { get { return default(System.Security.Permissions.UIPermissionWindow); } set { } }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        public bool IsUnrestricted() { return default(bool); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UIPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UIPermission.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class UIPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
     {
@@ -6,14 +10,12 @@
         public UIPermission(System.Security.Permissions.UIPermissionClipboard clipboardFlag) { }
         public UIPermission(System.Security.Permissions.UIPermissionWindow windowFlag) { }
         public UIPermission(System.Security.Permissions.UIPermissionWindow windowFlag, System.Security.Permissions.UIPermissionClipboard clipboardFlag) { }
-        public System.Security.Permissions.UIPermissionClipboard Clipboard { get { return default(System.Security.Permissions.UIPermissionClipboard); } set { } }
-        public System.Security.Permissions.UIPermissionWindow Window { get { return default(System.Security.Permissions.UIPermissionWindow); } set { } }
-        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public System.Security.Permissions.UIPermissionClipboard Clipboard { get; set; }
+        public System.Security.Permissions.UIPermissionWindow Window { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
         public bool IsUnrestricted() { return default(bool); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class UIPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public UIPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public System.Security.Permissions.UIPermissionClipboard Clipboard { get { return default(System.Security.Permissions.UIPermissionClipboard); } set { } }
+        public System.Security.Permissions.UIPermissionWindow Window { get { return default(System.Security.Permissions.UIPermissionWindow); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionAttribute.cs
@@ -1,11 +1,15 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class UIPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public UIPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public System.Security.Permissions.UIPermissionClipboard Clipboard { get { return default(System.Security.Permissions.UIPermissionClipboard); } set { } }
-        public System.Security.Permissions.UIPermissionWindow Window { get { return default(System.Security.Permissions.UIPermissionWindow); } set { } }
+        public System.Security.Permissions.UIPermissionClipboard Clipboard { get; set; }
+        public System.Security.Permissions.UIPermissionWindow Window { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionClipboard.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionClipboard.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Security.Permissions
+{
+    public enum UIPermissionClipboard
+    {
+        AllClipboard = 2,
+        NoClipboard = 0,
+        OwnClipboard = 1,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionClipboard.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionClipboard.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public enum UIPermissionClipboard
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionWindow.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionWindow.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Security.Permissions
+{
+    public enum UIPermissionWindow
+    {
+        AllWindows = 3,
+        NoWindows = 0,
+        SafeSubWindows = 1,
+        SafeTopLevelWindows = 2,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionWindow.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionWindow.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public enum UIPermissionWindow
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermission.cs
@@ -1,0 +1,15 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class UrlIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public UrlIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public UrlIdentityPermission(string site) { }
+        public string Url { get { return default(string); } set { } }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermission.cs
@@ -1,15 +1,17 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class UrlIdentityPermission : System.Security.CodeAccessPermission
     {
         public UrlIdentityPermission(System.Security.Permissions.PermissionState state) { }
         public UrlIdentityPermission(string site) { }
-        public string Url { get { return default(string); } set { } }
+        public string Url { get; set; }
         public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement esd) { }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
         public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermissionAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Security.Permissions
+{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class UrlIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public UrlIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public string Url { get { return default(string); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermissionAttribute.cs
@@ -1,10 +1,14 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class UrlIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public UrlIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public string Url { get { return default(string); } set { } }
+        public string Url { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermission.cs
@@ -1,15 +1,17 @@
-﻿namespace System.Security.Permissions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
 {
     public sealed partial class ZoneIdentityPermission : System.Security.CodeAccessPermission
     {
         public ZoneIdentityPermission(System.Security.Permissions.PermissionState state) { }
         public ZoneIdentityPermission(System.Security.SecurityZone zone) { }
-        public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } set { } }
-        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
-        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public System.Security.SecurityZone SecurityZone { get; set; }
+        public override System.Security.IPermission Copy() { return this; }
         public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
         public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
-        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermission.cs
@@ -1,0 +1,15 @@
+﻿namespace System.Security.Permissions
+{
+    public sealed partial class ZoneIdentityPermission : System.Security.CodeAccessPermission
+    {
+        public ZoneIdentityPermission(System.Security.Permissions.PermissionState state) { }
+        public ZoneIdentityPermission(System.Security.SecurityZone zone) { }
+        public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } set { } }
+        public override System.Security.IPermission Copy() { return default(System.Security.IPermission); }
+        //    public override void FromXml(System.Security.SecurityElement esd) { }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { return default(System.Security.IPermission); }
+        public override bool IsSubsetOf(System.Security.IPermission target) { return default(bool); }
+        //    public override System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public override System.Security.IPermission Union(System.Security.IPermission target) { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermissionAttribute.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Security.Permissions{
+    [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
+    public sealed partial class ZoneIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
+    {
+        public ZoneIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
+        public System.Security.SecurityZone Zone { get { return default(System.Security.SecurityZone); } set { } }
+        public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermissionAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermissionAttribute.cs
@@ -1,9 +1,14 @@
-﻿namespace System.Security.Permissions{
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
+{
     [System.AttributeUsageAttribute((System.AttributeTargets)(109), AllowMultiple = true, Inherited = false)]
     public sealed partial class ZoneIdentityPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public ZoneIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base(default(System.Security.Permissions.SecurityAction)) { }
-        public System.Security.SecurityZone Zone { get { return default(System.Security.SecurityZone); } set { } }
+        public System.Security.SecurityZone Zone { get; set; }
         public override System.Security.IPermission CreatePermission() { return default(System.Security.IPermission); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/AllMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/AllMembershipCondition.cs
@@ -1,0 +1,16 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class AllMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public AllMembershipCondition() { }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+        public override bool Equals(object o) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement e) { }
+        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/AllMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/AllMembershipCondition.cs
@@ -1,16 +1,16 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class AllMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
     {
         public AllMembershipCondition() { }
         public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
         public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-        public override bool Equals(object o) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement e) { }
-        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationDirectory.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationDirectory.cs
@@ -1,12 +1,16 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class ApplicationDirectory : System.Security.Policy.EvidenceBase
     {
         public ApplicationDirectory(string name) { }
         public string Directory { get { return default(string); } }
         public object Copy() { return default(object); }
-        public override bool Equals(object o) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationDirectory.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationDirectory.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class ApplicationDirectory : System.Security.Policy.EvidenceBase
+    {
+        public ApplicationDirectory(string name) { }
+        public string Directory { get { return default(string); } }
+        public object Copy() { return default(object); }
+        public override bool Equals(object o) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationDirectoryMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationDirectoryMembershipCondition.cs
@@ -1,16 +1,16 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class ApplicationDirectoryMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
     {
         public ApplicationDirectoryMembershipCondition() { }
         public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
         public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-        public override bool Equals(object o) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement e) { }
-        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationDirectoryMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationDirectoryMembershipCondition.cs
@@ -1,0 +1,16 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class ApplicationDirectoryMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public ApplicationDirectoryMembershipCondition() { }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+        public override bool Equals(object o) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement e) { }
+        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrust.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrust.cs
@@ -1,0 +1,17 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class ApplicationTrust : System.Security.Policy.EvidenceBase, System.Security.ISecurityEncodable
+    {
+        public ApplicationTrust() { }
+        //    public ApplicationTrust(System.ApplicationIdentity applicationIdentity) { }
+        public ApplicationTrust(System.Security.PermissionSet defaultGrantSet, System.Collections.Generic.IEnumerable<System.Security.Policy.StrongName> fullTrustAssemblies) { }
+        //    public System.ApplicationIdentity ApplicationIdentity { get { return default(System.ApplicationIdentity); } set { } }
+        public System.Security.Policy.PolicyStatement DefaultGrantSet { get { return default(System.Security.Policy.PolicyStatement); } set { } }
+        public object ExtraInfo { get { return default(object); } set { } }
+        public System.Collections.Generic.IList<System.Security.Policy.StrongName> FullTrustAssemblies { get { return default(System.Collections.Generic.IList<System.Security.Policy.StrongName>); } }
+        public bool IsApplicationTrustedToRun { get { return default(bool); } set { } }
+        public bool Persist { get { return default(bool); } set { } }
+        //    public void FromXml(System.Security.SecurityElement element) { }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrust.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrust.cs
@@ -1,17 +1,17 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class ApplicationTrust : System.Security.Policy.EvidenceBase, System.Security.ISecurityEncodable
     {
         public ApplicationTrust() { }
-        //    public ApplicationTrust(System.ApplicationIdentity applicationIdentity) { }
         public ApplicationTrust(System.Security.PermissionSet defaultGrantSet, System.Collections.Generic.IEnumerable<System.Security.Policy.StrongName> fullTrustAssemblies) { }
-        //    public System.ApplicationIdentity ApplicationIdentity { get { return default(System.ApplicationIdentity); } set { } }
-        public System.Security.Policy.PolicyStatement DefaultGrantSet { get { return default(System.Security.Policy.PolicyStatement); } set { } }
-        public object ExtraInfo { get { return default(object); } set { } }
+        public System.Security.Policy.PolicyStatement DefaultGrantSet { get; set; }
+        public object ExtraInfo { get; set; }
         public System.Collections.Generic.IList<System.Security.Policy.StrongName> FullTrustAssemblies { get { return default(System.Collections.Generic.IList<System.Security.Policy.StrongName>); } }
-        public bool IsApplicationTrustedToRun { get { return default(bool); } set { } }
-        public bool Persist { get { return default(bool); } set { } }
-        //    public void FromXml(System.Security.SecurityElement element) { }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        public bool IsApplicationTrustedToRun { get; set; }
+        public bool Persist { get; set; }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrustCollection.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrustCollection.cs
@@ -1,0 +1,25 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class ApplicationTrustCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal ApplicationTrustCollection() { }
+        public int Count { get { return default(int); } }
+        public bool IsSynchronized { get { return default(bool); } }
+        public System.Security.Policy.ApplicationTrust this[int index] { get { return default(System.Security.Policy.ApplicationTrust); } }
+        public System.Security.Policy.ApplicationTrust this[string appFullName] { get { return default(System.Security.Policy.ApplicationTrust); } }
+        public object SyncRoot { get { return default(object); } }
+        public int Add(System.Security.Policy.ApplicationTrust trust) { return default(int); }
+        public void AddRange(System.Security.Policy.ApplicationTrust[] trusts) { }
+        public void AddRange(System.Security.Policy.ApplicationTrustCollection trusts) { }
+        public void Clear() { }
+        public void CopyTo(System.Security.Policy.ApplicationTrust[] array, int index) { }
+        //    public System.Security.Policy.ApplicationTrustCollection Find(System.ApplicationIdentity applicationIdentity, System.Security.Policy.ApplicationVersionMatch versionMatch) { return default(System.Security.Policy.ApplicationTrustCollection); }
+        public System.Security.Policy.ApplicationTrustEnumerator GetEnumerator() { return default(System.Security.Policy.ApplicationTrustEnumerator); }
+        //    public void Remove(System.ApplicationIdentity applicationIdentity, System.Security.Policy.ApplicationVersionMatch versionMatch) { }
+        public void Remove(System.Security.Policy.ApplicationTrust trust) { }
+        public void RemoveRange(System.Security.Policy.ApplicationTrust[] trusts) { }
+        public void RemoveRange(System.Security.Policy.ApplicationTrustCollection trusts) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrustCollection.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrustCollection.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class ApplicationTrustCollection : System.Collections.ICollection, System.Collections.IEnumerable
     {
@@ -13,9 +17,7 @@
         public void AddRange(System.Security.Policy.ApplicationTrustCollection trusts) { }
         public void Clear() { }
         public void CopyTo(System.Security.Policy.ApplicationTrust[] array, int index) { }
-        //    public System.Security.Policy.ApplicationTrustCollection Find(System.ApplicationIdentity applicationIdentity, System.Security.Policy.ApplicationVersionMatch versionMatch) { return default(System.Security.Policy.ApplicationTrustCollection); }
         public System.Security.Policy.ApplicationTrustEnumerator GetEnumerator() { return default(System.Security.Policy.ApplicationTrustEnumerator); }
-        //    public void Remove(System.ApplicationIdentity applicationIdentity, System.Security.Policy.ApplicationVersionMatch versionMatch) { }
         public void Remove(System.Security.Policy.ApplicationTrust trust) { }
         public void RemoveRange(System.Security.Policy.ApplicationTrust[] trusts) { }
         public void RemoveRange(System.Security.Policy.ApplicationTrustCollection trusts) { }

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrustEnumerator.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrustEnumerator.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class ApplicationTrustEnumerator : System.Collections.IEnumerator
     {

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrustEnumerator.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrustEnumerator.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class ApplicationTrustEnumerator : System.Collections.IEnumerator
+    {
+        internal ApplicationTrustEnumerator() { }
+        public System.Security.Policy.ApplicationTrust Current { get { return default(System.Security.Policy.ApplicationTrust); } }
+        object System.Collections.IEnumerator.Current { get { return default(object); } }
+        public bool MoveNext() { return default(bool); }
+        public void Reset() { }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationVersionMatch.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationVersionMatch.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public enum ApplicationVersionMatch
     {

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationVersionMatch.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationVersionMatch.cs
@@ -1,0 +1,8 @@
+﻿namespace System.Security.Policy
+{
+    public enum ApplicationVersionMatch
+    {
+        MatchAllVersions = 1,
+        MatchExactVersion = 0,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/CodeConnectAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/CodeConnectAccess.cs
@@ -1,0 +1,17 @@
+﻿namespace System.Security.Policy
+{
+    public partial class CodeConnectAccess
+    {
+        public static readonly string AnyScheme;
+        public static readonly int DefaultPort;
+        public static readonly int OriginPort;
+        public static readonly string OriginScheme;
+        public CodeConnectAccess(string allowScheme, int allowPort) { }
+        public int Port { get { return default(int); } }
+        public string Scheme { get { return default(string); } }
+        public static System.Security.Policy.CodeConnectAccess CreateAnySchemeAccess(int allowPort) { return default(System.Security.Policy.CodeConnectAccess); }
+        public static System.Security.Policy.CodeConnectAccess CreateOriginSchemeAccess(int allowPort) { return default(System.Security.Policy.CodeConnectAccess); }
+        public override bool Equals(object o) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/CodeConnectAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/CodeConnectAccess.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public partial class CodeConnectAccess
     {
@@ -11,7 +15,7 @@
         public string Scheme { get { return default(string); } }
         public static System.Security.Policy.CodeConnectAccess CreateAnySchemeAccess(int allowPort) { return default(System.Security.Policy.CodeConnectAccess); }
         public static System.Security.Policy.CodeConnectAccess CreateOriginSchemeAccess(int allowPort) { return default(System.Security.Policy.CodeConnectAccess); }
-        public override bool Equals(object o) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/CodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/CodeGroup.cs
@@ -1,29 +1,27 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public abstract partial class CodeGroup
     {
         protected CodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) { }
         public virtual string AttributeString { get { return default(string); } }
-        public System.Collections.IList Children { get { return default(System.Collections.IList); } set { } }
-        public string Description { get { return default(string); } set { } }
-        public System.Security.Policy.IMembershipCondition MembershipCondition { get { return default(System.Security.Policy.IMembershipCondition); } set { } }
+        public System.Collections.IList Children { get; set; }
+        public string Description { get; set; }
+        public System.Security.Policy.IMembershipCondition MembershipCondition { get; set; }
         public abstract string MergeLogic { get; }
-        public string Name { get { return default(string); } set { } }
+        public string Name { get; set; }
         public virtual string PermissionSetName { get { return default(string); } }
-        public System.Security.Policy.PolicyStatement PolicyStatement { get { return default(System.Security.Policy.PolicyStatement); } set { } }
+        public System.Security.Policy.PolicyStatement PolicyStatement { get; set; }
         public void AddChild(System.Security.Policy.CodeGroup group) { }
         public abstract System.Security.Policy.CodeGroup Copy();
-        //    protected virtual void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
-        public override bool Equals(object o) { return default(bool); }
+        public override bool Equals(object o) => base.Equals(o);
         public bool Equals(System.Security.Policy.CodeGroup cg, bool compareChildren) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement e) { }
-        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-        public override int GetHashCode() { return default(int); }
-        //    protected virtual void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() => base.GetHashCode();
         public void RemoveChild(System.Security.Policy.CodeGroup group) { }
         public abstract System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence);
         public abstract System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence);
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/CodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/CodeGroup.cs
@@ -1,0 +1,29 @@
+﻿namespace System.Security.Policy
+{
+    public abstract partial class CodeGroup
+    {
+        protected CodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) { }
+        public virtual string AttributeString { get { return default(string); } }
+        public System.Collections.IList Children { get { return default(System.Collections.IList); } set { } }
+        public string Description { get { return default(string); } set { } }
+        public System.Security.Policy.IMembershipCondition MembershipCondition { get { return default(System.Security.Policy.IMembershipCondition); } set { } }
+        public abstract string MergeLogic { get; }
+        public string Name { get { return default(string); } set { } }
+        public virtual string PermissionSetName { get { return default(string); } }
+        public System.Security.Policy.PolicyStatement PolicyStatement { get { return default(System.Security.Policy.PolicyStatement); } set { } }
+        public void AddChild(System.Security.Policy.CodeGroup group) { }
+        public abstract System.Security.Policy.CodeGroup Copy();
+        //    protected virtual void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
+        public override bool Equals(object o) { return default(bool); }
+        public bool Equals(System.Security.Policy.CodeGroup cg, bool compareChildren) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement e) { }
+        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() { return default(int); }
+        //    protected virtual void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public void RemoveChild(System.Security.Policy.CodeGroup group) { }
+        public abstract System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence);
+        public abstract System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence);
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/Evidence.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Evidence.cs
@@ -1,0 +1,30 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class Evidence : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public Evidence() { }
+        [System.ObsoleteAttribute]
+        public Evidence(object[] hostEvidence, object[] assemblyEvidence) { }
+        public Evidence(System.Security.Policy.Evidence evidence) { }
+        [System.ObsoleteAttribute]
+        public int Count { get { return default(int); } }
+        public bool IsReadOnly { get { return default(bool); } }
+        public bool IsSynchronized { get { return default(bool); } }
+        public bool Locked { get { return default(bool); } set { } }
+        public object SyncRoot { get { return default(object); } }
+        [System.ObsoleteAttribute]
+        public void AddAssembly(object id) { }
+        [System.ObsoleteAttribute]
+        public void AddHost(object id) { }
+        public void Clear() { }
+        public System.Security.Policy.Evidence Clone() { return default(System.Security.Policy.Evidence); }
+        [System.ObsoleteAttribute]
+        public void CopyTo(System.Array array, int index) { }
+        public System.Collections.IEnumerator GetAssemblyEnumerator() { return default(System.Collections.IEnumerator); }
+        [System.ObsoleteAttribute]
+        public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
+        public System.Collections.IEnumerator GetHostEnumerator() { return default(System.Collections.IEnumerator); }
+        public void Merge(System.Security.Policy.Evidence evidence) { }
+        public void RemoveType(System.Type t) { }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/Evidence.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Evidence.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class Evidence : System.Collections.ICollection, System.Collections.IEnumerable
     {
@@ -10,7 +14,7 @@
         public int Count { get { return default(int); } }
         public bool IsReadOnly { get { return default(bool); } }
         public bool IsSynchronized { get { return default(bool); } }
-        public bool Locked { get { return default(bool); } set { } }
+        public bool Locked { get; set; }
         public object SyncRoot { get { return default(object); } }
         [System.ObsoleteAttribute]
         public void AddAssembly(object id) { }

--- a/src/System.Security.Permissions/src/System/Security/Policy/EvidenceBase.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/EvidenceBase.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public abstract partial class EvidenceBase
     {

--- a/src/System.Security.Permissions/src/System/Security/Policy/EvidenceBase.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/EvidenceBase.cs
@@ -1,0 +1,8 @@
+﻿namespace System.Security.Policy
+{
+    public abstract partial class EvidenceBase
+    {
+        protected EvidenceBase() { }
+        public virtual System.Security.Policy.EvidenceBase Clone() { return default(System.Security.Policy.EvidenceBase); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/FileCodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/FileCodeGroup.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class FileCodeGroup : System.Security.Policy.CodeGroup
     {
@@ -7,10 +11,8 @@
         public override string MergeLogic { get { return default(string); } }
         public override string PermissionSetName { get { return default(string); } }
         public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
-        //    protected override void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
-        public override bool Equals(object o) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        //    protected override void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
         public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
         public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
     }

--- a/src/System.Security.Permissions/src/System/Security/Policy/FileCodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/FileCodeGroup.cs
@@ -1,0 +1,17 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class FileCodeGroup : System.Security.Policy.CodeGroup
+    {
+        public FileCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Permissions.FileIOPermissionAccess access) : base(default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+        public override string AttributeString { get { return default(string); } }
+        public override string MergeLogic { get { return default(string); } }
+        public override string PermissionSetName { get { return default(string); } }
+        public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
+        //    protected override void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
+        public override bool Equals(object o) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        //    protected override void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+        public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/FirstMatchCodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/FirstMatchCodeGroup.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class FirstMatchCodeGroup : System.Security.Policy.CodeGroup
+    {
+        public FirstMatchCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) : base(default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+        public override string MergeLogic { get { return default(string); } }
+        public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
+        public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+        public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/FirstMatchCodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/FirstMatchCodeGroup.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class FirstMatchCodeGroup : System.Security.Policy.CodeGroup
     {

--- a/src/System.Security.Permissions/src/System/Security/Policy/GacInstalled.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/GacInstalled.cs
@@ -1,12 +1,16 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class GacInstalled : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
     {
         public GacInstalled() { }
         public object Copy() { return default(object); }
         public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-        public override bool Equals(object o) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/GacInstalled.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/GacInstalled.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class GacInstalled : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public GacInstalled() { }
+        public object Copy() { return default(object); }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/GacMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/GacMembershipCondition.cs
@@ -1,16 +1,16 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class GacMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
     {
         public GacMembershipCondition() { }
         public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
         public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-        public override bool Equals(object o) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement e) { }
-        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/GacMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/GacMembershipCondition.cs
@@ -1,0 +1,16 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class GacMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public GacMembershipCondition() { }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+        public override bool Equals(object o) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement e) { }
+        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/Hash.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Hash.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class Hash : System.Security.Policy.EvidenceBase /*, System.Runtime.Serialization.ISerializable */
     {
@@ -8,7 +12,6 @@
         public static System.Security.Policy.Hash CreateMD5(byte[] md5) { return default(System.Security.Policy.Hash); }
         public static System.Security.Policy.Hash CreateSHA1(byte[] sha1) { return default(System.Security.Policy.Hash); }
         public byte[] GenerateHash(System.Security.Cryptography.HashAlgorithm hashAlg) { return default(byte[]); }
-        // public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public override string ToString() { return default(string); }
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/Hash.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Hash.cs
@@ -1,0 +1,14 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class Hash : System.Security.Policy.EvidenceBase /*, System.Runtime.Serialization.ISerializable */
+    {
+        public Hash(System.Reflection.Assembly assembly) { }
+        public byte[] MD5 { get { return default(byte[]); } }
+        public byte[] SHA1 { get { return default(byte[]); } }
+        public static System.Security.Policy.Hash CreateMD5(byte[] md5) { return default(System.Security.Policy.Hash); }
+        public static System.Security.Policy.Hash CreateSHA1(byte[] sha1) { return default(System.Security.Policy.Hash); }
+        public byte[] GenerateHash(System.Security.Cryptography.HashAlgorithm hashAlg) { return default(byte[]); }
+        // public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public override string ToString() { return default(string); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/HashMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/HashMembershipCondition.cs
@@ -1,0 +1,20 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class HashMembershipCondition : /* System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable, */ System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public HashMembershipCondition(System.Security.Cryptography.HashAlgorithm hashAlg, byte[] value) { }
+        public System.Security.Cryptography.HashAlgorithm HashAlgorithm { get { return default(System.Security.Cryptography.HashAlgorithm); } set { } }
+        public byte[] HashValue { get { return default(byte[]); } set { } }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+        public override bool Equals(object o) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement e) { }
+        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() { return default(int); }
+        //    void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
+        //    void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public override string ToString() { return default(string); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/HashMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/HashMembershipCondition.cs
@@ -1,20 +1,18 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class HashMembershipCondition : /* System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable, */ System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
     {
         public HashMembershipCondition(System.Security.Cryptography.HashAlgorithm hashAlg, byte[] value) { }
-        public System.Security.Cryptography.HashAlgorithm HashAlgorithm { get { return default(System.Security.Cryptography.HashAlgorithm); } set { } }
-        public byte[] HashValue { get { return default(byte[]); } set { } }
+        public System.Security.Cryptography.HashAlgorithm HashAlgorithm { get; set; }
+        public byte[] HashValue { get; set; }
         public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-        public override bool Equals(object o) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement e) { }
-        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-        public override int GetHashCode() { return default(int); }
-        //    void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-        //    void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public override string ToString() { return default(string); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/IIdentityPermissionFactory.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/IIdentityPermissionFactory.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public partial interface IIdentityPermissionFactory
     {

--- a/src/System.Security.Permissions/src/System/Security/Policy/IIdentityPermissionFactory.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/IIdentityPermissionFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace System.Security.Policy
+{
+    public partial interface IIdentityPermissionFactory
+    {
+        System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence);
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/IMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/IMembershipCondition.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Security.Policy
+{
+    public partial interface IMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable
+    {
+        bool Check(System.Security.Policy.Evidence evidence);
+        System.Security.Policy.IMembershipCondition Copy();
+        bool Equals(object obj);
+        string ToString();
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/IMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/IMembershipCondition.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public partial interface IMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable
     {

--- a/src/System.Security.Permissions/src/System/Security/Policy/NetCodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/NetCodeGroup.cs
@@ -1,0 +1,22 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class NetCodeGroup : System.Security.Policy.CodeGroup
+    {
+        public static readonly string AbsentOriginScheme;
+        public static readonly string AnyOtherOriginScheme;
+        public NetCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition) : base(default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+        public override string AttributeString { get { return default(string); } }
+        public override string MergeLogic { get { return default(string); } }
+        public override string PermissionSetName { get { return default(string); } }
+        public void AddConnectAccess(string originScheme, System.Security.Policy.CodeConnectAccess connectAccess) { }
+        public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
+        //    protected override void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
+        public override bool Equals(object o) { return default(bool); }
+        public System.Collections.DictionaryEntry[] GetConnectAccessRules() { return default(System.Collections.DictionaryEntry[]); }
+        public override int GetHashCode() { return default(int); }
+        //    protected override void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public void ResetConnectAccess() { }
+        public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+        public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/NetCodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/NetCodeGroup.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class NetCodeGroup : System.Security.Policy.CodeGroup
     {
@@ -10,11 +14,9 @@
         public override string PermissionSetName { get { return default(string); } }
         public void AddConnectAccess(string originScheme, System.Security.Policy.CodeConnectAccess connectAccess) { }
         public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
-        //    protected override void CreateXml(System.Security.SecurityElement element, System.Security.Policy.PolicyLevel level) { }
-        public override bool Equals(object o) { return default(bool); }
+        public override bool Equals(object o) => base.Equals(o);
         public System.Collections.DictionaryEntry[] GetConnectAccessRules() { return default(System.Collections.DictionaryEntry[]); }
-        public override int GetHashCode() { return default(int); }
-        //    protected override void ParseXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() => base.GetHashCode();
         public void ResetConnectAccess() { }
         public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
         public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }

--- a/src/System.Security.Permissions/src/System/Security/Policy/PermissionRequestEvidence.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PermissionRequestEvidence.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class PermissionRequestEvidence : System.Security.Policy.EvidenceBase
     {
@@ -7,6 +11,6 @@
         public System.Security.PermissionSet OptionalPermissions { get { return default(System.Security.PermissionSet); } }
         public System.Security.PermissionSet RequestedPermissions { get { return default(System.Security.PermissionSet); } }
         public System.Security.Policy.PermissionRequestEvidence Copy() { return default(System.Security.Policy.PermissionRequestEvidence); }
-        public override string ToString() { return default(string); }
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/PermissionRequestEvidence.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PermissionRequestEvidence.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class PermissionRequestEvidence : System.Security.Policy.EvidenceBase
+    {
+        public PermissionRequestEvidence(System.Security.PermissionSet request, System.Security.PermissionSet optional, System.Security.PermissionSet denied) { }
+        public System.Security.PermissionSet DeniedPermissions { get { return default(System.Security.PermissionSet); } }
+        public System.Security.PermissionSet OptionalPermissions { get { return default(System.Security.PermissionSet); } }
+        public System.Security.PermissionSet RequestedPermissions { get { return default(System.Security.PermissionSet); } }
+        public System.Security.Policy.PermissionRequestEvidence Copy() { return default(System.Security.Policy.PermissionRequestEvidence); }
+        public override string ToString() { return default(string); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/PolicyException.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PolicyException.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Security.Policy
+{
+    public partial class PolicyException : System.SystemException
+    {
+        public PolicyException() { }
+        //    protected PolicyException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public PolicyException(string message) { }
+        public PolicyException(string message, System.Exception exception) { }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/PolicyException.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PolicyException.cs
@@ -1,9 +1,12 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public partial class PolicyException : System.SystemException
     {
         public PolicyException() { }
-        //    protected PolicyException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public PolicyException(string message) { }
         public PolicyException(string message, System.Exception exception) { }
     }

--- a/src/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
@@ -1,0 +1,34 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class PolicyLevel
+    {
+        internal PolicyLevel() { }
+        [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+        public System.Collections.IList FullTrustAssemblies { get { return default(System.Collections.IList); } }
+        public string Label { get { return default(string); } }
+        public System.Collections.IList NamedPermissionSets { get { return default(System.Collections.IList); } }
+        public System.Security.Policy.CodeGroup RootCodeGroup { get { return default(System.Security.Policy.CodeGroup); } set { } }
+        public string StoreLocation { get { return default(string); } }
+        public System.Security.PolicyLevelType Type { get { return default(System.Security.PolicyLevelType); } }
+        [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+        public void AddFullTrustAssembly(System.Security.Policy.StrongName sn) { }
+        [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+        public void AddFullTrustAssembly(System.Security.Policy.StrongNameMembershipCondition snMC) { }
+        public void AddNamedPermissionSet(System.Security.NamedPermissionSet permSet) { }
+        public System.Security.NamedPermissionSet ChangeNamedPermissionSet(string name, System.Security.PermissionSet pSet) { return default(System.Security.NamedPermissionSet); }
+        public static System.Security.Policy.PolicyLevel CreateAppDomainLevel() { return default(System.Security.Policy.PolicyLevel); }
+        //    public void FromXml(System.Security.SecurityElement e) { }
+        public System.Security.NamedPermissionSet GetNamedPermissionSet(string name) { return default(System.Security.NamedPermissionSet); }
+        public void Recover() { }
+        [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+        public void RemoveFullTrustAssembly(System.Security.Policy.StrongName sn) { }
+        [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
+        public void RemoveFullTrustAssembly(System.Security.Policy.StrongNameMembershipCondition snMC) { }
+        public System.Security.NamedPermissionSet RemoveNamedPermissionSet(System.Security.NamedPermissionSet permSet) { return default(System.Security.NamedPermissionSet); }
+        public System.Security.NamedPermissionSet RemoveNamedPermissionSet(string name) { return default(System.Security.NamedPermissionSet); }
+        public void Reset() { }
+        public System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+        public System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class PolicyLevel
     {
@@ -7,7 +11,7 @@
         public System.Collections.IList FullTrustAssemblies { get { return default(System.Collections.IList); } }
         public string Label { get { return default(string); } }
         public System.Collections.IList NamedPermissionSets { get { return default(System.Collections.IList); } }
-        public System.Security.Policy.CodeGroup RootCodeGroup { get { return default(System.Security.Policy.CodeGroup); } set { } }
+        public System.Security.Policy.CodeGroup RootCodeGroup { get; set; }
         public string StoreLocation { get { return default(string); } }
         public System.Security.PolicyLevelType Type { get { return default(System.Security.PolicyLevelType); } }
         [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
@@ -17,7 +21,6 @@
         public void AddNamedPermissionSet(System.Security.NamedPermissionSet permSet) { }
         public System.Security.NamedPermissionSet ChangeNamedPermissionSet(string name, System.Security.PermissionSet pSet) { return default(System.Security.NamedPermissionSet); }
         public static System.Security.Policy.PolicyLevel CreateAppDomainLevel() { return default(System.Security.Policy.PolicyLevel); }
-        //    public void FromXml(System.Security.SecurityElement e) { }
         public System.Security.NamedPermissionSet GetNamedPermissionSet(string name) { return default(System.Security.NamedPermissionSet); }
         public void Recover() { }
         [System.ObsoleteAttribute("All GACed assemblies are now fully trusted and all permissions now succeed on fully trusted code.")]
@@ -29,6 +32,5 @@
         public void Reset() { }
         public System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
         public System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/PolicyStatement.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PolicyStatement.cs
@@ -1,0 +1,18 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class PolicyStatement : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable
+    {
+        public PolicyStatement(System.Security.PermissionSet permSet) { }
+        public PolicyStatement(System.Security.PermissionSet permSet, System.Security.Policy.PolicyStatementAttribute attributes) { }
+        public System.Security.Policy.PolicyStatementAttribute Attributes { get { return default(System.Security.Policy.PolicyStatementAttribute); } set { } }
+        public string AttributeString { get { return default(string); } }
+        public System.Security.PermissionSet PermissionSet { get { return default(System.Security.PermissionSet); } set { } }
+        public System.Security.Policy.PolicyStatement Copy() { return default(System.Security.Policy.PolicyStatement); }
+        public override bool Equals(object obj) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement et) { }
+        //    public void FromXml(System.Security.SecurityElement et, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() { return default(int); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/PolicyStatement.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PolicyStatement.cs
@@ -1,18 +1,18 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class PolicyStatement : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable
     {
         public PolicyStatement(System.Security.PermissionSet permSet) { }
         public PolicyStatement(System.Security.PermissionSet permSet, System.Security.Policy.PolicyStatementAttribute attributes) { }
-        public System.Security.Policy.PolicyStatementAttribute Attributes { get { return default(System.Security.Policy.PolicyStatementAttribute); } set { } }
+        public System.Security.Policy.PolicyStatementAttribute Attributes { get; set; }
         public string AttributeString { get { return default(string); } }
-        public System.Security.PermissionSet PermissionSet { get { return default(System.Security.PermissionSet); } set { } }
-        public System.Security.Policy.PolicyStatement Copy() { return default(System.Security.Policy.PolicyStatement); }
-        public override bool Equals(object obj) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement et) { }
-        //    public void FromXml(System.Security.SecurityElement et, System.Security.Policy.PolicyLevel level) { }
-        public override int GetHashCode() { return default(int); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+        public System.Security.PermissionSet PermissionSet { get; set; }
+        public System.Security.Policy.PolicyStatement Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/PolicyStatementAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PolicyStatementAttribute.cs
@@ -1,4 +1,9 @@
-﻿namespace System.Security.Policy{
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
+{
     [System.FlagsAttribute]
     public enum PolicyStatementAttribute
     {

--- a/src/System.Security.Permissions/src/System/Security/Policy/PolicyStatementAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PolicyStatementAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Security.Policy{
+    [System.FlagsAttribute]
+    public enum PolicyStatementAttribute
+    {
+        All = 3,
+        Exclusive = 1,
+        LevelFinal = 2,
+        Nothing = 0,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/Publisher.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Publisher.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class Publisher : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
     {
@@ -6,8 +10,8 @@
         public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } }
         public object Copy() { return default(object); }
         public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-        public override bool Equals(object o) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/Publisher.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Publisher.cs
@@ -1,0 +1,13 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class Publisher : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public Publisher(System.Security.Cryptography.X509Certificates.X509Certificate cert) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } }
+        public object Copy() { return default(object); }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/PublisherMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PublisherMembershipCondition.cs
@@ -1,0 +1,17 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class PublisherMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public PublisherMembershipCondition(System.Security.Cryptography.X509Certificates.X509Certificate certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } set { } }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+        public override bool Equals(object o) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement e) { }
+        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/PublisherMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PublisherMembershipCondition.cs
@@ -1,17 +1,17 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class PublisherMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
     {
         public PublisherMembershipCondition(System.Security.Cryptography.X509Certificates.X509Certificate certificate) { }
-        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } set { } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get; set; }
         public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-        public override bool Equals(object o) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement e) { }
-        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/Site.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Site.cs
@@ -1,0 +1,14 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class Site : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public Site(string name) { }
+        public string Name { get { return default(string); } }
+        public object Copy() { return default(object); }
+        public static System.Security.Policy.Site CreateFromUrl(string url) { return default(System.Security.Policy.Site); }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/Site.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Site.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class Site : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
     {
@@ -7,8 +11,8 @@
         public object Copy() { return default(object); }
         public static System.Security.Policy.Site CreateFromUrl(string url) { return default(System.Security.Policy.Site); }
         public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-        public override bool Equals(object o) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/SiteMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/SiteMembershipCondition.cs
@@ -1,17 +1,17 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class SiteMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
     {
         public SiteMembershipCondition(string site) { }
-        public string Site { get { return default(string); } set { } }
+        public string Site { get; set; }
         public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
         public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-        public override bool Equals(object o) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement e) { }
-        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/SiteMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/SiteMembershipCondition.cs
@@ -1,0 +1,17 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class SiteMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public SiteMembershipCondition(string site) { }
+        public string Site { get { return default(string); } set { } }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+        public override bool Equals(object o) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement e) { }
+        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/StrongName.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/StrongName.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class StrongName : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
     {
@@ -8,8 +12,8 @@
         public System.Version Version { get { return default(System.Version); } }
         public object Copy() { return default(object); }
         public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-        public override bool Equals(object o) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/StrongName.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/StrongName.cs
@@ -1,0 +1,15 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class StrongName : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public StrongName(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
+        public string Name { get { return default(string); } }
+        public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } }
+        public System.Version Version { get { return default(System.Version); } }
+        public object Copy() { return default(object); }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/StrongNameMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/StrongNameMembershipCondition.cs
@@ -1,0 +1,19 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class StrongNameMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public StrongNameMembershipCondition(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
+        public string Name { get { return default(string); } set { } }
+        public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } set { } }
+        public System.Version Version { get { return default(System.Version); } set { } }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+        public override bool Equals(object o) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement e) { }
+        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/StrongNameMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/StrongNameMembershipCondition.cs
@@ -1,19 +1,19 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class StrongNameMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
     {
         public StrongNameMembershipCondition(System.Security.Permissions.StrongNamePublicKeyBlob blob, string name, System.Version version) { }
-        public string Name { get { return default(string); } set { } }
-        public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get { return default(System.Security.Permissions.StrongNamePublicKeyBlob); } set { } }
-        public System.Version Version { get { return default(System.Version); } set { } }
+        public string Name { get; set; }
+        public System.Security.Permissions.StrongNamePublicKeyBlob PublicKey { get; set; }
+        public System.Version Version { get; set; }
         public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-        public override bool Equals(object o) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement e) { }
-        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/TrustManagerContext.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/TrustManagerContext.cs
@@ -1,0 +1,20 @@
+﻿namespace System.Security.Policy
+{
+    public partial class TrustManagerContext
+    {
+        public TrustManagerContext() { }
+        public TrustManagerContext(System.Security.Policy.TrustManagerUIContext uiContext) { }
+        public virtual bool IgnorePersistedDecision { get { return default(bool); } set { } }
+        public virtual bool KeepAlive { get { return default(bool); } set { } }
+        public virtual bool NoPrompt { get { return default(bool); } set { } }
+        public virtual bool Persist { get { return default(bool); } set { } }
+        //    public virtual System.ApplicationIdentity PreviousApplicationIdentity { get { return default(System.ApplicationIdentity); } set { } }
+        public virtual System.Security.Policy.TrustManagerUIContext UIContext { get { return default(System.Security.Policy.TrustManagerUIContext); } set { } }
+    }
+    public enum TrustManagerUIContext
+    {
+        Install = 0,
+        Run = 2,
+        Upgrade = 1,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/TrustManagerContext.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/TrustManagerContext.cs
@@ -1,15 +1,18 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public partial class TrustManagerContext
     {
         public TrustManagerContext() { }
         public TrustManagerContext(System.Security.Policy.TrustManagerUIContext uiContext) { }
-        public virtual bool IgnorePersistedDecision { get { return default(bool); } set { } }
-        public virtual bool KeepAlive { get { return default(bool); } set { } }
-        public virtual bool NoPrompt { get { return default(bool); } set { } }
-        public virtual bool Persist { get { return default(bool); } set { } }
-        //    public virtual System.ApplicationIdentity PreviousApplicationIdentity { get { return default(System.ApplicationIdentity); } set { } }
-        public virtual System.Security.Policy.TrustManagerUIContext UIContext { get { return default(System.Security.Policy.TrustManagerUIContext); } set { } }
+        public virtual bool IgnorePersistedDecision { get; set; }
+        public virtual bool KeepAlive { get; set; }
+        public virtual bool NoPrompt { get; set; }
+        public virtual bool Persist { get; set; }
+        public virtual System.Security.Policy.TrustManagerUIContext UIContext { get; set; }
     }
     public enum TrustManagerUIContext
     {

--- a/src/System.Security.Permissions/src/System/Security/Policy/UnionCodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/UnionCodeGroup.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class UnionCodeGroup : System.Security.Policy.CodeGroup
     {

--- a/src/System.Security.Permissions/src/System/Security/Policy/UnionCodeGroup.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/UnionCodeGroup.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class UnionCodeGroup : System.Security.Policy.CodeGroup
+    {
+        public UnionCodeGroup(System.Security.Policy.IMembershipCondition membershipCondition, System.Security.Policy.PolicyStatement policy) : base(default(System.Security.Policy.IMembershipCondition), default(System.Security.Policy.PolicyStatement)) { }
+        public override string MergeLogic { get { return default(string); } }
+        public override System.Security.Policy.CodeGroup Copy() { return default(System.Security.Policy.CodeGroup); }
+        public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.PolicyStatement); }
+        public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { return default(System.Security.Policy.CodeGroup); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/Url.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Url.cs
@@ -1,0 +1,13 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class Url : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public Url(string name) { }
+        public string Value { get { return default(string); } }
+        public object Copy() { return default(object); }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/Url.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Url.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class Url : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
     {
@@ -6,8 +10,8 @@
         public string Value { get { return default(string); } }
         public object Copy() { return default(object); }
         public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-        public override bool Equals(object o) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/UrlMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/UrlMembershipCondition.cs
@@ -1,0 +1,17 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class UrlMembershipCondition : System.Security.ISecurityEncodable, System.Security.Policy.IMembershipCondition //System.Security.ISecurityPolicyEncodable
+    {
+        public UrlMembershipCondition(string url) { }
+        public string Url { get { return default(string); } set { } }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+        public override bool Equals(object o) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement e) { }
+        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/UrlMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/UrlMembershipCondition.cs
@@ -1,17 +1,17 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class UrlMembershipCondition : System.Security.ISecurityEncodable, System.Security.Policy.IMembershipCondition //System.Security.ISecurityPolicyEncodable
     {
         public UrlMembershipCondition(string url) { }
-        public string Url { get { return default(string); } set { } }
+        public string Url { get; set; }
         public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
         public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-        public override bool Equals(object o) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement e) { }
-        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+        public override bool Equals(object obj) => base.Equals(obj);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/Zone.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Zone.cs
@@ -1,0 +1,14 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class Zone : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
+    {
+        public Zone(System.Security.SecurityZone zone) { }
+        public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } }
+        public object Copy() { return default(object); }
+        public static System.Security.Policy.Zone CreateFromUrl(string url) { return default(System.Security.Policy.Zone); }
+        public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
+        public override bool Equals(object o) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/Zone.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Zone.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class Zone : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
     {
@@ -7,8 +11,8 @@
         public object Copy() { return default(object); }
         public static System.Security.Policy.Zone CreateFromUrl(string url) { return default(System.Security.Policy.Zone); }
         public System.Security.IPermission CreateIdentityPermission(System.Security.Policy.Evidence evidence) { return default(System.Security.IPermission); }
-        public override bool Equals(object o) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/ZoneMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ZoneMembershipCondition.cs
@@ -1,0 +1,17 @@
+﻿namespace System.Security.Policy
+{
+    public sealed partial class ZoneMembershipCondition : System.Security.ISecurityEncodable, System.Security.Policy.IMembershipCondition
+    {
+        public ZoneMembershipCondition(System.Security.SecurityZone zone) { }
+        public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } set { } }
+        public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
+        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
+        public override bool Equals(object o) { return default(bool); }
+        //    public void FromXml(System.Security.SecurityElement e) { }
+        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
+        public override int GetHashCode() { return default(int); }
+        public override string ToString() { return default(string); }
+        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
+        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Policy/ZoneMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ZoneMembershipCondition.cs
@@ -1,17 +1,17 @@
-﻿namespace System.Security.Policy
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Policy
 {
     public sealed partial class ZoneMembershipCondition : System.Security.ISecurityEncodable, System.Security.Policy.IMembershipCondition
     {
         public ZoneMembershipCondition(System.Security.SecurityZone zone) { }
-        public System.Security.SecurityZone SecurityZone { get { return default(System.Security.SecurityZone); } set { } }
+        public System.Security.SecurityZone SecurityZone { get; set; }
         public bool Check(System.Security.Policy.Evidence evidence) { return default(bool); }
-        public System.Security.Policy.IMembershipCondition Copy() { return default(System.Security.Policy.IMembershipCondition); }
-        public override bool Equals(object o) { return default(bool); }
-        //    public void FromXml(System.Security.SecurityElement e) { }
-        //    public void FromXml(System.Security.SecurityElement e, System.Security.Policy.PolicyLevel level) { }
-        public override int GetHashCode() { return default(int); }
-        public override string ToString() { return default(string); }
-        //    public System.Security.SecurityElement ToXml() { return default(System.Security.SecurityElement); }
-        //    public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { return default(System.Security.SecurityElement); }
+        public System.Security.Policy.IMembershipCondition Copy() { return this; }
+        public override bool Equals(object o) => base.Equals(o);
+        public override int GetHashCode() => base.GetHashCode();
+        public override string ToString() => base.ToString();
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/PolicyLevelType.cs
+++ b/src/System.Security.Permissions/src/System/Security/PolicyLevelType.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Security
+{
+    public enum PolicyLevelType
+    {
+        AppDomain = 3,
+        Enterprise = 2,
+        Machine = 1,
+        User = 0,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/PolicyLevelType.cs
+++ b/src/System.Security.Permissions/src/System/Security/PolicyLevelType.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public enum PolicyLevelType
     {

--- a/src/System.Security.Permissions/src/System/Security/SecurityContext.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityContext.cs
@@ -1,16 +1,18 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public sealed partial class SecurityContext : System.IDisposable
     {
         internal SecurityContext() { }
-        public static System.Security.SecurityContext Capture() { return default(System.Security.SecurityContext); }
-        public System.Security.SecurityContext CreateCopy() { return default(System.Security.SecurityContext); }
-        public void Dispose() { }
-        public static bool IsFlowSuppressed() { return default(bool); }
-        public static bool IsWindowsIdentityFlowSuppressed() { return default(bool); }
-        public static void RestoreFlow() { }
-        public static void Run(System.Security.SecurityContext securityContext, System.Threading.ContextCallback callback, object state) { }
-        //    public static System.Threading.AsyncFlowControl SuppressFlow() { return default(System.Threading.AsyncFlowControl); }
-        //    public static System.Threading.AsyncFlowControl SuppressFlowWindowsIdentity() { return default(System.Threading.AsyncFlowControl); }
+        public static System.Security.SecurityContext Capture() { throw new System.NotSupportedException(); }
+        public System.Security.SecurityContext CreateCopy() { throw new System.NotSupportedException(); }
+        public void Dispose() { throw new System.NotSupportedException(); }
+        public static bool IsFlowSuppressed() { throw new System.NotSupportedException(); }
+        public static bool IsWindowsIdentityFlowSuppressed() { throw new System.NotSupportedException(); }
+        public static void RestoreFlow() { throw new System.NotSupportedException(); }
+        public static void Run(System.Security.SecurityContext securityContext, System.Threading.ContextCallback callback, object state) { throw new System.NotSupportedException(); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/SecurityContext.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityContext.cs
@@ -1,0 +1,16 @@
+﻿namespace System.Security
+{
+    public sealed partial class SecurityContext : System.IDisposable
+    {
+        internal SecurityContext() { }
+        public static System.Security.SecurityContext Capture() { return default(System.Security.SecurityContext); }
+        public System.Security.SecurityContext CreateCopy() { return default(System.Security.SecurityContext); }
+        public void Dispose() { }
+        public static bool IsFlowSuppressed() { return default(bool); }
+        public static bool IsWindowsIdentityFlowSuppressed() { return default(bool); }
+        public static void RestoreFlow() { }
+        public static void Run(System.Security.SecurityContext securityContext, System.Threading.ContextCallback callback, object state) { }
+        //    public static System.Threading.AsyncFlowControl SuppressFlow() { return default(System.Threading.AsyncFlowControl); }
+        //    public static System.Threading.AsyncFlowControl SuppressFlowWindowsIdentity() { return default(System.Threading.AsyncFlowControl); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/SecurityContextSource.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityContextSource.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public enum SecurityContextSource
     {

--- a/src/System.Security.Permissions/src/System/Security/SecurityContextSource.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityContextSource.cs
@@ -1,0 +1,8 @@
+﻿namespace System.Security
+{
+    public enum SecurityContextSource
+    {
+        CurrentAppDomain = 0,
+        CurrentAssembly = 1,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/SecurityCriticalScope.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityCriticalScope.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Security
+{
+    [System.ObsoleteAttribute("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
+    public enum SecurityCriticalScope
+    {
+        Everything = 1,
+        Explicit = 0,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/SecurityCriticalScope.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityCriticalScope.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     [System.ObsoleteAttribute("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
     public enum SecurityCriticalScope

--- a/src/System.Security.Permissions/src/System/Security/SecurityManager.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityManager.cs
@@ -1,0 +1,33 @@
+﻿namespace System.Security
+{
+    public static partial class SecurityManager
+    {
+        [System.ObsoleteAttribute]
+        public static bool CheckExecutionRights { get { return default(bool); } set { } }
+        [System.ObsoleteAttribute("The security manager cannot be turned off on MS runtime")]
+        public static bool SecurityEnabled { get { return default(bool); } set { } }
+        public static void GetZoneAndOrigin(out System.Collections.ArrayList zone, out System.Collections.ArrayList origin) { zone = default(System.Collections.ArrayList); origin = default(System.Collections.ArrayList); }
+        [System.ObsoleteAttribute]
+        public static bool IsGranted(System.Security.IPermission perm) { return default(bool); }
+        [System.ObsoleteAttribute]
+        public static System.Security.Policy.PolicyLevel LoadPolicyLevelFromFile(string path, System.Security.PolicyLevelType type) { return default(System.Security.Policy.PolicyLevel); }
+        [System.ObsoleteAttribute]
+        public static System.Security.Policy.PolicyLevel LoadPolicyLevelFromString(string str, System.Security.PolicyLevelType type) { return default(System.Security.Policy.PolicyLevel); }
+        [System.ObsoleteAttribute]
+        public static System.Collections.IEnumerator PolicyHierarchy() { return default(System.Collections.IEnumerator); }
+        [System.ObsoleteAttribute]
+        public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
+        [System.ObsoleteAttribute]
+        public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence evidence, System.Security.PermissionSet reqdPset, System.Security.PermissionSet optPset, System.Security.PermissionSet denyPset, out System.Security.PermissionSet denied) { denied = default(System.Security.PermissionSet); return default(System.Security.PermissionSet); }
+        [System.ObsoleteAttribute]
+        public static System.Security.PermissionSet ResolvePolicy(System.Security.Policy.Evidence[] evidences) { return default(System.Security.PermissionSet); }
+        [System.ObsoleteAttribute]
+        public static System.Collections.IEnumerator ResolvePolicyGroups(System.Security.Policy.Evidence evidence) { return default(System.Collections.IEnumerator); }
+        [System.ObsoleteAttribute]
+        public static System.Security.PermissionSet ResolveSystemPolicy(System.Security.Policy.Evidence evidence) { return default(System.Security.PermissionSet); }
+        [System.ObsoleteAttribute]
+        public static void SavePolicy() { }
+        [System.ObsoleteAttribute]
+        public static void SavePolicyLevel(System.Security.Policy.PolicyLevel level) { }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/SecurityManager.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityManager.cs
@@ -1,11 +1,15 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public static partial class SecurityManager
     {
         [System.ObsoleteAttribute]
-        public static bool CheckExecutionRights { get { return default(bool); } set { } }
+        public static bool CheckExecutionRights { get; set; }
         [System.ObsoleteAttribute("The security manager cannot be turned off on MS runtime")]
-        public static bool SecurityEnabled { get { return default(bool); } set { } }
+        public static bool SecurityEnabled { get; set; }
         public static void GetZoneAndOrigin(out System.Collections.ArrayList zone, out System.Collections.ArrayList origin) { zone = default(System.Collections.ArrayList); origin = default(System.Collections.ArrayList); }
         [System.ObsoleteAttribute]
         public static bool IsGranted(System.Security.IPermission perm) { return default(bool); }

--- a/src/System.Security.Permissions/src/System/Security/SecurityState.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityState.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Security
+{
+    public abstract partial class SecurityState
+    {
+        protected SecurityState() { }
+        public abstract void EnsureState();
+        public bool IsStateAvailable() { return default(bool); }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/SecurityState.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityState.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public abstract partial class SecurityState
     {

--- a/src/System.Security.Permissions/src/System/Security/SecurityZone.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityZone.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Security
+{
+    public enum SecurityZone
+    {
+        Internet = 3,
+        Intranet = 1,
+        MyComputer = 0,
+        NoZone = -1,
+        Trusted = 2,
+        Untrusted = 4,
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/SecurityZone.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityZone.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public enum SecurityZone
     {

--- a/src/System.Security.Permissions/src/System/Security/XmlSyntaxException.cs
+++ b/src/System.Security.Permissions/src/System/Security/XmlSyntaxException.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Security
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security
 {
     public sealed partial class XmlSyntaxException : System.SystemException
     {

--- a/src/System.Security.Permissions/src/System/Security/XmlSyntaxException.cs
+++ b/src/System.Security.Permissions/src/System/Security/XmlSyntaxException.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Security
+{
+    public sealed partial class XmlSyntaxException : System.SystemException
+    {
+        public XmlSyntaxException() { }
+        public XmlSyntaxException(int lineNumber) { }
+        public XmlSyntaxException(int lineNumber, string message) { }
+        public XmlSyntaxException(string message) { }
+        public XmlSyntaxException(string message, System.Exception inner) { }
+    }
+}

--- a/src/System.Security.Permissions/src/System/SystemException.cs
+++ b/src/System.Security.Permissions/src/System/SystemException.cs
@@ -1,0 +1,6 @@
+﻿namespace System
+{
+    public class SystemException : Exception
+    {
+    }
+}

--- a/src/System.Security.Permissions/src/System/SystemException.cs
+++ b/src/System.Security.Permissions/src/System/SystemException.cs
@@ -1,4 +1,8 @@
-﻿namespace System
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
 {
     public class SystemException : Exception
     {

--- a/src/System.Security.Permissions/src/project.json
+++ b/src/System.Security.Permissions/src/project.json
@@ -1,0 +1,26 @@
+{
+  "frameworks": {
+    "netstandard1.3": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Collections.NonGeneric": "4.0.0",
+        "System.Reflection": "4.1.0",
+        "System.Runtime.Extensions": "4.1.0",
+        "System.Runtime": "4.1.0",
+        "System.Security.AccessControl": "4.0.0",
+        "System.Security.Cryptography.Primitives": "4.0.0",
+        "System.Security.Cryptography.X509Certificates": "4.1.0",
+        "System.Security.Principal": "4.0.0",
+        "System.Threading": "4.0.10"
+      },
+      "imports": [
+        "dotnet5.4"
+      ]
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    }
+  }
+}

--- a/src/System.Security.Permissions/tests/ApplicationTrustTests.cs
+++ b/src/System.Security.Permissions/tests/ApplicationTrustTests.cs
@@ -1,0 +1,31 @@
+﻿using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class ApplicationTrustTests
+    {
+        [Fact]
+        public static void ApplicationTrustCollectionCallMethods()
+        {
+            Policy.ApplicationTrustCollection atc = (Policy.ApplicationTrustCollection) Activator.CreateInstance(typeof(Policy.ApplicationTrustCollection), true);
+            Policy.ApplicationTrust at = new Policy.ApplicationTrust();
+            int testint = atc.Add(at);
+            Policy.ApplicationTrust[] atarray = new Policy.ApplicationTrust[1];
+            atc.AddRange(atarray);
+            atc.AddRange(atc);
+            atc.Clear();
+            atc.CopyTo(atarray, 0);
+            Policy.ApplicationTrustEnumerator ate = atc.GetEnumerator();
+            atc.Remove(at);
+            atc.RemoveRange(atarray);
+            atc.RemoveRange(atc);
+        }
+        [Fact]
+        public static void ApplicationTrustEnumeratorCallMethods()
+        {
+            Policy.ApplicationTrustEnumerator ate = (Policy.ApplicationTrustEnumerator)Activator.CreateInstance(typeof(Policy.ApplicationTrustEnumerator), true);
+            bool testbool = ate.MoveNext();
+            ate.Reset();
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/ApplicationTrustTests.cs
+++ b/src/System.Security.Permissions/tests/ApplicationTrustTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Security.Permissions.Tests
 {
@@ -7,7 +11,7 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void ApplicationTrustCollectionCallMethods()
         {
-            Policy.ApplicationTrustCollection atc = (Policy.ApplicationTrustCollection) Activator.CreateInstance(typeof(Policy.ApplicationTrustCollection), true);
+            Policy.ApplicationTrustCollection atc = (Policy.ApplicationTrustCollection)Activator.CreateInstance(typeof(Policy.ApplicationTrustCollection), true);
             Policy.ApplicationTrust at = new Policy.ApplicationTrust();
             int testint = atc.Add(at);
             Policy.ApplicationTrust[] atarray = new Policy.ApplicationTrust[1];

--- a/src/System.Security.Permissions/tests/CodeConnectAccessTests.cs
+++ b/src/System.Security.Permissions/tests/CodeConnectAccessTests.cs
@@ -1,0 +1,22 @@
+﻿using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class CodeConnectAccessTests
+    {
+        [Fact]
+        public static void CodeConnectAccessCallMethods()
+        {
+            Policy.CodeConnectAccess cca = new Policy.CodeConnectAccess("test", 0);
+            string teststring = Policy.CodeConnectAccess.AnyScheme;
+            int testint = Policy.CodeConnectAccess.DefaultPort;
+            testint = Policy.CodeConnectAccess.OriginPort;
+            teststring = Policy.CodeConnectAccess.OriginScheme;
+            cca = Policy.CodeConnectAccess.CreateAnySchemeAccess(0);
+            cca = Policy.CodeConnectAccess.CreateOriginSchemeAccess(0);
+            cca = new Policy.CodeConnectAccess("test", 0);
+            bool testbool = cca.Equals(new object());
+            testint = cca.GetHashCode();
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/CodeConnectAccessTests.cs
+++ b/src/System.Security.Permissions/tests/CodeConnectAccessTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Security.Permissions.Tests
 {

--- a/src/System.Security.Permissions/tests/CodeGroupTests.cs
+++ b/src/System.Security.Permissions/tests/CodeGroupTests.cs
@@ -1,0 +1,49 @@
+﻿using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class CodeGroupTests
+    {
+        [Fact]
+        public static void FileCodeGroupCallMethods()
+        {
+            Policy.FileCodeGroup fcg = new Policy.FileCodeGroup(new Policy.GacMembershipCondition(), new FileIOPermissionAccess());
+            Policy.CodeGroup cg = fcg.Copy();
+            bool equals = fcg.Equals(new object());
+            int hash = fcg.GetHashCode();
+            Policy.PolicyStatement ps = fcg.Resolve(new Policy.Evidence());
+            cg = fcg.ResolveMatchingCodeGroups(new Policy.Evidence());
+        }
+        [Fact]
+        public static void FirstMatchCodeGroupCallMethods()
+        {
+            Policy.FirstMatchCodeGroup fmcg = new Policy.FirstMatchCodeGroup(new Policy.GacMembershipCondition(), new Policy.PolicyStatement(new PermissionSet(new PermissionState())));
+            Policy.CodeGroup cg = fmcg.Copy();
+            Policy.PolicyStatement ps = fmcg.Resolve(new Policy.Evidence());
+            cg = fmcg.ResolveMatchingCodeGroups(new Policy.Evidence());
+        }
+        [Fact]
+        public static void NetCodeGroupCallMethods()
+        {
+            Policy.NetCodeGroup ncg = new Policy.NetCodeGroup(new Policy.GacMembershipCondition());
+            string teststring = Policy.NetCodeGroup.AbsentOriginScheme;
+            teststring = Policy.NetCodeGroup.AnyOtherOriginScheme;
+            ncg.AddConnectAccess("test", new Policy.CodeConnectAccess("test", 0));
+            Policy.CodeGroup cg = ncg.Copy();
+            bool equals = ncg.Equals(new object());
+            System.Collections.DictionaryEntry[] de = ncg.GetConnectAccessRules();
+            int hash = ncg.GetHashCode();
+            ncg.ResetConnectAccess();
+            Policy.PolicyStatement ps = ncg.Resolve(new Policy.Evidence());
+            cg = ncg.ResolveMatchingCodeGroups(new Policy.Evidence());
+        }
+        [Fact]
+        public static void UnionCodeGroupCallMethods()
+        {
+            Policy.UnionCodeGroup ucg = new Policy.UnionCodeGroup(new Policy.GacMembershipCondition(), new Policy.PolicyStatement(new PermissionSet(new PermissionState())));
+            Policy.CodeGroup cg = ucg.Copy();
+            Policy.PolicyStatement ps = ucg.Resolve(new Policy.Evidence());
+            cg = ucg.ResolveMatchingCodeGroups(new Policy.Evidence());
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/CodeGroupTests.cs
+++ b/src/System.Security.Permissions/tests/CodeGroupTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Security.Permissions.Tests
 {

--- a/src/System.Security.Permissions/tests/EvidenceBaseTests.cs
+++ b/src/System.Security.Permissions/tests/EvidenceBaseTests.cs
@@ -1,0 +1,49 @@
+﻿using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class EvidenceBaseTests
+    {
+        [Fact]
+        public static void ApplicationDirectoryCallMethods()
+        {
+            Policy.ApplicationDirectory ad = new Policy.ApplicationDirectory("test");
+            object obj = ad.Copy();
+            bool check = ad.Equals(new object());
+            int hash = ad.GetHashCode();
+            string str = ad.ToString();
+        }
+        [Fact]
+        public static void ApplicationTrustCallMethods()
+        {
+            Policy.ApplicationTrust at = new Policy.ApplicationTrust();
+        }
+        [Fact]
+        public static void GacInstalledCallMethods()
+        {
+            Policy.GacInstalled gi = new Policy.GacInstalled();
+            object obj = gi.Copy();
+            IPermission ip = gi.CreateIdentityPermission(new Policy.Evidence());
+            bool check = gi.Equals(new object());
+            int hash = gi.GetHashCode();
+            string str = gi.ToString();
+        }
+        [Fact]
+        public static void HashCallMethods()
+        {
+            Policy.Hash hash = new Policy.Hash(Reflection.Assembly.Load(new Reflection.AssemblyName("System.Reflection")));
+            byte[] barr = hash.GenerateHash(Cryptography.SHA1.Create());
+            string str = hash.ToString();
+            hash = Policy.Hash.CreateMD5(new byte[1]);
+            hash = Policy.Hash.CreateSHA1(new byte[1]);
+        }
+        [Fact]
+        public static void PermissionRequestEvidenceCallMethods()
+        {
+            PermissionSet ps = new PermissionSet(new PermissionState());
+            Policy.PermissionRequestEvidence pre = new Policy.PermissionRequestEvidence(ps, ps, ps);
+            Policy.PermissionRequestEvidence obj = pre.Copy();
+            string str = ps.ToString();
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/EvidenceBaseTests.cs
+++ b/src/System.Security.Permissions/tests/EvidenceBaseTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Security.Permissions.Tests
 {

--- a/src/System.Security.Permissions/tests/EvidenceTests.cs
+++ b/src/System.Security.Permissions/tests/EvidenceTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Security.Permissions.Tests
 {

--- a/src/System.Security.Permissions/tests/EvidenceTests.cs
+++ b/src/System.Security.Permissions/tests/EvidenceTests.cs
@@ -1,0 +1,19 @@
+﻿using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class EvidenceTests
+    {
+        [Fact]
+        public static void EvidenceCallMethods()
+        {
+            Policy.Evidence e = new Policy.Evidence();
+            e = new Policy.Evidence(new Policy.Evidence());
+            e.Clear();
+            Policy.Evidence e2 = e.Clone();
+            System.Collections.IEnumerator ie = e.GetAssemblyEnumerator();
+            ie = e.GetHostEnumerator();
+            e.Merge(e2);
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/HostProtectionTests.cs
+++ b/src/System.Security.Permissions/tests/HostProtectionTests.cs
@@ -1,0 +1,20 @@
+﻿using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class HostProtectionTests
+    {
+        [Fact]
+        public static void HostProtectionExceptionCallMethods()
+        {
+            HostProtectionException hpe = new HostProtectionException();
+            hpe.ToString();
+        }
+        [Fact]
+        public static void HostProtectionAttributeCallMethods()
+        {
+            HostProtectionAttribute hpa = new HostProtectionAttribute();
+            IPermission ip = hpa.CreatePermission();
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/HostProtectionTests.cs
+++ b/src/System.Security.Permissions/tests/HostProtectionTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Security.Permissions.Tests
 {

--- a/src/System.Security.Permissions/tests/HostSecurityManagerTests.cs
+++ b/src/System.Security.Permissions/tests/HostSecurityManagerTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Security.Permissions.Tests
 {
@@ -10,7 +14,6 @@ namespace System.Security.Permissions.Tests
             HostSecurityManager hsm = new HostSecurityManager();
             Policy.ApplicationTrust at = hsm.DetermineApplicationTrust(new Policy.Evidence(), new Policy.Evidence(), new Policy.TrustManagerContext());
             Policy.Evidence e = hsm.ProvideAppDomainEvidence(new Policy.Evidence());
-            PermissionSet ps = hsm.ResolvePolicy(new Policy.Evidence());
         }
     }
 }

--- a/src/System.Security.Permissions/tests/HostSecurityManagerTests.cs
+++ b/src/System.Security.Permissions/tests/HostSecurityManagerTests.cs
@@ -1,0 +1,16 @@
+﻿using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class HostSecurityManagerTests
+    {
+        [Fact]
+        public static void CallMethods()
+        {
+            HostSecurityManager hsm = new HostSecurityManager();
+            Policy.ApplicationTrust at = hsm.DetermineApplicationTrust(new Policy.Evidence(), new Policy.Evidence(), new Policy.TrustManagerContext());
+            Policy.Evidence e = hsm.ProvideAppDomainEvidence(new Policy.Evidence());
+            PermissionSet ps = hsm.ResolvePolicy(new Policy.Evidence());
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/MembershipConditionTests.cs
+++ b/src/System.Security.Permissions/tests/MembershipConditionTests.cs
@@ -1,0 +1,78 @@
+﻿using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class MembershipConditionTests
+    {
+        [Fact]
+        public static void AllMembershipConditionCallMethods()
+        {
+            Policy.AllMembershipCondition amc = new Policy.AllMembershipCondition();
+            bool check = amc.Check(new Policy.Evidence());
+            Policy.IMembershipCondition imc = amc.Copy();
+            check = amc.Equals(new object());
+            int hash = amc.GetHashCode();
+            string str = amc.ToString();
+        }
+        [Fact]
+        public static void ApplicationDirectoryMembershipConditionCallMethods()
+        {
+            Policy.ApplicationDirectoryMembershipCondition admc = new Policy.ApplicationDirectoryMembershipCondition();
+            bool check = admc.Check(new Policy.Evidence());
+            Policy.IMembershipCondition obj = admc.Copy();
+            check = admc.Equals(new object());
+            int hash = admc.GetHashCode();
+            string str = admc.ToString();
+        }
+        [Fact]
+        public static void GacMembershipConditionCallMethods()
+        {
+            Policy.GacMembershipCondition gmc = new Policy.GacMembershipCondition();
+            bool check = gmc.Check(new Policy.Evidence());
+            Policy.IMembershipCondition obj = gmc.Copy();
+            check = gmc.Equals(new object());
+            int hash = gmc.GetHashCode();
+            string str = gmc.ToString();
+        }
+        [Fact]
+        public static void HashMembershipConditionCallMethods()
+        {
+            Policy.HashMembershipCondition hmc = new Policy.HashMembershipCondition(Cryptography.SHA1.Create(), new byte[1]);
+            bool check = hmc.Check(new Policy.Evidence());
+            Policy.IMembershipCondition obj = hmc.Copy();
+            check = hmc.Equals(new object());
+            int hash = hmc.GetHashCode();
+            string str = hmc.ToString();
+        }
+        [Fact]
+        public static void PublisherMembershipConditionCallMethods()
+        {
+            Policy.PublisherMembershipCondition pmc = new Policy.PublisherMembershipCondition(new System.Security.Cryptography.X509Certificates.X509Certificate());
+            bool check = pmc.Check(new Policy.Evidence());
+            Policy.IMembershipCondition obj = pmc.Copy();
+            check = pmc.Equals(new object());
+            int hash = pmc.GetHashCode();
+            string str = pmc.ToString();
+        }
+        [Fact]
+        public static void SiteMembershipConditionCallMethods()
+        {
+            Policy.SiteMembershipCondition smc = new Policy.SiteMembershipCondition("test");
+            bool check = smc.Check(new Policy.Evidence());
+            Policy.IMembershipCondition obj = smc.Copy();
+            check = smc.Equals(new object());
+            int hash = smc.GetHashCode();
+            string str = smc.ToString();
+        }
+        [Fact]
+        public static void StrongNameMembershipConditionCallMethods()
+        {
+            Policy.StrongNameMembershipCondition snmc = new Policy.StrongNameMembershipCondition(new StrongNamePublicKeyBlob(new byte[1]), "test", new System.Version(0,1));
+            bool check = snmc.Check(new Policy.Evidence());
+            Policy.IMembershipCondition obj = snmc.Copy();
+            check = snmc.Equals(new object());
+            int hash = snmc.GetHashCode();
+            string str = snmc.ToString();
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/MembershipConditionTests.cs
+++ b/src/System.Security.Permissions/tests/MembershipConditionTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Security.Permissions.Tests
 {
@@ -67,7 +71,7 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void StrongNameMembershipConditionCallMethods()
         {
-            Policy.StrongNameMembershipCondition snmc = new Policy.StrongNameMembershipCondition(new StrongNamePublicKeyBlob(new byte[1]), "test", new System.Version(0,1));
+            Policy.StrongNameMembershipCondition snmc = new Policy.StrongNameMembershipCondition(new StrongNamePublicKeyBlob(new byte[1]), "test", new System.Version(0, 1));
             bool check = snmc.Check(new Policy.Evidence());
             Policy.IMembershipCondition obj = snmc.Copy();
             check = snmc.Equals(new object());

--- a/src/System.Security.Permissions/tests/PermissionSetTests.cs
+++ b/src/System.Security.Permissions/tests/PermissionSetTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Security.Permissions.Tests
 {
@@ -10,11 +14,9 @@ namespace System.Security.Permissions.Tests
             PermissionSet ps = new PermissionSet(new PermissionState());
             ps.Assert();
             bool containspermissions = ps.ContainsNonCodeAccessPermissions();
-            byte[] testbytearray = PermissionSet.ConvertPermissionSet("TestFormat", new byte[1], "TestFormat");
             PermissionSet ps2 = ps.Copy();
             ps.CopyTo(new int[1], 0);
             ps.Demand();
-            ps.Deny();
             ps.Equals(ps2);
             System.Collections.IEnumerator ie = ps.GetEnumerator();
             int hash = ps.GetHashCode();
@@ -22,7 +24,6 @@ namespace System.Security.Permissions.Tests
             bool isempty = ps.IsEmpty();
             bool issubsetof = ps.IsSubsetOf(ps2);
             bool isunrestricted = ps.IsUnrestricted();
-            ps.PermitOnly();
             string s = ps.ToString();
             PermissionSet ps4 = ps.Union(ps2);
         }

--- a/src/System.Security.Permissions/tests/PermissionSetTests.cs
+++ b/src/System.Security.Permissions/tests/PermissionSetTests.cs
@@ -1,0 +1,46 @@
+﻿using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class PermissionSetTests
+    {
+        [Fact]
+        public static void PermissionSetCallMethods()
+        {
+            PermissionSet ps = new PermissionSet(new PermissionState());
+            ps.Assert();
+            bool containspermissions = ps.ContainsNonCodeAccessPermissions();
+            byte[] testbytearray = PermissionSet.ConvertPermissionSet("TestFormat", new byte[1], "TestFormat");
+            PermissionSet ps2 = ps.Copy();
+            ps.CopyTo(new int[1], 0);
+            ps.Demand();
+            ps.Deny();
+            ps.Equals(ps2);
+            System.Collections.IEnumerator ie = ps.GetEnumerator();
+            int hash = ps.GetHashCode();
+            PermissionSet ps3 = ps.Intersect(ps2);
+            bool isempty = ps.IsEmpty();
+            bool issubsetof = ps.IsSubsetOf(ps2);
+            bool isunrestricted = ps.IsUnrestricted();
+            ps.PermitOnly();
+            string s = ps.ToString();
+            PermissionSet ps4 = ps.Union(ps2);
+        }
+        [Fact]
+        public static void PermissionSetAttributeCallMethods()
+        {
+            PermissionSetAttribute psa = new PermissionSetAttribute(new Permissions.SecurityAction());
+            IPermission ip = psa.CreatePermission();
+            PermissionSet ps = psa.CreatePermissionSet();
+        }
+        [Fact]
+        public static void NamedPermissionSetCallMethods()
+        {
+            NamedPermissionSet nps = new NamedPermissionSet("Test");
+            PermissionSet ps = nps.Copy();
+            NamedPermissionSet nps2 = nps.Copy("Test");
+            nps.Equals(nps2);
+            int hash = nps.GetHashCode();
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/PermissionTests.cs
+++ b/src/System.Security.Permissions/tests/PermissionTests.cs
@@ -1,0 +1,270 @@
+﻿using Xunit;
+using System.Reflection;
+
+namespace System.Security.Permissions.Tests
+{
+    public class PermissionTests
+    {
+        [Fact]
+        public static void EnvironmentPermissionCallMethods()
+        {
+            EnvironmentPermission ep = new EnvironmentPermission(new Permissions.EnvironmentPermissionAccess(), "testpath");
+            ep.AddPathList(new Permissions.EnvironmentPermissionAccess(), "testpath");
+            string path = ep.GetPathList(new Permissions.EnvironmentPermissionAccess());
+            bool isunrestricted = ep.IsUnrestricted();
+            ep.SetPathList(new Permissions.EnvironmentPermissionAccess(), "testpath2");
+        }
+        [Fact]
+        public static void EnvironmentPermissionsAttributeCallMethods()
+        {
+            EnvironmentPermissionAttribute epa = new EnvironmentPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = epa.CreatePermission();
+
+        }
+        [Fact]
+        public static void FileDialogPermissionCallMethods()
+        {
+            FileDialogPermission fdp = new FileDialogPermission(new Permissions.FileDialogPermissionAccess());
+            IPermission ip = fdp.Copy();
+            IPermission ip2 = fdp.Intersect(ip);
+            bool issubset = fdp.IsSubsetOf(ip);
+            bool isunrestricted = fdp.IsUnrestricted();
+            IPermission ip3 = fdp.Union(ip2);
+        }
+        [Fact]
+        public static void FileDialogPermissionAttributeCallMethods()
+        {
+            FileDialogPermissionAttribute fspa = new FileDialogPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = fspa.CreatePermission();
+        }
+        [Fact]
+        public static void FileIOPermissionCallMethods()
+        {
+            FileIOPermissionAccess fiopa = new Permissions.FileIOPermissionAccess();
+            FileIOPermission fiop = new FileIOPermission(fiopa, "testpath");
+            FileIOPermission fiop2 = new FileIOPermission(new Permissions.PermissionState());
+            fiop.AddPathList(fiopa, "testpath");
+            fiop.AddPathList(fiopa, new string[1] {"testpath"});
+            IPermission ip = fiop.Copy();
+            fiop.Equals(new object());
+            int hash = fiop.GetHashCode();
+            string[] pathlist = fiop.GetPathList(fiopa);
+            IPermission ip2 = fiop.Intersect(ip);
+            fiop.IsSubsetOf(ip);
+            bool isunrestricted = fiop.IsUnrestricted();
+            fiop.SetPathList(fiopa, "testpath");
+            fiop.SetPathList(fiopa, new string[1] { "testpath" });
+            IPermission ip3 = fiop.Union(ip);
+        }
+        [Fact]
+        public static void GacIdentityPermissionCallMethods()
+        {
+            GacIdentityPermission gip = new GacIdentityPermission();
+            IPermission ip = gip.Copy();
+            IPermission ip2 = gip.Intersect(ip);
+            bool issubset = gip.IsSubsetOf(ip);
+            IPermission ip3 = gip.Union(ip2);
+        }
+        [Fact]
+        public static void GacIdentityPermissionAttributeCallMethods()
+        {
+            GacIdentityPermissionAttribute gipa = new GacIdentityPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = gipa.CreatePermission();
+        }
+        [Fact]
+        public static void PrincipalPermissionCallMethods()
+        {
+            PrincipalPermission pp = new PrincipalPermission(new Permissions.PermissionState());
+            PrincipalPermission pp2 = new PrincipalPermission("name", "role");
+            PrincipalPermission pp3 = new PrincipalPermission("name", "role", true);
+            IPermission ip = pp.Copy();
+            pp.Demand();
+            bool testbool = pp.Equals(new object());
+            int testint = pp.GetHashCode();
+            IPermission ip2 = pp.Intersect(ip);
+            testbool = pp.IsSubsetOf(ip);
+            testbool = pp.IsUnrestricted();
+            string teststring = pp.ToString();
+            ip2 = pp.Union(ip);
+        }
+        [Fact]
+        public static void PrincipalPermissionAttributeCallMethods()
+        {
+            PrincipalPermissionAttribute ppa = new PrincipalPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = ppa.CreatePermission();
+        }
+        [Fact]
+        public static void PublisherIdentityPermissionCallMethods()
+        {
+            PublisherIdentityPermission pip = new PublisherIdentityPermission(new System.Security.Cryptography.X509Certificates.X509Certificate());
+            PublisherIdentityPermission pip2 = new PublisherIdentityPermission(new Permissions.PermissionState());
+            IPermission ip = pip.Copy();
+            IPermission ip2 = pip.Intersect(ip);
+            bool testbool = pip.IsSubsetOf(ip);
+            ip2 = pip.Union(ip);
+        }
+        [Fact]
+        public static void PublisherIdentityPermissionAttributeCallMethods()
+        {
+            PublisherIdentityPermissionAttribute pipa = new PublisherIdentityPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = pipa.CreatePermission();
+        }
+        [Fact]
+        public static void ReflectionPermissionCallMethods()
+        {
+            ReflectionPermission rp = new ReflectionPermission(new Permissions.PermissionState());
+            ReflectionPermission rp2 = new ReflectionPermission(new Permissions.ReflectionPermissionFlag());
+            IPermission ip = rp.Copy();
+            IPermission ip2 = rp.Intersect(ip);
+            bool testbool = rp.IsSubsetOf(ip);
+            testbool = rp.IsUnrestricted();
+            ip2 = rp.Union(ip);
+        }
+        [Fact]
+        public static void ReflectionPermissionAttributeCallMethods()
+        {
+            ReflectionPermissionAttribute rpa = new ReflectionPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = rpa.CreatePermission();
+        }
+        [Fact]
+        public static void RegistryPermissionCallMethods()
+        {
+            Permissions.RegistryPermissionAccess rpa = new Permissions.RegistryPermissionAccess();
+            RegistryPermission rp = new RegistryPermission(new Permissions.PermissionState());
+            RegistryPermission rp2 = new RegistryPermission(rpa, new System.Security.AccessControl.AccessControlActions(), "testpath");
+            RegistryPermission rp3 = new RegistryPermission(rpa, "testpath");
+            rp.AddPathList(rpa, "testpath");
+            IPermission ip = rp.Copy();
+            string path = rp.GetPathList(rpa);
+            IPermission ip2 = rp.Intersect(ip);
+            bool testbool = rp.IsSubsetOf(ip);
+            testbool = rp.IsUnrestricted();
+            rp.SetPathList(rpa, "testpath");
+            ip2 = rp.Union(ip);
+        }
+        [Fact]
+        public static void RegistryPermissionAttributeCallMethods()
+        {
+            RegistryPermissionAttribute rpa = new RegistryPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = rpa.CreatePermission();
+        }
+        [Fact]
+        public static void SecurityPermissionCallMethods()
+        {
+            SecurityPermission sp = new SecurityPermission(new Permissions.PermissionState());
+            SecurityPermission sp2 = new SecurityPermission(new Permissions.SecurityPermissionFlag());
+            IPermission ip = sp.Copy();
+            IPermission ip2 = sp.Intersect(ip);
+            bool testbool = sp.IsSubsetOf(ip);
+            testbool = sp.IsUnrestricted();
+            ip2 = sp.Union(ip);
+        }
+        [Fact]
+        public static void SecurityPermissionAttributeCallMethods()
+        {
+            SecurityPermissionAttribute spa = new SecurityPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = spa.CreatePermission();
+        }
+        [Fact]
+        public static void SiteIdentityPermissionCallMethods()
+        {
+            SiteIdentityPermission sip = new SiteIdentityPermission(new Permissions.PermissionState());
+            SiteIdentityPermission sip2 = new SiteIdentityPermission("testsite");
+            IPermission ip = sip.Copy();
+            IPermission ip2 = sip.Intersect(ip);
+            bool testbool = sip.IsSubsetOf(ip);
+            ip2 = sip.Union(ip);
+        }
+        [Fact]
+        public static void SiteIdentityPermissionAttributeCallMethods()
+        {
+            SiteIdentityPermissionAttribute sipa = new SiteIdentityPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = sipa.CreatePermission();
+        }
+        [Fact]
+        public static void StrongNameIdentityPermissionCallMethods()
+        {
+            StrongNameIdentityPermission snip = new StrongNameIdentityPermission(new Permissions.PermissionState());
+            StrongNameIdentityPermission snip2 = new StrongNameIdentityPermission(new Permissions.StrongNamePublicKeyBlob(new byte[1]), "test", new System.Version(1, 2));
+            IPermission ip = snip.Copy();
+            IPermission ip2 = snip.Intersect(ip);
+            bool testbool = snip.IsSubsetOf(ip);
+            ip2 = snip.Union(ip);
+        }
+        [Fact]
+        public static void StrongNameIdentityPermissionAttributeCallMethods()
+        {
+            StrongNameIdentityPermissionAttribute snipa = new StrongNameIdentityPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = snipa.CreatePermission();
+        }
+        [Fact]
+        public static void StrongNamePublicKeyBlobTests()
+        {
+            StrongNamePublicKeyBlob snpkb = new StrongNamePublicKeyBlob(new byte[1]);
+            bool testbool = snpkb.Equals(new object());
+            int hash = snpkb.GetHashCode();
+            string teststring = snpkb.ToString();
+        }
+        [Fact]
+        public static void TypeDescriptorPermissionCallMethods()
+        {
+            TypeDescriptorPermission tdp = new TypeDescriptorPermission(new PermissionState());
+            TypeDescriptorPermission tdp2 = new TypeDescriptorPermission(new TypeDescriptorPermissionFlags());
+            IPermission ip = tdp.Copy();
+            IPermission ip2 = tdp.Intersect(ip);
+            bool testbool = tdp.IsSubsetOf(ip);
+            testbool = tdp.IsUnrestricted();
+            ip2 = tdp.Union(ip);
+        }
+        [Fact]
+        public static void UIPermissionCallMethods()
+        {
+            UIPermission uip = new UIPermission(new PermissionState());
+            UIPermission uip2 = new UIPermission(new UIPermissionClipboard());
+            UIPermission uip3 = new UIPermission(new UIPermissionWindow());
+            UIPermission uip4 = new UIPermission(new UIPermissionWindow(), new UIPermissionClipboard());
+            IPermission ip = uip.Copy();
+            IPermission ip2 = uip.Intersect(ip);
+            bool testbool = uip.IsSubsetOf(ip);
+            testbool = uip.IsUnrestricted();
+            ip2 = uip.Union(ip);
+        }
+        [Fact]
+        public static void UIPermissionAttributeCallMethods()
+        {
+            UIPermissionAttribute uipa = new UIPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = uipa.CreatePermission();
+        }
+        [Fact]
+        public static void UrlIdentityPermissionCallMethods()
+        {
+            UrlIdentityPermission uip = new UrlIdentityPermission(new PermissionState());
+            UrlIdentityPermission uip2 = new UrlIdentityPermission("testsite");
+            IPermission ip = uip.Copy();
+            IPermission ip2 = uip.Intersect(ip);
+            bool testbool = uip.IsSubsetOf(ip);
+            ip2 = uip.Union(ip);
+        }
+        [Fact]
+        public static void UrlIdentityPermissionAttributeCallMethods()
+        {
+            UrlIdentityPermissionAttribute uipa = new UrlIdentityPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = uipa.CreatePermission();
+        }
+        [Fact]
+        public static void ZoneIdentityPermissionCallMethods()
+        {
+            ZoneIdentityPermission zip = new ZoneIdentityPermission(new PermissionState());
+            ZoneIdentityPermission zip2 = new ZoneIdentityPermission(new SecurityZone());
+            IPermission ip = zip.Copy();
+            IPermission ip2 = zip.Intersect(ip);
+            bool testbool = zip.IsSubsetOf(ip);
+        }
+        [Fact]
+        public static void ZoneIdentityPermissionAttributeCallMethods()
+        {
+            ZoneIdentityPermissionAttribute zipa = new ZoneIdentityPermissionAttribute(new Permissions.SecurityAction());
+            IPermission ip = zipa.CreatePermission();
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/PermissionTests.cs
+++ b/src/System.Security.Permissions/tests/PermissionTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 using System.Reflection;
 
 namespace System.Security.Permissions.Tests
@@ -19,7 +23,6 @@ namespace System.Security.Permissions.Tests
         {
             EnvironmentPermissionAttribute epa = new EnvironmentPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = epa.CreatePermission();
-
         }
         [Fact]
         public static void FileDialogPermissionCallMethods()
@@ -44,7 +47,7 @@ namespace System.Security.Permissions.Tests
             FileIOPermission fiop = new FileIOPermission(fiopa, "testpath");
             FileIOPermission fiop2 = new FileIOPermission(new Permissions.PermissionState());
             fiop.AddPathList(fiopa, "testpath");
-            fiop.AddPathList(fiopa, new string[1] {"testpath"});
+            fiop.AddPathList(fiopa, new string[1] { "testpath" });
             IPermission ip = fiop.Copy();
             fiop.Equals(new object());
             int hash = fiop.GetHashCode();
@@ -78,7 +81,6 @@ namespace System.Security.Permissions.Tests
             PrincipalPermission pp2 = new PrincipalPermission("name", "role");
             PrincipalPermission pp3 = new PrincipalPermission("name", "role", true);
             IPermission ip = pp.Copy();
-            pp.Demand();
             bool testbool = pp.Equals(new object());
             int testint = pp.GetHashCode();
             IPermission ip2 = pp.Intersect(ip);

--- a/src/System.Security.Permissions/tests/PolicyTests.cs
+++ b/src/System.Security.Permissions/tests/PolicyTests.cs
@@ -1,0 +1,39 @@
+﻿using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class PolicyTests
+    {
+        [Fact]
+        public static void PolicyExceptionCallMethods()
+        {
+            Policy.PolicyException pe = new Policy.PolicyException();
+            pe = new Policy.PolicyException("test");
+        }
+        [Fact]
+        public static void PolicyLevelCallMethods()
+        {
+            Policy.PolicyLevel pl = (Policy.PolicyLevel)Activator.CreateInstance(typeof(Policy.PolicyLevel), true);
+            NamedPermissionSet nps = new NamedPermissionSet("test");
+            pl.AddNamedPermissionSet(nps);
+            nps = pl.ChangeNamedPermissionSet("test", new PermissionSet(new Permissions.PermissionState()));
+            Policy.PolicyLevel.CreateAppDomainLevel();
+            nps = pl.GetNamedPermissionSet("test");
+            pl.Recover();
+            NamedPermissionSet nps2 = pl.RemoveNamedPermissionSet(nps);
+            nps2 = pl.RemoveNamedPermissionSet("test");
+            pl.Reset();
+            Policy.Evidence evidence = new Policy.Evidence();
+            Policy.PolicyStatement ps = pl.Resolve(evidence);
+            Policy.CodeGroup cg = pl.ResolveMatchingCodeGroups(evidence);
+        }
+    [Fact]
+        public static void PolicyStatementCallMethods()
+        {
+            Policy.PolicyStatement ps = new Policy.PolicyStatement(new PermissionSet(new PermissionState()));
+            Policy.PolicyStatement ps2 = ps.Copy();
+            bool equals = ps.Equals(ps2);
+            int hash = ps.GetHashCode();
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/PolicyTests.cs
+++ b/src/System.Security.Permissions/tests/PolicyTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Security.Permissions.Tests
 {
@@ -27,7 +31,7 @@ namespace System.Security.Permissions.Tests
             Policy.PolicyStatement ps = pl.Resolve(evidence);
             Policy.CodeGroup cg = pl.ResolveMatchingCodeGroups(evidence);
         }
-    [Fact]
+        [Fact]
         public static void PolicyStatementCallMethods()
         {
             Policy.PolicyStatement ps = new Policy.PolicyStatement(new PermissionSet(new PermissionState()));

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.builds
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.Numerics.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.Security.Permissions.Tests</RootNamespace>
+    <AssemblyName>System.Security.Permissions.Tests</AssemblyName>
+    <NugetTargetMoniker>.NETStandard,Version=v1.6</NugetTargetMoniker>
+    <ProjectGuid>{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}</ProjectGuid>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Compile tests against the System.Runtime contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="..\pkg\System.Security.Permissions.pkgproj">
+      <Name>System.Security.Permissions</Name>
+      <!-- Don't copy the reference assembly to output -->
+      <Private>false</Private>
+      <UndefineProperties>OSGroup</UndefineProperties>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Security.Permissions.csproj">
+      <Name>System.Runtime</Name>
+      <!-- Don't reference implementation assembly, but do deploy it. -->
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ApplicationTrustTests.cs" />
+    <Compile Include="CodeConnectAccessTests.cs" />
+    <Compile Include="EvidenceTests.cs" />
+    <Compile Include="CodeGroupTests.cs" />
+    <Compile Include="MembershipConditionTests.cs" />
+    <Compile Include="EvidenceBaseTests.cs" />
+    <Compile Include="PolicyTests.cs" />
+    <Compile Include="TrustManagerContextTests.cs" />
+    <Compile Include="PermissionSetTests.cs" />
+    <Compile Include="PermissionTests.cs" />
+    <Compile Include="HostSecurityManagerTests.cs" />
+    <Compile Include="HostProtectionTests.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Permissions/tests/TrustManagerContextTests.cs
+++ b/src/System.Security.Permissions/tests/TrustManagerContextTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Security.Permissions.Tests
 {

--- a/src/System.Security.Permissions/tests/TrustManagerContextTests.cs
+++ b/src/System.Security.Permissions/tests/TrustManagerContextTests.cs
@@ -1,0 +1,14 @@
+﻿using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class TrustManagerContextTests
+    {
+        [Fact]
+        public static void TrustManagerContextCallMethods()
+        {
+            Policy.TrustManagerContext tmc = new Policy.TrustManagerContext();
+            tmc = new Policy.TrustManagerContext(new Policy.TrustManagerUIContext());
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/project.json
+++ b/src/System.Security.Permissions/tests/project.json
@@ -1,0 +1,29 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.2-beta-24224-02",
+    "System.Collections": "4.0.12-beta-24224-02",
+    "System.Console": "4.0.1-beta-24224-02",
+    "System.Globalization": "4.0.12-beta-24224-02",
+    "System.Linq.Expressions": "4.1.1-beta-24224-02",
+    "System.ObjectModel": "4.0.13-beta-24224-02",
+    "System.Runtime": "4.1.1-beta-24224-02",
+    "System.Runtime.Extensions": "4.1.1-beta-24224-02",
+    "System.Text.RegularExpressions": "4.2.0-beta-24224-02",
+    "System.Threading.Tasks": "4.0.12-beta-24224-02",
+    "System.Security.AccessControl": "4.0.0",
+    "System.Security.Cryptography.Primitives": "4.0.0",
+    "System.Security.Cryptography.X509Certificates": "4.1.0",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.6": {}
+  },
+  "supports": {
+    "coreFx.Test.netcoreapp1.0": {},
+  }
+}

--- a/src/System.Security.Principal/System.Security.Principal.sln
+++ b/src/System.Security.Principal/System.Security.Principal.sln
@@ -1,9 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Principal", "src\System.Security.Principal.csproj", "{FBE16BC8-AE2D-422C-861E-861814F53AF7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{4E760F4E-8D14-4E84-B982-C07CE5D577DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Principal", "ref\System.Security.Principal.csproj", "{DD4C4D55-5089-46E7-8D93-339EAF35FE2E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +19,15 @@ Global
 		{FBE16BC8-AE2D-422C-861E-861814F53AF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FBE16BC8-AE2D-422C-861E-861814F53AF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FBE16BC8-AE2D-422C-861E-861814F53AF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD4C4D55-5089-46E7-8D93-339EAF35FE2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD4C4D55-5089-46E7-8D93-339EAF35FE2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD4C4D55-5089-46E7-8D93-339EAF35FE2E}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD4C4D55-5089-46E7-8D93-339EAF35FE2E}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{DD4C4D55-5089-46E7-8D93-339EAF35FE2E} = {4E760F4E-8D14-4E84-B982-C07CE5D577DC}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Security.Principal/ref/System.Security.Principal.cs
+++ b/src/System.Security.Principal/ref/System.Security.Principal.cs
@@ -27,4 +27,8 @@ namespace System.Security.Principal
         Impersonation = 3,
         None = 0,
     }
+    public class SecurityElement
+    {
+
+    }
 }


### PR DESCRIPTION
- Creates System.Security.Permissions contract
- Adds types (and their members) that were in Xamarin but not .NET Core from namespaces System.Security, System.Security.Permissions, System.Security.Policy
- Added basic method tests

Resolves #9482
@danmosemsft @ellismg 