### PR TITLE
Added Json type for DbTypes

### DIFF
--- a/src/System.Data.Common/src/System/Data/DbType.cs
+++ b/src/System.Data.Common/src/System/Data/DbType.cs
@@ -37,5 +37,6 @@ namespace System.Data
         Xml = 25,
         DateTime2 = 26,
         DateTimeOffset = 27,
+        Json = 28,
     }
 }


### PR DESCRIPTION
/cc @saurabh500
As MySQL 5.7 has supported json field.(and PostgreSQL has already supported json type) We need a new db type. I am just implementing the MySQL provider for EF Core. There is no type for json blocked my works https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/11
Thanks.