### PR TITLE
We shipped assembly file version 4.6.x up until the end of rc3.  Vers…

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -2,6 +2,12 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
 
+  <!-- We shipped assembly file version 4.6.x up until the end of rc3.  Version assembly as 
+        4.6.x to ensure compatability in Visual Studio for an in-place update. -->
+  <PropertyGroup>
+    <MajorVersion>4</MajorVersion>
+    <MinorVersion>6</MinorVersion>
+  </PropertyGroup>
   <!--
     $(OS) is set to Unix/Windows_NT. This comes from an environment variable on Windows and MSBuild on Unix.
   -->

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -12,10 +12,6 @@
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>
     <AssemblyVersion>1.2.1</AssemblyVersion>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
-    <!-- We shipped assembly file version 4.6.x up until the end of rc3.  Version assembly as 
-         4.6.x to ensure compatability in Visual Studio for an in-place update. -->
-    <MajorVersion>4</MajorVersion>
-    <MinorVersion>6</MinorVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageDestination Include="lib/netstandard1.0">

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -12,6 +12,10 @@
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>
     <AssemblyVersion>1.2.1</AssemblyVersion>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <!-- We shipped assembly file version 4.6.x up until the end of rc3.  Version assembly as 
+         4.6.x to ensure compatability in Visual Studio for an in-place update. -->
+    <MajorVersion>4</MajorVersion>
+    <MinorVersion>6</MinorVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageDestination Include="lib/netstandard1.0">


### PR DESCRIPTION
…ion assembly as 4.6.x to ensure compatability in Visual Studio for an in-place update.

Note that I didn't set "AssemblyFileVersion" because I wanted to ensure buildnumbermajor and buildnumberminor continue to increment per current conventions, but setting "AssemblyFileVersion" explicitly appears to lock the file version rather than allowing it to increment the buildnumbermajor/minor version.

/cc @ericstj @weshaggard 