### PR TITLE
Disable outerloop runs on Windows 10

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -206,7 +206,7 @@ def osShortName = ['Windows 10': 'win10',
 // Define outerloop testing for OSes that can build and run.  Run locally on each machine.
 // **************************
 [true, false].each { isPR ->
-    ['Windows 10', 'Windows 7', 'Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2', 'Fedora23', 'Debian8.4', 'OSX'].each { os ->
+    ['Windows 7', 'Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2', 'Fedora23', 'Debian8.4', 'OSX'].each { os ->
         ['Debug', 'Release'].each { configurationGroup ->
 
             def newJobName = "outerloop_${osShortName[os]}_${configurationGroup.toLowerCase()}"


### PR DESCRIPTION
The machines we were using for these runs in Jenkins are using an expired
version of a Windows Server 2016 technical preview. Disable them until we
can upgrade the image and move them over to the new auto image
infrastructure.

#10177 tracks getting this back online.  We should take this PR and also move the changes into dev/api and dev/unix_cms as they presently have jobs that do these runs.  Today we're just generating jobs in Jenkins that never run and we have to go manually stop.