### PR TITLE
Prohibit open generic or address types on Goto etc.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Dynamic.Utils;
 
@@ -354,16 +353,30 @@ namespace System.Linq.Expressions
         /// </returns>
         public static GotoExpression MakeGoto(GotoExpressionKind kind, LabelTarget target, Expression value, Type type)
         {
-            ValidateGoto(target, ref value, nameof(target), nameof(value));
+            ValidateGoto(target, ref value, nameof(target), nameof(value), type);
             return new GotoExpression(kind, target, value, type);
         }
 
-        private static void ValidateGoto(LabelTarget target, ref Expression value, string targetParameter, string valueParameter)
+        private static void ValidateGoto(LabelTarget target, ref Expression value, string targetParameter, string valueParameter, Type type)
         {
             ContractUtils.RequiresNotNull(target, targetParameter);
             if (value == null)
             {
                 if (target.Type != typeof(void)) throw Error.LabelMustBeVoidOrHaveExpression(nameof(target));
+
+                if (type != null)
+                {
+                    TypeUtils.ValidateType(type, nameof(type));
+                    if (type.IsByRef)
+                    {
+                        throw Error.TypeMustNotBeByRef(nameof(type));
+                    }
+
+                    if (type.IsPointer)
+                    {
+                        throw Error.TypeMustNotBePointer(nameof(type));
+                    }
+                }
             }
             else
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelExpression.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 
 namespace System.Linq.Expressions
@@ -106,7 +105,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="LabelExpression"/> with the given default value.</returns>
         public static LabelExpression Label(LabelTarget target, Expression defaultValue)
         {
-            ValidateGoto(target, ref defaultValue, nameof(target), nameof(defaultValue));
+            ValidateGoto(target, ref defaultValue, nameof(target), nameof(defaultValue), null);
             return new LabelExpression(target, defaultValue);
         }
     }

--- a/src/System.Linq.Expressions/tests/Goto/Break.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Break.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -187,6 +186,31 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Constant(0);
             GotoExpression ret = Expression.Break(Expression.Label(typeof(int)), value);
             Assert.NotSame(ret, ret.Update(Expression.Label(typeof(int)), value));
+        }
+
+        [Fact]
+        public void OpenGenericType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Break(Expression.Label(typeof(void)), typeof(List<>)));
+        }
+
+        [Fact]
+        public static void TypeContainsGenericParameters()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Break(Expression.Label(typeof(void)), typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Break(Expression.Label(typeof(void)), typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+
+        [Fact]
+        public void PointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Break(Expression.Label(typeof(void)), typeof(int).MakePointerType()));
+        }
+
+        [Fact]
+        public void ByRefType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Break(Expression.Label(typeof(void)), typeof(int).MakeByRefType()));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Goto/Continue.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Continue.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -64,6 +63,31 @@ namespace System.Linq.Expressions.Tests
         public void ExplicitNullTypeWithValue(object value)
         {
             Assert.Throws<ArgumentException>("target", () => Expression.Continue(Expression.Label(value.GetType()), default(Type)));
+        }
+
+        [Fact]
+        public void OpenGenericType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Continue(Expression.Label(typeof(void)), typeof(List<>)));
+        }
+
+        [Fact]
+        public static void TypeContainsGenericParameters()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Continue(Expression.Label(typeof(void)), typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Continue(Expression.Label(typeof(void)), typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+
+        [Fact]
+        public void PointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Continue(Expression.Label(typeof(void)), typeof(int).MakePointerType()));
+        }
+
+        [Fact]
+        public void ByRefType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Continue(Expression.Label(typeof(void)), typeof(int).MakeByRefType()));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Goto/Goto.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Goto.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -187,6 +186,31 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Constant(0);
             GotoExpression ret = Expression.Goto(Expression.Label(typeof(int)), value);
             Assert.NotSame(ret, ret.Update(Expression.Label(typeof(int)), value));
+        }
+
+        [Fact]
+        public void OpenGenericType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Goto(Expression.Label(typeof(void)), typeof(List<>)));
+        }
+
+        [Fact]
+        public static void TypeContainsGenericParameters()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Goto(Expression.Label(typeof(void)), typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Goto(Expression.Label(typeof(void)), typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+
+        [Fact]
+        public void PointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Goto(Expression.Label(typeof(void)), typeof(int).MakePointerType()));
+        }
+
+        [Fact]
+        public void ByRefType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Goto(Expression.Label(typeof(void)), typeof(int).MakeByRefType()));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Goto/MakeGoto.cs
+++ b/src/System.Linq.Expressions/tests/Goto/MakeGoto.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class MakeGoto
+    {
+        public static IEnumerable<object[]> GotoTypes
+            => ((GotoExpressionKind[])Enum.GetValues(typeof(GotoExpressionKind))).Select(kind => new object[] {kind});
+
+        [Theory]
+        [MemberData(nameof(GotoTypes))]
+        public void OpenGenericType(GotoExpressionKind kind)
+        {
+            Assert.Throws<ArgumentException>(
+                "type", () => Expression.MakeGoto(kind, Expression.Label(typeof(void)), null, typeof(List<>)));
+        }
+
+        [Theory]
+        [MemberData(nameof(GotoTypes))]
+        public static void TypeContainsGenericParameters(GotoExpressionKind kind)
+        {
+            Assert.Throws<ArgumentException>(
+                "type", () => Expression.MakeGoto(kind, Expression.Label(typeof(void)), null, typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>(
+                "type",
+                () =>
+                    Expression.MakeGoto(
+                        kind, Expression.Label(typeof(void)), null, typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+
+        [Theory]
+        [MemberData(nameof(GotoTypes))]
+        public void PointerType(GotoExpressionKind kind)
+        {
+            Assert.Throws<ArgumentException>(
+                "type",
+                () => Expression.MakeGoto(kind, Expression.Label(typeof(void)), null, typeof(int).MakePointerType()));
+        }
+
+        [Theory]
+        [MemberData(nameof(GotoTypes))]
+        public void ByRefType(GotoExpressionKind kind)
+        {
+            Assert.Throws<ArgumentException>(
+                "type",
+                () => Expression.MakeGoto(kind, Expression.Label(typeof(void)), null, typeof(int).MakeByRefType()));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Goto/Return.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Return.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -187,6 +186,31 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Constant(0);
             GotoExpression ret = Expression.Return(Expression.Label(typeof(int)), value);
             Assert.NotSame(ret, ret.Update(Expression.Label(typeof(int)), value));
+        }
+
+        [Fact]
+        public void OpenGenericType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Return(Expression.Label(typeof(void)), typeof(List<>)));
+        }
+
+        [Fact]
+        public static void TypeContainsGenericParameters()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Return(Expression.Label(typeof(void)), typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Return(Expression.Label(typeof(void)), typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+
+        [Fact]
+        public void PointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Return(Expression.Label(typeof(void)), typeof(int).MakePointerType()));
+        }
+
+        [Fact]
+        public void ByRefType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Return(Expression.Label(typeof(void)), typeof(int).MakeByRefType()));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Goto\Continue.cs" />
     <Compile Include="Goto\Goto.cs" />
     <Compile Include="Goto\GotoExpressionTests.cs" />
+    <Compile Include="Goto\MakeGoto.cs" />
     <Compile Include="Goto\Return.cs" />
     <Compile Include="HelperTypes.cs" />
     <Compile Include="Invoke\InvocationTests.cs" />


### PR DESCRIPTION
Contributes to #8081.

Only explicit use of the types are corrected here; creating an open generic or byref jump expression through use of a value of such a type will be prohibited by the rest of #8081 preventing such values ever existing.

cc: @VSadov 