### PR TITLE
Change capital letters in ConfigurationGroup settings

### DIFF
--- a/config.json
+++ b/config.json
@@ -462,15 +462,15 @@
     "build-native":{
       "alias":{
         "debug":{
-          "description": "Passes DEBUG to respective build-native script.",
+          "description": "Passes Debug to respective build-native script.",
           "settings":{
-            "CmakeBuildType": "DEBUG"
+            "CmakeBuildType": "Debug"
           }
         },
         "release":{
-          "description": "Passes RELEASE to respective build-native script.",
+          "description": "Passes Release to respective build-native script.",
           "settings":{
-            "CmakeBuildType": "RELEASE"
+            "CmakeBuildType": "Release"
           }
         },
         "buildArch":{


### PR DESCRIPTION
For the native builds, the `configuration group` string was getting passed in all caps, so native components would wind up in Linux.x64.RELEASE. 
Since Linux is case sensitive, and netci.groovy attempts to tar up Linux.x64.{ConfigurationGroup}, which resolves to Linux.x64.Release, we weren’t tarring up the native stuff.

cc: @wtgodbe 