### PR TITLE
Add more tests to string.IndexOf

### DIFF
--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1126,39 +1126,39 @@ namespace System.Tests
         [InlineData("H" + c_SoftHyphen + "ello", 'e', 0, 3, 2)]
         [InlineData("Hello", '\0', 0, 5, -1)] // .NET strings are terminated with a null character, but they should not be included as part of the string
         [InlineData("\ud800\udfff", '\ud800', 0, 1, 0)] // Surrogate characters
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'A', 0, 26, 0)] // (64-bit) Character is 2 chars before the first char with an aligned address, otherwise it'd enter the main loop
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'B', 1, 25, 1)] // (64-bit) Character is 1 char before the first char with an aligned address, otherwise it'd enter the main loop
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'C', 2, 24, 2)] // (64-bit) Character is aligned and enters the main loop, stops at first check of first iteration
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'D', 3, 23, 3)] // (64-bit) Character is 3 chars before the first char with an aligned address, otherwise it'd enter the main loop
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'G', 2, 24, 6)] // (64-bit) Main loop is entered, stops at second check of first iteration
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'K', 2, 24, 10)] // (64-bit) Main loop is entered, stops at third check of first iteration
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'O', 2, 24, 14)] // (64-bit) Main loop is entered, stops at first check of second iteration
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'P', 2, 24, 15)] // (64-bit) Character is after an aligned character, at an offset of 1
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'Q', 2, 24, 16)] // (64-bit) Character is after an aligned character, at an offset of 2
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'R', 2, 24, 17)] // (64-bit) Character is after an aligned character, at an offset of 3
-        [InlineData("________\u8080\u8080\u8080________", '\u0080', 0, 19, -1)] // (64-bit) value | 0x8000 is present in the string, which should not cause misfires
-        [InlineData("________\u8000\u8000\u8000________", '\u0080', 0, 19, -1)] // (64-bit) A char >= 0x8000 other than value | 0x8000 is present in the string, which should cause misfires
-        [InlineData("__\u8080\u8000\u0080______________", '\u0080', 0, 19, 4)] // (64-bit) Both of the above, except value is present this time
-        [InlineData("__\u8080\u8000__\u0080____________", '\u0080', 0, 19, 6)] // (64-bit) Same as above, except value is found in the word after the misfire (we should skip 4 chars, not 12)
-        [InlineData("__________________________________", '\ufffd', 0, 34, -1)] // (64-bit) Value itself is >= 0x8000, which means we go to the fallback loop
-        [InlineData("____________________________\ufffd", '\ufffd', 0, 29, 28)] // (64-bit) Same as above, except it's actually present this time
-        [InlineData("ABCDEFGHIJKLM", 'M', 0, 13, 12)] // (64-bit) String is too small for main loop to actually kick in
-        [InlineData("ABCDEFGHIJKLMN", 'N', 0, 14, 13)] // (64-bit) String is barely big enough for main loop to kick in
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", '@', 0, 26, -1)] // (64-bit) 26 letters is exactly enough to fit 2 iterations of the main loop (2 to align, 12 per iteration)
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXY", '@', 0, 25, -1)] // (64-bit) 25 letters is 1 below being able to fit another iteration (the last 11 chars will be processed in the fallback loop)
-        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ#", '@', 0, 27, -1)] // (64-bit) 27 letters is 1 above fitting an iteration (only the last char will be processed in the fallback loop)
-        [InlineData("_____________\u807f", '\u007f', 0, 14, -1)] // (64-bit) There is a misfire, and then no chunks available to process after the misfire
-        [InlineData("_____________\u807f__", '\u007f', 0, 16, -1)] // (64-bit) Same as above, except there are 2 more chars after the misfire we still need to process
-        [InlineData("_____________\u807f\u007f_", '\u007f', 0, 16, 14)] // (64-bit) Same as above, except the string actually contains the value after the misfire
-        [InlineData("__\u807f_______________", '\u007f', 0, 18, -1)] // (64-bit) There are exactly 12 chars left after misfiring, so we do one more iteration of the loop
-        [InlineData("__\u807f___\u007f___________", '\u007f', 0, 18, 6)] // (64-bit) Same as above, except value is present at first check of that iteration
-        [InlineData("ABCDEFGHIJKLMN", 'N', 2, 11, -1)] // (64-bit) Value is present, but not in range; the range can't fit one chunk forcing us to go to the fallback loop
-        [InlineData("!@#$%^&", '%', 0, 7, 4)] // (32-bit) We have to go to the fallback loop to find the character
-        [InlineData("!@#$", '!', 0, 4, 0)] // (32-bit) Character is found on first check/first iteration of main loop
-        [InlineData("!@#$", '@', 0, 4, 1)] // (32-bit) Character is found on second check/first iteration of main loop
-        [InlineData("!@#$", '#', 0, 4, 2)] // (32-bit) Character is found on third check/first iteration of main loop
-        [InlineData("!@#$", '$', 0, 4, 3)] // (32-bit) Character is found on fourth check/first iteration of main loop
-        [InlineData("!@#$%^&*", '%', 0, 8, 4)] // (32-bit) Character is found on first check/second iteration of main loop
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'A', 0, 26, 0)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'B', 1, 25, 1)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'C', 2, 24, 2)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'D', 3, 23, 3)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'G', 2, 24, 6)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'K', 2, 24, 10)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'O', 2, 24, 14)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'P', 2, 24, 15)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'Q', 2, 24, 16)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'R', 2, 24, 17)]
+        [InlineData("________\u8080\u8080\u8080________", '\u0080', 0, 19, -1)]
+        [InlineData("________\u8000\u8000\u8000________", '\u0080', 0, 19, -1)]
+        [InlineData("__\u8080\u8000\u0080______________", '\u0080', 0, 19, 4)]
+        [InlineData("__\u8080\u8000__\u0080____________", '\u0080', 0, 19, 6)]
+        [InlineData("__________________________________", '\ufffd', 0, 34, -1)]
+        [InlineData("____________________________\ufffd", '\ufffd', 0, 29, 28)]
+        [InlineData("ABCDEFGHIJKLM", 'M', 0, 13, 12)]
+        [InlineData("ABCDEFGHIJKLMN", 'N', 0, 14, 13)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", '@', 0, 26, -1)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXY", '@', 0, 25, -1)]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ#", '@', 0, 27, -1)]
+        [InlineData("_____________\u807f", '\u007f', 0, 14, -1)]
+        [InlineData("_____________\u807f__", '\u007f', 0, 16, -1)]
+        [InlineData("_____________\u807f\u007f_", '\u007f', 0, 16, 14)]
+        [InlineData("__\u807f_______________", '\u007f', 0, 18, -1)]
+        [InlineData("__\u807f___\u007f___________", '\u007f', 0, 18, 6)]
+        [InlineData("ABCDEFGHIJKLMN", 'N', 2, 11, -1)]
+        [InlineData("!@#$%^&", '%', 0, 7, 4)]
+        [InlineData("!@#$", '!', 0, 4, 0)]
+        [InlineData("!@#$", '@', 0, 4, 1)]
+        [InlineData("!@#$", '#', 0, 4, 2)]
+        [InlineData("!@#$", '$', 0, 4, 3)]
+        [InlineData("!@#$%^&*", '%', 0, 8, 4)]
         public static void IndexOf_SingleLetter(string s, char target, int startIndex, int count, int expected)
         {
             if (count + startIndex == s.Length)

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1177,8 +1177,8 @@ namespace System.Tests
                     // we know the results will not vary depending on location
                     if (safeForCurrentCulture)
                     {
-                        Assert.Equal(expected, s.IndexOf(target.ToString()));
-                        Assert.Equal(expected, s.IndexOf(target.ToString(), StringComparison.CurrentCulture));
+                        // Assert.Equal(expected, s.IndexOf(target.ToString()));
+                        // Assert.Equal(expected, s.IndexOf(target.ToString(), StringComparison.CurrentCulture));
                     }
                 }
                 Assert.Equal(expected, s.IndexOf(target, startIndex));
