### PR TITLE
Prepare dev/api for build pipeline: change prerelease label and add feed

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PreReleaseLabel>beta</PreReleaseLabel>
+    <PreReleaseLabel>beta-dev-api</PreReleaseLabel>
     <PackageDescriptionFile>$(ProjectDir)pkg/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(ProjectDir)pkg/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)pkg/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>

--- a/dir.props
+++ b/dir.props
@@ -146,6 +146,7 @@
     <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
     <!-- Including buildtools to pull in TestSuite packages and repackaged xunit dependencies-->
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core-dev-api/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" />
   </ItemGroup>

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -4,6 +4,7 @@
   <!-- The command-line doesn't need it, but the IDE does.                    -->
   <packageSources>
     <clear/>
+    <add key="myget.org dotnet-core-dev-api" value="https://dotnet.myget.org/F/dotnet-core-dev-api/api/v3/index.json" />
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>


### PR DESCRIPTION
Changes `PreReleaseLabel` to `beta-dev-api` to avoid conflict with master's `beta` builds, and adds a new feed "dotnet-core-dev-api" where the dev/api packages will be published. (This allows prerelease dependencies to be updated to dev/api packages.)

If it turns out we can publish dev/api packages onto the dotnet-core feed, the feeds added here can be removed.

/cc @danmosemsft @ellismg @stephentoub 