### PR TITLE
Implement Key Length Retrieval in EnvelopedCms for Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
@@ -67,6 +67,23 @@ internal static partial class Interop
             }
         }
 
+        internal static string GetOidValue(SafeAsn1ObjectHandle asn1Object)
+        {
+            Debug.Assert(asn1Object != null);
+
+            bool added = false;
+            try
+            {
+                asn1Object.DangerousAddRef(ref added);
+                return GetOidValue(asn1Object.DangerousGetHandle());
+            }
+            finally
+            {
+                if (added)
+                    asn1Object.DangerousRelease();
+            }
+        }
+
         internal static unsafe string GetOidValue(IntPtr asn1ObjectPtr)
         {
             // OBJ_obj2txt returns the number of bytes that should have been in the answer, but it does not accept

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Cms.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Cms.cs
@@ -112,5 +112,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsSetEmbeddedContentType")]
         internal static extern int CmsSetEmbeddedContentType(SafeCmsHandle cms, SafeAsn1ObjectHandle oid);
+        
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CmsGetAlgorithmKeyLength")]
+        internal static extern int CmsGetAlgorithmKeyLength(byte[] algorithmIdentifier, int length);
     }
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_cms.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_cms.h
@@ -122,3 +122,10 @@ Shims the CMS_set1_eContentType method.
 Returns -1 on invalid input, 0 on OpenSSL error, and 1 on success.
 */
 extern "C" int CryptoNative_CmsSetEmbeddedContentType(CMS_ContentInfo* cms, ASN1_OBJECT* oid);
+
+/*
+Given a DER encoded AlgorithmIdentifier returns key length in bits.
+
+keylen is set to -1 in case there's an OpenSSL error, or -2 or input error.
+*/
+extern "C" int CryptoNative_CmsGetAlgorithmKeyLength(const uint8_t* algor, int32_t len);

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/PkcsPalOpenSsl.Encrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Unix/PkcsPalOpenSsl.Encrypt.cs
@@ -30,6 +30,20 @@ namespace Internal.Cryptography.Pal.OpenSsl
                 throw new PlatformNotSupportedException(SR.Cryptography_Cms_AddOriginatorCertsPlatformNotSupported);
             }
 
