### PR TITLE
Prohibit open generic or address types on Expression.Catch

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Dynamic.Utils;
 
@@ -158,7 +157,20 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
             ContractUtils.Requires(variable == null || TypeUtils.AreEquivalent(variable.Type, type), nameof(variable));
-            if (variable != null && variable.IsByRef)
+            if (variable == null)
+            {
+                TypeUtils.ValidateType(type, nameof(type));
+                if (type.IsByRef)
+                {
+                    throw Error.TypeMustNotBeByRef(nameof(type));
+                }
+
+                if (type.IsPointer)
+                {
+                    throw Error.TypeMustNotBePointer(nameof(type));
+                }
+            }
+            else if (variable.IsByRef)
             {
                 throw Error.VariableMustNotBeByRef(variable, variable.Type, nameof(variable));
             }

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Text;
 using Xunit;
 
@@ -1196,6 +1197,41 @@ namespace System.Linq.Expressions.Tests
         {
             TryExpression tryExp = Expression.TryFault(Expression.Empty(), Expression.Empty());
             Assert.NotSame(tryExp, tryExp.Update(tryExp.Body, tryExp.Handlers, tryExp.Finally, Expression.Empty()));
+        }
+
+        [Fact]
+        public void OpenGenericExceptionType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Catch(typeof(List<>), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Catch(typeof(List<>), Expression.Constant(0), Expression.Constant(true)));
+            Assert.Throws<ArgumentException>("type", () => Expression.MakeCatchBlock(typeof(List<>), null, Expression.Constant(0), null));
+        }
+
+        [Fact]
+        public void ExceptionTypeContainingGenericParameters()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Catch(typeof(List<>.Enumerator), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Catch(typeof(List<>.Enumerator), Expression.Constant(0), Expression.Constant(true)));
+            Assert.Throws<ArgumentException>("type", () => Expression.MakeCatchBlock(typeof(List<>.Enumerator), null, Expression.Constant(0), null));
+            Assert.Throws<ArgumentException>("type", () => Expression.Catch(typeof(List<>).MakeGenericType(typeof(List<>)), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Catch(typeof(List<>).MakeGenericType(typeof(List<>)), Expression.Constant(0), Expression.Constant(true)));
+            Assert.Throws<ArgumentException>("type", () => Expression.MakeCatchBlock(typeof(List<>).MakeGenericType(typeof(List<>)), null, Expression.Constant(0), null));
+        }
+
+        [Fact]
+        public void PointerExceptionType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Catch(typeof(int*), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Catch(typeof(int*), Expression.Constant(0), Expression.Constant(true)));
+            Assert.Throws<ArgumentException>("type", () => Expression.MakeCatchBlock(typeof(int*), null, Expression.Constant(0), null));
+        }
+
+        [Fact]
+        public void TypedByRefExceptionType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Catch(typeof(int).MakeByRefType(), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Catch(typeof(int).MakeByRefType(), Expression.Constant(0), Expression.Constant(true)));
+            Assert.Throws<ArgumentException>("type", () => Expression.MakeCatchBlock(typeof(int).MakeByRefType(), null, Expression.Constant(0), null));
         }
     }
 }


### PR DESCRIPTION
Contributes to #8081.

cc: @VSadov 