### PR TITLE
Change dispose logic of certificates in OpenSslX509ChainProcessor

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -498,14 +498,18 @@ namespace Internal.Cryptography.Pal
                 X509Certificate2Collection userIntermediateCerts = userIntermediateStore.Certificates;
 
                 // fill the system trusted collection
-                foreach (X509Certificate2 systemRootCert in systemRootCerts)
-                {
-                    systemTrusted.Add(systemRootCert);
-                }
                 foreach (X509Certificate2 userRootCert in userRootCerts)
                 {
                     systemTrusted.Add(userRootCert);
                 }
+
+                foreach (X509Certificate2 systemRootCert in systemRootCerts)
+                {
+                    systemTrusted.Add(systemRootCert);
+                }
+
+                // ordering in storesToCheck must match how we read into the systemTrusted collection, that is 
+                // first in first checked due to how we eventually use the collection in candidatesByReference 
 
                 X509Certificate2Collection[] storesToCheck =
                 {
@@ -539,6 +543,8 @@ namespace Internal.Cryptography.Pal
                         }
                     }
                 }
+
+                // Avoid sending unused certs into the finalizer queue by doing only a ref check
 
                 var candidatesByReference = new HashSet<X509Certificate2>(
                     candidates,


### PR DESCRIPTION
Currently: certificates are loaded from both the System root store and also from a user root store. Once finished, OpenSslX509ChainProcessor.FindCandidates will go thorugh the certs and dispose of ones that are deemed not needed.

This particular approach caused an issue when the same certificate appears in both the System root certificate store AND the user root certificate store. The following chain of events would happen:

1. Certs would be loaded from the system root cert store into `systemTrusted` (a HashSet scoped to the method)
2. Certs would be loaded from the user root cert store into `systemTrusted` However, if the same cert was found, HashSet would not add it into `systemTrusted` and will fail silently
3. FindIssuer happens to find the issuer that comes from the user's root store based on the ordering in `storesToCheck`
4. The candidate list is populated with the end cert and a the root cert coming from the user store
6. Eventually we create the `candidatesByReference` HashSet from the list of candidate certificates (which is the user root store one, not the system store one)
5. The certificate coming from the system root cert store is Disposed (no references to it)
6. However, since `systemTrusted` only contained the root cert from the system store and not the user store, and ultimately `OpenSslX509ChainProcessor.BuildChain` tries to build from the candidate (user root cert) but uses the `systemTrusted` HashSet (system root cert), the chain fails to build.

This fix would do a deep check into `systemTrusted`'s certificates to match using X509Certificate2's comparer rather than using a (likely faster) ref comparer; this prevents the issue of disposing a certificate that might ultimately be used.

There are a couple of alternatives that I milled over, but ultimately I thought that the other ways might cause more confusion/code complication - for example, it might be possible to always read in certs into collections with ReferenceEqualityComparers instead of the current hybrid model where we only use the ReferenceEqualityComparers upon cleanup time

cc @bartonjs 

P.S. - this is blocking WCF testing scenarios from working