### PR TITLE
Prohibit address types from Convert/ConvertChecked expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -787,6 +787,15 @@ namespace System.Linq.Expressions
             RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
+            if (type.IsByRef)
+            {
+                throw Error.TypeMustNotBeByRef(nameof(type));
+            }
+
+            if (type.IsPointer)
+            {
+                throw Error.TypeMustNotBePointer(nameof(type));
+            }
 
             if (method == null)
             {
@@ -828,6 +837,15 @@ namespace System.Linq.Expressions
             RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
+            if (type.IsByRef)
+            {
+                throw Error.TypeMustNotBeByRef(nameof(type));
+            }
+
+            if (type.IsPointer)
+            {
+                throw Error.TypeMustNotBePointer(nameof(type));
+            }
 
             if (method == null)
             {

--- a/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -18397,5 +18398,30 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
+        [Fact]
+        public static void OpenGenericnType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.ConvertChecked(Expression.Constant(null), typeof(List<>)));
+        }
+
+        [Fact]
+        public static void TypeContainingGenericParameters()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.ConvertChecked(Expression.Constant(null), typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>("type", () => Expression.ConvertChecked(Expression.Constant(null), typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+
+        [Fact]
+        public static void ByRefType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.ConvertChecked(Expression.Constant(null), typeof(object).MakeByRefType()));
+        }
+
+        [Fact]
+        public static void PointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.ConvertChecked(Expression.Constant(null), typeof(int*)));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -16477,6 +16478,31 @@ namespace System.Linq.Expressions.Tests
         public static void ExplicitOpImplicit()
         {
             Assert.Throws<InvalidOperationException>(() => Expression.Convert(Expression.Constant(new PerverselyNamedMembers(0)), typeof(uint)));
+        }
+
+        [Fact]
+        public static void OpenGenericnType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Convert(Expression.Constant(null), typeof(List<>)));
+        }
+
+        [Fact]
+        public static void TypeContainingGenericParameters()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Convert(Expression.Constant(null), typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Convert(Expression.Constant(null), typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+
+        [Fact]
+        public static void ByRefType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Convert(Expression.Constant(null), typeof(object).MakeByRefType()));
+        }
+
+        [Fact]
+        public static void PointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Convert(Expression.Constant(null), typeof(int*)));
         }
     }
 }


### PR DESCRIPTION
Also test open generics are prohibited.

Contributes to #8081

cc: @VSadov 