+            if (contentEncryptionAlgorithm.KeyLength != 0 && contentEncryptionAlgorithm.KeyLength != KeyLengths.DefaultKeyLengthForRc2AndRc4)
+            {
+                switch (contentEncryptionAlgorithm.Oid.Value)
+                {
+                    case Oids.Rc2:
+                        throw new PlatformNotSupportedException(SR.Cryptography_Cms_Rc2VariableKeyLengthPlatformNotSupported);
+                    case Oids.Rc4:
+                        throw new PlatformNotSupportedException(SR.Cryptography_Cms_Rc4VariableKeyLengthPlatformNotSupported);
+                    default:
+                        // RC2 and RC4 are the only ciphers for which we support a variable key length that we need to worry about.
+                        break;
+                }
+            }
+
             using (SafeBioHandle contentBio = Interop.Crypto.CreateMemoryBio())
             using (SafeAsn1ObjectHandle algoOid = Interop.Crypto.ObjTxt2Obj(contentEncryptionAlgorithm.Oid.Value))
             {

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -147,6 +147,12 @@
   <data name="Cryptography_Cms_KeyAgreementPlatformNotSupported" xml:space="preserve">
     <value>This platform does not support encrypting for KeyAgreement recipients.</value>
   </data>
+  <data name="Cryptography_Cms_Rc4VariableKeyLengthPlatformNotSupported" xml:space="preserve">
+    <value>This platform does not support encrypting messages using RC4 with a keylength other than the default one.</value>
+  </data>
+  <data name="Cryptography_Cms_Rc2VariableKeyLengthPlatformNotSupported" xml:space="preserve">
+    <value>This platform does not support encrypting messages using RC2 with a keylength other than the default one.</value>
+  </data>
   <data name="Cryptography_Cms_AddOriginatorCertsPlatformNotSupported" xml:space="preserve">
     <value>This platform does not support encoding originator certificates in an Enveloped CMS.</value>
   </data>

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/ContentEncryptionAlgorithmTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/ContentEncryptionAlgorithmTests.cs
@@ -21,6 +21,21 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 {
     public static partial class ContentEncryptionAlgorithmTests
     {
+        [ConditionalFact(nameof(EncryptionSupportsVariableKeyLengths))]
+        public static void EncryptionAlgorithmRc2_InvalidKeyLength()
+        {
+            // For desktop compat, variable key length ciphers throw an error if the key length provided
+            // is not a multiple of 8.
+            AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Rc2), 3);
+            ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
+            EnvelopedCms ecms = new EnvelopedCms(contentInfo, algorithm);
+            using (X509Certificate2 cert = Certificates.RSAKeyTransfer1.GetCertificate())
+            {
+                CmsRecipient cmsRecipient = new CmsRecipient(cert);
+                Assert.ThrowsAny<CryptographicException>(() => ecms.Encrypt(cmsRecipient));
+            }
+        }
+
         [Fact]
         public static void DecodeAlgorithmRc2_128_RoundTrip()
         {
@@ -57,6 +72,101 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.NotNull(algorithm.Oid);
             Assert.Equal(Oids.Rc2, algorithm.Oid.Value);
             Assert.Equal(128, algorithm.KeyLength);
+        }
+
+        [Fact]
+        public static void DecodeAlgorithmRc2_40_FixedValue()
+        {
+            ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3, 4 });
+            byte[] encodedMessage =
+                ("3082011806092A864886F70D010703A0820109308201050201003181CC3081C90201003032301E311C301A0"
+                + "60355040313135253414B65795472616E73666572436170693102105D2FFFF863BABC9B4D3C80AB178A4CCA"
+                + "300D06092A864886F70D010101050004818004E46A48651034B01134B0D4F665C9E85F6C45B58458ECDBAFE"
+                + "B6B55CBFA9AEBEFA52BCBEF3C8811B5118970562623FC35D4B733B55CBC50DA4F49822E1D198834897D3540"
+                + "7B329FECF49277159F2FEAB31173004776B03746381E0DA660B6D656A861E54E79186F36F450105DEB2714D"
+                + "02DB5500921EBE4F1A7D3DFB07E4EE9303106092A864886F70D010701301A06082A864886F70D0302300E02"
+                + "0200A00408D621253C94AF659B800802930ACE6A997122").HexToByteArray();
+            EnvelopedCms ecms = new EnvelopedCms();
+            ecms.Decode(encodedMessage);
+
+            AlgorithmIdentifier algorithm = ecms.ContentEncryptionAlgorithm;
+            Assert.NotNull(algorithm.Oid);
+            Assert.Equal(Oids.Rc2, algorithm.Oid.Value);
+            Assert.Equal(40, algorithm.KeyLength);
+        }
+
+        [ConditionalFact(nameof(EncryptionSupportsVariableKeyLengths))]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void DecodeAlgorithmRc2_40_RoundTrip()
+        {
+            ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3, 4 });
+            EnvelopedCms ecms = new EnvelopedCms(contentInfo, new AlgorithmIdentifier(new Oid(Oids.Rc2), 40));
+
+            using (X509Certificate2 cert =  Certificates.RSAKeyTransferCapi1.GetCertificate())
+            {
+                ecms.Encrypt(new CmsRecipient(SubjectIdentifierType.IssuerAndSerialNumber, cert));
+            }
+
+            byte[] encodedMessage = ecms.Encode();
+
+            ecms = new EnvelopedCms();
+            ecms.Decode(encodedMessage);
+
+            AlgorithmIdentifier algorithm = ecms.ContentEncryptionAlgorithm;
+            Assert.NotNull(algorithm.Oid);
+            Assert.Equal(Oids.Rc2, algorithm.Oid.Value);
+            Assert.Equal(40, algorithm.KeyLength);
+        }
+
+        [ConditionalFact(nameof(EncryptionSupportsVariableKeyLengths))]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void DecodeAlgorithmRc4_40_RoundTrip()
+        {
+            ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3, 4 });
+            EnvelopedCms ecms = new EnvelopedCms(contentInfo, new AlgorithmIdentifier(new Oid(Oids.Rc4), 40));
+
+            using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.GetCertificate())
+            {
+                ecms.Encrypt(new CmsRecipient(SubjectIdentifierType.IssuerAndSerialNumber, cert));
+            }
+
+            byte[] encodedMessage = ecms.Encode();
+
+            ecms = new EnvelopedCms();
+            ecms.Decode(encodedMessage);
+
+            AlgorithmIdentifier algorithm = ecms.ContentEncryptionAlgorithm;
+            Assert.NotNull(algorithm.Oid);
+            Assert.Equal(Oids.Rc4, algorithm.Oid.Value);
+            Assert.Equal(40, algorithm.KeyLength);
+        }
+
+        [ConditionalFact(nameof(EncryptionDoesNotSupportVariableKeyLengths))]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void DecodeAlgorithmRc2_40_PlatformNotSupported()
+        {
+            ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3, 4 });
+            EnvelopedCms ecms = new EnvelopedCms(contentInfo, new AlgorithmIdentifier(new Oid(Oids.Rc2), 40));
+
+            using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.GetCertificate())
+            {
+                CmsRecipient recipient = new CmsRecipient(SubjectIdentifierType.IssuerAndSerialNumber, cert);
+                Assert.Throws<PlatformNotSupportedException>(() => ecms.Encrypt(recipient));
+            }
+        }
+
+        [ConditionalFact(nameof(EncryptionDoesNotSupportVariableKeyLengths))]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
+        public static void DecodeAlgorithmRc4_40_PlatformNotSupported()
+        {
+            ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3, 4 });
+            EnvelopedCms ecms = new EnvelopedCms(contentInfo, new AlgorithmIdentifier(new Oid(Oids.Rc4), 40));
+
+            using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.GetCertificate())
+            {
+                CmsRecipient recipient = new CmsRecipient(SubjectIdentifierType.IssuerAndSerialNumber, cert);
+                Assert.Throws<PlatformNotSupportedException>(() => ecms.Encrypt(recipient));
+            }
         }
 
         [Fact]
