### PR TITLE
set __CrossBuild in src/Native/build-native.sh automatically

### DIFF
--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -192,16 +192,22 @@ fi
 
 case $CPUName in
     i686)
-        if [ $__BuildArch != "x64" ]; then
+        if [ $__BuildArch != x86 ]; then
+            echo "Cross!"
             __CrossBuild=1
         fi
         ;;
-    i86_64)
-        if [ $__BuildArch != "x86" ] ;then
+    x86_64)
+        if [ $__BuildArch != x64 ]; then
+            echo "Cross!"
             __CrossBuild=1
         fi
+        echo "this"
         ;;
 esac
+
+#__CrossBuild=1
+#__BuildArch="arm"
 
 # Set the remaining variables based upon the determined build configuration
 __IntermediatesDir="$__rootbinpath/obj/$__BuildOS.$__BuildArch.$__BuildType/Native"

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -183,6 +183,26 @@ while :; do
     shift
 done
 
+# Set cross build
+CPUName=$(uname -p)
+# Some Linux platforms report unknown for platform, but the arch for machine.
+if [ $CPUName == "unknown" ]; then
+    CPUName=$(uname -m)
+fi
+
+case $CPUName in
+    i686)
+        if [ $__BuildArch != "x64" ]; then
+            __CrossBuild=1
+        fi
+        ;;
+    i86_64)
+        if [ $__BuildArch != "x86" ] ;then
+            __CrossBuild=1
+        fi
+        ;;
+esac
+
 # Set the remaining variables based upon the determined build configuration
 __IntermediatesDir="$__rootbinpath/obj/$__BuildOS.$__BuildArch.$__BuildType/Native"
 __BinDir="$__rootbinpath/$__BuildOS.$__BuildArch.$__BuildType/Native"

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -193,11 +193,13 @@ case $CPUName in
     i686)
         if [ $__BuildArch != x86 ]; then
             __CrossBuild=1
+            echo "Set CrossBuild for $__BuildArch build"
         fi
         ;;
     x86_64)
         if [ $__BuildArch != x64 ]; then
             __CrossBuild=1
+            echo "Set CrossBuild for $__BuildArch build"
         fi
         ;;
 esac

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -189,25 +189,18 @@ CPUName=$(uname -p)
 if [ $CPUName == "unknown" ]; then
     CPUName=$(uname -m)
 fi
-
 case $CPUName in
     i686)
         if [ $__BuildArch != x86 ]; then
-            echo "Cross!"
             __CrossBuild=1
         fi
         ;;
     x86_64)
         if [ $__BuildArch != x64 ]; then
-            echo "Cross!"
             __CrossBuild=1
         fi
-        echo "this"
         ;;
 esac
-
-#__CrossBuild=1
-#__BuildArch="arm"
 
 # Set the remaining variables based upon the determined build configuration
 __IntermediatesDir="$__rootbinpath/obj/$__BuildOS.$__BuildArch.$__BuildType/Native"


### PR DESCRIPTION
`Run.exe` call by `build-native.sh` pass `__BuildArch`, `__BuildType`, `__HostOS`, and `__NumProc` to `src/Native/build-native.sh` using Actions. 

Add setting `__CrossBuild` when `__BuildArch` is different with host architecture automatically.