### PR TITLE
Allow netcoreapp1.1 as a valid TestTFM

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -126,7 +126,7 @@
     </ValidationPattern>
     <ValidationPattern Include="buildToolsTestSuiteVersions">
       <IdentityRegex>^(?i)Microsoft\.DotNet\.BuildTools\.TestSuite$</IdentityRegex>
-      <ExpectedVersion>1.0.0-prerelease-00520-02</ExpectedVersion>
+      <ExpectedVersion>1.0.0-prerelease-00629-04</ExpectedVersion>
     </ValidationPattern>
     <ValidationPattern Include="uwpRunnerVersion">
       <IdentityRegex>^(?i)microsoft\.xunit\.runner\.uwp$</IdentityRegex>
@@ -278,6 +278,7 @@
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netstandard15aot'))">netstandard15aot</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50'))">netcore50</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcoreapp1.0'))">netcoreapp1.0</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcoreapp1.1'))">netcoreapp1.1</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('dnxcore50'))">dnxcore50</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net463'))">net463</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net462'))">net462</TargetGroup>
@@ -452,6 +453,12 @@
         <NuGetTargetMoniker>.NETCoreApp,Version=v1.0</NuGetTargetMoniker>
       </PropertyGroup>
     </When>
+    <When Condition="'$(TargetGroup)'=='netcoreapp1.1'">
+      <PropertyGroup>
+        <PackageTargetFramework>netcoreapp1.1</PackageTargetFramework>
+        <NuGetTargetMoniker>.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
     <When Condition="'$(TargetGroup)'=='dnxcore50'">
       <PropertyGroup>
         <ConfigurationErrorMsg>$(ConfigurationErrorMsg);DNXCore50 has been deprecated.  Please use NETStandard1.X or NETCoreApp1.0 instead.</ConfigurationErrorMsg>
@@ -520,9 +527,10 @@
 
   <!-- Default Test platform to deploy the netstandard compiled tests to -->
   <PropertyGroup>
-    <TestTFM Condition="'$(TestTFM)'==''">netcoreapp1.0</TestTFM>
-    <!-- we default FilterToTestTFM to netcoreapp1.0 if it is not explicity defined -->
-    <FilterToTestTFM Condition="'$(FilterToTestTFM)'==''">netcoreapp1.0</FilterToTestTFM>        
+    <!-- we default TestTFM and FilterToTestTFM to netcoreapp1.0 if they are not explicity defined -->
+    <DefaultTestTFM Condition="'$(DefaultTestTFM)'==''">netcoreapp1.0</DefaultTestTFM>
+    <TestTFM Condition="'$(TestTFM)'==''">$(DefaultTestTFM)</TestTFM>
+    <FilterToTestTFM Condition="'$(FilterToTestTFM)'==''">$(DefaultTestTFM)</FilterToTestTFM>        
   </PropertyGroup>
 
   <PropertyGroup>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -123,6 +123,7 @@
 
       <!-- for projects not defining TestTFM in .builds files, we assume the TestTFM is the default which is netcoreapp1.0 -->
       <ProjectsToTest Include="@(Project)" Condition="'%(Project.Extension)'=='.csproj' And '$(FilterToTestTFM)' == 'netcoreapp1.0' And '%(Project.TestTFMs)' == ''" />
+      <ProjectsToTest Include="@(Project)" Condition="'%(Project.Extension)'=='.csproj' And '$(FilterToTestTFM)' == 'netcoreapp1.1' And '%(Project.TestTFMs)' == ''" />
 
       <!-- include the projects have TestTFM value match FilterToTestTFM -->
       <ProjectsToTest Include="@(Project)" Condition="'%(Project.Extension)'=='.csproj' And $([System.String]::new('%(Project.TestTFMs)').Contains(';$(FilterToTestTFM);'))" /> 

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24327-03",
     "Microsoft.NETCore.Targets": "1.0.3-beta-24327-03",
