### PR TITLE
ARM-CI : Check a device is already mounted while mounting a device.

### DIFF
--- a/scripts/arm32_ci_script.sh
+++ b/scripts/arm32_ci_script.sh
@@ -98,9 +98,6 @@ function unmount_emulator {
 
 #Clean the changes made to the environment by the script
 function clean_env {
-    #Unmount the emulator
-    unmount_emulator
-
     #Check for revert of git changes
     check_git_head
 }
@@ -111,11 +108,34 @@ function handle_ctrl_c {
 
     echo 'ERROR: Ctrl-C handled. Script aborted before complete execution.'
 
-    clean_env
-
     exit 1
 }
 trap handle_ctrl_c INT
+
+#Trap Exit and handle it
+ function handle_exit {
+    set +x
+
+    echo 'The script is exited. Cleaning environment..'
+
+    clean_env
+ }
+trap handle_exit EXIT
+
+#Mount with checking to be already existed
+function mount_with_checking {
+    set +x
+    local options="$1"
+    local from="$2"
+    local rootfsFolder="$3"
+
+    if mountpoint -q -- "$rootfsFolder"; then
+        (set +x; echo "$rootfsFolder is already mounted.")
+    else {
+        (set -x; sudo mount $options "$from" "$rootfsFolder")
+    }
+    fi
+}
 
 #Mount emulator to the target mount path
 function mount_emulator {
@@ -124,15 +144,13 @@ function mount_emulator {
         sudo mkdir "$__ARMRootfsMountPath"
     fi
 
-    #Unmount the emulator if already mounted at the mount path and mount again
-    unmount_emulator
-
-    sudo mount "$__ARMEmulPath"/platform/rootfs-t30.ext4 "$__ARMRootfsMountPath"
-    sudo mount -t proc /proc    "$__ARMRootfsMountPath"/proc
-    sudo mount -o bind /dev/    "$__ARMRootfsMountPath"/dev
-    sudo mount -o bind /dev/pts "$__ARMRootfsMountPath"/dev/pts
-    sudo mount -t tmpfs shm     "$__ARMRootfsMountPath"/run/shm
-    sudo mount -o bind /sys     "$__ARMRootfsMountPath"/sys
+    set +x
+    mount_with_checking "" "$__ARMEmulPath/platform/rootfs-t30.ext4" "$__ARMRootfsMountPath"
+    mount_with_checking "-t proc" "/proc"    "$__ARMRootfsMountPath/proc"
+    mount_with_checking "-o bind" "/dev/"    "$__ARMRootfsMountPath/dev"
+    mount_with_checking "-o bind" "/dev/pts" "$__ARMRootfsMountPath/dev/pts"
+    mount_with_checking "-t tmpfs" "shm"     "$__ARMRootfsMountPath/run/shm"
+    mount_with_checking "-o bind" "/sys"     "$__ARMRootfsMountPath/sys"
 }
 
 #Cross builds corefx


### PR DESCRIPTION
Now ARM-CI makes building failure frequently with below messages.

http://dotnet-ci.cloudapp.net/job/dotnet_corefx/job/master/job/linuxarmemulator_cross_release/127/console
19:21:33 + unmount_rootfs /opt/linux-arm-emulator-root/dev
19:21:33 + local rootfsFolder=/opt/linux-arm-emulator-root/dev
19:21:33 + grep -qs /opt/linux-arm-emulator-root/dev /proc/mounts
19:21:33 + sudo umount /opt/linux-arm-emulator-root/dev
umount: /opt/linux-arm-emulator-root/dev: device is busy.
19:21:33         (In some cases useful info about processes that use
19:21:33          the device is found by lsof(8) or fuser(1))
19:21:33 Build step 'Execute shell' marked build as failure

I suggest though the script is exited by any cases, the script would not run un-mounting.
But whenever CI is running and mounting a device, It will check the device is already mounted.

I think this error is occurred from the script of running tests. I hope to resolve this problem As soon as possible.
In before resolving this problem, It would rather apply it than errors are occurred.