### PR TITLE
Added UnprotectedAttributes to the encoding in EnvelopedCms for Unix

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DerEncoder.cs
+++ b/src/Common/src/System/Security/Cryptography/DerEncoder.cs
@@ -118,6 +118,13 @@ namespace System.Security.Cryptography
             return SegmentedEncodeUnsignedInteger(bigEndianBytes, 0, bigEndianBytes.Length);
         }
 
+        internal static byte[] EncodeUnsignedInteger(byte[] bigEndianBytes)
+        {
+            Debug.Assert(bigEndianBytes != null);
+
+            return ConcatenateArrays(SegmentedEncodeUnsignedInteger(bigEndianBytes, 0, bigEndianBytes.Length));
+        }
+
         /// <summary>
         /// Encode the segments { tag, length, value } of an unsigned integer represented within a bounded array.
         /// </summary>

--- a/src/Common/src/System/Security/Cryptography/DerEncoder.cs
+++ b/src/Common/src/System/Security/Cryptography/DerEncoder.cs
@@ -550,15 +550,56 @@ namespace System.Security.Cryptography
             return ConstructSequenceWithTag(ConstructedSequenceTag, items);
         }
 
+        private static byte[][] ConstructSegmentedConstructedImplicit(int contextNumber, params byte[][][] items)
+        {
+            Debug.Assert(contextNumber >= 0 && contextNumber < 32);
+            return ConstructSequenceWithTag((byte)(ConstructedImplicitTag | contextNumber), items);
+        }
+
         internal static byte[][] ConstructSegmentedImplicitSequence(int contextNumber, params byte[][][] items)
         {
-            return ConstructSequenceWithTag((byte)(ConstructedImplicitTag | contextNumber), items);
+            return ConstructSegmentedConstructedImplicit(contextNumber, items);
+        }
+
+        internal static byte[][] ConstructSegmentedImplicitSet(int contextNumber, params byte[][][] items)
+        {
+            return ConstructSegmentedConstructedImplicit(contextNumber, items);
         }
 
         internal static byte[][] ConstructSegmentedExplicitSequence(int contextNumber, params byte[][][] items)
         {
             byte[][] innerSequence = ConstructSegmentedSequence(items);
             return ConstructSegmentedImplicitSequence(contextNumber, innerSequence);
+        }
+
+        internal static byte[][] ConstructSegmentedExplicitSequenceFromPayload(int contextNumber, params byte[][] items)
+        {
+            byte[][] innerSequence = ConstructSegmentedSequenceFromPayload(items);
+            return ConstructSegmentedImplicitSequence(contextNumber, innerSequence);
+        }
+
+        private static byte[][] ConstructSegmentedFromPayloadWithTag(byte tag, params byte[][] items)
+        {
+            Debug.Assert(items != null);
+
+            byte[] data = ConcatenateArrays(items);
+
+            return new byte[][]
+            {
+                new byte[] { tag },
+                EncodeLength(data.Length),
+                data,
+            };
+        }
+
+        internal static byte[][] ConstructSegmentedSequenceFromPayload(params byte[][] items)
+        {
+            return ConstructSegmentedFromPayloadWithTag(ConstructedSequenceTag, items);
+        }
+
+        internal static byte[][] ConstructSegmentedSetFromPayload(params byte[][] items)
+        {
+            return ConstructSegmentedFromPayloadWithTag(ConstructedSetTag, items);
         }
 
         /// <summary>
@@ -569,16 +610,7 @@ namespace System.Security.Cryptography
         /// <returns>The encoded segments { tag, length, value }</returns>
         internal static byte[][] ConstructSegmentedSet(params byte[][][] items)
         {
-            Debug.Assert(items != null);
-
-            byte[] data = ConcatenateArrays(items);
-
-            return new byte[][]
-            {
-                new byte[] { ConstructedSetTag },
-                EncodeLength(data.Length),
-                data,
-            };
+            return ConstructSequenceWithTag(ConstructedSetTag, items);
         }
 
         /// <summary>

--- a/src/Common/src/System/Security/Cryptography/DerEncoder.cs
+++ b/src/Common/src/System/Security/Cryptography/DerEncoder.cs
@@ -550,7 +550,7 @@ namespace System.Security.Cryptography
             return ConstructSequenceWithTag(ConstructedSequenceTag, items);
         }
 