-    "Microsoft.NETCore.TestHost": "1.0.0-rc4-24131-00",
+    "Microsoft.NETCore.TestHost": "1.0.1-beta-24401-01",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.4-beta-24329-03",
     "System.Diagnostics.Contracts": "4.0.2-beta-24327-03",
     "System.IO.Compression": "4.1.2-beta-24327-03",
@@ -15,7 +15,7 @@
     "Microsoft.DotNet.xunit.performance.analysis.cli": "1.0.0-alpha-build0037",
     "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0037",
     "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0037",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "xunit.console.netcore": "1.0.3-prerelease-00607-01"
   },
   "frameworks": {

--- a/src/Common/tests/project.json
+++ b/src/Common/tests/project.json
@@ -26,7 +26,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/Microsoft.CSharp/tests/project.json
+++ b/src/Microsoft.CSharp/tests/project.json
@@ -25,7 +25,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Microsoft.VisualBasic/tests/project.json
+++ b/src/Microsoft.VisualBasic/tests/project.json
@@ -27,7 +27,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Microsoft.Win32.Primitives/tests/project.json
+++ b/src/Microsoft.Win32.Primitives/tests/project.json
@@ -11,7 +11,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Microsoft.Win32.Registry/tests/project.json
+++ b/src/Microsoft.Win32.Registry/tests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.AppContext/tests/project.json
+++ b/src/System.AppContext/tests/project.json
@@ -11,7 +11,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Buffers/tests/project.json
+++ b/src/System.Buffers/tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Collections.Concurrent/tests/project.json
+++ b/src/System.Collections.Concurrent/tests/project.json
@@ -20,7 +20,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Collections.Immutable/tests/project.json
+++ b/src/System.Collections.Immutable/tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Collections.NonGeneric/tests/Performance/project.json
+++ b/src/System.Collections.NonGeneric/tests/Performance/project.json
@@ -19,7 +19,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -19,7 +19,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Collections.Specialized/tests/project.json
+++ b/src/System.Collections.Specialized/tests/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Collections/tests/Performance/project.json
+++ b/src/System.Collections/tests/Performance/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.ComponentModel.Annotations/tests/project.json
+++ b/src/System.ComponentModel.Annotations/tests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.4": {}

--- a/src/System.ComponentModel.EventBasedAsync/tests/project.json
+++ b/src/System.ComponentModel.EventBasedAsync/tests/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.ComponentModel.Primitives/tests/project.json
+++ b/src/System.ComponentModel.Primitives/tests/project.json
@@ -11,7 +11,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.ComponentModel.TypeConverter/tests/Performance/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/Performance/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.ComponentModel/tests/project.json
+++ b/src/System.ComponentModel/tests/project.json
@@ -10,7 +10,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Composition.Convention/tests/project.json
+++ b/src/System.Composition.Convention/tests/project.json
@@ -9,7 +9,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Composition/tests/project.json
+++ b/src/System.Composition/tests/project.json
@@ -9,7 +9,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Console/tests/Performance/project.json
+++ b/src/System.Console/tests/Performance/project.json
@@ -20,7 +20,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -20,7 +20,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Data.Common/tests/project.json
+++ b/src/System.Data.Common/tests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Data.SqlClient/tests/ManualTests/project.json
+++ b/src/System.Data.SqlClient/tests/ManualTests/project.json
@@ -53,7 +53,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.Contracts/tests/project.json
+++ b/src/System.Diagnostics.Contracts/tests/project.json
@@ -13,7 +13,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -10,7 +10,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.Process/tests/Performance/project.json
+++ b/src/System.Diagnostics.Process/tests/Performance/project.json
@@ -28,7 +28,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Diagnostics.Process/tests/project.json
+++ b/src/System.Diagnostics.Process/tests/project.json
@@ -28,7 +28,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.Tools/tests/project.json
+++ b/src/System.Diagnostics.Tools/tests/project.json
@@ -10,7 +10,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.TraceSource/tests/project.json
+++ b/src/System.Diagnostics.TraceSource/tests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Diagnostics.Tracing/tests/project.json
+++ b/src/System.Diagnostics.Tracing/tests/project.json
@@ -21,7 +21,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Drawing.Primitives/tests/project.json
+++ b/src/System.Drawing.Primitives/tests/project.json
@@ -11,7 +11,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Dynamic.Runtime/tests/project.json
+++ b/src/System.Dynamic.Runtime/tests/project.json
@@ -23,7 +23,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Globalization.Calendars/tests/project.json
+++ b/src/System.Globalization.Calendars/tests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.2.0-beta-24327-03",
     "System.Threading.Tasks": "4.0.12-beta-24327-03",
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Globalization.Extensions/tests/project.json
+++ b/src/System.Globalization.Extensions/tests/project.json
@@ -13,7 +13,7 @@
     "System.Text.RegularExpressions": "4.2.0-beta-24327-03",
     "System.Threading.Tasks": "4.0.12-beta-24327-03",
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Globalization/tests/Performance/project.json
+++ b/src/System.Globalization/tests/Performance/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037",
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24327-03",
     "System.Diagnostics.Process": "4.1.1-beta-24327-03",

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037",
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24327-03",
     "System.Diagnostics.Process": "4.1.1-beta-24327-03",

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -24,7 +24,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.Compression/tests/Performance/project.json
+++ b/src/System.IO.Compression/tests/Performance/project.json
@@ -22,7 +22,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -22,7 +22,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.IO.FileSystem.AccessControl/tests/project.json
+++ b/src/System.IO.FileSystem.AccessControl/tests/project.json
@@ -23,7 +23,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.FileSystem.DriveInfo/tests/project.json
+++ b/src/System.IO.FileSystem.DriveInfo/tests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.FileSystem.Primitives/tests/project.json
+++ b/src/System.IO.FileSystem.Primitives/tests/project.json
@@ -10,7 +10,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.FileSystem.Watcher/tests/project.json
+++ b/src/System.IO.FileSystem.Watcher/tests/project.json
@@ -21,7 +21,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.FileSystem/tests/Performance/project.json
+++ b/src/System.IO.FileSystem/tests/Performance/project.json
@@ -26,7 +26,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -26,7 +26,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.IO.MemoryMappedFiles/tests/Performance/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/Performance/project.json
@@ -19,7 +19,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.IO.MemoryMappedFiles/tests/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/project.json
@@ -19,7 +19,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.IO.Packaging/tests/project.json
+++ b/src/System.IO.Packaging/tests/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.Pipes.AccessControl/tests/project.json
+++ b/src/System.IO.Pipes.AccessControl/tests/project.json
@@ -28,7 +28,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.IO.Pipes/tests/Performance/project.json
+++ b/src/System.IO.Pipes/tests/Performance/project.json
@@ -21,7 +21,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.IO.Pipes/tests/project.json
+++ b/src/System.IO.Pipes/tests/project.json
@@ -21,7 +21,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.IO.UnmanagedMemoryStream/tests/project.json
+++ b/src/System.IO.UnmanagedMemoryStream/tests/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO/tests/project.json
+++ b/src/System.IO/tests/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Linq.Expressions/tests/project.json
+++ b/src/System.Linq.Expressions/tests/project.json
@@ -19,7 +19,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Linq.Parallel/tests/project.json
+++ b/src/System.Linq.Parallel/tests/project.json
@@ -20,7 +20,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Linq.Queryable/tests/project.json
+++ b/src/System.Linq.Queryable/tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Linq/tests/Performance/project.json
+++ b/src/System.Linq/tests/Performance/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -25,7 +25,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Http/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/unix/project.json
@@ -25,7 +25,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Http/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/win/project.json
@@ -26,7 +26,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Http/tests/UnitTests/project.json
+++ b/src/System.Net.Http/tests/UnitTests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NameResolution/tests/FunctionalTests/project.json
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NameResolution/tests/PalTests/project.json
+++ b/src/System.Net.NameResolution/tests/PalTests/project.json
@@ -29,7 +29,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NameResolution/tests/UnitTests/project.json
+++ b/src/System.Net.NameResolution/tests/UnitTests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NetworkInformation/tests/UnitTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/UnitTests/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Ping/tests/FunctionalTests/project.json
+++ b/src/System.Net.Ping/tests/FunctionalTests/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Primitives/tests/FunctionalTests/project.json
+++ b/src/System.Net.Primitives/tests/FunctionalTests/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Primitives/tests/PalTests/project.json
+++ b/src/System.Net.Primitives/tests/PalTests/project.json
@@ -20,7 +20,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Primitives/tests/PerformanceTests/project.json
+++ b/src/System.Net.Primitives/tests/PerformanceTests/project.json
@@ -9,7 +9,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Net.Primitives/tests/UnitTests/project.json
+++ b/src/System.Net.Primitives/tests/UnitTests/project.json
@@ -21,7 +21,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Requests/tests/project.json
+++ b/src/System.Net.Requests/tests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -26,7 +26,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -22,7 +22,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Security/tests/UnitTests/project.json
+++ b/src/System.Net.Security/tests/UnitTests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Sockets/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets/tests/FunctionalTests/project.json
@@ -20,7 +20,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Sockets/tests/PerformanceTests/project.json
+++ b/src/System.Net.Sockets/tests/PerformanceTests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.WebHeaderCollection/tests/project.json
+++ b/src/System.Net.WebHeaderCollection/tests/project.json
@@ -7,7 +7,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.WebSockets.Client/tests/project.json
+++ b/src/System.Net.WebSockets.Client/tests/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.WebSockets/tests/project.json
+++ b/src/System.Net.WebSockets/tests/project.json
@@ -11,7 +11,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Numerics.Vectors/tests/Performance/project.json
+++ b/src/System.Numerics.Vectors/tests/Performance/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Numerics.Vectors/tests/project.json
+++ b/src/System.Numerics.Vectors/tests/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.ObjectModel/tests/project.json
+++ b/src/System.ObjectModel/tests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Uri/tests/FunctionalTests/project.json
+++ b/src/System.Private.Uri/tests/FunctionalTests/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Uri/tests/UnitTests/project.json
+++ b/src/System.Private.Uri/tests/UnitTests/project.json
@@ -9,7 +9,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Context/tests/project.json
+++ b/src/System.Reflection.Context/tests/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.DispatchProxy/tests/project.json
+++ b/src/System.Reflection.DispatchProxy/tests/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Emit.ILGeneration/tests/project.json
+++ b/src/System.Reflection.Emit.ILGeneration/tests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Emit.Lightweight/tests/project.json
+++ b/src/System.Reflection.Emit.Lightweight/tests/project.json
@@ -13,7 +13,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Emit/tests/project.json
+++ b/src/System.Reflection.Emit/tests/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Extensions/tests/project.json
+++ b/src/System.Reflection.Extensions/tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Metadata/tests/project.json
+++ b/src/System.Reflection.Metadata/tests/project.json
@@ -28,7 +28,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
@@ -19,7 +19,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.TypeExtensions/tests/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Reflection/tests/CoreCLR/project.json
+++ b/src/System.Reflection/tests/CoreCLR/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Reflection/tests/project.json
+++ b/src/System.Reflection/tests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Resources.Reader/tests/project.json
+++ b/src/System.Resources.Reader/tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Resources.ResourceManager/tests/project.json
+++ b/src/System.Resources.ResourceManager/tests/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Resources.Writer/tests/project.json
+++ b/src/System.Resources.Writer/tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/project.json
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/project.json
@@ -7,7 +7,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Extensions/tests/Performance/project.json
+++ b/src/System.Runtime.Extensions/tests/Performance/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Runtime.Handles/tests/project.json
+++ b/src/System.Runtime.Handles/tests/project.json
@@ -11,7 +11,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
@@ -13,7 +13,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.InteropServices/tests/project.json
+++ b/src/System.Runtime.InteropServices/tests/project.json
@@ -10,7 +10,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Loader/tests/DefaultContext/project.json
+++ b/src/System.Runtime.Loader/tests/DefaultContext/project.json
@@ -20,7 +20,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Runtime.Loader/tests/project.json
+++ b/src/System.Runtime.Loader/tests/project.json
@@ -19,7 +19,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Runtime.Numerics/tests/project.json
+++ b/src/System.Runtime.Numerics/tests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Serialization.Formatters/tests/project.json
+++ b/src/System.Runtime.Serialization.Formatters/tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Json/tests/Performance/ContractReferences/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/ContractReferences/project.json
@@ -28,7 +28,7 @@
     },
     "Newtonsoft.Json": "8.0.4-beta1",
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Json/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/project.json
@@ -24,7 +24,7 @@
     },
     "Newtonsoft.Json": "8.0.4-beta1",
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Json/tests/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/project.json
@@ -24,7 +24,7 @@
     },
     "Newtonsoft.Json": "8.0.4-beta1",
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/ContractReferences/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/ContractReferences/project.json
@@ -27,7 +27,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
@@ -23,7 +23,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -23,7 +23,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Runtime/tests/Performance/project.json
+++ b/src/System.Runtime/tests/Performance/project.json
@@ -19,7 +19,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Runtime/tests/project.json
+++ b/src/System.Runtime/tests/project.json
@@ -19,7 +19,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Security.AccessControl/tests/project.json
+++ b/src/System.Security.AccessControl/tests/project.json
@@ -32,7 +32,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Security.Claims/tests/project.json
+++ b/src/System.Security.Claims/tests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.Cryptography.Algorithms/tests/project.json
+++ b/src/System.Security.Cryptography.Algorithms/tests/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Security.Cryptography.Cng/tests/project.json
+++ b/src/System.Security.Cryptography.Cng/tests/project.json
@@ -20,7 +20,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Security.Cryptography.Csp/tests/project.json
+++ b/src/System.Security.Cryptography.Csp/tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.Cryptography.Encoding/tests/project.json
+++ b/src/System.Security.Cryptography.Encoding/tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037",
     "System.Xml.XmlSerializer": "4.0.12-beta-24327-03"
   },

