### PR TITLE
Specify Xunit.PlatformID where ambiguous in dev/api tests

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsEventSourceLifetime.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsEventSourceLifetime.cs
@@ -20,7 +20,7 @@ namespace BasicEventSourceTests
         /// alive.
         /// </summary>
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // non-Windows EventSources don't have lifetime
+        [PlatformSpecific(Xunit.PlatformID.Windows)] // non-Windows EventSources don't have lifetime
         public void Test_EventSource_Lifetime()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");

--- a/src/System.Runtime/tests/System/GCTests.cs
+++ b/src/System.Runtime/tests/System/GCTests.cs
@@ -398,7 +398,7 @@ namespace System.Tests
         }
 
         [Theory]
-        [PlatformSpecific(PlatformID.Windows)] //Concurent GC is not enabled on Unix. Recombine to TestLatencyRoundTrips once addressed.
+        [PlatformSpecific(Xunit.PlatformID.Windows)] //Concurent GC is not enabled on Unix. Recombine to TestLatencyRoundTrips once addressed.
         [InlineData(GCLatencyMode.LowLatency)]
         [InlineData(GCLatencyMode.SustainedLowLatency)]
         public static void LatencyRoundtrips_LowLatency(GCLatencyMode value) => LatencyRoundtrips(value);

--- a/src/System.Runtime/tests/System/Threading/WaitHandleTests.cs
+++ b/src/System.Runtime/tests/System/Threading/WaitHandleTests.cs
@@ -84,7 +84,7 @@ namespace System.Threading.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // names aren't supported on Unix
+        [PlatformSpecific(Xunit.PlatformID.Windows)] // names aren't supported on Unix
         public static void WaitAll_SameNames()
         {
             Mutex[] wh = new Mutex[2];

--- a/src/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -1671,7 +1671,7 @@ namespace System.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(Xunit.PlatformID.AnyUnix)]
         public static void IsDaylightSavingTime_CatamarcaMultiYearDaylightSavings()
         {
             // America/Catamarca had DST from
@@ -1694,7 +1694,7 @@ namespace System.Tests
         }
 
         [Theory]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(Xunit.PlatformID.AnyUnix)]
         [InlineData("1940-02-24T23:59:59.0000000Z", false, "0:00:00")]
         [InlineData("1940-02-25T00:00:00.0000000Z", true, "1:00:00")]
         [InlineData("1940-11-20T00:00:00.0000000Z", true, "1:00:00")]
@@ -1718,7 +1718,7 @@ namespace System.Tests
         }
 
         [Theory]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(Xunit.PlatformID.AnyUnix)]
         // in 1996 Europe/Lisbon changed from standard time to DST without changing the UTC offset
         [InlineData("1995-09-30T17:00:00.0000000Z", false, "1:00:00")]
         [InlineData("1996-03-31T00:59:59.0000000Z", false, "1:00:00")]
@@ -1835,7 +1835,7 @@ namespace System.Tests
         /// See https://github.com/dotnet/coreclr/issues/2185
         /// </summary>
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(Xunit.PlatformID.AnyUnix)]
         public static void DaylightTransitionsExactTime_Johannesburg()
         {
             DateTimeOffset transition = new DateTimeOffset(1943, 3, 20, 23, 0, 0, TimeSpan.Zero);


### PR DESCRIPTION
When the build pipeline runs `build-tests.cmd` for the dev/api branch it hits these errors (taken from one leg, but they appear to all be the same):

```
BasicEventSourceTest\TestsEventSourceLifetime.cs(23,27): error CS0104: 'PlatformID' is an ambiguous reference between 'System.PlatformID' and 'Xunit.PlatformID' [D:\A\_work\3\s\src\System.Diagnostics.Tracing\tests\System.Diagnostics.Tracing.Tests.csproj]
System\Threading\WaitHandleTests.cs(87,38): error CS0117: 'PlatformID' does not contain a definition for 'Windows' [D:\A\_work\3\s\src\System.Runtime\tests\System.Runtime.Tests.csproj]
System\GCTests.cs(401,38): error CS0117: 'PlatformID' does not contain a definition for 'Windows' [D:\A\_work\3\s\src\System.Runtime\tests\System.Runtime.Tests.csproj]
System\TimeZoneInfoTests.cs(1674,38): error CS0117: 'PlatformID' does not contain a definition for 'AnyUnix' [D:\A\_work\3\s\src\System.Runtime\tests\System.Runtime.Tests.csproj]
System\TimeZoneInfoTests.cs(1697,38): error CS0117: 'PlatformID' does not contain a definition for 'AnyUnix' [D:\A\_work\3\s\src\System.Runtime\tests\System.Runtime.Tests.csproj]
System\TimeZoneInfoTests.cs(1721,38): error CS0117: 'PlatformID' does not contain a definition for 'AnyUnix' [D:\A\_work\3\s\src\System.Runtime\tests\System.Runtime.Tests.csproj]
System\TimeZoneInfoTests.cs(1838,38): error CS0117: 'PlatformID' does not contain a definition for 'AnyUnix' [D:\A\_work\3\s\src\System.Runtime\tests\System.Runtime.Tests.csproj]
```

`System.PlatformID` was introduced in https://github.com/dotnet/corefx/pull/9851, and some references to `Xunit.PlatformID` were changed to explicitly reference the xunit one, but not these. I haven't been able to track down yet why this error happens in the pipeline but not CI or local builds.

There are many build-tests legs in the pipeline so I'm working on confirming that these are the only ambiguous references.

/cc @danmosemsft @stephentoub 