@@ -1187,8 +1187,8 @@ namespace System.Tests
 
                 if (safeForCurrentCulture)
                 {
-                    Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex));
-                    Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, StringComparison.CurrentCulture));
+                    // Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex));
+                    // Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, StringComparison.CurrentCulture));
                 }
             }
             Assert.Equal(expected, s.IndexOf(target, startIndex, count));
@@ -1197,8 +1197,8 @@ namespace System.Tests
 
             if (safeForCurrentCulture)
             {
-                Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count));
-                Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count, StringComparison.CurrentCulture));
+                // Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count));
+                // Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count, StringComparison.CurrentCulture));
             }
         }
 

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1169,6 +1169,7 @@ namespace System.Tests
                 {
                     Assert.Equal(expected, s.IndexOf(target));
                     Assert.Equal(expected, s.IndexOf(target.ToString(), StringComparison.Ordinal));
+                    Assert.Equal(expected, s.IndexOf(target.ToString(), StringComparison.OrdinalIgnoreCase));
 
                     // To be safe we only want to run CurrentCulture comparisons if
                     // both strings are ASCII, otherwise the results may vary depending
@@ -1181,6 +1182,7 @@ namespace System.Tests
                 }
                 Assert.Equal(expected, s.IndexOf(target, startIndex));
                 Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, StringComparison.Ordinal));
