### PR TITLE
Turned tests that use KeyAgreement certs or add OriginatorCerts into ConditionalFacts in EnvelopedCms

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/CertificateTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/CertificateTests.cs
@@ -58,8 +58,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(0, certs.Count);
         }
 
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(EncryptionSupportsAddingOriginatorCerts))]
         public static void DecodeCertificates3_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -157,6 +156,8 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
                 Assert.Equal<byte>(expectedDer, actualDer);
             }
         }
+
+        private static bool EncryptionSupportsAddingOriginatorCerts => SupportedBehaviors.EncryptionSupportsAddingOriginatorCerts;
 
         private static X509Certificate2[] s_certs =
         {

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
@@ -3,12 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.Pkcs.Tests;
 using System.Security.Cryptography.Xml;
 using System.Security.Cryptography.X509Certificates;
-using Xunit;
 
 using Test.Cryptography;
-using System.Security.Cryptography.Pkcs.Tests;
+using Xunit;
 
 namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 {
@@ -51,8 +52,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(0, version);
         }
 
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(EncryptionSupportsAddingOriginatorCerts))]
         public static void DecodeRecipients3_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -236,6 +236,10 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(contentInfo.ContentType.Value, ecms.ContentInfo.ContentType.Value);
             Assert.Equal<byte>(contentInfo.Content, ecms.ContentInfo.Content);
         }
+
+        private static bool EncryptionSupportsAddingOriginatorCerts => SupportedBehaviors.EncryptionSupportsAddingOriginatorCerts;
+
+        private static bool EncryptionDoesNotSupportAddingOriginatorCerts => SupportedBehaviors.EncryptionSupportsAddingOriginatorCerts;
 
         private static X509Certificate2[] s_certs =
         {

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
@@ -4,8 +4,8 @@
 
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.Pkcs.Tests;
-using System.Security.Cryptography.Xml;
 using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
 
 using Test.Cryptography;
 using Xunit;
@@ -14,8 +14,19 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 {
     public static partial class KeyAgreeRecipientInfoTests
     {
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(DoesNotSupportKeyAgreementCerts))]
+        public static void TestKeyAgreement_PlatformNotSupported()
+        {
+            ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
+            EnvelopedCms ecms = new EnvelopedCms(contentInfo);
+            using (X509Certificate2 cert = Certificates.DHKeyAgree1.GetCertificate())
+            {
+                CmsRecipient cmsRecipient = new CmsRecipient(cert);
+                Assert.Throws<PlatformNotSupportedException>(() => ecms.Encrypt(cmsRecipient));
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsKeyAgreementCerts))]
         public static void TestKeyAgreeVersion_RoundTrip()
         {
             KeyAgreeRecipientInfo recipient = EncodeKeyAgreel();
@@ -29,8 +40,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(3, recipient.Version);
         }
 
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(SupportsKeyAgreementCerts))]
         public static void TestKeyAgreeType_RoundTrip()
         {
             KeyAgreeRecipientInfo recipient = EncodeKeyAgreel();
@@ -44,8 +54,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(RecipientInfoType.KeyAgreement, recipient.Type);
         }
 
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(SupportsKeyAgreementCerts))]
         public static void TestKeyAgreesRecipientIdType_RoundTrip()
         {
             KeyAgreeRecipientInfo recipient = EncodeKeyAgreel();
@@ -61,8 +70,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(SubjectIdentifierType.IssuerAndSerialNumber, subjectIdentifier.Type);
         }
 
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(SupportsKeyAgreementCerts))]
         public static void TestKeyAgreeRecipientIdValue_RoundTrip()
         {
             KeyAgreeRecipientInfo recipient = EncodeKeyAgreel();
@@ -124,8 +132,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal("10DA1370316788112EB8594C864C2420AE7FBA42", ski);
         }
 
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(SupportsKeyAgreementCerts))]
         public static void TestKeyAgreeKeyEncryptionAlgorithm_RoundTrip()
         {
             KeyAgreeRecipientInfo recipient = EncodeKeyAgreel();
@@ -143,8 +150,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(0, a.KeyLength);
         }
 
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(SupportsKeyAgreementCerts))]
         public static void TestKeyAgreeEncryptedKey_RoundTrip()
         {
             KeyAgreeRecipientInfo recipient = EncodeKeyAgreel();
@@ -162,8 +168,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal<byte>(expectedEncryptedKey, encryptedKey);
         }
 
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(SupportsKeyAgreementCerts))]
         public static void TestKeyAgreeOriginatorIdentifierOrKey_RoundTrip()
         {
             KeyAgreeRecipientInfo recipient = EncodeKeyAgreel();
@@ -199,8 +204,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(expectedKey, key);
         }
 
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(SupportsKeyAgreementCerts))]
         public static void TestKeyAgreeDate_RoundTrip()
         {
             KeyAgreeRecipientInfo recipient = EncodeKeyAgreel();
@@ -216,8 +220,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Throws<InvalidOperationException>(() => ignore = recipient.Date);
         }
 
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(SupportsKeyAgreementCerts))]
         public static void TestKeyAgreeDate_RoundTrip_Ski()
         {
             KeyAgreeRecipientInfo recipient = EncodeKeyAgreel(SubjectIdentifierType.SubjectKeyIdentifier);
@@ -238,8 +241,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
 
-        [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(SupportsKeyAgreementCerts))]
         public static void TestKeyAgreeOtherKeyAttribute_RoundTrip()
         {
             KeyAgreeRecipientInfo recipient = EncodeKeyAgreel();
@@ -390,6 +392,9 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.True(recipientInfo is KeyAgreeRecipientInfo);
             return (KeyAgreeRecipientInfo)recipientInfo;
         }
