### PR TITLE
Fill some minor gaps in Expression tests

### DIFF
--- a/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
@@ -10,6 +10,13 @@ namespace System.Linq.Expressions.Tests
 {
     public static class AsNullableTests
     {
+        [Fact]
+        public static void NotLiftedEvenOnNullableOperandOrType()
+        {
+            Assert.False(Expression.TypeAs(Expression.Constant(E.A, typeof(E?)), typeof(E?)).IsLifted);
+            Assert.False(Expression.TypeAs(Expression.Constant(E.A, typeof(E?)), typeof(Enum)).IsLifted);
+        }
+
         #region Test methods
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Expressions.Tests
     public static class AsNullableTests
     {
         [Fact]
-        public static void NotLiftedEvenOnNullableOperandOrType()
+        public static void NotLiftedEvenOnNullableOperand()
         {
             Assert.False(Expression.TypeAs(Expression.Constant(E.A, typeof(E?)), typeof(E?)).IsLifted);
             Assert.False(Expression.TypeAs(Expression.Constant(E.A, typeof(E?)), typeof(Enum)).IsLifted);

--- a/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
@@ -178,5 +178,41 @@ namespace System.Linq.Expressions.Tests
             };
             Assert.Equal(expected.OrderBy(kvp => kvp.Key), func().OrderBy(kvp => kvp.Key));
         }
+
+        [Fact]
+        public void UpdateSameReturnsSame()
+        {
+            var init = Expression.ListInit(
+                Expression.New(typeof(List<int>)),
+                Expression.Constant(1),
+                Expression.Constant(2),
+                Expression.Constant(3));
+            Assert.Same(init, init.Update(init.NewExpression, init.Initializers));
+        }
+
+        [Fact]
+        public void UpdateDifferentNewReturnsDifferent()
+        {
+            var init = Expression.ListInit(
+                Expression.New(typeof(List<int>)),
+                Expression.Constant(1),
+                Expression.Constant(2),
+                Expression.Constant(3));
+            Assert.NotSame(init, init.Update(Expression.New(typeof(List<int>)), init.Initializers));
+        }
+
+        [Fact]
+        public void UpdateDifferentInitializersReturnsDifferent()
+        {
+            var meth = typeof(List<int>).GetMethod("Add");
+            var inits = new[]
+            {
+                Expression.ElementInit(meth, Expression.Constant(1)),
+                Expression.ElementInit(meth, Expression.Constant(2)),
+                Expression.ElementInit(meth, Expression.Constant(3))
+            };
+            var init = Expression.ListInit(Expression.New(typeof(List<int>)), inits);
+            Assert.NotSame(init, init.Update(Expression.New(typeof(List<int>)), inits));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeBinaryTests.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeBinaryTests.cs
@@ -92,5 +92,7 @@ namespace System.Linq.Expressions.Tests
                 return Types.SelectMany(t => Constants, (t, c) => new object[] { c, t });
             }
         }
+
+        public static IEnumerable<object[]> TypeArguments => Types.Select(t => new object[] {t});
     }
 }

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
@@ -172,5 +172,20 @@ namespace System.Linq.Expressions.Tests
             Assert.True(isActStr(a));
             Assert.False(isActStr(b));
         }
+
+        [Theory, PerCompilationType(nameof(TypeArguments))]
+        public void TypeEqualConstant(Type type, bool useInterpreter)
+        {
+            Func<bool> isNullOfType = Expression.Lambda<Func<bool>>(
+                Expression.TypeEqual(Expression.Constant(null), type)
+                ).Compile(useInterpreter);
+            Assert.False(isNullOfType());
+
+            isNullOfType = Expression.Lambda<Func<bool>>(
+                Expression.TypeEqual(Expression.Constant(null, typeof(string)), type)
+                ).Compile(useInterpreter);
+
+            Assert.False(isNullOfType());
+        }
     }
 }


### PR DESCRIPTION
A few items that are untested within parts of the Expressions that are otherwise well-covered:

1. Test the optimised path for `TypeEqual` with constant null expressions is correct.
2. Test `TypeAs` is always `false` for `Islifted`.
3. Test `Update()` on `ListInitExpression`.