### PR TITLE
[ARM] [Linux] Fix crash on ARM due to incorrect marshalling ULONG64 to int  in SymbolReader

### DIFF
--- a/src/System.Diagnostics.Debug.SymbolReader/src/System/Diagnostics/Debug/SymbolReader/SymbolReader.cs
+++ b/src/System.Diagnostics.Debug.SymbolReader/src/System/Diagnostics/Debug/SymbolReader/SymbolReader.cs
@@ -173,7 +173,7 @@ namespace System.Diagnostics.Debug.SymbolReader
         /// <param name="lineNumber">source line number return</param>
         /// <param name="fileName">source file name return</param>
         /// <returns> true if information is available</returns>
-        public static bool GetLineByILOffset(string assemblyFileName, int methodToken, int ilOffset, out int lineNumber, out IntPtr fileName)
+        public static bool GetLineByILOffset(string assemblyFileName, int methodToken, long ilOffset, out int lineNumber, out IntPtr fileName)
         {
             lineNumber = 0;
             fileName = IntPtr.Zero;
@@ -197,7 +197,7 @@ namespace System.Diagnostics.Debug.SymbolReader
         /// <param name="lineNumber">source line number return</param>
         /// <param name="fileName">source file name return</param>
         /// <returns> true if information is available</returns>
-        private static bool GetSourceLineByILOffset(string assemblyFileName, int methodToken, int ilOffset, out int lineNumber, out string fileName)
+        private static bool GetSourceLineByILOffset(string assemblyFileName, int methodToken, long ilOffset, out int lineNumber, out string fileName)
         {
             MetadataReader peReader, pdbReader;
             lineNumber = 0;


### PR DESCRIPTION
System.Diagnostics.Debug.SymbolReader.dll is crashing on Linux ARM while using `clrstack` SOS command.  The reason of this crash was incorrect marshalling `ULONG64` native to `int` managed code in `GetLineByILOffset` method. This PR fixed this issue. 
Related PR: https://github.com/dotnet/coreclr/pull/6010
CC: @Dmitri-Botcharnikov @chunseoklee @seanshpark @kvochko