### PR TITLE
Adding ITuple interface and implementation in ValueTuple

### DIFF
--- a/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
@@ -920,7 +920,7 @@ namespace System
         }
         #endregion
 
-        private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct =>
+        private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct, ITuple =>
             new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
 
         private static Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLongRef<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) =>

--- a/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
@@ -141,12 +141,12 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Length => 0;
+        int ITuple.Length => 0;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        public object this[int index]
+        object ITuple.this[int index]
         {
             get
             {
@@ -451,12 +451,12 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Length => 1;
+        int ITuple.Length => 1;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        public object this[int index]
+        object ITuple.this[int index]
         {
             get
             {
@@ -654,12 +654,12 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Length => 2;
+        int ITuple.Length => 2;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        public object this[int index]
+        object ITuple.this[int index]
         {
             get
             {
@@ -857,12 +857,12 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Length => 3;
+        int ITuple.Length => 3;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        public object this[int index]
+        object ITuple.this[int index]
         {
             get
             {
@@ -1079,12 +1079,12 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Length => 4;
+        int ITuple.Length => 4;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        public object this[int index]
+        object ITuple.this[int index]
         {
             get
             {
@@ -1320,12 +1320,12 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Length => 5;
+        int ITuple.Length => 5;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        public object this[int index]
+        object ITuple.this[int index]
         {
             get
             {
@@ -1580,12 +1580,12 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Length => 6;
+        int ITuple.Length => 6;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        public object this[int index]
+        object ITuple.this[int index]
         {
             get
             {
@@ -1859,12 +1859,12 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Length => 7;
+        int ITuple.Length => 7;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        public object this[int index]
+        object ITuple.this[int index]
         {
             get
             {
@@ -1904,7 +1904,7 @@ namespace System
     /// <typeparam name="TRest">The type of the tuple's eigth component.</typeparam>
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, ITupleInternal, ITuple
-        where TRest : struct
+        where TRest : struct, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's first component.
@@ -2272,19 +2272,18 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Length
+        int ITuple.Length
         {
             get
             {
-                ITupleInternal rest = Rest as ITupleInternal;
-                return rest == null ? 8 : 7 + rest.Length;
+                return 7 + ((ITuple)Rest).Length;
             }
         }
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        public object this[int index]
+        object ITuple.this[int index]
         {
             get
             {
@@ -2306,15 +2305,7 @@ namespace System
                         return Item7;
                 }
 
-                ITupleInternal rest = Rest as ITupleInternal;
-                if (index > 0 && index < Length && rest != null)
-                {
-                    return rest[index - 7];
-                }
-                else
-                {
-                    throw new IndexOutOfRangeException();
-                }
+                return ((ITuple)Rest)[index - 7];
             }
         }
     }

--- a/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
@@ -2276,7 +2276,7 @@ namespace System
         {
             get
             {
-                return 7 + ((ITuple)Rest).Length;
+                return 7 + Rest.Length;
             }
         }
 
@@ -2305,7 +2305,7 @@ namespace System
                         return Item7;
                 }
 
-                return ((ITuple)Rest)[index - 7];
+                return Rest[index - 7];
             }
         }
     }

--- a/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
@@ -9,12 +9,27 @@ using System.Diagnostics;
 namespace System
 {
     /// <summary>
+    /// This interface is required for types that want to be indexed into by dynamic patterns.
+    /// </summary>
+    public interface ITuple
+    {
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int Size { get; }
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object this[int index] { get; }
+    }
+
+    /// <summary>
     /// Helper so we can call some tuple methods recursively without knowing the underlying types.
     /// </summary>
-    internal interface ITupleInternal
+    internal interface ITupleInternal : ITuple
     {
         int GetHashCode(IEqualityComparer comparer);
-        int Size { get; }
         string ToStringEnd();
     }
 
@@ -27,7 +42,7 @@ namespace System
     /// - their members (such as Item1, Item2, etc) are fields rather than properties.
     /// </summary>
     public struct ValueTuple
-        : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, ITupleInternal
+        : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, ITupleInternal, ITuple
     {
         /// <summary>
         /// Returns a value that indicates whether the current <see cref="ValueTuple"/> instance is equal to a specified object.
@@ -69,7 +84,7 @@ namespace System
         /// <returns>
         /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
         /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
-        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
         public int CompareTo(ValueTuple other)
@@ -123,7 +138,21 @@ namespace System
             return ")";
         }
 
-        int ITupleInternal.Size => 0;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        public int Size => 0;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        public object this[int index]
+        {
+            get
+            {
+                throw new IndexOutOfRangeException();
+            }
+        }
 
         /// <summary>Creates a new struct 0-tuple.</summary>
         /// <returns>A 0-tuple.</returns>
@@ -282,7 +311,7 @@ namespace System
     /// <summary>Represents a 1-tuple, or singleton, as a value type.</summary>
     /// <typeparam name="T1">The type of the tuple's only component.</typeparam>
     public struct ValueTuple<T1>
-        : IEquatable<ValueTuple<T1>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1>>, ITupleInternal
+        : IEquatable<ValueTuple<T1>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1>>, ITupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1}"/> instance's first component.
@@ -359,7 +388,7 @@ namespace System
         /// <returns>
         /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
         /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
-        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
         public int CompareTo(ValueTuple<T1> other)
@@ -419,7 +448,25 @@ namespace System
             return Item1?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 1;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        public int Size => 1;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        public object this[int index]
+        {
+            get
+            {
+                if (index != 0)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+                return Item1;
+            }
+        }
     }
 
     /// <summary>
@@ -428,7 +475,7 @@ namespace System
     /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
     /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
     public struct ValueTuple<T1, T2>
-        : IEquatable<ValueTuple<T1, T2>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2>>, ITupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2}"/> instance's first component.
@@ -530,7 +577,7 @@ namespace System
         /// <returns>
         /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
         /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
-        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
         public int CompareTo(ValueTuple<T1, T2> other)
@@ -604,7 +651,29 @@ namespace System
             return Item1?.ToString() + ", " + Item2?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 2;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        public int Size => 2;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        public object this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -614,7 +683,7 @@ namespace System
     /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
     /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
     public struct ValueTuple<T1, T2, T3>
-        : IEquatable<ValueTuple<T1, T2, T3>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2, T3>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3>>, ITupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's first component.
@@ -705,7 +774,7 @@ namespace System
         /// <returns>
         /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
         /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
-        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3> other)
@@ -785,7 +854,31 @@ namespace System
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 3;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        public int Size => 3;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        public object this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -796,7 +889,7 @@ namespace System
     /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
     /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
     public struct ValueTuple<T1, T2, T3, T4>
-        : IEquatable<ValueTuple<T1, T2, T3, T4>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2, T3, T4>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4>>, ITupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's first component.
@@ -895,7 +988,7 @@ namespace System
         /// <returns>
         /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
         /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
-        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3, T4> other)
@@ -983,7 +1076,33 @@ namespace System
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 4;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        public int Size => 4;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        public object this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -995,7 +1114,7 @@ namespace System
     /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
     /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
     public struct ValueTuple<T1, T2, T3, T4, T5>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5>>, ITupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's first component.
@@ -1102,7 +1221,7 @@ namespace System
         /// <returns>
         /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
         /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
-        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3, T4, T5> other)
@@ -1198,7 +1317,35 @@ namespace System
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 5;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        public int Size => 5;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        public object this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -1211,7 +1358,7 @@ namespace System
     /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
     /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
     public struct ValueTuple<T1, T2, T3, T4, T5, T6>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6>>, ITupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's first component.
@@ -1326,7 +1473,7 @@ namespace System
         /// <returns>
         /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
         /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
-        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6> other)
@@ -1430,7 +1577,37 @@ namespace System
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 6;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        public int Size => 6;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        public object this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -1444,7 +1621,7 @@ namespace System
     /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
     /// <typeparam name="T7">The type of the tuple's seventh component.</typeparam>
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ITupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's first component.
@@ -1567,7 +1744,7 @@ namespace System
         /// <returns>
         /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
         /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
-        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
@@ -1679,7 +1856,39 @@ namespace System
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 7;
+        /// <summary>
+        ///
+        /// </summary>
+        public int Size => 7;
+
+        /// <summary>
+        ///
+        /// </summary>
+        public object this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    case 6:
+                        return Item7;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -1694,7 +1903,7 @@ namespace System
     /// <typeparam name="T7">The type of the tuple's seventh component.</typeparam>
     /// <typeparam name="TRest">The type of the tuple's eigth component.</typeparam>
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, ITupleInternal, ITuple
         where TRest : struct
     {
         /// <summary>
@@ -1831,7 +2040,7 @@ namespace System
         /// <returns>
         /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
         /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
-        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
@@ -2060,12 +2269,52 @@ namespace System
             }
         }
 
-        int ITupleInternal.Size
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        public int Size
         {
             get
             {
                 ITupleInternal rest = Rest as ITupleInternal;
                 return rest == null ? 8 : 7 + rest.Size;
+            }
+        }
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        public object this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    case 6:
+                        return Item7;
+                }
+
+                ITupleInternal rest = Rest as ITupleInternal;
+                if (index > 0 && index < Size && rest != null)
+                {
+                    return rest[index - 7];
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException();
+                }
             }
         }
     }

