### PR TITLE
Add ARM64 private jobs to Jenkins

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -118,10 +118,10 @@
                                        ValidationPatterns="@(ValidationPattern)"
                                        UpdateInvalidDependencies="true" />
   </Target>
-
+  
   <!-- Task from buildtools that uses lockfiles to validate that packages restored are exactly what were specified. -->
   <UsingTask TaskName="ValidateExactRestore" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-
+  
   <Target Name="ValidateExactRestore"
           Condition="'$(AllowInexactRestore)'!='true'">
     <ValidateExactRestore ProjectLockJsons="@(ProjectJsonFiles->'%(RootDir)%(Directory)%(Filename).lock.json')" />
@@ -137,6 +137,28 @@
                                     NewVersion="$(NewVersion)" />
   </Target>
 
+  <!-- Packages.zip creation -->
+  <UsingTask TaskName="ZipFileCreateFromDependencyLists" Condition="'$(ArchiveTests)' == 'true'" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <Target Name="ArchiveTestBuild" Condition="'$(ArchiveTests)' == 'true'" AfterTargets="Build" >
+    <ItemGroup>
+      <ExcludeFromArchive Include="nupkg$" />
+      <ExcludeFromArchive Include="Microsoft.DotNet.BuildTools" />
+      <ExcludeFromArchive Include="TestData" />
+      <TestDependencyListFile Include="$(BinDir)/TestDependencies/*.dependencylist.txt" />
+    </ItemGroup>
+    
+    <PropertyGroup>
+      <TestArchiveDir>$(TestWorkingDir)$(OSPlatformConfig)/archive/tests/</TestArchiveDir>
+      <TestArchiveDir Condition="'$(TestTFM)' != ''">$(TestArchiveDir)$(TestTFM)/</TestArchiveDir>
+    </PropertyGroup>
+
+    <ZipFileCreateFromDependencyLists
+      DependencyListFiles="@(TestDependencyListFile)"
+      DestinationArchive="$(TestArchiveDir)\Packages.zip"
+      RelativePathBaseDirectory="$(PackagesDir)"
+      OverwriteDestination="true" />
+  </Target>
+  
   <!-- Override RestorePackages from dir.traversal.targets and do a batch restore -->
   <Target Name="RestorePackages" DependsOnTargets="BatchRestorePackages" />
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -285,6 +285,59 @@ def osShortName = ['Windows 10': 'win10',
 }
 
 // **************************
+// Define ARM64 testing.  Built locally and submitted to lab machines
+// **************************
+['Windows_NT'].each { os ->
+    ['Debug', 'Release'].each { configurationGroup ->
+        def newJobName = "arm64_${os.toLowerCase()}_${configurationGroup.toLowerCase()}"
+        def arm64Users = ['ianhays', 'kyulee1', 'gkhanna79', 'weshaggard', 'stephentoub', 'rahku', 'ramarag']
+        def newJob = job(Utilities.getFullJobName(project, newJobName, /* isPR */ false)) {
+            steps {
+                // build the world, but don't run the tests
+                batchFile("build-native.cmd -buildArch=arm64 -${configurationGroup} -- toolsetDir=C:\\ats2")
+                batchFile("build-managed.cmd -- /p:Creator=dotnet-bot /p:ArchiveTests=true /p:ConfigurationGroup=${configurationGroup} /p:TestDisabled=true /p:TestProduct=CoreFx /p:Branch=${branch} /p:FilterToOSGroup=${os} /p:TargetOS=${os} /p:OSGroup=${os} /p:Platform=ARM64 /p:TestArchitecture=arm64 /p:DefaultTestTFM=netcoreapp1.1 /p:TestNugetRuntimeId=win10-arm64")
+            }
+            label("arm64_corefx")
+            
+            // Kick off the test run
+            publishers {
+                archiveArtifacts {
+                    pattern("bin/tests/${os}.ARM64.${configurationGroup}/archive/tests/netcoreapp1.1/**")
+                    onlyIfSuccessful(true)
+                    allowEmpty(false)
+                }
+                postBuildScripts {
+                    steps {
+                        // Transfer the tests to the ARM64 machine and signal it to begin
+                        batchFile("Z:\\arm64\\common\\scripts_corefx\\JenkinsPostBuild.cmd %WORKSPACE% ${configurationGroup} %BUILD_NUMBER%")
+                    }
+                    onlyIfBuildSucceeds(true)
+                    onlyIfBuildFails(false)
+                }
+            }
+        }
+
+        // Set up standard options.
+        Utilities.standardJobSetup(newJob, project, /* isPR */ false, "*/${branch}")
+        
+        // Set a periodic trigger
+        // Temporarily disabled until private triggers are stable
+        // Utilities.addPeriodicTrigger(newJob, '@daily')
+        
+        // Set up a PR trigger that is only triggerable by certain members
+        Utilities.addPrivateGithubPRTriggerForBranch(newJob, branch, "Windows_NT ARM64 ${configurationGroup} Build and Test", "(?i).*test\\W+ARM64\\W+${os}\\W+${configurationGroup}", null, arm64Users)
+
+        // Set up a per-push trigger
+        // Temporarily disabled until private triggers are stable
+        // Utilities.addGithubPushTrigger(newJob)
+
+        // Get results
+        Utilities.addXUnitDotNETResults(newJob, 'bin/tests/testresults/**/testResults.xml')
+    }
+}
+
+
+// **************************
 // Define innerloop testing.  These jobs run on every merge and a subset of them run on every PR, the ones
 // that don't run per PR can be requested via a magic phrase.
 // **************************


### PR DESCRIPTION
Adds ARM64 build and test job definition to the Jenkins netci.groovy file. For now only private job initiations are allowed by a small set of users, though both per-push and daily triggers are coming.

depends on: <strike>https://github.com/dotnet/corefx/pull/10043, https://github.com/dotnet/buildtools/pull/906, SNI ARM64 Codeflow</strike>, https://github.com/dotnet/corefx/pull/10429

remaining ARM64 work: 
- Merge the above PRs. 
- Push a commit to dotnet-buildpipeline to add an ARM64 invocation to the pipelines.corefx.json file.
- Add 'arm64' labeled x64 machines to Jenkins.
- Bump the CoreFX buildtools version to consume the above changes as a part of this PR.
- Merge this PR
- Kick off some private test jobs on Jenkins to ensure the targets and scripts function as expected. Make changes where necessary.
- Push a(nother) PR to CoreFX to enable per-push and daily builds (currently commented out).

resolves https://github.com/dotnet/corefx/issues/6899

@mmitche @stephentoub @gkhanna79 @ericstj @weshaggard @kyulee1 @Priya91 