### PR TITLE
Remove TODO comment from Socket ArgumentValidation tests

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -12,17 +12,6 @@ using Xunit;
 
 namespace System.Net.Sockets.Tests
 {
-    // TODO (#7852):
-    //
-    // - Connect(EndPoint):
-    //   - disconnected socket
-    // - Accept(EndPoint):
-    //   - disconnected socket
-    //
-    // End*:
-    // - Invalid asyncresult type
-    // - asyncresult from different object
-    // - asyncresult with end already called
     public class ArgumentValidation
     {
         // This type is used to test Socket.Select's argument validation.


### PR DESCRIPTION
The Accept/Connect suggestions in this comment don't make much sense in the current API, as there is no "disconnect" API in CoreFx.

The End* suggestions would be great, except that the public Begin*/End* methods are implemented using generic wrappers over Task-based async methods, and so are not likely to ever pass such tests.  It doesn't seem worth complicating the implementation for this.

Fixes #7852