--- a/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
@@ -16,7 +16,7 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        int Size { get; }
+        int Length { get; }
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
@@ -141,7 +141,7 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Size => 0;
+        public int Length => 0;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
@@ -451,7 +451,7 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Size => 1;
+        public int Length => 1;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
@@ -654,7 +654,7 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Size => 2;
+        public int Length => 2;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
@@ -857,7 +857,7 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Size => 3;
+        public int Length => 3;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
@@ -1079,7 +1079,7 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Size => 4;
+        public int Length => 4;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
@@ -1320,7 +1320,7 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Size => 5;
+        public int Length => 5;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
@@ -1580,7 +1580,7 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Size => 6;
+        public int Length => 6;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
@@ -1857,12 +1857,12 @@ namespace System
         }
 
         /// <summary>
-        ///
+        /// The number of positions in this data structure.
         /// </summary>
-        public int Size => 7;
+        public int Length => 7;
 
         /// <summary>
-        ///
+        /// Get the element at position <param name="index"/>.
         /// </summary>
         public object this[int index]
         {
@@ -2123,7 +2123,7 @@ namespace System
                                                    EqualityComparer<T7>.Default.GetHashCode(Item7));
             }
 
-            int size = rest.Size;
+            int size = rest.Length;
             if (size >= 8) { return rest.GetHashCode(); }
 
             // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