--- a/src/System.Security.Cryptography.OpenSsl/tests/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/tests/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Security.Cryptography.Pkcs/tests/project.json
+++ b/src/System.Security.Cryptography.Pkcs/tests/project.json
@@ -13,7 +13,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.Cryptography.Primitives/tests/project.json
+++ b/src/System.Security.Cryptography.Primitives/tests/project.json
@@ -11,7 +11,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.Cryptography.ProtectedData/tests/project.json
+++ b/src/System.Security.Cryptography.ProtectedData/tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.json
@@ -20,7 +20,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.4": {}

--- a/src/System.Security.Principal.Windows/tests/project.json
+++ b/src/System.Security.Principal.Windows/tests/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.SecureString/tests/project.json
+++ b/src/System.Security.SecureString/tests/project.json
@@ -7,7 +7,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.4": {}

--- a/src/System.Text.Encoding.CodePages/tests/project.json
+++ b/src/System.Text.Encoding.CodePages/tests/project.json
@@ -13,7 +13,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Text.Encoding.Extensions/tests/project.json
+++ b/src/System.Text.Encoding.Extensions/tests/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Text.Encoding/tests/Performance/project.json
+++ b/src/System.Text.Encoding/tests/Performance/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Text.Encoding/tests/project.json
+++ b/src/System.Text.Encoding/tests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Text.Encodings.Web/tests/project.json
+++ b/src/System.Text.Encodings.Web/tests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Text.RegularExpressions/tests/project.json
+++ b/src/System.Text.RegularExpressions/tests/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Threading.AccessControl/tests/project.json
+++ b/src/System.Threading.AccessControl/tests/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading.Overlapped/tests/project.json
+++ b/src/System.Threading.Overlapped/tests/project.json
@@ -10,7 +10,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading.Tasks.Dataflow/tests/project.json
+++ b/src/System.Threading.Tasks.Dataflow/tests/project.json
@@ -23,7 +23,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading.Tasks.Extensions/tests/project.json
+++ b/src/System.Threading.Tasks.Extensions/tests/project.json
@@ -11,7 +11,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading.Tasks.Parallel/tests/project.json
+++ b/src/System.Threading.Tasks.Parallel/tests/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Threading.Tasks/tests/project.json
+++ b/src/System.Threading.Tasks/tests/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Threading.Timer/tests/project.json
+++ b/src/System.Threading.Timer/tests/project.json
@@ -13,7 +13,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading/tests/Performance/project.json
+++ b/src/System.Threading/tests/Performance/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Threading/tests/project.json
+++ b/src/System.Threading/tests/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.ValueTuple/tests/project.json
+++ b/src/System.ValueTuple/tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
@@ -11,7 +11,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XDocument/tests/Properties/project.json
+++ b/src/System.Xml.XDocument/tests/Properties/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XDocument/tests/SDMSample/project.json
+++ b/src/System.Xml.XDocument/tests/SDMSample/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XDocument/tests/Streaming/project.json
+++ b/src/System.Xml.XDocument/tests/Streaming/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XDocument/tests/TreeManipulation/project.json
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XDocument/tests/XDocument.Common/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Common/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XDocument/tests/axes/project.json
+++ b/src/System.Xml.XDocument/tests/axes/project.json
@@ -13,7 +13,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XDocument/tests/events/project.json
+++ b/src/System.Xml.XDocument/tests/events/project.json
@@ -14,7 +14,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XDocument/tests/misc/project.json
+++ b/src/System.Xml.XDocument/tests/misc/project.json
@@ -15,7 +15,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
@@ -18,7 +18,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XDocument/tests/xNodeReader/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeReader/project.json
@@ -16,7 +16,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XPath.XDocument/tests/project.json
+++ b/src/System.Xml.XPath.XDocument/tests/project.json
@@ -19,7 +19,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XPath.XmlDocument/tests/project.json
+++ b/src/System.Xml.XPath.XmlDocument/tests/project.json
@@ -19,7 +19,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XPath/tests/project.json
+++ b/src/System.Xml.XPath/tests/project.json
@@ -17,7 +17,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Xml.XmlDocument/tests/Performance/project.json
+++ b/src/System.Xml.XmlDocument/tests/Performance/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Xml.XmlDocument/tests/project.json
+++ b/src/System.Xml.XmlDocument/tests/project.json
@@ -12,7 +12,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Xml.XmlSerializer/tests/Performance/ContractReferences/project.json
+++ b/src/System.Xml.XmlSerializer/tests/Performance/ContractReferences/project.json
@@ -26,7 +26,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Xml.XmlSerializer/tests/Performance/project.json
+++ b/src/System.Xml.XmlSerializer/tests/Performance/project.json
@@ -22,7 +22,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Xml.XmlSerializer/tests/project.json
+++ b/src/System.Xml.XmlSerializer/tests/project.json
@@ -22,7 +22,7 @@
       "exclude": "compile"
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00508-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00629-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {


### PR DESCRIPTION
Updates buildtools and BuildTest versions to consume some changes that allow netcoreapp1.1 as a TestTFM. <strike>I also modified the CoreFX targets to use netcoreapp1.1 as the new default.</strike>

to be merged after https://github.com/dotnet/corefx/pull/10423/files

@ericstj @weshaggard @karajas 