-        private static byte[][] ConstructSegmentedConstructedImplicit(int contextNumber, params byte[][][] items)
+        private static byte[][] ConstructSegmentedImplicitSequenceOrSet(int contextNumber, params byte[][][] items)
         {
             Debug.Assert(contextNumber >= 0 && contextNumber < 32);
             return ConstructSequenceWithTag((byte)(ConstructedImplicitTag | contextNumber), items);
@@ -558,18 +558,7 @@ namespace System.Security.Cryptography
 
         internal static byte[][] ConstructSegmentedImplicitSequence(int contextNumber, params byte[][][] items)
         {
-            return ConstructSegmentedConstructedImplicit(contextNumber, items);
-        }
-
-        internal static byte[][] ConstructSegmentedImplicitSet(int contextNumber, params byte[][][] items)
-        {
-            return ConstructSegmentedConstructedImplicit(contextNumber, items);
-        }
-
-        internal static byte[][] ConstructSegmentedExplicitSequence(int contextNumber, params byte[][][] items)
-        {
-            byte[][] innerSequence = ConstructSegmentedSequence(items);
-            return ConstructSegmentedImplicitSequence(contextNumber, innerSequence);
+            return ConstructSegmentedImplicitSequenceOrSet(contextNumber, items);
         }
 
         internal static byte[][] ConstructSegmentedExplicitSequenceFromPayload(int contextNumber, params byte[][] items)
@@ -578,7 +567,7 @@ namespace System.Security.Cryptography
             return ConstructSegmentedImplicitSequence(contextNumber, innerSequence);
         }
 
-        private static byte[][] ConstructSegmentedFromPayloadWithTag(byte tag, params byte[][] items)
+        private static byte[][] ConstructSegmentedFromPayloadWithTag(byte tag, byte[][] items)
         {
             Debug.Assert(items != null);
 
@@ -592,14 +581,19 @@ namespace System.Security.Cryptography
             };
         }
 
-        internal static byte[][] ConstructSegmentedSequenceFromPayload(params byte[][] items)
+        internal static byte[][] ConstructSegmentedSequenceFromPayload(byte[][] items)
         {
             return ConstructSegmentedFromPayloadWithTag(ConstructedSequenceTag, items);
         }
 
-        internal static byte[][] ConstructSegmentedSetFromPayload(params byte[][] items)
+        internal static byte[][] ConstructSegmentedSetFromPayload(byte[][] items)
         {
             return ConstructSegmentedFromPayloadWithTag(ConstructedSetTag, items);
+        }
+
+        internal static byte[][] ConstructSegmentedImplicitSetFromPayload(int contextNumber, byte[][] items)
+        {
+            return ConstructSegmentedFromPayloadWithTag((byte)(ConstructedImplicitTag | contextNumber), items);
         }
 
         /// <summary>

--- a/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
+++ b/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
@@ -112,12 +112,22 @@ namespace System.Security.Cryptography
 
         internal byte[] ReadRemainingData()
         {
+            if (_end <= _position)
+                return Array.Empty<byte>();
+
             int remainingBytes = _end - _position;
             byte[] remainingData = new byte[remainingBytes];
             Buffer.BlockCopy(_data, _position, remainingData, 0, remainingBytes);
             return remainingData;
         }
 
