### PR TITLE
Fix to ignore codename (arm-softfp)

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -66,12 +66,12 @@ for i in "$@" ; do
             __UbuntuCodeName=jessie
             ;;
         vivid)
-            if [ __UbuntuCodeName != "jessie" ]; then
+            if [ "$__UbuntuCodeName" != "jessie" ]; then
                 __UbuntuCodeName=vivid
             fi
             ;;
         wily)
-            if [ __UbuntuCodeName != "jessie" ]; then
+            if [ "$__UbuntuCodeName" != "jessie" ]; then
                 __UbuntuCodeName=wily
             fi
             ;;


### PR DESCRIPTION
Fix if statement to ignore Ubuntu codename if BuildArch is arm-softfp.
Same issue in CoreCLR (https://github.com/dotnet/coreclr/issues/6347)