@@ -2195,7 +2195,7 @@ namespace System
                                                    comparer.GetHashCode(Item7));
             }
 
-            int size = rest.Size;
+            int size = rest.Length;
             if (size >= 8) { return rest.GetHashCode(comparer); }
 
             // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
@@ -2272,12 +2272,12 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        public int Size
+        public int Length
         {
             get
             {
                 ITupleInternal rest = Rest as ITupleInternal;
-                return rest == null ? 8 : 7 + rest.Size;
+                return rest == null ? 8 : 7 + rest.Length;
             }
         }
 
@@ -2307,7 +2307,7 @@ namespace System
                 }
 
                 ITupleInternal rest = Rest as ITupleInternal;
-                if (index > 0 && index < Size && rest != null)
+                if (index > 0 && index < Length && rest != null)
                 {
                     return rest[index - 7];
                 }

--- a/src/System.ValueTuple/tests/ValueTuple/UnitTests.cs
+++ b/src/System.ValueTuple/tests/ValueTuple/UnitTests.cs
@@ -724,6 +724,11 @@ public class ValueTupleTests
         Assert.Throws<ArgumentException>(() => ((IStructuralComparable)a).CompareTo("string", DummyTestComparer.Instance));
 
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, )", CreateLong(1, 2, 3, 4, 5, 6, 7, new ValueTuple()).ToString());
+
+        ITuple it = ValueTuple.Create();
+        Assert.Throws<IndexOutOfRangeException>(() => it[-1]);
+        Assert.Throws<IndexOutOfRangeException>(() => it[0]);
+        Assert.Throws<IndexOutOfRangeException>(() => it[1]);
     }
 
     [Fact]
