### PR TITLE
Implement Environment.Get/SetEnvironmentVariable(s) for User and Machine on Win32

### DIFF
--- a/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
+++ b/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
@@ -10,6 +10,7 @@
     <AssemblyName>Microsoft.Win32.Registry</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);REGISTRY_ASSEMBLY</DefineConstants>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
@@ -8,7 +8,12 @@ using System.Diagnostics;
 namespace Microsoft.Win32
 {
     /// <summary>Registry encapsulation. Contains members representing all top level system keys.</summary>
-    public static class Registry
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    static class Registry
     {
         /// <summary>Current User Key. This key should be used as the root for all user specific settings.</summary>
         public static readonly RegistryKey CurrentUser = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default);

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryHive.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryHive.cs
@@ -7,7 +7,12 @@ namespace Microsoft.Win32
     /**
      * Registry hive values.  Useful only for GetRemoteBaseKey
      */
-    public enum RegistryHive
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    enum RegistryHive
     {
         ClassesRoot = unchecked((int)0x80000000),
         CurrentUser = unchecked((int)0x80000001),

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.FileSystem.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.FileSystem.cs
@@ -8,7 +8,12 @@ using System.Security.AccessControl;
 
 namespace Microsoft.Win32
 {
-    public sealed partial class RegistryKey : IDisposable
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    sealed partial class RegistryKey : IDisposable
     {
         private void ClosePerfDataKey()
         {

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -13,7 +13,12 @@ using System.Text;
 namespace Microsoft.Win32
 {
     /// <summary>Registry encapsulation. To get an instance of a RegistryKey use the Registry class's static members then call OpenSubKey.</summary>
-    public sealed partial class RegistryKey : IDisposable
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    sealed partial class RegistryKey : IDisposable
     {
         private static readonly IntPtr HKEY_CLASSES_ROOT = new IntPtr(unchecked((int)0x80000000));
         private static readonly IntPtr HKEY_CURRENT_USER = new IntPtr(unchecked((int)0x80000001));

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryOptions.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryOptions.cs
@@ -7,7 +7,12 @@ using System;
 namespace Microsoft.Win32
 {
     [Flags]
-    public enum RegistryOptions
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    enum RegistryOptions
     {
         None = Interop.mincore.RegistryOptions.REG_OPTION_NON_VOLATILE,       // 0x0000
         Volatile = Interop.mincore.RegistryOptions.REG_OPTION_VOLATILE,      // 0x0001

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryValueKind.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryValueKind.cs
@@ -4,7 +4,12 @@
 
 namespace Microsoft.Win32
 {
-    public enum RegistryValueKind
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    enum RegistryValueKind
     {
         String = Interop.mincore.RegistryValues.REG_SZ,
         ExpandString = Interop.mincore.RegistryValues.REG_EXPAND_SZ,

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryValueOptions.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryValueOptions.cs
@@ -7,7 +7,12 @@ using System;
 namespace Microsoft.Win32
 {
     [Flags]
-    public enum RegistryValueOptions
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    enum RegistryValueOptions
     {
         None = 0,
         DoNotExpandEnvironmentNames = 1

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryView.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryView.cs
@@ -6,7 +6,12 @@ using System;
 
 namespace Microsoft.Win32
 {
-    public enum RegistryView
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    enum RegistryView
     {
         Default = 0, // 0x0000 operate on the default registry view
         Registry64 = Interop.mincore.RegistryView.KEY_WOW64_64KEY, // 0x0100 operate on the 64-bit registry view

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/SafeHandles/SafeRegistryHandle.FileSystem.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/SafeHandles/SafeRegistryHandle.FileSystem.cs
@@ -6,7 +6,12 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    public sealed partial class SafeRegistryHandle : SafeHandle
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    sealed partial class SafeRegistryHandle : SafeHandle
     {
         // TODO: implement this if necessary
         protected override bool ReleaseHandle() => true;

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/SafeHandles/SafeRegistryHandle.Windows.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/SafeHandles/SafeRegistryHandle.Windows.cs
@@ -6,7 +6,12 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    public sealed partial class SafeRegistryHandle : SafeHandle
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    sealed partial class SafeRegistryHandle : SafeHandle
     {
         protected override bool ReleaseHandle() =>
             Interop.mincore.RegCloseKey(handle) == Interop.mincore.Errors.ERROR_SUCCESS;

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/SafeHandles/SafeRegistryHandle.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/SafeHandles/SafeRegistryHandle.cs
@@ -7,7 +7,12 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    public sealed partial class SafeRegistryHandle : SafeHandle
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    sealed partial class SafeRegistryHandle : SafeHandle
     {
         internal SafeRegistryHandle() : base(IntPtr.Zero, true) { }
 

--- a/src/Microsoft.Win32.Registry/src/System/Security/AccessControl/RegistryRights.cs
+++ b/src/Microsoft.Win32.Registry/src/System/Security/AccessControl/RegistryRights.cs
@@ -10,7 +10,12 @@ namespace System.Security.AccessControl
     // winnt.h and from MSDN, plus some experimental validation with regedit.
     // http://msdn.microsoft.com/library/default.asp?url=/library/en-us/sysinfo/base/registry_key_security_and_access_rights.asp
     [Flags]
-    public enum RegistryRights
+#if REGISTRY_ASSEMBLY
+    public
+#else
+    internal
+#endif
+    enum RegistryRights
     {
         // No None field - An ACE with the value 0 cannot grant nor deny.
         QueryValues = Interop.mincore.RegistryOperations.KEY_QUERY_VALUE,          // 0x0001 query the values of a registry key

--- a/src/System.Runtime.Extensions/src/Resources/Strings.resx
+++ b/src/System.Runtime.Extensions/src/Resources/Strings.resx
@@ -249,4 +249,79 @@
   <data name="Argument_StringZeroLength" xml:space="preserve">
     <value>String cannot be of zero length.</value>
   </data>
+  <data name="Arg_RegSubKeyAbsent" xml:space="preserve">
+    <value>Cannot delete a subkey tree because the subkey does not exist.</value>
+  </data>
+  <data name="Arg_RegKeyDelHive" xml:space="preserve">
+    <value>Cannot delete a registry hive's subtree.</value>
+  </data>
+  <data name="Arg_RegKeyNoRemoteConnect" xml:space="preserve">
+    <value>No remote connection to '{0}' while trying to read the registry.</value>
+  </data>
+  <data name="Arg_RegKeyOutOfRange" xml:space="preserve">
+    <value>Registry HKEY was out of the legal range.</value>
+  </data>
+  <data name="Arg_RegKeyNotFound" xml:space="preserve">
+    <value>The specified registry key does not exist.</value>
+  </data>
+  <data name="Arg_RegKeyStrLenBug" xml:space="preserve">
+    <value>Registry key names should not be greater than 255 characters.</value>
+  </data>
+  <data name="Arg_RegValStrLenBug" xml:space="preserve">
+    <value>Registry value names should not be greater than 16,383 characters.</value>
+  </data>
+  <data name="Arg_RegBadKeyKind" xml:space="preserve">
+    <value>The specified RegistryValueKind is an invalid value.</value>
+  </data>
+  <data name="Arg_RegGetOverflowBug" xml:space="preserve">
+    <value>RegistryKey.GetValue does not allow a String that has a length greater than Int32.MaxValue.</value>
+  </data>
+  <data name="Arg_RegSetMismatchedKind" xml:space="preserve">
+    <value>The type of the value object did not match the specified RegistryValueKind or the object could not be properly converted.</value>
+  </data>
+  <data name="Arg_RegSetBadArrType" xml:space="preserve">
+    <value>RegistryKey.SetValue does not support arrays of type '{0}'. Only Byte[] and String[] are supported.</value>
+  </data>
+  <data name="Arg_RegSetStrArrNull" xml:space="preserve">
+    <value>RegistryKey.SetValue does not allow a String[] that contains a null String reference.</value>
+  </data>
+  <data name="Arg_RegInvalidKeyName" xml:space="preserve">
+    <value>Registry key name must start with a valid base key name.</value>
+  </data>
+  <data name="Arg_DllInitFailure" xml:space="preserve">
+    <value>One machine may not have remote administration enabled, or both machines may not be running the remote registry service.</value>
+  </data>
+  <data name="Arg_EnumIllegalVal" xml:space="preserve">
+    <value>Illegal enum value: {0}.</value>
+  </data>
+  <data name="Arg_RegSubKeyValueAbsent" xml:space="preserve">
+    <value>No value exists with that name.</value>
+  </data>
+  <data name="Argument_InvalidRegistryOptionsCheck" xml:space="preserve">
+    <value>The specified RegistryOptions value is invalid.</value>
+  </data>
+  <data name="Argument_InvalidRegistryViewCheck" xml:space="preserve">
+    <value>The specified RegistryView value is invalid.</value>
+  </data>
+  <data name="Argument_InvalidRegistryKeyPermissionCheck" xml:space="preserve">
+    <value>The specified RegistryKeyPermissionCheck value is invalid.</value>
+  </data>
+  <data name="InvalidOperation_RegRemoveSubKey" xml:space="preserve">
+    <value>Registry key has subkeys and recursive removes are not supported by this method.</value>
+  </data>
+  <data name="ObjectDisposed_RegKeyClosed" xml:space="preserve">
+    <value>Cannot access a closed registry key.</value>
+  </data>
+  <data name="Security_RegistryPermission" xml:space="preserve">
+    <value>Requested registry access is not allowed.</value>
+  </data>
+  <data name="UnauthorizedAccess_RegistryKeyGeneric_Key" xml:space="preserve">
+    <value>Access to the registry key '{0}' is denied.</value>
+  </data>
+  <data name="UnauthorizedAccess_RegistryNoWrite" xml:space="preserve">
+    <value>Cannot write to the registry key.</value>
+  </data>
+  <data name="UnknownError_Num" xml:space="preserve">
+    <value>Unknown error '{0}'.</value>
+  </data>
 </root>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -176,6 +176,35 @@
       <Link>Common\Interop\Windows\mincore\Interop.LookupAccountNameW.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(CoreClrOrCorRt)' == 'true'"> <!-- Microsoft.Win32.Registry, needed for some Environment env var support -->
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\Microsoft\Win32\Registry.cs" />
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\Microsoft\Win32\RegistryKey.cs" />
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\Microsoft\Win32\RegistryHive.cs" />
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\Microsoft\Win32\RegistryOptions.cs" />
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\Microsoft\Win32\RegistryValueKind.cs" />
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\Microsoft\Win32\RegistryValueOptions.cs" />
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\Microsoft\Win32\RegistryView.cs" />
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\Microsoft\Win32\RegistryKey.Windows.cs" />
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs" />
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\Microsoft\Win32\SafeHandles\SafeRegistryHandle.Windows.cs" />
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\Microsoft\Win32\ThrowHelper.cs" />
+    <Compile Include="..\..\Microsoft.Win32.Registry\src\System\Security\AccessControl\RegistryRights.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegCloseKey.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegConnectRegistry.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegCreateKeyEx.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegDeleteKeyEx.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegDeleteValue.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegEnumKeyEx.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegEnumValue.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegFlushKey.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegOpenKeyEx.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegQueryInfoKey.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegQueryValueEx.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegSetValueEx.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegistryOptions.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.BOOL.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SECURITY_ATTRIBUTES.cs" />
+  </ItemGroup>
   <!-- UNIX: CoreCLR -->
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Environment.Unix.cs" />

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -11,11 +11,27 @@ namespace System.Tests
     public class GetEnvironmentVariable
     {
         [Fact]
-        public void NullVariableThrowsArgumentNull()
+        public void InvalidArguments_ThrowsExceptions()
         {
-            Assert.Throws<ArgumentNullException>(() => Environment.GetEnvironmentVariable(null));
-            Assert.Throws<ArgumentNullException>(() => Environment.SetEnvironmentVariable(null, "test"));
-            Assert.Throws<ArgumentException>(() => Environment.SetEnvironmentVariable("", "test"));
+            Assert.Throws<ArgumentNullException>("variable", () => Environment.GetEnvironmentVariable(null));
+            Assert.Throws<ArgumentNullException>("variable", () => Environment.GetEnvironmentVariable(null, EnvironmentVariableTarget.Process));
+
+            Assert.Throws<ArgumentNullException>("variable", () => Environment.SetEnvironmentVariable(null, "test"));
+            Assert.Throws<ArgumentNullException>("variable", () => Environment.SetEnvironmentVariable(null, "test", EnvironmentVariableTarget.User));
+
+            Assert.Throws<ArgumentException>("variable", () => Environment.SetEnvironmentVariable("", "test"));
+            Assert.Throws<ArgumentException>("variable", () => Environment.SetEnvironmentVariable("", "test", EnvironmentVariableTarget.Machine));
+
+            Assert.Throws<ArgumentOutOfRangeException>("target", () => Environment.GetEnvironmentVariable("test", (EnvironmentVariableTarget)42));
+            Assert.Throws<ArgumentOutOfRangeException>("target", () => Environment.SetEnvironmentVariable("test", "test", (EnvironmentVariableTarget)(-1)));
+            Assert.Throws<ArgumentOutOfRangeException>("target", () => Environment.GetEnvironmentVariables((EnvironmentVariableTarget)(3)));
+
+            Assert.Throws<ArgumentException>("value", () => Environment.SetEnvironmentVariable("test", new string('s', 65 * 1024)));
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Throws<ArgumentException>("variable", () => Environment.SetEnvironmentVariable(new string('s', 256), "value", EnvironmentVariableTarget.User));
+            }
         }
 
         [Fact]
@@ -117,6 +133,37 @@ namespace System.Tests
                 // Clear the variables we just set
                 Environment.SetEnvironmentVariable(envVar1, null);
                 Environment.SetEnvironmentVariable(envVar2, null);
+            }
+        }
+
+        [OuterLoop] // manipulating environment variables broader in scope than the process
+        [Theory]
+        [InlineData(EnvironmentVariableTarget.Process)]
+        [InlineData(EnvironmentVariableTarget.Machine)]
+        [InlineData(EnvironmentVariableTarget.User)]
+        public void EnumerateEnvironmentVariables(EnvironmentVariableTarget target)
+        {
+            IDictionary results = Environment.GetEnvironmentVariables(target);
+            foreach (DictionaryEntry result in results)
+            {
+                string key = (string)result.Key;
+                string value = (string)result.Value ?? string.Empty;
+
+                // Make sure the iterated value we got matches the one we get explicitly
+                Assert.NotNull(result.Key as string);
+                Assert.Equal(value, Environment.GetEnvironmentVariable(key, target));
+
+                try
+                {
+                    // Change it to something else.  Not all values can be changed and will silently
+                    // not change, so we don't re-check and assert for equality.
+                    Environment.SetEnvironmentVariable(key, value + "changed", target);
+                }
+                finally
+                {
+                    // Change it back
+                    Environment.SetEnvironmentVariable(key, value, target);
+                }
             }
         }
 


### PR DESCRIPTION
The implementations are currently commented out because they rely on the registry.  It looks like we're going to land in a place where Environment doesn't have access to Microsoft.Win32.Registry, so we need an alternative.  Various options include:
1. Exposing the Registry implementation from coreclr for System.Runtime.Extensions to use
2. Using Microsoft.Win32.Registry.dll via reflection.
3. Writing a custom implementation of registry access for System.Runtime.Extensions.
4. Compiling the relevant code from Microsoft.Win32.Registry into System.Runtime.Extensions, with the types as internal in S.R.E and public in M.W.R.

I've gone with (4).  It's all implementation detail, so we can change it in the future if an alternative approach proves better.  We can also explore refactoring further some of the code in Microsoft.Win32.Registry to allow us to pull in less of it, but since we're reading and writing various registry keys, it's not clear to me we'd be able to make a significant dent without really unnatural changes.

cc: @jkotas, @weshaggard, @ellismg 
Fixes #8533