### PR TITLE
Disable automatic package restore in VS

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -10,4 +10,9 @@
   <config>
     <add key="repositoryPath" value="..\packages" />
   </config>
+  <packageRestore>
+    <!-- Automated package restore in VS does not work at this time with
+         this project and it causes build failures in VS. Disable it. -->
+    <add key="automatic" value="false" />
+  </packageRestore>
 </configuration>


### PR DESCRIPTION
It is breaking the VS build unless you disable it globally, which would interfere with work on other projects that depend on it working.

I assume that running sync.cmd to restore packages is already a requirement before opening projects in VS, so this shouldn't break anything, but makes the VS experience work without damaging your global VS settings.