### PR TITLE
System.Transactions: Avoid box allocations when enumerating Hashtable

### DIFF
--- a/src/System.Transactions/src/System/Transactions/TransactionManager.cs
+++ b/src/System.Transactions/src/System/Transactions/TransactionManager.cs
@@ -62,9 +62,11 @@ namespace System.Transactions
         {
             lock (PromotedTransactionTable)
             {
-                foreach (DictionaryEntry entry in PromotedTransactionTable)
+                // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+                IDictionaryEnumerator e = PromotedTransactionTable.GetEnumerator();
+                while (e.MoveNext())
                 {
-                    WeakReference weakRef = (WeakReference)entry.Value;
+                    WeakReference weakRef = (WeakReference)e.Value;
                     Transaction tx = (Transaction)weakRef.Target;
                     if (tx != null)
                     {


### PR DESCRIPTION
Enumerating `Hashtable` using `foreach` results in box allocations for each entry in the `Hashtable` because `Current` returns a `DictionaryEntry` struct but is typed as `object`.

These box allocations can be avoided by using `IDictionaryEnumerator` directly.

Related: #7539, #9050

cc: @stephentoub, @dmetzgar, @jimcarley