### PR TITLE
Remove dash from PreReleaseLabel to keep total length under 20 chars

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PreReleaseLabel>beta-dev-api</PreReleaseLabel>
+    <PreReleaseLabel>beta-devapi</PreReleaseLabel>
     <PackageDescriptionFile>$(ProjectDir)pkg/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(ProjectDir)pkg/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)pkg/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>


### PR DESCRIPTION
NuGet has a limit of 20 characters maximum for the "special version part". In local builds this limit isn't met because the version is "XXXXX-X", but in the build pipeline it's "XXXXX-XX". The extra digit brought it to 21 characters--so I didn't catch this earlier when testing out https://github.com/dotnet/corefx/pull/10151.

The error that shows up is: `Error when creating nuget lib package from [...nuspec]. System.InvalidOperationException: The special version part cannot exceed 20 characters.`

/cc @danmosemsft @ellismg @stephentoub 