### PR TITLE
Add cross-process BinaryFormatter test

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.builds
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.Runtime.Serialization.Formatters.Tests.csproj"/>
     <Project Include="System.Runtime.Serialization.Formatters.Tests.csproj">
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -24,11 +24,21 @@
     <Compile Include="SerializationInfoTests.cs" />
     <Compile Include="SerializationTypes.cs" />
     <Compile Include="SurrogateSelectorTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
+      <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
     <ProjectReference Include="..\pkg\System.Runtime.Serialization.Formatters.pkgproj">
       <Project>{ca488507-3b6e-4494-b7be-7b4eeeb2c4d1}</Project>
       <Name>System.Runtime.Serialization.Formatters</Name>

--- a/src/System.Runtime.Serialization.Formatters/tests/project.json
+++ b/src/System.Runtime.Serialization.Formatters/tests/project.json
@@ -4,6 +4,8 @@
     "System.Collections": "4.0.12-beta-devapi-24321-02",
     "System.Collections.NonGeneric": "4.0.2-beta-devapi-24321-02",
     "System.Diagnostics.Debug": "4.0.12-beta-devapi-24321-02",
+    "System.Diagnostics.Process": "4.1.1-beta-devapi-24321-02",
+    "System.IO.FileSystem": "4.0.2-beta-devapi-24321-02",
     "System.ObjectModel": "4.0.13-beta-devapi-24321-02",
     "System.Reflection.TypeExtensions": "4.1.1-beta-devapi-24321-02",
     "System.Runtime": "4.1.1-beta-devapi-24321-02",
@@ -22,7 +24,6 @@
     "netstandard1.3": {}
   },
   "supports": {
-    "coreFx.Test.netcore50": {},
     "coreFx.Test.netcoreapp1.0": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},


### PR DESCRIPTION
All of the tests I previously added serialized/deserialized to MemoryStreams handled by the same process. This adds a test that serializes/deserializes with FileStreams that are read and written by other processes.

cc: @danmosemsft 