### PR TITLE
ARM-CI : Disable automatic checks for resolving the unmounting error

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -393,7 +393,7 @@ def osShortName = ['Windows 10': 'win10',
             // Set up triggers
             if (isPR) {
                 if (os == 'LinuxARMEmulator') {
-                    Utilities.addGithubPRTriggerForBranch(newJob, branch, "Innerloop Linux ARM Emulator ${configurationGroup} Cross Build")
+                    Utilities.addGithubPRTriggerForBranch(newJob, branch, "Innerloop Linux ARM Emulator ${configurationGroup} Cross Build", "(?i).*test\\W+Innerloop\\W+Linux\\W+ARM\\W+Emulator\\W+${configurationGroup}\\W+Cross\\W+Build.*")
                 }
             }
             else {


### PR DESCRIPTION
Now ARM-CI makes building failure frequently with below messages.

http://dotnet-ci.cloudapp.net/job/dotnet_corefx/job/master/job/linuxarmemulator_cross_release_prtest/159/console
00:01:27.252 + sudo umount /opt/linux-arm-emulator-root/dev
00:01:27.260 umount: /opt/linux-arm-emulator-root/dev: device is busy.
00:01:27.260 (In some cases useful info about processes that use
00:01:27.260 the device is found by lsof(8) or fuser(1))
00:01:27.265 Build step 'Execute shell' marked build as failure

We are looking into why this failure is occurring basically but we can't get normal results from ARM CI now. So I would disable automatic checks temporarily.

You can check manually with comment for a while.