### PR TITLE
Port Stream.CopyTo changes from CoreCLR

### DIFF
--- a/src/System.IO/src/System/IO/Stream.cs
+++ b/src/System.IO/src/System/IO/Stream.cs
@@ -94,7 +94,38 @@ namespace System.IO
 
         public Task CopyToAsync(Stream destination)
         {
-            return CopyToAsync(destination, DefaultCopyBufferSize);
+            int bufferSize = DefaultCopyBufferSize;
+
+            if (CanSeek)
+            {
+                long length = Length;
+                long position = Position;
+                if (length <= position) // Handles negative overflows
+                {
+                    // If we go down this branch, it means there are
+                    // no bytes left in this stream.
+
+                    // Ideally we would just return Task.CompletedTask here,
+                    // but CopyToAsync(Stream, int, CancellationToken) was already
+                    // virtual at the time this optimization was introduced. So
+                    // if it does things like argument validation (checking if destination
+                    // is null and throwing an exception), then await fooStream.CopyToAsync(null)
+                    // would no longer throw if there were no bytes left. On the other hand,
+                    // we also can't roll our own argument validation and return Task.CompletedTask,
+                    // because it would be a breaking change if the stream's override didn't throw before,
+                    // or in a different order. So for simplicity, we just set the bufferSize to 1
+                    // (not 0 since the default implementation throws for 0) and forward to the virtual method.
+                    bufferSize = 1; 
+                }
+                else
+                {
+                    long remaining = length - position;
+                    if (remaining > 0) // In the case of a positive overflow, stick to the default size
+                        bufferSize = (int)Math.Min(bufferSize, remaining);
+                }
+            }
+            
+            return CopyToAsync(destination, bufferSize);
         }
 
         public Task CopyToAsync(Stream destination, int bufferSize)
@@ -129,7 +160,28 @@ namespace System.IO
         // the current position.
         public void CopyTo(Stream destination)
         {
-            CopyTo(destination, DefaultCopyBufferSize);
+            int bufferSize = DefaultCopyBufferSize;
+
+            if (CanSeek)
+            {
+                long length = Length;
+                long position = Position;
+                if (length <= position) // Handles negative overflows
+                {
+                    // No bytes left in stream
+                    // Call the other overload with a bufferSize of 1,
+                    // in case it's made virtual in the future
+                    bufferSize = 1;
+                }
+                else
+                {
+                    long remaining = length - position;
+                    if (remaining > 0) // In the case of a positive overflow, stick to the default size
+                        bufferSize = (int)Math.Min(bufferSize, remaining);
+                }
+            }
+            
+            CopyTo(destination, bufferSize);
         }
 
         public void CopyTo(Stream destination, int bufferSize)


### PR DESCRIPTION
This change elides making a buffer of size 81920 for the overloads of `CopyTo` and `CopyToAsync` that don't accept a buffer size, instead using the `Length` and `Position` properties to smartly determine how much the default size should be if the stream supports seeking.

Port of dotnet/coreclr#4540

cc @stephentoub @ianhays @mellinoe @justinvp @jkotas 