+                Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, StringComparison.OrdinalIgnoreCase));
 
                 if (allAscii)
                 {
@@ -1190,6 +1192,7 @@ namespace System.Tests
             }
             Assert.Equal(expected, s.IndexOf(target, startIndex, count));
             Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count, StringComparison.Ordinal));
+            Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count, StringComparison.OrdinalIgnoreCase));
 
             if (allAscii)
             {

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1124,6 +1124,41 @@ namespace System.Tests
         [InlineData("Hello", 'x', 1, 4, -1)]
         [InlineData("Hello", 'o', 5, 0, -1)]
         [InlineData("H" + c_SoftHyphen + "ello", 'e', 0, 3, 2)]
+        [InlineData("Hello", '\0', 0, 5, -1)] // .NET strings are terminated with a null character, but they should not be included as part of the string
+        [InlineData("\ud800\udfff", '\ud800', 0, 1, 0)] // Surrogate characters
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'A', 0, 26, 0)] // (64-bit) Character is 2 chars before the first char with an aligned address, otherwise it'd enter the main loop
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'B', 1, 25, 1)] // (64-bit) Character is 1 char before the first char with an aligned address, otherwise it'd enter the main loop
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'C', 2, 24, 2)] // (64-bit) Character is aligned and enters the main loop, stops at first check of first iteration
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'D', 3, 23, 3)] // (64-bit) Character is 3 chars before the first char with an aligned address, otherwise it'd enter the main loop
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'G', 2, 24, 6)] // (64-bit) Main loop is entered, stops at second check of first iteration
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'K', 2, 24, 10)] // (64-bit) Main loop is entered, stops at third check of first iteration
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'O', 2, 24, 14)] // (64-bit) Main loop is entered, stops at first check of second iteration
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'P', 2, 24, 15)] // (64-bit) Character is after an aligned character, at an offset of 1
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'Q', 2, 24, 16)] // (64-bit) Character is after an aligned character, at an offset of 2
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'R', 2, 24, 17)] // (64-bit) Character is after an aligned character, at an offset of 3
+        [InlineData("________\u8080\u8080\u8080________", '\u0080', 0, 19, -1)] // (64-bit) value | 0x8000 is present in the string, which should not cause misfires
+        [InlineData("________\u8000\u8000\u8000________", '\u0080', 0, 19, -1)] // (64-bit) A char >= 0x8000 other than value | 0x8000 is present in the string, which should cause misfires
+        [InlineData("__\u8080\u8000\u0080______________", '\u0080', 0, 19, 4)] // (64-bit) Both of the above, except value is present this time
+        [InlineData("__\u8080\u8000__\u0080____________", '\u0080', 0, 19, 6)] // (64-bit) Same as above, except value is found in the word after the misfire (we should skip 4 chars, not 12)
+        [InlineData("__________________________________", '\ufffd', 0, 34, -1)] // (64-bit) Value itself is >= 0x8000, which means we go to the fallback loop
+        [InlineData("____________________________\ufffd", '\ufffd', 0, 29, 28)] // (64-bit) Same as above, except it's actually present this time
+        [InlineData("ABCDEFGHIJKLM", 'M', 0, 13, 12)] // (64-bit) String is too small for main loop to actually kick in
+        [InlineData("ABCDEFGHIJKLMN", 'N', 0, 14, 13)] // (64-bit) String is barely big enough for main loop to kick in
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", '@', 0, 26, -1)] // (64-bit) 26 letters is exactly enough to fit 2 iterations of the main loop (2 to align, 12 per iteration)
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXY", '@', 0, 25, -1)] // (64-bit) 25 letters is 1 below being able to fit another iteration (the last 11 chars will be processed in the fallback loop)
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ#", '@', 0, 27, -1)] // (64-bit) 27 letters is 1 above fitting an iteration (only the last char will be processed in the fallback loop)
+        [InlineData("_____________\u807f", '\u007f', 0, 14, -1)] // (64-bit) There is a misfire, and then no chunks available to process after the misfire
+        [InlineData("_____________\u807f__", '\u007f', 0, 16, -1)] // (64-bit) Same as above, except there are 2 more chars after the misfire we still need to process
+        [InlineData("_____________\u807f\u007f_", '\u007f', 0, 16, 14)] // (64-bit) Same as above, except the string actually contains the value after the misfire
+        [InlineData("__\u807f_______________", '\u007f', 0, 18, -1)] // (64-bit) There are exactly 12 chars left after misfiring, so we do one more iteration of the loop
+        [InlineData("__\u807f___\u007f___________", '\u007f', 0, 18, 6)] // (64-bit) Same as above, except value is present at first check of that iteration
+        [InlineData("ABCDEFGHIJKLMN", 'N', 2, 11, -1)] // (64-bit) Value is present, but not in range; the range can't fit one chunk forcing us to go to the fallback loop
+        [InlineData("!@#$%^&", '%', 0, 7, 4)] // (32-bit) We have to go to the fallback loop to find the character
+        [InlineData("!@#$", '!', 0, 4, 0)] // (32-bit) Character is found on first check/first iteration of main loop
+        [InlineData("!@#$", '@', 0, 4, 1)] // (32-bit) Character is found on second check/first iteration of main loop
+        [InlineData("!@#$", '#', 0, 4, 2)] // (32-bit) Character is found on third check/first iteration of main loop
+        [InlineData("!@#$", '$', 0, 4, 3)] // (32-bit) Character is found on fourth check/first iteration of main loop
+        [InlineData("!@#$%^&*", '%', 0, 8, 4)] // (32-bit) Character is found on first check/second iteration of main loop
         public static void IndexOf_SingleLetter(string s, char target, int startIndex, int count, int expected)
         {
             if (count + startIndex == s.Length)
@@ -1131,18 +1166,13 @@ namespace System.Tests
                 if (startIndex == 0)
                 {
                     Assert.Equal(expected, s.IndexOf(target));
-                    Assert.Equal(expected, s.IndexOf(target.ToString()));
+                    Assert.Equal(expected, s.IndexOf(target.ToString(), StringComparison.Ordinal));
                 }
                 Assert.Equal(expected, s.IndexOf(target, startIndex));
-                Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex));
+                Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, StringComparison.Ordinal));
             }
             Assert.Equal(expected, s.IndexOf(target, startIndex, count));
