### PR TITLE
Implements support for Embedded Portable PDB

### DIFF
--- a/src/System.Reflection.Metadata/System.Reflection.Metadata.sln
+++ b/src/System.Reflection.Metadata/System.Reflection.Metadata.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.Metadata", "src\System.Reflection.Metadata.csproj", "{F3E433C8-352F-4944-BF7F-765CE435370D}"
 EndProject

--- a/src/System.Reflection.Metadata/specs/PE-COFF.md
+++ b/src/System.Reflection.Metadata/specs/PE-COFF.md
@@ -45,11 +45,14 @@ Declares that debugging information is embedded in the PE file at location speci
 
 | Offset | Size           | Field            | Description                                           |
 |:-------|:---------------|:-----------------|-------------------------------------------------------|
-| 0      | 4              | UncompressedSize | The size of decompressed Portable PDB image           |
-| 4      | SizeOfData - 4 | PortablePdbImage | Portable PDB image compressed using Deflate algorithm | 
+| 0      | 4              | Signature        | 0x4D 0x50 0x44 0x42                                   |
+| 4      | 4              | UncompressedSize | The size of decompressed Portable PDB image           |
+| 8      | SizeOfData - 8 | PortablePdbImage | Portable PDB image compressed using Deflate algorithm | 
 
 If this entry is present and the reader recognizes this entry the debugging information for the PE file shall be read from the embedded data. If a CodeView entry is also present it shall be ignored. 
 
 > Note: Including both entries enables a tool that does not recognize Embedded Portable PDB entry to locate debug infomration as long as it is also available in a file specified in CodeView entry. Such file can be created by extracting the embedded Portable PDB image to a separate file.
 
 The Major version specified in the entry indicates the version of the Portable PDB format. The Minor version indicates the version of the Embedded Portable PDB data format.
+
+The value of Stamp field in the entry shall be 0.

--- a/src/System.Reflection.Metadata/specs/PE-COFF.md
+++ b/src/System.Reflection.Metadata/specs/PE-COFF.md
@@ -29,10 +29,27 @@ The associated .pdb file may not exist at the path indicated by Path field. If i
 
 If the containing PE/COFF file is deterministic the Guid field above and DateTimeStamp field of the directory entry are  calculated deterministically based solely on the content of the associated .pdb file. Otherwise the value of Guid is random and the value of DateTimeStamp indicates the time and date that the debug data was created.
 
-*Version Major=0x0100, Minor=0x504d* of the data format has the same structure as above. The Age shall be 1. The format of the associated .pdb file is Portable PDB. Together 16B of the Guid concatenated with 4B of the TimeDateStamp field of the entry form a PDB ID that should be used to match the PE/COFF image with the associated PDB (instead of Guid and Age). Matching PDB ID is stored in the #Pdb stream of the .pdb file.
+*Version Major=any, Minor=0x504d* of the data format has the same structure as above. The Age shall be 1. The format of the associated .pdb file is Portable PDB. The Major version specified in the entry indicates the version of the Portable PDB format. Together 16B of the Guid concatenated with 4B of the TimeDateStamp field of the entry form a PDB ID that should be used to match the PE/COFF image with the associated PDB (instead of Guid and Age). Matching PDB ID is stored in the #Pdb stream of the .pdb file.
 
 ### Deterministic Debug Directory Entry (type 16)
 
 The entry doesn't have any data associated with it. All fields of the entry, but Type shall be zero.
 
 Presence of this entry indicates that the containing PE/COFF file is deterministic. 
+
+### Embedded Portable PDB Debug Directory Entry (type 17)
+
+Declares that debugging information is embedded in the PE file at location specified by PointerToRawData. 
+
+*Version Major=any, Minor=0x0100* of the data format:
+
+| Offset | Size           | Field            | Description                                           |
+|:-------|:---------------|:-----------------|-------------------------------------------------------|
+| 0      | 4              | UncompressedSize | The size of decompressed Portable PDB image           |
+| 4      | SizeOfData - 4 | PortablePdbImage | Portable PDB image compressed using Deflate algorithm | 
+
+If this entry is present and the reader recognizes this entry the debugging information for the PE file shall be read from the embedded data. If a CodeView entry is also present it shall be ignored. 
+
+> Note: Including both entries enables a tool that does not recognize Embedded Portable PDB entry to locate debug infomration as long as it is also available in a file specified in CodeView entry. Such file can be created by extracting the embedded Portable PDB image to a separate file.
+
+The Major version specified in the entry indicates the version of the Portable PDB format. The Minor version indicates the version of the Embedded Portable PDB data format.

