### PR TITLE
Remove duplicate addresses from the result returned from getaddrinfo.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
@@ -22,7 +22,7 @@ internal static partial class Interop
         // NOTE: `_isIPv6` cannot be of type `bool` because `bool` is not a blittable type and this struct is
         //       embedded in other structs for interop purposes.
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct IPAddress
+        internal unsafe struct IPAddress : IEquatable<IPAddress>
         {
             public bool IsIPv6
             {
@@ -33,6 +33,46 @@ internal static partial class Interop
             internal fixed byte Address[MAX_IP_ADDRESS_BYTES]; // Buffer to fit an IPv4 or IPv6 address
             private  uint _isIPv6;                             // Non-zero if this is an IPv6 address; zero for IPv4.
             internal uint ScopeId;                             // Scope ID (IPv6 only)
+
+            public bool Equals(IPAddress other)
+            {
+                int addressByteCount;
+                if (IsIPv6)
+                {
+                    if (!other.IsIPv6)
+                    {
+                        return false;
+                    }
+                    if (ScopeId != other.ScopeId)
+                    {
+                        return false;
+                    }
+
+                    addressByteCount = IPv6AddressBytes;
+                }
+                else
+                {
+                    if (other.IsIPv6)
+                    {
+                        return false;
+                    }
+
+                    addressByteCount = IPv4AddressBytes;
+                }
+
+                fixed (byte* thisAddress = Address)
+                {
+                    for (int i = 0; i < addressByteCount; i++)
+                    {
+                        if (thisAddress[i] != other.Address[i])
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_IPv6StringToAddress", SetLastError = true)]

--- a/src/System.Net.NameResolution/tests/FunctionalTests/DnsTests.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/DnsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -27,9 +28,12 @@ namespace System.Net.NameResolution.Tests
             Assert.NotNull(list2);
 
             Assert.Equal(list1.Length, list2.Length);
+
+            var set = new HashSet<IPAddress>();
             for (int i = 0; i < list1.Length; i++)
             {
                 Assert.Equal(list1[i], list2[i]);
+                Assert.True(set.Add(list1[i]), "Multiple entries for address " + list1[i]);
             }
         }
 


### PR DESCRIPTION
`getaddrinfo` returns one entry per socket type (raw, datagram, stream), for each address.  We don't currently take this into account, resulting in duplicate IP addresses returned from all DNS lookups on Linux.

This change filters the list to include only unique IP addresses.  It also consolidates the handling of these results in one place (we previously had two separate copies of essentially the same code).

Fixes #9764.

@CIPop @stephentoub 