@@ -135,7 +245,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void DecodeAlgorithmRc4_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Rc4));
@@ -151,7 +260,6 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
         public static void DecodeAlgorithmRc4_FixedValue()
         {
             byte[] encodedMessage =
@@ -171,7 +279,51 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             AlgorithmIdentifier algorithm = ecms.ContentEncryptionAlgorithm;
             Assert.NotNull(algorithm.Oid);
             Assert.Equal(Oids.Rc4, algorithm.Oid.Value);
-            Assert.Equal(128, algorithm.KeyLength);
+            if (EncryptionSupportsVariableKeyLengths)
+                Assert.Equal(128, algorithm.KeyLength);
+            else
+                Assert.Equal(0, algorithm.KeyLength);
+        }
+
+        [Fact]
+        [ActiveIssue(10311, PlatformID.AnyUnix)]
+        public static void DecodeAlgorithmRc4_40_FixedValue()
+        {
+            byte[] encodedMessage =
+                ("3082011006092A864886F70D010703A08201013081FE0201003181CC3081C90201003032301E311C301A060"
+                + "355040313135253414B65795472616E73666572436170693102105D2FFFF863BABC9B4D3C80AB178A4CCA30"
+                + "0D06092A864886F70D01010105000481809D242C1517B82A58335E0337B0B2CE97B2789AF31A6B31311417B"
+                + "A069D0D76FD08AE5B4F58C290116667FFD00319AA7AFED4EEAD9D5031C0D17A48E6CB39A5EB62C8BD7F4C2C"
+                + "BE8E581EF8B7FF7BA9376923A367B9B7E031F630E4CA6ADCB31209B04B03E64076FB0465E7E437B13D4AEA2"
+                + "70CA89EB58C1A598F0AC88DCB4024302A06092A864886F70D010701301706082A864886F70D0304040B4B5A"
+                + "8F64D714F933642D4A8004C68A936F").HexToByteArray();
+
+            EnvelopedCms ecms = new EnvelopedCms();
+            ecms.Decode(encodedMessage);
+            AlgorithmIdentifier algorithm = ecms.ContentEncryptionAlgorithm;
+            Assert.NotNull(algorithm.Oid);
+            Assert.Equal(Oids.Rc4, algorithm.Oid.Value);
+            Assert.Equal(40, algorithm.KeyLength);
+        }
+
+        [Fact]
+        public static void EncryptionAlgorithmAes128_IgnoresKeyLength()
+        {
+            // For desktop compat, static key length ciphers ignore the key lengths supplied
+            AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Aes128), 3);
+            ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
+            EnvelopedCms ecms = new EnvelopedCms(contentInfo, algorithm);
+            using (X509Certificate2 cert = Certificates.RSAKeyTransfer1.GetCertificate())
+            {
+                CmsRecipient cmsRecipient = new CmsRecipient(cert);
+                ecms.Encrypt(cmsRecipient);
+            }
+            byte[] encodedMessage = ecms.Encode();
+
+            ecms.Decode(encodedMessage);
+
+            Assert.Equal(Oids.Aes128, ecms.ContentEncryptionAlgorithm.Oid.Value);
+            Assert.Equal(0, ecms.ContentEncryptionAlgorithm.KeyLength);
         }
 
         [Fact]
