### PR TITLE
Change ActiveIssue to PlatformSpecific for issue 4002.

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -248,7 +248,7 @@ namespace System.Net.Sockets.Tests
         [InlineData(SocketImplementationType.Async)]
         [Trait("IPv4", "true")]
         [Trait("IPv6", "true")]
-        [ActiveIssue(4002, PlatformID.AnyUnix)]
+        [PlatformSpecific(PlatformID.Windows)] // "localhost" only guaranteed to resolve to v4 *and* v6 on Windows.
         public void Socket_StaticConnectAsync_Success(SocketImplementationType type)
         {
             Assert.True(Capability.IPv4Support() && Capability.IPv6Support());

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -609,7 +609,7 @@ namespace System.Net.Sockets.Tests
 
         [Theory]
         [MemberData(nameof(DualMode_Connect_IPAddress_DualMode_Data))]
-        [ActiveIssue(4002, PlatformID.AnyUnix)]
+        [PlatformSpecific(PlatformID.Windows)] // "localhost" only guaranteed to resolve to v4 *and* v6 on Windows.
         public void DualModeConnectAsync_Static_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
         {
             int port;


### PR DESCRIPTION
There's no guarantee on non-Windows platforms that "localhost" will resolve to v4 and v6 addresses.

Fixes #4002.