@@ -748,6 +753,11 @@ public class ValueTupleTests
         var tupleWithNull = new Tuple<string>(null);
         Assert.Equal("()", vtWithNull.ToString());
         Assert.Equal(tupleWithNull.ToString(), vtWithNull.ToString());
+
+        ITuple it = ValueTuple.Create(1);
+        Assert.Throws<IndexOutOfRangeException>(() => it[-1]);
+        Assert.Equal(1, it[0]);
+        Assert.Throws<IndexOutOfRangeException>(() => it[1]);
     }
 
     [Fact]
@@ -773,6 +783,12 @@ public class ValueTupleTests
         var tupleWithNull = new Tuple<string, string>(null, null);
         Assert.Equal("(, )", vtWithNull.ToString());
         Assert.Equal(tupleWithNull.ToString(), vtWithNull.ToString());
+
+        ITuple it = ValueTuple.Create(1, 2);
+        Assert.Throws<IndexOutOfRangeException>(() => it[-1]);
+        Assert.Equal(1, it[0]);
+        Assert.Equal(2, it[1]);
+        Assert.Throws<IndexOutOfRangeException>(() => it[2]);
     }
 
     [Fact]
@@ -800,6 +816,13 @@ public class ValueTupleTests
         var tupleWithNull = new Tuple<string, string, string>(null, null, null);
         Assert.Equal("(, , )", vtWithNull.ToString());
         Assert.Equal(tupleWithNull.ToString(), vtWithNull.ToString());
+
+        ITuple it = ValueTuple.Create(1, 2, 3);
+        Assert.Throws<IndexOutOfRangeException>(() => it[-1]);
+        Assert.Equal(1, it[0]);
+        Assert.Equal(2, it[1]);
+        Assert.Equal(3, it[2]);
+        Assert.Throws<IndexOutOfRangeException>(() => it[3]);
     }
 
     [Fact]
@@ -830,6 +853,14 @@ public class ValueTupleTests
         var tupleWithNull = new Tuple<string, string, string, string>(null, null, null, null);
         Assert.Equal("(, , , )", vtWithNull.ToString());
         Assert.Equal(tupleWithNull.ToString(), vtWithNull.ToString());
+
+        ITuple it = ValueTuple.Create(1, 2, 3, 4);
+        Assert.Throws<IndexOutOfRangeException>(() => it[-1]);
+        Assert.Equal(1, it[0]);
+        Assert.Equal(2, it[1]);
+        Assert.Equal(3, it[2]);
+        Assert.Equal(4, it[3]);
+        Assert.Throws<IndexOutOfRangeException>(() => it[4]);
     }
 
     [Fact]
@@ -862,6 +893,15 @@ public class ValueTupleTests
         var tupleWithNull = new Tuple<string, string, string, string, string>(null, null, null, null, null);
         Assert.Equal("(, , , , )", vtWithNull.ToString());
         Assert.Equal(tupleWithNull.ToString(), vtWithNull.ToString());
+
+        ITuple it = ValueTuple.Create(1, 2, 3, 4, 5);
+        Assert.Throws<IndexOutOfRangeException>(() => it[-1]);
+        Assert.Equal(1, it[0]);
+        Assert.Equal(2, it[1]);
+        Assert.Equal(3, it[2]);
+        Assert.Equal(4, it[3]);
+        Assert.Equal(5, it[4]);
+        Assert.Throws<IndexOutOfRangeException>(() => it[5]);
     }
 
     [Fact]
@@ -896,6 +936,16 @@ public class ValueTupleTests
         var tupleWithNull = new Tuple<string, string, string, string, string, string>(null, null, null, null, null, null);
         Assert.Equal("(, , , , , )", vtWithNull.ToString());
         Assert.Equal(tupleWithNull.ToString(), vtWithNull.ToString());
