### PR TITLE
Fix typos in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ usage()
     echo
 }
 
-if [ $1 == "-?" ]; then
+if [ "$1" == "-?" ]; then
     usage
 fi
 


### PR DESCRIPTION
Fixes ~~a couple~~ one problem:

* Parameter wasn't quoted, so if nothing is passed to the script, there's a syntax error.
* ~~The build still runs even if you pass `-?`~~

@maririos @Priya91 