### PR TITLE
Use package reports to produce flat layouts of different targets

### DIFF
--- a/layout/dir.proj
+++ b/layout/dir.proj
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <LayoutBasePath>$(BaseOutputPath)/layout</LayoutBasePath>
+  </PropertyGroup>
+  <ItemGroup>
+    <TargetFrameworkMonikers Include="netstandard1.0" />
+    <TargetFrameworkMonikers Include="netstandard1.1" />
+    <TargetFrameworkMonikers Include="netstandard1.2" />
+    <TargetFrameworkMonikers Include="netstandard1.3" />
+    <TargetFrameworkMonikers Include="netstandard1.4" />
+    <TargetFrameworkMonikers Include="netstandard1.5" />
+    <TargetFrameworkMonikers Include="netstandard1.6" />
+    <TargetFrameworkMonikers Include="netstandard1.7" />
+    <TargetFrameworkMonikers Include="netcoreapp1.0">
+      <RID>win7-x64</RID>
+      <AdditionalBinaryPath>
+        $(PackagesDir)/runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.4-$(CoreClrExpectedPrerelease)/runtimes/win7-x64/lib/netstandard1.0;
+        $(PackagesDir)/runtime.win7.System.Private.Uri\4.0.3-$(CoreFxExpectedPrerelease)\runtimes\win\lib\netstandard1.0;
+        $(PackagesDir)/System.Private.DataContractSerialization\4.1.2-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
+      </AdditionalBinaryPath>
+    </TargetFrameworkMonikers>
+    <TargetFrameworkMonikers Include="uap10.0">
+      <RID>win10-x64-aot</RID>
+      <AdditionalBinaryPath>$(PackagesDir)/Microsoft.TargetingPack.Private.NETNative/1.0.1-$(ExternalExpectedPrerelease)/lib/netcore50</AdditionalBinaryPath>
+    </TargetFrameworkMonikers>
+  </ItemGroup>
+
+  <UsingTask TaskName="GetApplicableAssetsFromPackageReports" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+
+  <Target Name="Build" />
+  <Target Name="Clean">
+    <RemoveDir Directories="$(LayoutBasePath)" />
+  </Target>
+
+  <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
+
+  <Target Name="GetAssetsFromReports" BeforeTargets="Build"
+    Inputs="'%(TargetFrameworkMonikers.Identity)'"
+    Outputs="'%(TargetFrameworkMonikers.Identity).output'">
+
+    <PropertyGroup>
+      <TargetFrameworkMoniker>%(TargetFrameworkMonikers.Identity)</TargetFrameworkMoniker>
+      <TargetRuntime>%(TargetFrameworkMonikers.RID)</TargetRuntime>
+      <AdditionalBinaryPath>%(TargetFrameworkMonikers.AdditionalBinaryPath)</AdditionalBinaryPath>
+      <RelOutputPath>ref/$(TargetFrameworkMoniker)</RelOutputPath>
+      <RelOutputPath Condition="'$(TargetRuntime)' != ''">runtime/$(TargetFrameworkMoniker).$(TargetRuntime)</RelOutputPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReports Include="$(PackageOutputPath)reports/*.json" />
+      <AdditionalBinaryPaths Include="$(AdditionalBinaryPath)" />
+    </ItemGroup>
+
+    <GetApplicableAssetsFromPackageReports
+      PackageReports="@(PackageReports)"
+      TargetMoniker="$(TargetFrameworkMoniker)"
+      TargetRuntime="$(TargetRuntime)"
+      >
+      <Output TaskParameter="CompileAssets" ItemName="_CompileAssets" />
+      <Output TaskParameter="RuntimeAssets" ItemName="_RuntimeAssets" />
+    </GetApplicableAssetsFromPackageReports>
+
+    <!-- Need to use CreateItem to get it to resolve the nested wildcards -->
+    <CreateItem Include="@(AdditionalBinaryPaths->'%(FullPath)\**\*')">
+      <Output TaskParameter="Include" ItemName="AdditionalBinaryAssets" />
+    </CreateItem>
+
+    <Error Text="Additional Directory %(AdditionalBinaryPaths.Identity) doesn't exist"
+      Condition="'%(AdditionalBinaryPaths.Identity)' != '' and !Exists('%(AdditionalBinaryPaths.Identity)')" />
+
+    <ItemGroup>
+      <AssetsToCopy Condition="'$(TargetRuntime)' == ''" Include="@(_CompileAssets)" />
+      <AssetsToCopy Condition="'$(TargetRuntime)' != ''" Include="@(_RuntimeAssets)" />
+      <AssetsToCopy Include="@(AdditionalBinaryAssets)" />
+    </ItemGroup>
+
+    <Copy
+      SourceFiles="@(AssetsToCopy)"
+      DestinationFolder="$(LayoutBasePath)/$(RelOutputPath)" />
+
+  </Target>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
This project isn't hooked up by default right now but you can
build layout\dir.proj and it will produce the following in the output.

bin\layout\ref\netstandard1.x
bin\layout\runtime\netcoreapp.<RID>
bin\layout\runtime\uap.<RID>

The layouts under ref folder represent the set of reference assemblies
for the given target framework. The stuff under the runtime folder
represents the concrete implementations for things in corefx, plus
the runtime coreclr/netnative. The runtime folder however is not setup
to be runnable, its primary purpose is for reporting the set of APIs
we have for a given target runtime.

cc @ericstj @joperezr 