### PR TITLE
Remove automatic curl Expect header if the request disabled it

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -621,6 +621,14 @@ namespace System.Net.Http
                     ThrowOOMIfFalse(Interop.Http.SListAppend(slist, NoTransferEncoding));
                 }
 
+                // Since libcurl adds an Expect header if it sees enough post data, we need to explicitly block
+                // it if caller specifically does not want to set the header
+                if (_requestMessage.Headers.ExpectContinue.HasValue &&
+                    !_requestMessage.Headers.ExpectContinue.Value)
+                {
+                    ThrowOOMIfFalse(Interop.Http.SListAppend(slist, NoExpect));
+                }
+
                 if (!slist.IsInvalid)
                 {
                     SafeCurlSListHandle prevList = _requestHeaders;

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -101,6 +101,7 @@ namespace System.Net.Http
         private const int MaxRequestBufferSize = 16384; // Default used by libcurl
         private const string NoTransferEncoding = HttpKnownHeaderNames.TransferEncoding + ":";
         private const string NoContentType = HttpKnownHeaderNames.ContentType + ":";
+        private const string NoExpect = HttpKnownHeaderNames.Expect + ":";
         private const int CurlAge = 5;
         private const int MinCurlAge = 3;
 


### PR DESCRIPTION
Attempts to fix #10051, but having issues with the full build on my machine.  Cannot verify it passes all tests but we are running it in production and it seems to work.