### PR TITLE
Use newer linux kernel for some outer-loop jobs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -230,6 +230,12 @@ def osShortName = ['Windows 10': 'win10',
             if (os == 'Windows_NT' || os == 'OSX') {
                 Utilities.setMachineAffinity(newJob, os, "latest-or-auto-elevated")
             }
+            if (os == 'Ubuntu16.04') {
+                Utilities.setMachineAffinity(newJob, os, "outer-linux462")
+            }
+            if (os == 'Centos7.1') {
+                Utilities.setMachineAffinity(newJob, os, "outer-linux464")
+            }
             else if (osGroupMap[os] == 'Linux') {
                 Utilities.setMachineAffinity(newJob, os, 'outer-latest-or-auto')
             } else {


### PR DESCRIPTION
Ubuntu 16.04: Linux 4.6.2
Centos 7.1: Linux 4.6.4

Needs this first: https://github.com/dotnet/dotnet-ci/pull/368

The current version of the CLI we are pulling down with init-tools.sh seems to still have the seg-fault that prompted this testing. So we may also want to wait for our CLI version to get updated before pulling this in.

Addresses #10076 

@joshfree , @Priya91 , @mmitche 