+        
+        private static bool SupportsKeyAgreementCerts => SupportedBehaviors.SupportsKeyAgreementCerts;
+        private static bool DoesNotSupportKeyAgreementCerts => SupportedBehaviors.DoesNotSupportKeyAgreementCerts;
 
         private static byte[] s_KeyAgreeEncodedMessage =
              ("3082019b06092a864886f70d010703a082018c3082018802010231820154a1820150020103a08195a18192300906072a8648"

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
@@ -409,11 +409,10 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
             Assert.Equal<byte>(expected, actual);
         }
+        
+        private static bool EncryptionSupportsAddingOriginatorCerts => SupportedBehaviors.EncryptionSupportsAddingOriginatorCerts;
 
-        private static bool EncryptionSupportsAddingOriginatorCerts =>
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-        private static bool EncryptionDoesNotSupportAddingOriginatorCerts => !EncryptionSupportsAddingOriginatorCerts;
+        private static bool EncryptionDoesNotSupportAddingOriginatorCerts => SupportedBehaviors.EncryptionDoesNotSupportAddingOriginatorCerts;
     }
 }
 

--- a/src/System.Security.Cryptography.Pkcs/tests/SupportedBehaviors.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/SupportedBehaviors.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Security.Cryptography.Pkcs.Tests
+{
+    internal static class SupportedBehaviors
+    {
+        // As of OpenSSL 1.0.2g, there is no support for the use of KeyAgreement certificates to encrypt
+        // enveloped messages
+        public static bool SupportsKeyAgreementCerts => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        public static bool DoesNotSupportKeyAgreementCerts => !SupportsKeyAgreementCerts;
+
+        // As of OpenSSL 1.0.2g, there's no support for adding originator certificates to a newly instantiated CMS_ContentInfo structure
+        // so we can't support this for the encryption process.
+        public static bool EncryptionSupportsAddingOriginatorCerts =>
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public static bool EncryptionDoesNotSupportAddingOriginatorCerts => !EncryptionSupportsAddingOriginatorCerts;
+    }
+}

--- a/src/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
+++ b/src/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -12,7 +12,6 @@
     <RootNamespace>System.Security.Cryptography.Pkcs.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-
   <!-- Don't delete these clauses even if they look useless. They tell the VS IDE that "Windows_Debug", etc., are
        valid configuration for this project and stop it from trying to "fix up" the .sln file -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
@@ -21,20 +20,17 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
-
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Security.Cryptography.Pkcs.pkgproj">
       <Project>{03D84CBD-896D-4B2F-9A22-07034F51E73D}</Project>
       <Name>System.Security.Cryptography.Pkcs</Name>
     </ProjectReference>
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="Certificates.cs" />
     <Compile Include="CertLoader.cs" />
@@ -50,11 +46,11 @@
     <Compile Include="EnvelopedCms\KeyTransRecipientInfoTests.cs" />
     <Compile Include="EnvelopedCms\StateTests.cs" />
     <Compile Include="EnvelopedCms\UnprotectedAttributeTests.cs" />
+    <Compile Include="SupportedBehaviors.cs" />
     <Compile Include="Oids.cs" />
     <Compile Include="Pkcs9AttributeTests.cs" />
     <Compile Include="RecipientInfoCollectionTests.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>


### PR DESCRIPTION
As KeyAgreement certs can't be used for encryption or decryption on the
current implementation of EnvelopedCms for Unix, the tests were turned
into conditional facts and tests were added to ensure that the Unix
implementation throws a PlatformNotSupportedException.

Similarly tests that added originator certificates were made
ConditionalFacts as OpenSSL doesn't support adding these and a test was
added to ensure that the Unix implementation throws a
PlatformNotSupportedException.

@bartonjs @weshaggard 