+        /// <summary>
+        /// Splits a DER encoded value in a byte[] into a byte[][3] containing {tag, encodedLength, value}
+        /// </summary>
+        /// <param name="payload">DER value</param>
+        /// <param name="offset">REference parameter on where to start splitting. it will change to the value
+        /// after the end of the element being split as specified by the encoded length</param>
+        /// <returns>DER value split as byte[][3] containing {tag, encodedLength, value}</returns>
         private static byte[][] SplitValue(byte[] payload, ref int offset)
         {
             int lengthLength;

--- a/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
@@ -404,9 +404,12 @@ namespace System.Security.Cryptography.Encoding.Tests
         {
             byte[][] expected =
             {
-                /* Tag */     new byte[] { 0x30 },
-                /* Length */   new byte[] { 0x07 },
-                /* Load */ new byte[] { 0x02, 0x01, 0x00, 0x02, 0x02, 0x01, 0x00},
+                // Tag
+                new byte[] { 0x30 },
+                // Length
+                new byte[] { 0x07 },
+                // Payload
+                new byte[] { 0x02, 0x01, 0x00, 0x02, 0x02, 0x01, 0x00},
             };
 
             byte[][] encoded = DerEncoder.ConstructSegmentedSequence(
@@ -426,12 +429,16 @@ namespace System.Security.Cryptography.Encoding.Tests
         {
             byte[][] expected =
             {
-                /* Tag */     new byte[] { 0xA1 },
-                /* Length */   new byte[] { 0x07 },
-                /* Load */ new byte[] { 0x02, 0x01, 0x00, 0x02, 0x02, 0x01, 0x00},
+                // Tag
+                new byte[] { 0xA1 },
+                // Length
+                new byte[] { 0x07 },
+                // Payload
+                new byte[] { 0x02, 0x01, 0x00, 0x02, 0x02, 0x01, 0x00},
             };
 
-            byte[][] encoded = DerEncoder.ConstructSegmentedImplicitSequence(1,
+            byte[][] encoded = DerEncoder.ConstructSegmentedImplicitSequence(
+                1,
                 DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x00 }),
                 DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x01, 0x00 }));
 
@@ -448,12 +455,16 @@ namespace System.Security.Cryptography.Encoding.Tests
         {
             byte[][] expected =
             {
-                /* Tag */     new byte[] { 0xA2 },
-                /* Length */   new byte[] { 0x09 },
-                /* Load (Has the sequence inside) */ new byte[] { 0x30, 0x07, 0x02, 0x01, 0x00, 0x02, 0x02, 0x01, 0x00},
+                // Tag
+                new byte[] { 0xA2 },
+                // Length
+                new byte[] { 0x09 },
+                // Payload
+                new byte[] { 0x30, 0x07, 0x02, 0x01, 0x00, 0x02, 0x02, 0x01, 0x00},
             };
 
-            byte[][] encoded = DerEncoder.ConstructSegmentedExplicitSequence(2,
+            byte[][] encoded = DerEncoder.ConstructSegmentedExplicitSequence(
+                2,
                 DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x00 }),
                 DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x01, 0x00 }));
 

--- a/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
@@ -451,7 +451,7 @@ namespace System.Security.Cryptography.Encoding.Tests
         }
 
         [Fact]
-        public static void TestConstructSegmentedExplicitSequence()
+        public static void TestConstructSegmentedExplicitSequenceFromPayload()
         {
             byte[][] expected =
             {
@@ -463,10 +463,10 @@ namespace System.Security.Cryptography.Encoding.Tests
                 new byte[] { 0x30, 0x07, 0x02, 0x01, 0x00, 0x02, 0x02, 0x01, 0x00},
             };
 
-            byte[][] encoded = DerEncoder.ConstructSegmentedExplicitSequence(
+            byte[][] encoded = DerEncoder.ConstructSegmentedExplicitSequenceFromPayload(
                 2,
-                DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x00 }),
-                DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x01, 0x00 }));
+                DerEncoder.EncodeUnsignedInteger(new byte[] { 0x00 }),
+                DerEncoder.EncodeUnsignedInteger(new byte[] { 0x01, 0x00 }));
 
             Assert.Equal(expected.Length, encoded.Length);
 

--- a/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
@@ -398,5 +398,71 @@ namespace System.Security.Cryptography.Encoding.Tests
 
             Assert.Equal(encodedExpected, encodedLocal);
         }