--- a/src/System.Reflection.Metadata/src/Resources/Strings.resx
+++ b/src/System.Reflection.Metadata/src/Resources/Strings.resx
@@ -426,6 +426,9 @@
   <data name="HashTooShort" xml:space="preserve">
     <value>Hash must be at least {0}B long.</value>
   </data>
+  <data name="UnexpectedArrayLength" xml:space="preserve">
+    <value>Expected array of length {0}.</value>
+  </data>
   <data name="ValueMustBeMultiple" xml:space="preserve">
     <value>Value must be multiple of {0}.</value>
   </data>

--- a/src/System.Reflection.Metadata/src/Resources/Strings.resx
+++ b/src/System.Reflection.Metadata/src/Resources/Strings.resx
@@ -441,4 +441,13 @@
   <data name="RowCountOutOfRange" xml:space="preserve">
     <value>Row count specified for table index {0} is out of allowed range.</value>
   </data>
+  <data name="SizeMismatch" xml:space="preserve">
+    <value>Declared size doesn't correspond to the actual size.</value>
+  </data>
+  <data name="DataTooBig" xml:space="preserve">
+    <value>Data too big to fit in memory.</value>
+  </data>
+  <data name="UnsupportedFormatVersion" xml:space="preserve">
+    <value>Unsupported format version: {0}</value>
+  </data>
 </root>

--- a/src/System.Reflection.Metadata/src/Resources/Strings.resx
+++ b/src/System.Reflection.Metadata/src/Resources/Strings.resx
@@ -348,6 +348,9 @@
   <data name="UnexpectedCodeViewDataSignature" xml:space="preserve">
     <value>Unexpected CodeView data signature value.</value>
   </data>
+  <data name="UnexpectedEmbeddedPortablePdbDataSignature" xml:space="preserve">
+    <value>Unexpected Embedded Portable PDB data signature value.</value>
+  </data>
   <data name="InvalidPathPadding" xml:space="preserve">
     <value>The path must be padded with NUL characters.</value>
   </data>

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -55,6 +55,7 @@
     <Compile Include="System\Reflection\Internal\Utilities\DecimalUtilities.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\EnumerableExtensions.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\CustomAttributeDecoder.cs" />