@@ -288,6 +440,12 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             Assert.Equal(Oids.Aes256, algorithm.Oid.Value);
             Assert.Equal(0, algorithm.KeyLength);
         }
+
+        private static bool EncryptionSupportsVariableKeyLengths => 
+            SupportedBehaviors.EncryptionSupportsVariableKeyLengths;
+
+        private static bool EncryptionDoesNotSupportVariableKeyLengths => 
+            SupportedBehaviors.EncryptionDoesNotSupportVariableKeyLengths;
     }
 }
 

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -155,7 +155,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Fact]
         [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [ActiveIssue(3334, PlatformID.AnyUnix)]
+        [ActiveIssue(10311, PlatformID.AnyUnix)]
         public static void Rc4AndCngWrappersDontMixTest()
         {
             //

--- a/src/System.Security.Cryptography.Pkcs/tests/SupportedBehaviors.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/SupportedBehaviors.cs
@@ -19,5 +19,11 @@ namespace System.Security.Cryptography.Pkcs.Tests
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         public static bool EncryptionDoesNotSupportAddingOriginatorCerts => !EncryptionSupportsAddingOriginatorCerts;
+
+        // As OpenSSL uses EVP_CIPHER_CTX to support ciphers with variable key length but their CMS API uses a EVP_CIPHER
+        // there's no direct way to support changing the key length.
+        public static bool EncryptionSupportsVariableKeyLengths => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public static bool EncryptionDoesNotSupportVariableKeyLengths => !EncryptionSupportsVariableKeyLengths;
     }
 }


### PR DESCRIPTION
Implemented key length retrieval from enveloped messages. This was missing
as variable key length ciphers such as RC2 were reporting the same
key length always. Encryption with variable key length and retrieving the
length of messages using RC4 as the algorithm and the appropriate tests
have been disabled according to Active Issues 10310 and 10311.

@bartonjs @weshaggard 