### PR TITLE
Allow TupleElementNamesAttribute on events

### DIFF
--- a/src/System.ValueTuple/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
+++ b/src/System.ValueTuple/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
@@ -9,7 +9,7 @@ namespace System.Runtime.CompilerServices
     /// <summary>
     /// Indicates that the use of <see cref="System.ValueTuple"/> on a member is meant to be treated as a tuple with element names.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Class | AttributeTargets.Struct )]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Event )]
     public sealed class TupleElementNamesAttribute : Attribute
     {
         private readonly string[] _transformNames;

--- a/src/System.ValueTuple/tests/TupleElementNamesAttribute/UnitTests.cs
+++ b/src/System.ValueTuple/tests/TupleElementNamesAttribute/UnitTests.cs
@@ -40,9 +40,13 @@ public class TupleElementNamesAttributeTests
     [TupleElementNames(new string[] { null, "name1", "name2" })]
     public static object AppliedToProperty2 { get; set; }
 
+    [event: TupleElementNames]
+    public static event Func<int> AppliedToEvent;
+
     [return: TupleElementNames]
     public static void AppliedToReturn()
     {
+        AppliedToEvent();
     }
 
     [TupleElementNames]


### PR DESCRIPTION
We realized that one AttributeTarget was missing.

@stephentoub for review
FYI for @agocke 