+
+        [Fact]
+        public static void TestConstructSegmentedSequence()
+        {
+            byte[][] expected =
+            {
+                /* Tag */     new byte[] { 0x30 },
+                /* Length */   new byte[] { 0x07 },
+                /* Load */ new byte[] { 0x02, 0x01, 0x00, 0x02, 0x02, 0x01, 0x00},
+            };
+
+            byte[][] encoded = DerEncoder.ConstructSegmentedSequence(
+                DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x00 }),
+                DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x01, 0x00 }));
+
+            Assert.Equal(expected.Length, encoded.Length);
+
+            for (int i = 0; i < encoded.Length; i++)
+            {
+                Assert.Equal<byte>(expected[i], encoded[i]);
+            }
+        }
+
+        [Fact]
+        public static void TestConstructSegmentedImplicitSequence()
+        {
+            byte[][] expected =
+            {
+                /* Tag */     new byte[] { 0xA1 },
+                /* Length */   new byte[] { 0x07 },
+                /* Load */ new byte[] { 0x02, 0x01, 0x00, 0x02, 0x02, 0x01, 0x00},
+            };
+
+            byte[][] encoded = DerEncoder.ConstructSegmentedImplicitSequence(1,
+                DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x00 }),
+                DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x01, 0x00 }));
+
+            Assert.Equal(expected.Length, encoded.Length);
+
+            for (int i = 0; i < encoded.Length; i++)
+            {
+                Assert.Equal<byte>(expected[i], encoded[i]);
+            }
+        }
+
+        [Fact]
+        public static void TestConstructSegmentedExplicitSequence()
+        {
+            byte[][] expected =
+            {
+                /* Tag */     new byte[] { 0xA2 },
+                /* Length */   new byte[] { 0x09 },
+                /* Load (Has the sequence inside) */ new byte[] { 0x30, 0x07, 0x02, 0x01, 0x00, 0x02, 0x02, 0x01, 0x00},
+            };
+
+            byte[][] encoded = DerEncoder.ConstructSegmentedExplicitSequence(2,
+                DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x00 }),
+                DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x01, 0x00 }));
+
+            Assert.Equal(expected.Length, encoded.Length);
+
+            for (int i = 0; i < encoded.Length; i++)
+            {
+                Assert.Equal<byte>(expected[i], encoded[i]);
+            }
+        }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/DerSequenceReaderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerSequenceReaderTests.cs
@@ -152,5 +152,87 @@ namespace System.Security.Cryptography.Encoding.Tests
 
             Assert.Throws<InvalidOperationException>(() => DerSequenceReader.CreateForPayload(encodedMessage).ReadOid());
         }