+    <Compile Include="System\Reflection\Metadata\PortablePdb\PortablePdbVersions.cs" />
     <Compile Include="System\Reflection\Metadata\Signatures\CustomAttributeNamedArgument.cs" />
     <Compile Include="System\Reflection\Metadata\Signatures\CustomAttributeTypedArgument.cs" />
     <Compile Include="System\Reflection\Metadata\Signatures\CustomAttributeValue.cs" />

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/PortablePdbBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/PortablePdbBuilder.cs
@@ -14,8 +14,8 @@ namespace System.Reflection.Metadata.Ecma335
     /// </summary>
     public sealed class PortablePdbBuilder
     {
-        public string MetadataVersion => "PDB v1.0";
-        public ushort FormatVersion => 0x0100;
+        public string MetadataVersion => PortablePdbVersions.DefaultMetadataVersion;
+        public ushort FormatVersion => PortablePdbVersions.DefaultFormatVersion;
 
         private Blob _pdbIdBlob;
         private readonly MethodDefinitionHandle _entryPoint;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
@@ -1191,7 +1191,6 @@ namespace System.Reflection.Metadata
 
         public CustomAttributeHandleCollection GetCustomAttributes(EntityHandle handle)
         {
-            Debug.Assert(!handle.IsNil);
             return new CustomAttributeHandleCollection(this, handle);
         }
 
@@ -1418,7 +1417,6 @@ namespace System.Reflection.Metadata
 
         public CustomDebugInformationHandleCollection GetCustomDebugInformation(EntityHandle handle)
         {
-            Debug.Assert(!handle.IsNil);
             return new CustomDebugInformationHandleCollection(this, handle);
         }
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/HandleCollections.Debug.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/HandleCollections.Debug.cs
@@ -745,7 +745,6 @@ namespace System.Reflection.Metadata
         internal CustomDebugInformationHandleCollection(MetadataReader reader, EntityHandle handle)
         {
             Debug.Assert(reader != null);
-            Debug.Assert(!handle.IsNil);
 
             _reader = reader;
             reader.CustomDebugInformationTable.GetRange(handle, out _firstRowId, out _lastRowId);

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/PortablePdbVersions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/PortablePdbVersions.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Reflection.Metadata
+{
+    internal static class PortablePdbVersions
+    {
+        /// <summary>
+        /// Version of Portable PDB format emitted by the writer by default. Metadata version string.
+        /// </summary>
+        internal const string DefaultMetadataVersion = "PDB v1.0";
+
+        /// <summary>
+        /// Version of Portable PDB format emitted by the writer by default.
+        /// </summary>
+        internal const ushort DefaultFormatVersion = 0x0100;
+
+        /// <summary>
+        /// Minimal supported version of Portable PDB format.
+        /// </summary>
+        internal const ushort MinFormatVersion = 0x0100;
+
+        /// <summary>
+        /// Minimal supported version of Embedded Portable PDB blob.
+        /// </summary>
+        internal const ushort MinEmbeddedVersion = 0x0100;
+
+        /// <summary>
+        /// Version of Embedded Portable PDB blob format emitted by the writer by default.
+        /// </summary>
+        internal const ushort DefaultEmbeddedVersion = 0x0100;
+
+        /// <summary>
+        /// Minimal version of the Embedded Portable PDB blob that the current reader can't interpret.
+        /// </summary>
+        internal const ushort MinUnsupportedEmbeddedVersion = 0x0200;
+
+        internal static uint DebugDirectoryEntryVersion(ushort portablePdbVersion) => 'P' << 24 | 'M' << 16 | (uint)portablePdbVersion;
+        internal static uint DebugDirectoryEmbeddedVersion(ushort portablePdbVersion) => (uint)DefaultEmbeddedVersion << 16 | portablePdbVersion;
+        internal static string Format(ushort version) => (version >> 8) + "." + (version & 0xff);
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/PortablePdbVersions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/PortablePdbVersions.cs
@@ -36,6 +36,8 @@ namespace System.Reflection.Metadata
         /// </summary>
         internal const ushort MinUnsupportedEmbeddedVersion = 0x0200;
 
+        internal const uint DebugDirectoryEmbeddedSignature = 0x4244504d;
+
         internal static uint DebugDirectoryEntryVersion(ushort portablePdbVersion) => 'P' << 24 | 'M' << 16 | (uint)portablePdbVersion;
         internal static uint DebugDirectoryEmbeddedVersion(ushort portablePdbVersion) => (uint)DefaultEmbeddedVersion << 16 | portablePdbVersion;
         internal static string Format(ushort version) => (version >> 8) + "." + (version & 0xff);

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/HandleCollections.TypeSystem.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/HandleCollections.TypeSystem.cs
@@ -243,7 +243,6 @@ namespace System.Reflection.Metadata
         internal CustomAttributeHandleCollection(MetadataReader reader, EntityHandle handle)
         {
             Debug.Assert(reader != null);
-            Debug.Assert(!handle.IsNil);
 
             _reader = reader;
             reader.CustomAttributeTable.GetAttributeRange(handle, out _firstRowId, out _lastRowId);

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
@@ -83,7 +83,8 @@ namespace System.Reflection.PortableExecutable
         {
             int start = builder.Count;
 
-            // header (decompressed size):
+            // header (signature, decompressed size):
+            builder.WriteUInt32(PortablePdbVersions.DebugDirectoryEmbeddedSignature);
             builder.WriteInt32(debugMetadata.Count);
 
             // compressed data:

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryEntryType.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryEntryType.cs
@@ -43,5 +43,17 @@ namespace System.Reflection.PortableExecutable
         /// </para>
         /// </remarks>
         Reproducible = 16,
+
+        /// <summary>
+        /// The entry points to a blob containing Embedded Portable PDB.
+        /// </summary>
+        /// <remarks>
+        /// The Embedded Portable PDB blob has the following format:
+        /// 
+        /// blob ::= uncompressed-size data
+        /// 
+        /// Data spans the remainder of the blob and contains a Deflate-compressed Portable PDB.
+        /// </remarks>
+        EmbeddedPortablePdb = 17,
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
@@ -586,9 +586,15 @@ namespace System.Reflection.PortableExecutable
         {
             byte[] decompressed;
             
-            const int headerSize = sizeof(int);
+            const int headerSize = 2 * sizeof(int);
 
             var headerReader = new BlobReader(block.Pointer, headerSize);
+
+            if (headerReader.ReadUInt32() != PortablePdbVersions.DebugDirectoryEmbeddedSignature)
+            {
+                throw new BadImageFormatException(SR.UnexpectedEmbeddedPortablePdbDataSignature);
+            }
+
             int decompressedSize = headerReader.ReadInt32();
 
             try

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Reflection.Internal;
 using System.Reflection.Metadata;
 using System.Threading;
@@ -533,6 +534,103 @@ namespace System.Reflection.PortableExecutable
 
                 return new CodeViewDebugDirectoryData(guid, age, path);
             }
+        }
+
+        /// <summary>
+        /// Reads the data pointed to by the specified Debug Directory entry and interprets them as Embedded Portable PDB blob.
+        /// </summary>
+        /// <returns>
+        /// Provider of a metadata reader reading Portable PDB image.
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="entry"/> is not a <see cref="DebugDirectoryEntryType.EmbeddedPortablePdb"/> entry.</exception>
+        /// <exception cref="BadImageFormatException">Bad format of the data.</exception>
+        public unsafe MetadataReaderProvider ReadEmbeddedPortablePdbDebugDirectoryData(DebugDirectoryEntry entry)
+        {
+            if (entry.Type != DebugDirectoryEntryType.EmbeddedPortablePdb)
+            {
+                throw new ArgumentException(SR.NotCodeViewEntry, nameof(entry));
+            }
+
+            ValidateEmbeddedPortablePdbVersion(entry);
+
+            using (AbstractMemoryBlock block = _peImage.GetMemoryBlock(entry.DataPointer, entry.DataSize))
+            {
+                var pdbImage = DecodeEmbeddedPortablePdbDebugDirectoryData(block);
+                return MetadataReaderProvider.FromPortablePdbImage(pdbImage);
+            }
+        }
+
+        // internal for testing
+        internal static void ValidateEmbeddedPortablePdbVersion(DebugDirectoryEntry entry)
+        {
+            // Major version encodes the version of Portable PDB format itself.
+            // Minor version encodes the version of Embedded Portable PDB blob.
+            // Accept any version of Portable PDB >= 1.0, 
+            // but only accept version 1.* of the Embedded Portable PDB blob.
+            // Any breaking change in the format should rev major version of the embedded blob.
+            ushort formatVersion = entry.MajorVersion;
+            if (formatVersion < PortablePdbVersions.MinFormatVersion)
+            {
+                throw new BadImageFormatException(SR.Format(SR.UnsupportedFormatVersion, PortablePdbVersions.Format(formatVersion)));
+            }
+
+            ushort embeddedBlobVersion = entry.MinorVersion;
+            if (embeddedBlobVersion != PortablePdbVersions.DefaultEmbeddedVersion)
+            {
+                throw new BadImageFormatException(SR.Format(SR.UnsupportedFormatVersion, PortablePdbVersions.Format(embeddedBlobVersion)));
+            }
+        }
+
+        // internal for testing
+        internal static unsafe ImmutableArray<byte> DecodeEmbeddedPortablePdbDebugDirectoryData(AbstractMemoryBlock block)
+        {
+            byte[] decompressed;
+            
+            const int headerSize = sizeof(int);
+
+            var headerReader = new BlobReader(block.Pointer, headerSize);
+            int decompressedSize = headerReader.ReadInt32();
+
+            try
+            {
+                decompressed = new byte[decompressedSize];
+            }
+            catch
+            {
+                throw new BadImageFormatException(SR.DataTooBig);
+            }
+
+            var compressed = new ReadOnlyUnmanagedMemoryStream(block.Pointer + headerSize, block.Size - headerSize);
+            var deflate = new DeflateStream(compressed, CompressionMode.Decompress, leaveOpen: true);
+
+            if (decompressedSize > 0)
+            {
+                int actualLength;
+
+                try
+                {
+                    actualLength = deflate.TryReadAll(decompressed, 0, decompressed.Length);
+                }
+                catch (InvalidDataException e)
+                {
+                    throw new BadImageFormatException(e.Message, e.InnerException);
+                }
+
+                if (actualLength != decompressed.Length)
+                {
+                    throw new BadImageFormatException(SR.SizeMismatch);
+                }
+            }
+
+            // Check that there is no more compressed data left, 
+            // in case the decompressed size specified in the header is smaller 
+            // than the actual decompressed size of the data.
+            if (deflate.ReadByte() != -1)
+            {
+                throw new BadImageFormatException(SR.SizeMismatch);
+            }
+
+            return ImmutableByteArrayInterop.DangerousCreateFromUnderlyingArray(ref decompressed);
         }
     }
 }

--- a/src/System.Reflection.Metadata/src/project.json
+++ b/src/System.Reflection.Metadata/src/project.json
@@ -14,7 +14,8 @@
     "System.Runtime.InteropServices": "4.0.0",
     "System.Text.Encoding": "4.0.0",
     "System.Text.Encoding.Extensions": "4.0.0",
-    "System.Threading": "4.0.0"
+    "System.Threading": "4.0.0",
+    "System.IO.Compression": "4.0.0"
   },
   "frameworks": {
     "netstandard1.0": {

--- a/src/System.Reflection.Metadata/tests/Metadata/BlobContentIdTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/BlobContentIdTests.cs
@@ -22,7 +22,23 @@ namespace System.Reflection.Metadata.Tests
             Assert.Equal(0x12345678u, id2.Stamp);
             Assert.False(id2.IsDefault);
 
+            var id3 = new BlobContentId(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14 });
+            Assert.Equal(new Guid("04030201-0605-0807-090a-0b0c0d0e0f10"), id3.Guid);
+            Assert.Equal(0x14131211u, id3.Stamp);
+            Assert.False(id3.IsDefault);
+
             Assert.True(default(BlobContentId).IsDefault);
+        }
+
+        [Fact]
+        public void Ctor_Errors()
+        {
+            Assert.Throws<ArgumentNullException>("id", () => new BlobContentId(null));
+            Assert.Throws<ArgumentNullException>("id", () => new BlobContentId(default(ImmutableArray<byte>)));
+            Assert.Throws<ArgumentException>("id", () => new BlobContentId(ImmutableArray.Create<byte>()));
+            Assert.Throws<ArgumentException>("id", () => new BlobContentId(ImmutableArray.Create<byte>(0)));
+            Assert.Throws<ArgumentException>("id", () => new BlobContentId(ImmutableArray.Create<byte>(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13)));
+            Assert.Throws<ArgumentException>("id", () => new BlobContentId(ImmutableArray.Create<byte>(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15)));
         }
 
         [Fact]

--- a/src/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -91,17 +91,6 @@ namespace System.Reflection.Metadata.Tests
             return pinned;
         }
 
-        private List<CustomAttributeHandle> GetCustomAttributes(MetadataReader reader, int token)
-        {
-            var attributes = new List<CustomAttributeHandle>();
-            foreach (var caHandle in reader.GetCustomAttributes(new EntityHandle((uint)token)))
-            {
-                attributes.Add(caHandle);
-            }
-
-            return attributes;
-        }
-
         #endregion
 
         [Fact]
@@ -2047,6 +2036,20 @@ namespace System.Reflection.Metadata.Tests
             }
         }
 
