### PR TITLE
Fix two WebSocket issues on Unix

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -14,8 +14,8 @@
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
     <!-- // uncomment to use the managed "unix" implementation on Windows
-      <TargetsWindows>false</TargetsWindows>
-      <TargetsUnix>true</TargetsUnix>
+      <TargetsWindows Condition="'$(TargetGroup)' == ''">false</TargetsWindows>
+      <TargetsUnix Condition="'$(TargetGroup)' == ''">true</TargetsUnix>
     -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' and '$(ProjectJson)' == '' ">

--- a/src/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Net.Test.Common;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -243,6 +244,69 @@ namespace System.Net.WebSockets.Client.Tests
                 string closeDescription = null;
 
                 await cws.CloseOutputAsync(closeStatus, closeDescription, cts.Token);
+            }
+        }
+
+        [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
+        public async Task CloseOutputAsync_DuringConcurrentReceiveAsync_ExpectedStates(Uri server)
+        {
+            var receiveBuffer = new byte[1024];
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                // Issue a receive but don't wait for it.
+                var t = cws.ReceiveAsync(new ArraySegment<byte>(receiveBuffer), CancellationToken.None);
+                Assert.False(t.IsCompleted);
+                Assert.Equal(WebSocketState.Open, cws.State);
+
+                // Send a close frame.  After this completes, the state could be CloseSent if we haven't
+                // yet received the server response close frame, or it could be CloseReceived if we have.
+                await cws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                Assert.True(
+                    cws.State == WebSocketState.CloseSent || cws.State == WebSocketState.CloseReceived,
+                    $"Expected CloseSent or CloseReceived, got {cws.State}");
+
+                // Then wait for the receive.  After this completes, the state is most likely CloseReceived,
+                // however there is a race condition between the our realizing that the send has completed
+                // and a fast server sending back a close frame, such that we could end up noticing the
+                // receive completion before we notice the send completion.
+                WebSocketReceiveResult r = await t;
+                Assert.Equal(WebSocketMessageType.Close, r.MessageType);
+                Assert.True(
+                    cws.State == WebSocketState.CloseSent || cws.State == WebSocketState.CloseReceived,
+                    $"Expected CloseSent or CloseReceived, got {cws.State}");
+
+                // Then close
+                await cws.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                Assert.Equal(WebSocketState.Closed, cws.State);
+
+                // Another close should fail
+                await Assert.ThrowsAsync<WebSocketException>(() => cws.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None));
+            }
+        }
+
+        [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
+        public async Task CloseAsync_DuringConcurrentReceiveAsync_ExpectedStates(Uri server)
+        {
+            var receiveBuffer = new byte[1024];
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var t = cws.ReceiveAsync(new ArraySegment<byte>(receiveBuffer), CancellationToken.None);
+                Assert.False(t.IsCompleted);
+
+                await cws.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+
+                // There is a race condition in the above.  If the ReceiveAsync receives the sent close message from the server,
+                // then it will complete successfully and the socket will close successfully.  If the CloseAsync receive the sent
+                // close message from the server, then the receive async will end up getting aborted along with the socket.
+                try
+                {
+                    await t;
+                    Assert.Equal(WebSocketState.Closed, cws.State);
+                }
+                catch (WebSocketException)
+                {
+                    Assert.Equal(WebSocketState.Aborted, cws.State);
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes two issues in our managed ClientWebSocket implementation, both of which stemmed from a misunderstanding on my part of how things were supposed to work (or not work):
- I thought that if the WebSocket was already in a CloseSent state and then received a close frame that it should transition to Closed.  Instead, it's supposed to transition to CloseReceived.  Similarly, I thought a WebSocket that was already in a CloseReceived state and then sent a close frame was supposed to transition to Closed.  Instead, it's supposed to transition to CloseSent.  The WebSocket is only supposed to transition to Closed when the connection is closed, e.g. as part of CloseAsync after a close frame has been both sent and received.
- I thought that ReceiveAsync could only be used concurrently with a SendAsync.  Turns out we need to support it being used concurrently with a Close{Output}Async.

This commit fixes both.
Fixes https://github.com/dotnet/corefx/issues/9985
cc: @mconnew, @davidsh, @cipop, @ericeil