### PR TITLE
ARM-CI : Add logging for getting the reason of unmounting issue.

### DIFF
--- a/scripts/arm32_ci_script.sh
+++ b/scripts/arm32_ci_script.sh
@@ -78,7 +78,15 @@ function check_git_head {
 function unmount_rootfs {
     local rootfsFolder="$1"
 
-    if grep -qs "$rootfsFolder" /proc/mounts; then
+    #Check if there are any open files in this directory.
+    if [ -d $rootfsFolder ]; then
+        #If we find information about the file
+        if sudo lsof +D $rootfsFolder; then
+            (set +x; echo 'See above for lsof information. Continuing with the build.')
+        fi
+    fi
+
+    if mountpoint -q -- "$rootfsFolder"; then
         sudo umount "$rootfsFolder"
     fi
 }


### PR DESCRIPTION
    Recently I find unmount error frequently. (http://dotnet-ci.cloudapp.net/job/dotnet_corefx/job/master/job/linuxarmemulator_cross_debug/106/console)

    So I would take some below action temoprarily. I think this problem is different from CoreCLR. We have to get logs when the mounting error is occurred.

    [Add logging for getting the reason of unmounting issue.]