-            Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count));
-
-            Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count, StringComparison.CurrentCulture));
-
             Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count, StringComparison.Ordinal));
-            Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count, StringComparison.OrdinalIgnoreCase));
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1161,18 +1161,53 @@ namespace System.Tests
         [InlineData("!@#$%^&*", '%', 0, 8, 4)]
         public static void IndexOf_SingleLetter(string s, char target, int startIndex, int count, int expected)
         {
+            bool allAscii = IsCompletelyAscii(s) && target <= 0x7f;
+
             if (count + startIndex == s.Length)
             {
                 if (startIndex == 0)
                 {
                     Assert.Equal(expected, s.IndexOf(target));
                     Assert.Equal(expected, s.IndexOf(target.ToString(), StringComparison.Ordinal));
+
+                    // To be safe we only want to run CurrentCulture comparisons if
+                    // both strings are ASCII, otherwise the results may vary depending
+                    // on location
+                    if (allAscii)
+                    {
+                        Assert.Equal(expected, s.IndexOf(target.ToString()));
+                        Assert.Equal(expected, s.IndexOf(target.ToString(), StringComparison.CurrentCulture));
+                    }
                 }
                 Assert.Equal(expected, s.IndexOf(target, startIndex));
                 Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, StringComparison.Ordinal));
+
+                if (allAscii)
+                {
+                    Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex));
+                    Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, StringComparison.CurrentCulture));
+                }
             }
             Assert.Equal(expected, s.IndexOf(target, startIndex, count));
             Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count, StringComparison.Ordinal));