+
+        [Fact]
+        public static void SplitValues_SingleByteLength()
+        {
+            byte[] payload = ("180f31393932303732323133323130305a").HexToByteArray();
+            byte[][] splitPayload = DerSequenceReader.SplitValue(payload);
+
+            byte[] expectedTag = new byte[] { 0x18 };
+            byte[] expectedLength = new byte[] { 0x0f };
+            byte[] expectedValue = ("31393932303732323133323130305a").HexToByteArray();
+
+            Assert.Equal<byte>(expectedTag, splitPayload[0]);
+            Assert.Equal<byte>(expectedLength, splitPayload[1]);
+            Assert.Equal<byte>(expectedValue, splitPayload[2]);
+        }
+
+        [Fact]
+        public static void SplitValues_MultipleByteLength()
+        {
+            byte[] payload =
+                ("3181C83081C5020100302E301A311830160603550403130F5253414B65795472616E7366657231021031D935FB63E8CF"
+                + "AB48A0BF7B397B67C0300D06092A864886F70D01010105000481809203EC6AD0877AE56DBC8A480E59E94CA953839F8F"
+                + "769EC1B262B4F4916C9863EE9C41007C356FBF2FC3F3D03E4AA1EA46575D0FBC0C5F47E41778F34535EEA84E64800995"
+                + "5F271A9E3C24F8C192D31406D46A40396B78D4013CFE3DCC443AC9CA92137FFA503297CA1D241F68E905C60134C02E7C"
+                + "E8E1E67481ABEBE3D7FAA1").HexToByteArray();
+
+            byte[][] splitPayload = DerSequenceReader.SplitValue(payload);
+
+            byte[] expectedTag = new byte[] { 0x31 };
+            byte[] expectedLength = new byte[] { 0x81, 0xc8 };
+            byte[] expectedValue =
+                ("3081C5020100302E301A311830160603550403130F5253414B65795472616E7366657231021031D935FB63E8CF"
+                + "AB48A0BF7B397B67C0300D06092A864886F70D01010105000481809203EC6AD0877AE56DBC8A480E59E94CA953839F8F"
+                + "769EC1B262B4F4916C9863EE9C41007C356FBF2FC3F3D03E4AA1EA46575D0FBC0C5F47E41778F34535EEA84E64800995"
+                + "5F271A9E3C24F8C192D31406D46A40396B78D4013CFE3DCC443AC9CA92137FFA503297CA1D241F68E905C60134C02E7C"
+                + "E8E1E67481ABEBE3D7FAA1").HexToByteArray();
+
+            Assert.Equal<byte>(expectedTag, splitPayload[0]);
+            Assert.Equal<byte>(expectedLength, splitPayload[1]);
+            Assert.Equal<byte>(expectedValue, splitPayload[2]);
+        }
+
+        [Fact]
+        public static void ReadAndSplitNextEncodedValue_SingleByteLength()
+        {
+            DerSequenceReader reader = DerSequenceReader.CreateForPayload(("180f31393932303732323133323130305a").HexToByteArray());
+            byte[][] splitPayload = reader.ReadAndSplitNextEncodedValue();
+
+            byte[] expectedTag = new byte[] { 0x18 };
+            byte[] expectedLength = new byte[] { 0x0f };
+            byte[] expectedValue = ("31393932303732323133323130305a").HexToByteArray();
+
+            Assert.Equal<byte>(expectedTag, splitPayload[0]);
+            Assert.Equal<byte>(expectedLength, splitPayload[1]);
+            Assert.Equal<byte>(expectedValue, splitPayload[2]);
+        }
+
+        [Fact]
+        public static void ReadAndSplitNextEncodedValue_MultipleByteLength()
+        {
+            byte[] payload =
+                ("3181C83081C5020100302E301A311830160603550403130F5253414B65795472616E7366657231021031D935FB63E8CF"
+                + "AB48A0BF7B397B67C0300D06092A864886F70D01010105000481809203EC6AD0877AE56DBC8A480E59E94CA953839F8F"
+                + "769EC1B262B4F4916C9863EE9C41007C356FBF2FC3F3D03E4AA1EA46575D0FBC0C5F47E41778F34535EEA84E64800995"
+                + "5F271A9E3C24F8C192D31406D46A40396B78D4013CFE3DCC443AC9CA92137FFA503297CA1D241F68E905C60134C02E7C"
+                + "E8E1E67481ABEBE3D7FAA1").HexToByteArray();
+            DerSequenceReader reader = DerSequenceReader.CreateForPayload(payload);
+            byte[][] splitPayload = reader.ReadAndSplitNextEncodedValue();
+
+            byte[] expectedTag = new byte[] { 0x31 };
+            byte[] expectedLength = new byte[] { 0x81, 0xc8 };
+            byte[] expectedValue =
+                ("3081C5020100302E301A311830160603550403130F5253414B65795472616E7366657231021031D935FB63E8CF"
+                + "AB48A0BF7B397B67C0300D06092A864886F70D01010105000481809203EC6AD0877AE56DBC8A480E59E94CA953839F8F"
+                + "769EC1B262B4F4916C9863EE9C41007C356FBF2FC3F3D03E4AA1EA46575D0FBC0C5F47E41778F34535EEA84E64800995"
+                + "5F271A9E3C24F8C192D31406D46A40396B78D4013CFE3DCC443AC9CA92137FFA503297CA1D241F68E905C60134C02E7C"
+                + "E8E1E67481ABEBE3D7FAA1").HexToByteArray();
+
+            Assert.Equal<byte>(expectedTag, splitPayload[0]);
+            Assert.Equal<byte>(expectedLength, splitPayload[1]);
+            Assert.Equal<byte>(expectedValue, splitPayload[2]);
+        }
     }
 }

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/PkcsPalOpenSsl.Encrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/PkcsPalOpenSsl.Encrypt.cs
@@ -155,16 +155,16 @@ namespace Internal.Cryptography.Pal.OpenSsl
             //
             // UnprotectedAttributes ::= SET SIZE (1..MAX) OF Attribute
 
-            List<byte[]> setOfAttrs = new List<byte[]>(unprotectedAttributes.Count);
+            byte[][] setOfAttrs = new byte[unprotectedAttributes.Count][];
 
-            foreach (CryptographicAttributeObject attribute in unprotectedAttributes)
+            for (int i = 0; i < setOfAttrs.Length; i++)
             {
-                setOfAttrs.Add(EncodeAttribute(attribute));
+                setOfAttrs[i] = EncodeAttribute(unprotectedAttributes[i]);
             }
 
-            setOfAttrs.Sort((a, b) => CompareByteArrays(a, b));
+            Array.Sort(setOfAttrs, (a, b) => CompareByteArrays(a, b));
 
-            byte[][] segmentedSet = DerEncoder.ConstructSegmentedImplicitSetFromPayload(1 /* Context number */, setOfAttrs.ToArray());
+            byte[][] segmentedSet = DerEncoder.ConstructSegmentedImplicitSetFromPayload(1 /* Context number */, setOfAttrs);
             return ConcatenateArrays(segmentedSet);
         }
 
