### PR TITLE
[SOS] [OSX] Fix potential arithmetic overflow exception in SymbolReader 

### DIFF
--- a/src/System.Diagnostics.Debug.SymbolReader/src/System/Diagnostics/Debug/SymbolReader/SymbolReader.cs
+++ b/src/System.Diagnostics.Debug.SymbolReader/src/System/Diagnostics/Debug/SymbolReader/SymbolReader.cs
@@ -111,7 +111,7 @@ namespace System.Diagnostics.Debug.SymbolReader
             foreach (var info in points)
             {
                 Marshal.StructureToPtr(info, ptr, false);
-                ptr = (IntPtr)((int)ptr + structSize);
+                ptr = (IntPtr)(ptr.ToInt64() + structSize);
             }
 
             return true;


### PR DESCRIPTION
This PR fixes arithmetic overflow exception while using SymbolReader with enabled gdb-jit support from https://github.com/dotnet/coreclr/pull/6278. This arithmetic overflow were detected on OSX (it doesn't support gdb-jit feature now), but we might get the same issue on other platforms. 
@mikem8361 PTAL
\cc: @Dmitri-Botcharnikov @chunseoklee 