+
+        ITuple it = ValueTuple.Create(1, 2, 3, 4, 5, 6);
+        Assert.Throws<IndexOutOfRangeException>(() => it[-1]);
+        Assert.Equal(1, it[0]);
+        Assert.Equal(2, it[1]);
+        Assert.Equal(3, it[2]);
+        Assert.Equal(4, it[3]);
+        Assert.Equal(5, it[4]);
+        Assert.Equal(6, it[5]);
+        Assert.Throws<IndexOutOfRangeException>(() => it[6]);
     }
 
     [Fact]
@@ -932,6 +982,17 @@ public class ValueTupleTests
         var tupleWithNull = new Tuple<string, string, string, string, string, string, string>(null, null, null, null, null, null, null);
         Assert.Equal("(, , , , , , )", vtWithNull.ToString());
         Assert.Equal(tupleWithNull.ToString(), vtWithNull.ToString());
+
+        ITuple it = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7);
+        Assert.Throws<IndexOutOfRangeException>(() => it[-1]);
+        Assert.Equal(1, it[0]);
+        Assert.Equal(2, it[1]);
+        Assert.Equal(3, it[2]);
+        Assert.Equal(4, it[3]);
+        Assert.Equal(5, it[4]);
+        Assert.Equal(6, it[5]);
+        Assert.Equal(7, it[6]);
+        Assert.Throws<IndexOutOfRangeException>(() => it[7]);
     }
 
     public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct =>
@@ -1009,6 +1070,18 @@ public class ValueTupleTests
         var tupleWithNull = new Tuple<string, string, string, string, string, string, string, Tuple<string>>(null, null, null, null, null, null, null, new Tuple<string>(null));
         Assert.Equal("(, , , , , , , )", vtWithNull.ToString());
         Assert.Equal(tupleWithNull.ToString(), vtWithNull.ToString());
+
+        ITuple it = CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8));
+        Assert.Throws<IndexOutOfRangeException>(() => it[-1]);
+        Assert.Equal(1, it[0]);
+        Assert.Equal(2, it[1]);
+        Assert.Equal(3, it[2]);
+        Assert.Equal(4, it[3]);
+        Assert.Equal(5, it[4]);
+        Assert.Equal(6, it[5]);
+        Assert.Equal(7, it[6]);
+        Assert.Equal(8, it[7]);
+        Assert.Throws<IndexOutOfRangeException>(() => it[8]);
     }
 
     [Fact]
@@ -1088,6 +1161,17 @@ public class ValueTupleTests
         Assert.Equal(((IStructuralEquatable)ValueTuple.Create(1, 0, 0, 0, 0, 0, 0)).GetHashCode(TestEqualityComparer.Instance), ((IStructuralEquatable)d).GetHashCode(TestEqualityComparer.Instance));
 
         Assert.Equal("(1, 2, 3, 4, 5, 6, 7, 1, 0, 0, 0, 0, 0, 0, 42)", CreateLong(1, 2, 3, 4, 5, 6, 7, d).ToString());
+
+        ITuple it = d;
+        Assert.Throws<IndexOutOfRangeException>(() => it[-1]);
+        Assert.Equal(1, it[0]);
+        Assert.Equal(0, it[1]);
+        Assert.Equal(0, it[2]);
+        Assert.Equal(0, it[3]);
+        Assert.Equal(0, it[4]);
+        Assert.Equal(0, it[5]);
+        Assert.Equal(0, it[6]);
+        Assert.Throws<IndexOutOfRangeException>(() => it[7]);
     }
 
     private class TestClass : IComparable


### PR DESCRIPTION
Re-opening the discussion following C# language design meeting yesterday.

The purpose of this interface is to allow objects to be used in positional pattern matching.
`ValueTuple` is the first type to implement it.

From discussion with LDM yesterday, it seems that existing collection interfaces (IReadOnlyCollection and IReadOnlyList) don't fit the purpose. We feel there should be no iterator involved. Also we need an interface as a marker to identify types that are suitable for such usage.
We are still having some debate on the proper name for this interface (ITuple, IDeconstructable, IIndexable, ...).
I renamed `Size` to be `Length` to avoid introducing a new term.