@@ -176,21 +176,21 @@ namespace Internal.Cryptography.Pal.OpenSsl
 
             byte[][] attrType = DerEncoder.SegmentedEncodeOid(attribute.Oid);
             
-            List<byte[]> attrValues = new List<byte[]>(attribute.Values.Count);
+            byte[][] attrValues = new byte[attribute.Values.Count][];
 
-            foreach(AsnEncodedData encodedData in attribute.Values)
+            for (int i = 0; i < attrValues.Length; i++)
             {
-                attrValues.Add(encodedData.RawData);
+                attrValues[i] = attribute.Values[i].RawData;
             }
 
             // According to X.690:
             // The encodings of the component values of a set-of value shall appear in ascending order, the encodings being 
             // compared as octet strings with the shorter components being padded at their trailing end with 0 - octets.
-            attrValues.Sort((a, b) => CompareByteArrays(a,b));
+            Array.Sort(attrValues, (a, b) => CompareByteArrays(a,b));
 
             return ConcatenateArrays(DerEncoder.ConstructSegmentedSequence(
                 attrType,
-                DerEncoder.ConstructSegmentedSetFromPayload(attrValues.ToArray())));
+                DerEncoder.ConstructSegmentedSetFromPayload(attrValues)));
         }
 
         private int CompareByteArrays(byte[] a, byte[] b)

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -150,6 +150,9 @@
   <data name="Cryptography_Cms_AddOriginatorCertsPlatformNotSupported" xml:space="preserve">
     <value>This platform does not support encoding originator certificates in an Enveloped CMS.</value>
   </data>
+  <data name="Cryptography_Cms_VersionNumberPlatformNotSupported" xml:space="preserve">
+    <value>This platform does not support encoding unprotected attributes on a message with the given data.</value>
+  </data>
   <data name="Cryptography_Cms_Key_Agree_Date_Not_Available" xml:space="preserve">
     <value>The Date property is not available for none KID key agree recipient.</value>
   </data>

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -150,8 +150,8 @@
   <data name="Cryptography_Cms_AddOriginatorCertsPlatformNotSupported" xml:space="preserve">
     <value>This platform does not support encoding originator certificates in an Enveloped CMS.</value>
   </data>
-  <data name="Cryptography_Cms_VersionNumberPlatformNotSupported" xml:space="preserve">
-    <value>This platform does not support encoding unprotected attributes on a message with the given data.</value>
+  <data name="Cryptography_Cms_EncodeUnsupportedVersionPlatformNotSupported" xml:space="preserve">
+    <value>This platform does not support encoding messages of the version needed to encode the given data.</value>
   </data>
   <data name="Cryptography_Cms_Key_Agree_Date_Not_Available" xml:space="preserve">
     <value>The Date property is not available for none KID key agree recipient.</value>

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.Pkcs.Tests;
 using System.Security.Cryptography.Xml;
 using System.Security.Cryptography.X509Certificates;
-using Xunit;
 
 using Test.Cryptography;
-using System.Security.Cryptography.Pkcs.Tests;
+using Xunit;
 
 namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 {
@@ -390,7 +391,9 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             return (KeyAgreeRecipientInfo)recipientInfo;
         }
 
+        private static bool EncryptionSupportsKeyAgreementCerts => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
+        private static bool EncryptionDoesNotSupportKeyAgreementCerts => !EncryptionSupportsKeyAgreementCerts;
 
         private static byte[] s_KeyAgreeEncodedMessage =
              ("3082019b06092a864886f70d010703a082018c3082018802010231820154a1820150020103a08195a18192300906072a8648"

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
@@ -391,10 +391,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             return (KeyAgreeRecipientInfo)recipientInfo;
         }
 
