### PR TITLE
Fix bugs on EnvelopedCms.Encrypt on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Cms.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Cms.cs
@@ -110,7 +110,7 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsCompleteMessage")]
         internal static extern int CmsCompleteMessage(SafeCmsHandle cms, SafeBioHandle data, bool detached);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsAddOriginatorCert")]
-        internal static extern int CmsAddOriginatorCert(SafeCmsHandle cms, SafeX509Handle originatorCert);
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsSetEmbeddedContentType")]
+        internal static extern int CmsSetEmbeddedContentType(SafeCmsHandle cms, SafeAsn1ObjectHandle oid);
     }
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_cms.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_cms.cpp
@@ -298,16 +298,6 @@ extern "C" int CryptoNative_CmsAddIssuerAndSerialRecipient(CMS_ContentInfo* cms,
     return (CMS_add1_recipient_cert(cms, cert, 0) == nullptr) ? 0 : 1;
 }
 
-extern "C" int CryptoNative_CmsAddOriginatorCert(CMS_ContentInfo* cms, X509* cert)
-{
-    if (cms == nullptr || cert == nullptr)
-    {
-        return -1;
-    }
-
-    return CMS_add1_cert(cms, cert);
-}
-
 extern "C" int CryptoNative_CmsCompleteMessage(CMS_ContentInfo* cms, BIO* data, bool detached)
 {
     if (cms == nullptr || data == nullptr)
@@ -336,4 +326,14 @@ extern "C" int CryptoNative_CmsGetDerSize(CMS_ContentInfo* cms)
 extern "C" int CryptoNative_CmsEncode(CMS_ContentInfo* cms, uint8_t* buf)
 {
     return i2d_CMS_ContentInfo(cms, &buf);
+}
+
+extern "C" int CryptoNative_CmsSetEmbeddedContentType(CMS_ContentInfo* cms, ASN1_OBJECT* oid)
+{
+    if (cms == nullptr || oid == nullptr)
+    {
+        return -1;
+    }
+
+    return CMS_set1_eContentType(cms, oid);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_cms.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_cms.h
@@ -82,15 +82,6 @@ Status is set to 1 on success, 0 on unsupported algorithm, and -1 on invalid inp
 extern "C" CMS_ContentInfo* CryptoNative_CmsInitializeEnvelope(ASN1_OBJECT* algorithmOid, int32_t* status);
 
 /*
-Adds an originator certificate to the CMS_ContentInfo structure. If the CMS_ContentInfo structure
-is of type EnvelopedData it will be added to OriginatorInfo, and for SignedData it will be added to
-the certificates.
-
-Returns 1 on success, 0 on OpenSSL failure, and -1 on invalid input.
-*/
-extern "C" int CryptoNative_CmsAddOriginatorCert(CMS_ContentInfo* cms, X509* cert);
-
-/*
 Creates a KeyTransportRecipientInfo using the IssuerAndSerial identification method for
 the provided certificate and adds it to the CMS_ContentInfo structure.
 
@@ -124,3 +115,10 @@ extern "C" int CryptoNative_CmsGetDerSize(CMS_ContentInfo* cms);
 Shims the i2d_CMS_ContentInfo method.
 */
 extern "C" int CryptoNative_CmsEncode(CMS_ContentInfo* cms, uint8_t* buf);
+
+/*
+Shims the CMS_set1_eContentType method.
+
+Returns -1 on invalid input, 0 on OpenSSL error, and 1 on success.
+*/
+extern "C" int CryptoNative_CmsSetEmbeddedContentType(CMS_ContentInfo* cms, ASN1_OBJECT* oid);

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -147,6 +147,9 @@
   <data name="Cryptography_Cms_KeyAgreementPlatformNotSupported" xml:space="preserve">
     <value>This platform does not support encrypting for KeyAgreement recipients.</value>
   </data>
+  <data name="Cryptography_Cms_AddOriginatorCertsPlatformNotSupported" xml:space="preserve">
+    <value>This platform does not support encoding originator certificates in an Enveloped CMS.</value>
+  </data>
   <data name="Cryptography_Cms_Key_Agree_Date_Not_Available" xml:space="preserve">
     <value>The Date property is not available for none KID key agree recipient.</value>
   </data>

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -68,7 +68,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_SignedWithinEnveloped()
         {

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -119,7 +119,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Fact]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void ZeroLengthContent_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(Array.Empty<byte>());


### PR DESCRIPTION
+ The content enveloped would always get marked as Pkcs7Data, even if the
content was of another type. Now it reflects the type of the DER blob being
embedded.

+ Made the behavior of an empty enveloped message be consistent with the Windows
implementation.

+ Added PlatformNotSupportedException for adding originator certificates
during encryption due to lack of support from OpenSSL.

@bartonjs @weshaggard 