### PR TITLE
Add missing feed to NuGet.Config under src/

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -4,6 +4,7 @@
   <!-- The command-line doesn't need it, but the IDE does.                    -->
   <packageSources>
     <clear/>
+    <add key="myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>


### PR DESCRIPTION
This feed is present in dir.props, but isn't present here. This means package restore fails if done manually (i.e. not through the build scripts).

@weshaggard Any way we can remove the list in dir.props and just use this one?