### PR TITLE
Cleans up TupleElementNamesAttribute

### DIFF
--- a/src/System.ValueTuple/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
+++ b/src/System.ValueTuple/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
@@ -9,6 +9,7 @@ namespace System.Runtime.CompilerServices
     /// <summary>
     /// Indicates that the use of <see cref="System.ValueTuple"/> on a member is meant to be treated as a tuple with element names.
     /// </summary>
+    [CLSCompliant(false)]
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Event )]
     public sealed class TupleElementNamesAttribute : Attribute
     {

--- a/src/System.ValueTuple/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
+++ b/src/System.ValueTuple/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
@@ -15,21 +15,26 @@ namespace System.Runtime.CompilerServices
         private readonly string[] _transformNames;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TupleElementNamesAttribute"/> class.
+        /// Initializes a new instance of the <see
+        /// cref="TupleElementNamesAttribute"/> class.
         /// </summary>
         /// <param name="transformNames">
-        /// Specifies, in a prefix traversal of a type's
-        /// construction, which <see cref="System.ValueType"/> occurrences are meant to 
-        /// carry element names.
+        /// Specifies, in a pre-order depth-first traversal of a type's
+        /// construction, which <see cref="System.ValueType"/> occurrences are
+        /// meant to carry element names.
         /// </param>
         /// <remarks>
-        /// This constructor is meant to be used on types that are built on an underlying
-        /// occurrence of <see cref="System.ValueType"/> that is meant to carry element names.
-        /// For instance, if <c>C</c> is a generic type with two type parameters, then a
-        /// use of the constructed type <c>C{<see cref="System.ValueTuple{T1, T2}"/>, <see cref="System.ValueTuple{T1, T2, T3}"/></c>
-        /// might be intended to treat the first type argument as a tuple with element names
-        /// and the second as a tuple without element names. In which case, the appropriate attribute
-        /// specification should use <c>transformNames</c> value of <c>{ "name1", "name2", null }</c>.
+        /// This constructor is meant to be used on types that contain an
+        /// instantiation of <see cref="System.ValueType"/> that contains
+        /// element names.  For instance, if <c>C</c> is a generic type with
+        /// two type parameters, then a use of the constructed type <c>C{<see
+        /// cref="System.ValueTuple{T1, T2}"/>, <see
+        /// cref="System.ValueTuple{T1, T2, T3}"/></c> might be intended to
+        /// treat the first type argument as a tuple with element names and the
+        /// second as a tuple without element names. In which case, the
+        /// appropriate attribute specification should use a
+        /// <c>transformNames</c> value of <c>{ "name1", "name2", null, null,
+        /// null }</c>.
         /// </remarks>
         public TupleElementNamesAttribute(string[] transformNames)
         {
@@ -42,21 +47,9 @@ namespace System.Runtime.CompilerServices
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TupleElementNamesAttribute"/> class.
-        /// </summary>
-        /// <remarks>
-        /// When <see cref="TupleElementNamesAttribute"/> is created with this constructor,
-        /// it can be omitted instead.
-        /// </remarks>
-        public TupleElementNamesAttribute()
-        {
-            _transformNames = new string[] { };
-        }
-
-        /// <summary>
-        /// Specifies, in a prefix traversal of a type's
-        /// construction, which <see cref="System.ValueTuple"/> occurrences are meant to
-        /// carry element names.
+        /// Specifies, in a pre-order depth-first traversal of a type's
+        /// construction, which <see cref="System.ValueTuple"/> elements are
+        /// meant to carry element names.
         /// </summary>
         public IList<string> TransformNames => _transformNames;
     }

--- a/src/System.ValueTuple/tests/TupleElementNamesAttribute/UnitTests.cs
+++ b/src/System.ValueTuple/tests/TupleElementNamesAttribute/UnitTests.cs
@@ -9,14 +9,6 @@ using Xunit;
 public class TupleElementNamesAttributeTests
 {
     [Fact]
-    public static void DefaultConstructor()
-    {
-        var attribute = new TupleElementNamesAttribute();
-        Assert.NotNull(attribute.TransformNames);
-        Assert.Equal(0, attribute.TransformNames.Count);
-    }
-
-    [Fact]
     public static void Constructor()
     {
         var attribute = new TupleElementNamesAttribute(new string[] { "name1", "name2" });
@@ -26,38 +18,26 @@ public class TupleElementNamesAttributeTests
         Assert.Throws<ArgumentNullException>(() => new TupleElementNamesAttribute(null));
     }
 
-    [TupleElementNames]
+    [TupleElementNames(new string[] { null, "name1", "name2" })]
     public object appliedToField = null;
 
+    public static void AppliedToParameter([TupleElementNames(new string[] { "name1", null })] object parameter) { }
+
     [TupleElementNames(new string[] { null, "name1", "name2" })]
-    public object appliedToField2 = null;
-
-    public static void AppliedToParameter([TupleElementNames] object parameter, [TupleElementNames(new string[] { "name1", null })] object parameter2) { }
-
-    [TupleElementNames]
     public static object AppliedToProperty { get; set; }
 
-    [TupleElementNames(new string[] { null, "name1", "name2" })]
-    public static object AppliedToProperty2 { get; set; }
-
-    [event: TupleElementNames]
+    [event: TupleElementNames(new[] { null, "name1", "name2" })]
     public static event Func<int> AppliedToEvent;
 
-    [return: TupleElementNames]
+    [return: TupleElementNames(new[] { null, "name1", "name2" })]
     public static void AppliedToReturn()
     {
         AppliedToEvent();
     }
-
-    [TupleElementNames]
+    
+    [TupleElementNames(new string[] { null, "name1", "name2" })]
     public class AppliedToClass { }
-    
-    [TupleElementNames(new string[] { null, "name1", "name2" })]
-    public class AppliedToClass2 { }
 
-    [TupleElementNames]
-    public struct AppliedToStruct { }
-    
     [TupleElementNames(new string[] { null, "name1", "name2" })]
-    public class AppliedToStruct2 { }
+    public class AppliedToStruct { }
 }


### PR DESCRIPTION
The TupleElementNamesAttribute had an unused and incorrect constructor which
has been removed and some incorrect comments which have been updated.

/cc @stephentoub @jcouv @VSadov @jaredpar @dotnet/roslyn-compiler 