+        [Fact]
+        public void GetCustomAttributes()
+        {
+            var reader = GetMetadataReader(Interop.Interop_Mock01);
+
+            var attributes1 = reader.GetCustomAttributes(MetadataTokens.EntityHandle(0x02000006));
+            AssertEx.Equal(new[] { 0x16, 0x17, 0x18, 0x19 }, attributes1.Select(a => a.RowId));
+            Assert.Equal(4, attributes1.Count);
+
+            var attributes2 = reader.GetCustomAttributes(MetadataTokens.EntityHandle(0x02000000));
+            AssertEx.Equal(new int[0], attributes2.Select(a => a.RowId));
+            Assert.Equal(0, attributes2.Count);
+        }
+
         /// <summary>
         /// MethodSemantics Table
         ///     Semantic (2-byte unsigned)
@@ -2317,6 +2320,22 @@ namespace System.Reflection.Metadata.Tests
 
             Assert.Equal("Class1", name);
             Assert.Equal(0, genericParams.Count);
+        }
+
+        [Fact]
+        public void GetCustomDebugInformation()
+        {
+            using (var provider = MetadataReaderProvider.FromPortablePdbStream(new MemoryStream(PortablePdbs.DocumentsPdb)))
+            {
+                var reader = provider.GetMetadataReader();
+                var cdi1 = reader.GetCustomAttributes(MetadataTokens.EntityHandle(0x30000001));
+                AssertEx.Equal(new int[0], cdi1.Select(a => a.RowId));
+                Assert.Equal(0, cdi1.Count);
+
+                var cdi2 = reader.GetCustomAttributes(MetadataTokens.EntityHandle(0x03000000));
+                AssertEx.Equal(new int[0], cdi2.Select(a => a.RowId));
+                Assert.Equal(0, cdi2.Count);
+            }
         }
 
         [Fact]

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/DebugDirectoryBuilderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/DebugDirectoryBuilderTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
+using System.Reflection.Internal;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Tests;
 using Xunit;
