### PR TITLE
Fix FileStream.Flush on Unix when wrapping non-synchronizable descriptors

### DIFF
--- a/src/System.IO.FileSystem/tests/FileStream/Flush.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Flush.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Win32.SafeHandles;
+using System.IO.Pipes;
 using Xunit;
 
 namespace System.IO.Tests
@@ -127,6 +129,23 @@ namespace System.IO.Tests
                 fs.Flush();
                 Assert.True(fs.LastFlushArg.HasValue);
                 Assert.False(fs.LastFlushArg.Value);
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void FlushCanBeUsedOnPipes_Success(bool? flushToDisk)
+        {
+            using (var pipeStream = new AnonymousPipeServerStream(PipeDirection.In))
+            using (var clientHandle = pipeStream.ClientSafePipeHandle)
+            {
+                SafeFileHandle handle = new SafeFileHandle((IntPtr)int.Parse(pipeStream.GetClientHandleAsString()), false);
+                using (FileStream fs = new FileStream(handle, FileAccess.Write, 1, false))
+                {
+                    Flush(fs, flushToDisk);
+                }
             }
         }
 


### PR DESCRIPTION
FileStream can be used with any arbitrary file descriptor on Unix.  FileStream.Flush may use FSync to try to synchronize the file's state with the storage device, but that only makes sense and works for certain kinds of file descriptors.  For other file descriptors, currently we're throwing an exception if the operation fails, when really we should just ignore the failure, as there's no work to be done.

Fixes https://github.com/dotnet/corefx/issues/10084
cc: @agoretsky, @ianhays, @JeremyKuhne 