### PR TITLE
Using IArgumentProvider in more places to reduce collection allocations

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -265,16 +265,18 @@ namespace System.Linq.Expressions
 
             var index = (IndexExpression)_left;
 
-            var vars = new List<ParameterExpression>(index.Arguments.Count + 2);
-            var exprs = new List<Expression>(index.Arguments.Count + 3);
+            var vars = new List<ParameterExpression>(index.ArgumentCount + 2);
+            var exprs = new List<Expression>(index.ArgumentCount + 3);
 
             var tempObj = Expression.Variable(index.Object.Type, "tempObj");
             vars.Add(tempObj);
             exprs.Add(Expression.Assign(tempObj, index.Object));
 
-            var tempArgs = new List<Expression>(index.Arguments.Count);
-            foreach (var arg in index.Arguments)
+            var n = index.ArgumentCount;
+            var tempArgs = new List<Expression>(n);
+            for (var i = 0; i < n; i++)
             {
+                var arg = index.GetArgument(i);
                 var tempArg = Expression.Variable(arg.Type, "tempArg" + tempArgs.Count);
                 vars.Add(tempArg);
                 tempArgs.Add(tempArg);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
@@ -198,10 +198,10 @@ namespace System.Linq.Expressions.Compiler
                 return;
             }
 
-            if (node.Arguments.Count == 1)
+            if (node.ArgumentCount == 1)
             {
                 EmitExpression(node.Object);
-                EmitExpression(node.Arguments[0]);
+                EmitExpression(node.GetArgument(0));
                 _ilg.Emit(OpCodes.Ldelema, node.Type);
             }
             else
@@ -327,9 +327,11 @@ namespace System.Linq.Expressions.Compiler
 
             // Emit indexes. We don't allow byref args, so no need to worry
             // about write-backs or EmitAddress
-            List<LocalBuilder> args = new List<LocalBuilder>();
-            foreach (var arg in node.Arguments)
+            var n = node.ArgumentCount;
+            List<LocalBuilder> args = new List<LocalBuilder>(n);
+            for (var i = 0; i < n; i++)
             {
+                var arg = node.GetArgument(i);
                 EmitExpression(arg);
 
                 var argLocal = GetLocal(arg.Type);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -186,9 +186,8 @@ namespace System.Linq.Expressions.Compiler
                 // if the invoke target is a lambda expression tree, first compile it into a delegate
                 expr = Expression.Call(expr, expr.Type.GetMethod("Compile", Array.Empty<Type>()));
             }
-            expr = Expression.Call(expr, expr.Type.GetMethod("Invoke"), node.Arguments);
 
-            EmitExpression(expr);
+            EmitMethodCall(expr, expr.Type.GetMethod("Invoke"), node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitExpressionStart);
         }
 
         private void EmitInlinedInvoke(InvocationExpression invoke, CompilationFlags flags)
@@ -235,8 +234,9 @@ namespace System.Linq.Expressions.Compiler
 
             // Emit indexes. We don't allow byref args, so no need to worry
             // about write-backs or EmitAddress
-            foreach (var arg in node.Arguments)
+            for (int i = 0, n = node.ArgumentCount; i < n; i++)
             {
+                var arg = node.GetArgument(i);
                 EmitExpression(arg);
             }
 
@@ -258,8 +258,9 @@ namespace System.Linq.Expressions.Compiler
 
             // Emit indexes. We don't allow byref args, so no need to worry
             // about write-backs or EmitAddress
-            foreach (var arg in index.Arguments)
+            for (int i = 0, n = index.ArgumentCount; i < n; i++)
             {
+                var arg = index.GetArgument(i);
                 EmitExpression(arg);
             }
 
