### PR TITLE
Remove netcore50 support claim from System.Transactions

### DIFF
--- a/src/System.Transactions/pkg/System.Transactions.pkgproj
+++ b/src/System.Transactions/pkg/System.Transactions.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\src\System.Transactions.builds">
-      <SupportedFramework>net461;netcore50;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net461;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
 
     <InboxOnTargetFramework Include="net461">
@@ -29,6 +29,10 @@
     <InboxOnTargetFramework Include="xamarinwatchos10">
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>
+
+    <NotSupportedOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>win7</PackageTargetRuntime>
+    </NotSupportedOnTargetFramework>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Transactions/tests/project.json
+++ b/src/System.Transactions/tests/project.json
@@ -20,7 +20,6 @@
     "netstandard1.4": {}
   },
   "supports": {
-    "coreFx.Test.netcore50": {},
     "coreFx.Test.netcoreapp1.0": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},


### PR DESCRIPTION
I used System.Diagnostics.Process as my example for these changes.

I don't know if System.Transactions is intended to support netcore50, but at the moment I'm pretty sure this is breaking the test build in the new build pipeline. System.Transactions has dependencies on System.Threading.Thread, System.Threading.Threadpool, and System.Diagnostics.Process, none of which support netcore50. This means that when the test project.json tries to bring in those dependencies and says the tests support netcore50, restore breaks because there are no implementations.

(System.Transactions port PR: https://github.com/dotnet/corefx/pull/10089)

/cc @stephentoub @ericstj @danmosemsft