### PR TITLE
Fix the building failure occurred while unmounting device in ARM CI

### DIFF
--- a/cross/arm-softfp/toolchain.cmake
+++ b/cross/arm-softfp/toolchain.cmake
@@ -5,6 +5,7 @@ set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR armv7l)
 
 set(TOOLCHAIN "arm-linux-gnueabi")
+set(TOOLCHAIN_CUSTOM "armv7l-tizen-linux-gnueabi/4.9.2")
 
 add_compile_options(-target armv7-linux-gnueabi)
 add_compile_options(-mthumb)
@@ -13,8 +14,8 @@ add_compile_options(-mfloat-abi=softfp)
 add_compile_options(--sysroot=${CROSS_ROOTFS})
 
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -target ${TOOLCHAIN}")
-set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B${CROSS_ROOTFS}/usr/lib/gcc/${TOOLCHAIN}")
-set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -L${CROSS_ROOTFS}/lib/${TOOLCHAIN}")
+set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B${CROSS_ROOTFS}/usr/lib/gcc/${TOOLCHAIN_CUSTOM}")
+set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -L${CROSS_ROOTFS}/usr/lib/gcc/${TOOLCHAIN_CUSTOM}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} --sysroot=${CROSS_ROOTFS}")
 
 set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS}    ${CROSS_LINK_FLAGS}" CACHE STRING "" FORCE)

--- a/scripts/arm32_ci_script.sh
+++ b/scripts/arm32_ci_script.sh
@@ -79,7 +79,7 @@ function unmount_rootfs {
     local rootfsFolder="$1"
 
     if grep -qs "$rootfsFolder" /proc/mounts; then
-        sudo umount "$rootfsFolder"
+        sudo umount -l "$rootfsFolder"
     fi
 }
 


### PR DESCRIPTION
Now, while running arm32_ci_script.sh run from netci.groovy, the building failure is occurred frequently with below messages.

sudo umount /opt/linux-arm-emulator-root/dev
        umount: /opt/linux-arm-emulator-root/dev: device is busy.
       (In some cases useful info about processes that use
	the device is found by lsof(8) or fuser(1))
	step 'Execute shell' marked build as failure`

We are looking into why this failure is occurring basically but we can't get normal results from ARM CI now. So I would fix temporarily.