@@ -607,7 +608,7 @@ namespace System.Linq.Expressions.Compiler
             }
             else
             {
-                Debug.Assert(node.Arguments.Count == 0, "Node with arguments must have a constructor.");
+                Debug.Assert(node.ArgumentCount == 0, "Node with arguments must have a constructor.");
                 Debug.Assert(node.Type.GetTypeInfo().IsValueType, "Only value type may have constructor not set.");
                 LocalBuilder temp = GetLocal(node.Type);
                 _ilg.Emit(OpCodes.Ldloca, temp);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
@@ -171,10 +171,10 @@ namespace System.Linq.Expressions.Compiler
         {
             IndexExpression index = (IndexExpression)node.Left;
 
-            ChildRewriter cr = new ChildRewriter(this, stack, 2 + index.Arguments.Count);
+            ChildRewriter cr = new ChildRewriter(this, stack, 2 + index.ArgumentCount);
 
             cr.Add(index.Object);
-            cr.Add(index.Arguments);
+            cr.AddArguments(index);
             cr.Add(node.Right);
 
             if (cr.Action == RewriteAction.SpillStack)
@@ -396,12 +396,12 @@ namespace System.Linq.Expressions.Compiler
         {
             IndexExpression node = (IndexExpression)expr;
 
-            ChildRewriter cr = new ChildRewriter(this, stack, node.Arguments.Count + 1);
+            ChildRewriter cr = new ChildRewriter(this, stack, node.ArgumentCount + 1);
 
             // For instance methods, the instance executes on the
             // stack as is, but stays on the stack, making it non-empty.
             cr.Add(node.Object);
-            cr.Add(node.Arguments);
+            cr.AddArguments(node);
 
             if (cr.Action == RewriteAction.SpillStack)
             {
@@ -425,7 +425,7 @@ namespace System.Linq.Expressions.Compiler
         {
             MethodCallExpression node = (MethodCallExpression)expr;
 
-            ChildRewriter cr = new ChildRewriter(this, stack, node.Arguments.Count + 1);
+            ChildRewriter cr = new ChildRewriter(this, stack, node.ArgumentCount + 1);
 
             // For instance methods, the instance executes on the
             // stack as is, but stays on the stack, making it non-empty.
@@ -491,8 +491,8 @@ namespace System.Linq.Expressions.Compiler
             if (lambda != null)
             {
                 // Arguments execute on current stack
-                cr = new ChildRewriter(this, stack, node.Arguments.Count);
-                cr.Add(node.Arguments);
+                cr = new ChildRewriter(this, stack, node.ArgumentCount);
+                cr.AddArguments(node);
 
                 if (cr.Action == RewriteAction.SpillStack)
                 {
@@ -512,13 +512,13 @@ namespace System.Linq.Expressions.Compiler
                 return new Result(result.Action | spiller._lambdaRewrite, result.Node);
             }
 
-            cr = new ChildRewriter(this, stack, node.Arguments.Count + 1);
+            cr = new ChildRewriter(this, stack, node.ArgumentCount + 1);
 
             // first argument starts on stack as provided
             cr.Add(node.Expression);
 
             // rest of arguments have non-empty stack (delegate instance on the stack)
-            cr.Add(node.Arguments);
+            cr.AddArguments(node);
 
             if (cr.Action == RewriteAction.SpillStack)
             {
@@ -535,7 +535,7 @@ namespace System.Linq.Expressions.Compiler
 
             // The first expression starts on a stack as provided by parent,
             // rest are definitely non-empty (which ChildRewriter guarantees)
-            ChildRewriter cr = new ChildRewriter(this, stack, node.Arguments.Count);
+            ChildRewriter cr = new ChildRewriter(this, stack, node.ArgumentCount);
             cr.AddArguments(node);
 
             if (cr.Action == RewriteAction.SpillStack)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
@@ -88,7 +88,10 @@ namespace System.Linq.Expressions.Compiler
                 Visit(MergeScopes(lambda));
                 _scopes.Pop();
                 // visit the invoke's arguments
-                Visit(node.Arguments);
+                for (int i = 0, n = node.ArgumentCount; i < n; i++)
+                {
+                    Visit(node.GetArgument(i));
+                }
                 return node;
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
@@ -445,7 +445,7 @@ namespace System.Linq.Expressions
 
         protected internal override Expression VisitMemberInit(MemberInitExpression node)
         {
-            if (node.NewExpression.Arguments.Count == 0 &&
+            if (node.NewExpression.ArgumentCount == 0 &&
                 node.NewExpression.Type.Name.Contains("<"))
             {
                 // anonymous type constructor
@@ -513,7 +513,16 @@ namespace System.Linq.Expressions
         {
             Out(initializer.AddMethod.ToString());
             string sep = ", ";
-            VisitExpressions('(', initializer.Arguments, ')', sep);
+            Out('(');
+            for (int i = 0, n = initializer.ArgumentCount; i < n; i++)
+            {
+                if (i > 0)
+                {
+                    Out(sep);
+                }
+                Visit(initializer.GetArgument(i));
+            }
+            Out(')');
             return initializer;
         }
 
@@ -522,10 +531,10 @@ namespace System.Linq.Expressions
             Out("Invoke(");
             Visit(node.Expression);
             string sep = ", ";
-            for (int i = 0, n = node.Arguments.Count; i < n; i++)
+            for (int i = 0, n = node.ArgumentCount; i < n; i++)
             {
                 Out(sep);
-                Visit(node.Arguments[i]);
+                Visit(node.GetArgument(i));
             }
             Out(")");
             return node;
@@ -539,7 +548,7 @@ namespace System.Linq.Expressions
             if (node.Method.GetCustomAttribute(typeof(ExtensionAttribute)) != null)
             {
                 start = 1;
-                ob = node.Arguments[0];
+                ob = node.GetArgument(0);
             }
 
             if (ob != null)
@@ -549,11 +558,11 @@ namespace System.Linq.Expressions
             }
             Out(node.Method.Name);
             Out("(");
-            for (int i = start, n = node.Arguments.Count; i < n; i++)
+            for (int i = start, n = node.ArgumentCount; i < n; i++)
             {
                 if (i > start)
                     Out(", ");
-                Visit(node.Arguments[i]);
+                Visit(node.GetArgument(i));
             }
             Out(")");
             return node;
@@ -582,7 +591,7 @@ namespace System.Linq.Expressions
             Out("new " + node.Type.Name);
             Out("(");
             var members = node.Members;
-            for (int i = 0; i < node.Arguments.Count; i++)
+            for (int i = 0; i < node.ArgumentCount; i++)
             {
                 if (i > 0)
                 {
@@ -594,7 +603,7 @@ namespace System.Linq.Expressions
                     Out(name);
                     Out(" = ");
                 }
-                Visit(node.Arguments[i]);
+                Visit(node.GetArgument(i));
             }
             Out(")");
             return node;
@@ -791,7 +800,15 @@ namespace System.Linq.Expressions
                 Out(node.Indexer.Name);
             }
 
-            VisitExpressions('[', node.Arguments, ']');
+            Out('[');
+            for (int i = 0, n = node.ArgumentCount; i < n; i++)
+            {
+                if (i > 0)
+                    Out(", ");
+                Visit(node.GetArgument(i));
+            }
+            Out(']');
+
             return node;
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -255,7 +255,7 @@ namespace System.Linq.Expressions
 
             bool prefix = IsPrefix;
             var index = (IndexExpression)_operand;
-            int count = index.Arguments.Count;
+            int count = index.ArgumentCount;
             var block = new Expression[count + (prefix ? 2 : 4)];
             var temps = new ParameterExpression[count + (prefix ? 1 : 2)];
             var args = new ParameterExpression[count];
@@ -266,7 +266,7 @@ namespace System.Linq.Expressions
             i++;
             while (i <= count)
             {
-                var arg = index.Arguments[i - 1];
+                var arg = index.GetArgument(i - 1);
                 args[i - 1] = temps[i] = Parameter(arg.Type, null);
                 block[i] = Assign(temps[i], arg);
                 i++;


### PR DESCRIPTION
It seems a few nodes got the `IArgumentProvider` support later and its functionality wasn't used wherever it could be used. Note I'm not doing this for the `DebugView` given it has low value in that case, so mostly focusing on common code paths such as the compiler and interpreter.