@@ -221,6 +223,132 @@ namespace System.Reflection.PortableExecutable.Tests
                 0x01, 0x00, 0x00, 0x00, // age
                 (byte)'y', 0x00, // path
             }, blob.ToArray());
+        }
+
+        [Fact]
+        public void EmbeddedPortablePdb()
+        {
+            var b = new DebugDirectoryBuilder();
+
+            var pdb = new BlobBuilder();
+            pdb.WriteInt64(0x1122334455667788);
+
+            b.AddEmbeddedPortablePdbEntry(pdb, portablePdbVersion: 0x0100);
+
+            var blob = new BlobBuilder();
+            b.Serialize(blob, new SectionLocation(0, 0), sectionOffset: 0);
+            var bytes = blob.ToImmutableArray();
+
+            AssertEx.Equal(new byte[]
+            {
+                0x00, 0x00, 0x00, 0x00, // Characteristics
+                0x00, 0x00, 0x00, 0x00, // Stamp
+                0x00, 0x01, 0x00, 0x01, // Version
+                0x11, 0x00, 0x00, 0x00, // Type
+                0x0E, 0x00, 0x00, 0x00, // SizeOfData
+                0x1C, 0x00, 0x00, 0x00, // AddressOfRawData
+                0x1C, 0x00, 0x00, 0x00, // PointerToRawData
+
+                0x08, 0x00, 0x00, 0x00, // uncompressed size
+                0xEB, 0x28, 0x4F, 0x0B, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
+            }, bytes);
+
+            using (var pinned = new PinnedBlob(bytes))
+            {
+                var actual = PEReader.ReadDebugDirectoryEntries(pinned.CreateReader(0, DebugDirectoryEntry.Size));
+                Assert.Equal(1, actual.Length);
+                Assert.Equal(0u, actual[0].Stamp);
+                Assert.Equal(0x0100, actual[0].MajorVersion);
+                Assert.Equal(0x0100, actual[0].MinorVersion);
+                Assert.Equal(DebugDirectoryEntryType.EmbeddedPortablePdb, actual[0].Type);
+                Assert.Equal(0x0000000E, actual[0].DataSize);
+                Assert.Equal(0x0000001c, actual[0].DataRelativeVirtualAddress);
+                Assert.Equal(0x0000001c, actual[0].DataPointer);
+
+                var provider = new ByteArrayMemoryProvider(bytes);
+                using (var block = provider.GetMemoryBlock(actual[0].DataPointer, actual[0].DataSize))
+                {
+                    var decoded = PEReader.DecodeEmbeddedPortablePdbDebugDirectoryData(block);
+                    AssertEx.Equal(new byte[] { 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11 }, decoded);
+                }
+            }
+        }
+
+        [Fact]
+        public void EmbeddedPortablePdb_Errors()
+        {
+            var bytes1 = ImmutableArray.Create(new byte[]
+            {
+                0xFF, 0xFF, 0xFF, 0xFF, // uncompressed size
+                0xEB, 0x28, 0x4F, 0x0B, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
+            });
+
+            using (var block = new ByteArrayMemoryProvider(bytes1).GetMemoryBlock(0, bytes1.Length))
+            {
+                Assert.Throws<BadImageFormatException>(() => PEReader.DecodeEmbeddedPortablePdbDebugDirectoryData(block));
+            }
+
+            var bytes2 = ImmutableArray.Create(new byte[]
+            {
+                0x09, 0x00, 0x00, 0x00, // uncompressed size
+                0xEB, 0x28, 0x4F, 0x0B, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
+            });
+
+            using (var block = new ByteArrayMemoryProvider(bytes2).GetMemoryBlock(0, bytes2.Length))
+            {
+                Assert.Throws<BadImageFormatException>(() => PEReader.DecodeEmbeddedPortablePdbDebugDirectoryData(block));
+            }
+
+            var bytes3 = ImmutableArray.Create(new byte[]
+            {
+                0x00, 0x00, 0x00, 0x00, // uncompressed size
+                0xEB, 0x28, 0x4F, 0x0B, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
+            });
+
+            using (var block = new ByteArrayMemoryProvider(bytes3).GetMemoryBlock(0, bytes3.Length))
+            {
+                Assert.Throws<BadImageFormatException>(() => PEReader.DecodeEmbeddedPortablePdbDebugDirectoryData(block));
+            }
+
+            var bytes4 = ImmutableArray.Create(new byte[]
+            {
+                0xff, 0xff, 0xff, 0x7f, // uncompressed size
+                0xEB, 0x28, 0x4F, 0x0B, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
+            });
+
+            using (var block = new ByteArrayMemoryProvider(bytes4).GetMemoryBlock(0, bytes4.Length))
+            {
+                Assert.Throws<BadImageFormatException>(() => PEReader.DecodeEmbeddedPortablePdbDebugDirectoryData(block));
+            }
+
+            var bytes5 = ImmutableArray.Create(new byte[]
+            {
+                0x08, 0x00, 0x00, 0x00, // uncompressed size
+                0xEF, 0xFF, 0x4F, 0xFF, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
+            });
+
+            using (var block = new ByteArrayMemoryProvider(bytes4).GetMemoryBlock(0, bytes4.Length))
+            {
+                Assert.Throws<BadImageFormatException>(() => PEReader.DecodeEmbeddedPortablePdbDebugDirectoryData(block));
+            }
+        }
+
+        [Fact]
+        public void ValidateEmbeddedPortablePdbVersion()
+        {
+            // major version (Portable PDB format):
+            PEReader.ValidateEmbeddedPortablePdbVersion(new DebugDirectoryEntry(0, 0x0100, 0x0100, DebugDirectoryEntryType.EmbeddedPortablePdb, 0, 0, 0));
+            PEReader.ValidateEmbeddedPortablePdbVersion(new DebugDirectoryEntry(0, 0x0101, 0x0100, DebugDirectoryEntryType.EmbeddedPortablePdb, 0, 0, 0));
+            PEReader.ValidateEmbeddedPortablePdbVersion(new DebugDirectoryEntry(0, 0xffff, 0x0100, DebugDirectoryEntryType.EmbeddedPortablePdb, 0, 0, 0));
+
+            Assert.Throws<BadImageFormatException>(() => PEReader.ValidateEmbeddedPortablePdbVersion(new DebugDirectoryEntry(0, 0x0000, 0x0100, DebugDirectoryEntryType.EmbeddedPortablePdb, 0, 0, 0)));
+            Assert.Throws<BadImageFormatException>(() => PEReader.ValidateEmbeddedPortablePdbVersion(new DebugDirectoryEntry(0, 0x00ff, 0x0100, DebugDirectoryEntryType.EmbeddedPortablePdb, 0, 0, 0)));
+
+            // minor version (Embedded blob format):
+            Assert.Throws<BadImageFormatException>(() => PEReader.ValidateEmbeddedPortablePdbVersion(new DebugDirectoryEntry(0, 0x0100, 0x0101, DebugDirectoryEntryType.EmbeddedPortablePdb, 0, 0, 0)));
+            Assert.Throws<BadImageFormatException>(() => PEReader.ValidateEmbeddedPortablePdbVersion(new DebugDirectoryEntry(0, 0x0100, 0x0000, DebugDirectoryEntryType.EmbeddedPortablePdb, 0, 0, 0)));
+            Assert.Throws<BadImageFormatException>(() => PEReader.ValidateEmbeddedPortablePdbVersion(new DebugDirectoryEntry(0, 0x0100, 0x00ff, DebugDirectoryEntryType.EmbeddedPortablePdb, 0, 0, 0)));
+            Assert.Throws<BadImageFormatException>(() => PEReader.ValidateEmbeddedPortablePdbVersion(new DebugDirectoryEntry(0, 0x0100, 0x0200, DebugDirectoryEntryType.EmbeddedPortablePdb, 0, 0, 0)));
         }
     }
 }

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/DebugDirectoryBuilderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/DebugDirectoryBuilderTests.cs
@@ -245,10 +245,11 @@ namespace System.Reflection.PortableExecutable.Tests
                 0x00, 0x00, 0x00, 0x00, // Stamp
                 0x00, 0x01, 0x00, 0x01, // Version
                 0x11, 0x00, 0x00, 0x00, // Type
