### PR TITLE
Remove two Sockets tests

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -408,24 +408,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        public void BeginConnectV4IPEndPointToV6Host_Fails()
-        {
-            Assert.ThrowsAny<SocketException>(() =>
-            {
-                DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
-            });
-        }
-
-        [Fact]
-        public void BeginConnectV6IPEndPointToV4Host_Fails()
-        {
-            Assert.ThrowsAny<SocketException>(() =>
-            {
-                DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
-            });
-        }
-
-        [Fact]
         public void BeginConnectV4IPEndPointToDualHost_Success()
         {
             DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);


### PR DESCRIPTION
These tests try to connect to an endpoint that is not supposed to have an active listener, and expect to fail.  However, there's no guarantee that some other test (or other process) is not listening on that endpoint.  This leads to occasional failures in these tests (and may trigger failure in the *other* test that happens to have been allocated the port in question).

I don't know of a way to reliably force the failure these test cases are looking for, and I don't believe these tests provide enough value to justify "heroic" effor here.  So I'm simply removing them.

Fixes #8195.

@CIPop @stephentoub 