-        private static bool EncryptionSupportsKeyAgreementCerts => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-        private static bool EncryptionDoesNotSupportKeyAgreementCerts => !EncryptionSupportsKeyAgreementCerts;
-
         private static byte[] s_KeyAgreeEncodedMessage =
              ("3082019b06092a864886f70d010703a082018c3082018802010231820154a1820150020103a08195a18192300906072a8648"
             + "ce3e0201038184000281806f96ef8c53a6919cc976e88b8f426696e7b7970abc6bd4abbdcf4cf34f89ceb6e8ef675000fad2"

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
@@ -446,15 +446,18 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             }
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(false, 0)]
+        [InlineData(true, 2)]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        public static void TestVersionNumber_RoundTrip()
+        public static void TestVersionNumber_RoundTrip(bool addUnprotectedAttrs, int expectedVersion)
         {
             ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
             byte[] docName = ("0410AA00790020004E0061006D0065000000").HexToByteArray();
             EnvelopedCms ecms = new EnvelopedCms(expectedContentInfo);
 
-            ecms.UnprotectedAttributes.Add(new AsnEncodedData(new Oid(Oids.DocumentName), docName));
+            if (addUnprotectedAttrs)
+                ecms.UnprotectedAttributes.Add(new AsnEncodedData(new Oid(Oids.DocumentName), docName));
 
             using (X509Certificate2 cert = Certificates.RSAKeyTransfer1.GetCertificate())
             {
@@ -466,7 +469,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             ecms = new EnvelopedCms();
             ecms.Decode(encodedMessage);
 
-            Assert.Equal(2, ecms.Version);
+            Assert.Equal(expectedVersion, ecms.Version);
         }
 
         private static void AssertIsDocumentationDescription(this AsnEncodedData attribute, string expectedDocumentDescription)

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
@@ -15,7 +15,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     public static partial class UnprotectedAttributeTests
     {
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes0_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes();
@@ -44,7 +43,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes1_DocumentDescription_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(new Pkcs9DocumentDescription("My Description"));
@@ -75,7 +73,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes1_DocumenName_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(new Pkcs9DocumentName("My Name"));
@@ -106,7 +103,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes1_SigningTime_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(new Pkcs9SigningTime(new DateTime(2018, 4, 1, 8, 30, 05)));
@@ -114,7 +110,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes1_SigningTime_FixedValue()
         {
             byte[] encodedMessage =
@@ -140,7 +135,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes1_ContentType_RoundTrip()
         {
             byte[] rawData = "06072a9fa20082f300".HexToByteArray();
@@ -174,7 +168,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes1_MessageDigest_RoundTrip()
         {
             byte[] rawData = "0405032d58805d".HexToByteArray();
@@ -209,7 +202,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes1_Merge3_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(
@@ -247,7 +239,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes1_Heterogenous3_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(
@@ -324,7 +315,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes1_Arbitrary_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(
@@ -359,7 +349,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes1_OutOfNamespace_RoundTrip()
         {
             byte[] constraintsRawData = "30070101ff02020100".HexToByteArray();
@@ -398,7 +387,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void TestUnprotectedAttributes_AlwaysReturnsPkcs9AttributeObject()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(
@@ -419,15 +407,17 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Fact]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void PostEncrypt_UnprotectedAttributes()
         {
+            byte[] docDescription = ("041E4D00790020004400650073006300720069007000740069006F006E000000").HexToByteArray();
+            byte[] docName1 = ("0410AA00790020004E0061006D0065000000").HexToByteArray();
+            byte[] docName2 = ("04104D00790020004E0061006D0065000000").HexToByteArray();
             ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
             EnvelopedCms ecms = new EnvelopedCms(expectedContentInfo);
             AsnEncodedData[] attributes = {
-                new AsnEncodedData(Oids.DocumentName, new byte[] { 0x0a, 0x0b, 0x0c }),
-                new AsnEncodedData(Oids.DocumentName, new byte[] { 0x0b, 0x0c, 0x0d }),
-                new AsnEncodedData(Oids.DocumentDescription, new byte[] { 0x0d, 0x0e, 0x0f }) };
+                new AsnEncodedData(Oids.DocumentName, docName1),
+                new AsnEncodedData(Oids.DocumentName, docName2),
+                new AsnEncodedData(Oids.DocumentDescription, docDescription)};
             foreach (AsnEncodedData attribute in attributes)
             {
                 ecms.UnprotectedAttributes.Add(new AsnEncodedData(attribute));


### PR DESCRIPTION
+ UnprotectedAttributes now get added to the encoding of the message.

+ Expanded DerEncoder to support encoding implicit and explicit
sequences/sets and added approriate tests.

+ Expanded DerSequenceReader to allow getting split values to use with
DerEncoder and added appropriate tests.

@bartonjs @weshaggard 