-                0x0E, 0x00, 0x00, 0x00, // SizeOfData
+                0x12, 0x00, 0x00, 0x00, // SizeOfData
                 0x1C, 0x00, 0x00, 0x00, // AddressOfRawData
                 0x1C, 0x00, 0x00, 0x00, // PointerToRawData
 
+                0x4D, 0x50, 0x44, 0x42, // signature
                 0x08, 0x00, 0x00, 0x00, // uncompressed size
                 0xEB, 0x28, 0x4F, 0x0B, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
             }, bytes);
@@ -261,7 +262,7 @@ namespace System.Reflection.PortableExecutable.Tests
                 Assert.Equal(0x0100, actual[0].MajorVersion);
                 Assert.Equal(0x0100, actual[0].MinorVersion);
                 Assert.Equal(DebugDirectoryEntryType.EmbeddedPortablePdb, actual[0].Type);
-                Assert.Equal(0x0000000E, actual[0].DataSize);
+                Assert.Equal(0x00000012, actual[0].DataSize);
                 Assert.Equal(0x0000001c, actual[0].DataRelativeVirtualAddress);
                 Assert.Equal(0x0000001c, actual[0].DataPointer);
 
@@ -279,6 +280,7 @@ namespace System.Reflection.PortableExecutable.Tests
         {
             var bytes1 = ImmutableArray.Create(new byte[]
             {
+                0x4D, 0x50, 0x44, 0x42, // signature
                 0xFF, 0xFF, 0xFF, 0xFF, // uncompressed size
                 0xEB, 0x28, 0x4F, 0x0B, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
             });
@@ -290,6 +292,7 @@ namespace System.Reflection.PortableExecutable.Tests
 
             var bytes2 = ImmutableArray.Create(new byte[]
             {
+                0x4D, 0x50, 0x44, 0x42, // signature
                 0x09, 0x00, 0x00, 0x00, // uncompressed size
                 0xEB, 0x28, 0x4F, 0x0B, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
             });
@@ -301,6 +304,7 @@ namespace System.Reflection.PortableExecutable.Tests
 
             var bytes3 = ImmutableArray.Create(new byte[]
             {
+                0x4D, 0x50, 0x44, 0x42, // signature
                 0x00, 0x00, 0x00, 0x00, // uncompressed size
                 0xEB, 0x28, 0x4F, 0x0B, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
             });
@@ -312,6 +316,7 @@ namespace System.Reflection.PortableExecutable.Tests
 
             var bytes4 = ImmutableArray.Create(new byte[]
             {
+                0x4D, 0x50, 0x44, 0x42, // signature
                 0xff, 0xff, 0xff, 0x7f, // uncompressed size
                 0xEB, 0x28, 0x4F, 0x0B, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
             });
@@ -323,11 +328,46 @@ namespace System.Reflection.PortableExecutable.Tests
 
             var bytes5 = ImmutableArray.Create(new byte[]
             {
+                0x4D, 0x50, 0x44, 0x42, // signature
                 0x08, 0x00, 0x00, 0x00, // uncompressed size
                 0xEF, 0xFF, 0x4F, 0xFF, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
             });
 
             using (var block = new ByteArrayMemoryProvider(bytes4).GetMemoryBlock(0, bytes4.Length))
+            {
+                Assert.Throws<BadImageFormatException>(() => PEReader.DecodeEmbeddedPortablePdbDebugDirectoryData(block));
+            }
+
+            var bytes6 = ImmutableArray.Create(new byte[]
+            {
+                0x4D, 0x50, 0x44, 0x43, // signature
+                0x08, 0x00, 0x00, 0x00, // uncompressed size
+                0xEB, 0x28, 0x4F, 0x0B, 0x75, 0x31, 0x56, 0x12, 0x04, 0x00 // compressed data
+            });
+
+            using (var block = new ByteArrayMemoryProvider(bytes6).GetMemoryBlock(0, bytes6.Length))
+            {
+                Assert.Throws<BadImageFormatException>(() => PEReader.DecodeEmbeddedPortablePdbDebugDirectoryData(block));
+            }
+
+            var bytes7 = ImmutableArray.Create(new byte[]
+            {
+                0x4D, 0x50, 0x44, 0x43, // signature
+                0x08, 0x00, 0x00, 
+            });
+
+            using (var block = new ByteArrayMemoryProvider(bytes7).GetMemoryBlock(0, bytes7.Length))
+            {
+                Assert.Throws<BadImageFormatException>(() => PEReader.DecodeEmbeddedPortablePdbDebugDirectoryData(block));
+            }
+
+            var bytes8 = ImmutableArray.Create(new byte[]
+            {
+                0x4D, 0x50, 0x44, 0x43, // signature
+                0x08, 0x00, 0x00,
+            });
+
+            using (var block = new ByteArrayMemoryProvider(bytes8).GetMemoryBlock(0, bytes8.Length))
             {
                 Assert.Throws<BadImageFormatException>(() => PEReader.DecodeEmbeddedPortablePdbDebugDirectoryData(block));
             }

--- a/src/System.Reflection.Metadata/tests/TestUtilities/ByteArrayUtilities.cs
+++ b/src/System.Reflection.Metadata/tests/TestUtilities/ByteArrayUtilities.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
+
 namespace System.Reflection.Metadata.Tests
 {
     public static class ByteArrayUtilities
@@ -9,6 +11,11 @@ namespace System.Reflection.Metadata.Tests
         public static byte[] Slice(this BlobBuilder bytes, int start, int end)
         {
             return Slice(bytes.ToArray(), start, end);
+        }
+
+        public static byte[] Slice(this byte[] bytes, int start)
+        {
+            return Slice(bytes, start, bytes.Length);
         }
 
         public static byte[] Slice(this byte[] bytes, int start, int end)
@@ -21,6 +28,21 @@ namespace System.Reflection.Metadata.Tests
             var result = new byte[end - start];
             Array.Copy(bytes, start, result, 0, result.Length);
             return result;
+        }
+
+        public static ImmutableArray<byte> Slice(this ImmutableArray<byte> bytes, int start)
+        {
+            return Slice(bytes, start, bytes.Length);
+        }
+
+        public static ImmutableArray<byte> Slice(this ImmutableArray<byte> bytes, int start, int end)
+        {
+            if (end < 0)
+            {
+                end = bytes.Length + end;
+            }
+
+            return ImmutableArray.Create(bytes, start, end - start);
         }
     }
 }


### PR DESCRIPTION
Introduce a new type of Debug Directory Entry which embeds a compressed Portable PDB blob. 

See https://github.com/dotnet/corefx/pull/10199/commits/e1dd448af8a04c960377d3b8071f85b4ad43186a#diff-f595b39db5266b534bf46339a9f285efR40 for details.