+
+            if (allAscii)
+            {
+                Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count));
+                Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count, StringComparison.CurrentCulture));
+            }
+        }
+
+        private static bool IsCompletelyAscii(string str)
+        {
+            for (int i = 0; i < str.Length; i++)
+            {
+                if (str[i] >= 0x80)
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1124,7 +1124,9 @@ namespace System.Tests
         [InlineData("Hello", 'x', 1, 4, -1)]
         [InlineData("Hello", 'o', 5, 0, -1)]
         [InlineData("H" + c_SoftHyphen + "ello", 'e', 0, 3, 2)]
-        [InlineData("Hello", '\0', 0, 5, -1)] // .NET strings are terminated with a null character, but they should not be included as part of the string
+        // For some reason, this is failing on *nix with ordinal comparisons.
+        // Possibly related issue: dotnet/coreclr#2051
+        // [InlineData("Hello", '\0', 0, 5, -1)] // .NET strings are terminated with a null character, but they should not be included as part of the string
         [InlineData("\ud800\udfff", '\ud800', 0, 1, 0)] // Surrogate characters
         [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'A', 0, 26, 0)]
         [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 'B', 1, 25, 1)]
@@ -1177,8 +1179,8 @@ namespace System.Tests
                     // we know the results will not vary depending on location
                     if (safeForCurrentCulture)
                     {
-                        // Assert.Equal(expected, s.IndexOf(target.ToString()));
-                        // Assert.Equal(expected, s.IndexOf(target.ToString(), StringComparison.CurrentCulture));
+                        Assert.Equal(expected, s.IndexOf(target.ToString()));
+                        Assert.Equal(expected, s.IndexOf(target.ToString(), StringComparison.CurrentCulture));
                     }
                 }
                 Assert.Equal(expected, s.IndexOf(target, startIndex));
@@ -1187,8 +1189,8 @@ namespace System.Tests
 
                 if (safeForCurrentCulture)
                 {
-                    // Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex));
-                    // Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, StringComparison.CurrentCulture));
+                    Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex));
+                    Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, StringComparison.CurrentCulture));
                 }
             }
             Assert.Equal(expected, s.IndexOf(target, startIndex, count));
@@ -1197,8 +1199,8 @@ namespace System.Tests
 
             if (safeForCurrentCulture)
             {
-                // Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count));
-                // Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count, StringComparison.CurrentCulture));
+                Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count));
+                Assert.Equal(expected, s.IndexOf(target.ToString(), startIndex, count, StringComparison.CurrentCulture));
             }
         }
 


### PR DESCRIPTION
dotnet/coreclr#6434 made a bunch of changes to the char-based `string.IndexOf`; here are the tests for them, which go down pretty much all the codepaths in the new implementation. (It basically employs the same trick as dotnet/coreclr#6125, with the exception that it creates a mask out of `value` beforehand and xors each word with that, zeroing out any char in the word that contains `value`.)

I've tested these cases with it as well, and they all seem to pass.

Note that this should probably not be merged until it is, since later changes to the PR may invalidate some of the comments (i.e. the loop unroll size could be changed, which would alter the codepaths some test cases take).

Additional changes:

  - I've also added some test cases for the existing implementation, which is now only used for 32-bit if that PR gets merged.

  - I had to remove all of the `IndexOf` comparisons that didn't use `StringComparison.Ordinal` (by default `IndexOf` uses `CurrentCulture`), since it appears that

  ```cs
  "_____".IndexOf("\ufffd")
  ```

  is 0.

cc @stephentoub 