### PR TITLE
System.Transactions: Avoid box allocations in == and != operators

### DIFF
--- a/src/System.Transactions/src/System/Transactions/EnlistmentTraceIdentifier.cs
+++ b/src/System.Transactions/src/System/Transactions/EnlistmentTraceIdentifier.cs
@@ -9,7 +9,7 @@ namespace System.Transactions
     /// enlistments.  This identifier is only unique within
     /// a given AppDomain.
     /// </summary>
-    internal struct EnlistmentTraceIdentifier
+    internal struct EnlistmentTraceIdentifier : IEquatable<EnlistmentTraceIdentifier>
     {
         public static readonly EnlistmentTraceIdentifier Empty = new EnlistmentTraceIdentifier();
 
@@ -47,28 +47,15 @@ namespace System.Transactions
 
         public override int GetHashCode() => base.GetHashCode();  // Don't have anything better to do.
 
-        public override bool Equals(object objectToCompare)
-        {
-            if (!(objectToCompare is EnlistmentTraceIdentifier))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) => obj is EnlistmentTraceIdentifier && Equals((EnlistmentTraceIdentifier)obj);
 
-            EnlistmentTraceIdentifier id = (EnlistmentTraceIdentifier)objectToCompare;
-            if ((id.ResourceManagerIdentifier != ResourceManagerIdentifier) ||
-                (id.TransactionTraceId != TransactionTraceId) ||
-                (id.EnlistmentIdentifier != EnlistmentIdentifier))
-            {
-                return false;
-            }
+        public bool Equals(EnlistmentTraceIdentifier other) =>
+            _enlistmentIdentifier == other._enlistmentIdentifier &&
+            _resourceManagerIdentifier == other._resourceManagerIdentifier &&
+            _transactionTraceIdentifier == other._transactionTraceIdentifier;
 
-            return true;
-        }
+        public static bool operator ==(EnlistmentTraceIdentifier left, EnlistmentTraceIdentifier right) => left.Equals(right);
 
-        public static bool operator ==(EnlistmentTraceIdentifier id1, EnlistmentTraceIdentifier id2) => id1.Equals(id2);
-
-        // We need to equality operator and the compiler doesn't let us have an equality operator without an inequality operator,
-        // so we added it and FXCop doesn't like the fact that we don't call it.
-        public static bool operator !=(EnlistmentTraceIdentifier id1, EnlistmentTraceIdentifier id2) => !id1.Equals(id2);
+        public static bool operator !=(EnlistmentTraceIdentifier left, EnlistmentTraceIdentifier right) => !left.Equals(right);
     }
 }

--- a/src/System.Transactions/src/System/Transactions/TransactionOptions.cs
+++ b/src/System.Transactions/src/System/Transactions/TransactionOptions.cs
@@ -23,17 +23,11 @@ namespace System.Transactions
 
         public override int GetHashCode() => base.GetHashCode();  // Don't have anything better to do.
 
-        public override bool Equals(object obj)
-        {
-            if (!(obj is TransactionOptions))
-            {
-                // Can't use 'as' for a value type
-                return false;
-            }
-            TransactionOptions opts = (TransactionOptions)obj;
+        public override bool Equals(object obj) => obj is TransactionOptions && Equals((TransactionOptions)obj);
 
-            return (opts._timeout == _timeout) && (opts._isolationLevel == _isolationLevel);
-        }
+        private bool Equals(TransactionOptions other) =>
+            _timeout == other._timeout &&
+            _isolationLevel == other._isolationLevel;
 
         public static bool operator ==(TransactionOptions x, TransactionOptions y) => x.Equals(y);
 

--- a/src/System.Transactions/src/System/Transactions/TransactionTraceIdentifier.cs
+++ b/src/System.Transactions/src/System/Transactions/TransactionTraceIdentifier.cs
@@ -9,7 +9,7 @@ namespace System.Transactions
     /// of transaction objects.  This identifier is only unique within
     /// a given AppDomain.
     /// </summary>
-    internal struct TransactionTraceIdentifier
+    internal struct TransactionTraceIdentifier : IEquatable<TransactionTraceIdentifier>
     {
         public static readonly TransactionTraceIdentifier Empty = new TransactionTraceIdentifier();
 
@@ -19,13 +19,13 @@ namespace System.Transactions
             _cloneIdentifier = cloneIdentifier;
         }
 
-        private string _transactionIdentifier;
+        private readonly string _transactionIdentifier;
         /// <summary>
         /// The string representation of the transaction identifier.
         /// </summary>
         public string TransactionIdentifier => _transactionIdentifier;
 
-        private int _cloneIdentifier;
+        private readonly int _cloneIdentifier;
         /// <summary>
         /// An integer value that allows different clones of the same
         /// transaction to be distiguished in the tracing.
@@ -34,24 +34,14 @@ namespace System.Transactions
 
         public override int GetHashCode() => base.GetHashCode();  // Don't have anything better to do.
 
-        public override bool Equals(object objectToCompare)
-        {
-            if (!(objectToCompare is TransactionTraceIdentifier))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) => obj is TransactionTraceIdentifier && Equals((TransactionTraceIdentifier)obj);
 
-            TransactionTraceIdentifier id = (TransactionTraceIdentifier)objectToCompare;
-            if ((id.TransactionIdentifier != TransactionIdentifier) ||
-                (id.CloneIdentifier != CloneIdentifier))
-            {
-                return false;
-            }
-            return true;
-        }
+        public bool Equals(TransactionTraceIdentifier other) =>
+            _cloneIdentifier == other._cloneIdentifier &&
+            _transactionIdentifier == other._transactionIdentifier;
 
-        public static bool operator ==(TransactionTraceIdentifier id1, TransactionTraceIdentifier id2) => id1.Equals(id2);
+        public static bool operator ==(TransactionTraceIdentifier left, TransactionTraceIdentifier right) => left.Equals(right);
 
-        public static bool operator !=(TransactionTraceIdentifier id1, TransactionTraceIdentifier id2) => !id1.Equals(id2);
+        public static bool operator !=(TransactionTraceIdentifier left, TransactionTraceIdentifier right) => !left.Equals(right);
     }
 }


### PR DESCRIPTION
Avoid box allocations in the implementation of `==` and `!=` operators on value types, simplify the implementation of `Equals`, and minor cleanup.

cc: @stephentoub