### PR TITLE
Reving up the versions of the contracts where we have added Apis for netcoreapp1.1

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -439,6 +439,12 @@
         <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
       </PropertyGroup>
     </When>
+    <When Condition="'$(TargetGroup)'=='netstandard1.7'">
+      <PropertyGroup>
+        <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
+        <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
     <When Condition="'$(TargetGroup)'=='netstandard13aot'">
       <PropertyGroup>
         <PackageTargetFramework>netstandard1.3</PackageTargetFramework>

--- a/dir.props
+++ b/dir.props
@@ -433,6 +433,12 @@
         <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
       </PropertyGroup>
     </When>
+    <When Condition="'$(TargetGroup)'=='netstandard1.6'">
+      <PropertyGroup>
+        <PackageTargetFramework>netstandard1.6</PackageTargetFramework>
+        <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
     <When Condition="'$(TargetGroup)'=='netstandard13aot'">
       <PropertyGroup>
         <PackageTargetFramework>netstandard1.3</PackageTargetFramework>

--- a/src/System.Collections.NonGeneric/pkg/System.Collections.NonGeneric.pkgproj
+++ b/src/System.Collections.NonGeneric/pkg/System.Collections.NonGeneric.pkgproj
@@ -2,8 +2,11 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.1\System.Collections.NonGeneric.depproj">
+      <SupportedFramework>net46;netcore50;netcoreapp1.0</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.Collections.NonGeneric.csproj">
-      <SupportedFramework>net46;netcore50;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Collections.NonGeneric.builds" />
   </ItemGroup>

--- a/src/System.Collections.NonGeneric/pkg/ValidationSuppression.txt
+++ b/src/System.Collections.NonGeneric/pkg/ValidationSuppression.txt
@@ -1,0 +1,1 @@
+PermitHigherCompatibleImplementationVersion

--- a/src/System.Collections.NonGeneric/ref/4.0.1/System.Collections.NonGeneric.depproj
+++ b/src/System.Collections.NonGeneric/ref/4.0.1/System.Collections.NonGeneric.depproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections.NonGeneric/ref/4.0.1/System.Collections.NonGeneric.depproj
+++ b/src/System.Collections.NonGeneric/ref/4.0.1/System.Collections.NonGeneric.depproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.Collections.NonGeneric/ref/4.0.1/project.json
+++ b/src/System.Collections.NonGeneric/ref/4.0.1/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Collections.NonGeneric": "4.0.1"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4"
+      ]
+    }
+  }
+}

--- a/src/System.Collections.NonGeneric/ref/System.Collections.NonGeneric.csproj
+++ b/src/System.Collections.NonGeneric/ref/System.Collections.NonGeneric.csproj
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Collections.NonGeneric/ref/System.Collections.NonGeneric.csproj
+++ b/src/System.Collections.NonGeneric/ref/System.Collections.NonGeneric.csproj
@@ -5,7 +5,7 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Collections.NonGeneric.cs" />

--- a/src/System.Collections.NonGeneric/ref/project.json
+++ b/src/System.Collections.NonGeneric/ref/project.json
@@ -4,9 +4,9 @@
     "System.Globalization": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "imports": [
-        "dotnet5.4"
+        "dotnet5.8"
       ]
     }
   }

--- a/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.builds
+++ b/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.builds
@@ -4,7 +4,13 @@
   <ItemGroup>
     <Project Include="System.Collections.NonGeneric.csproj" />
     <Project Include="System.Collections.NonGeneric.csproj">
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </Project>
+    <Project Include="System.Collections.NonGeneric.csproj">
       <TargetGroup>net46</TargetGroup>
+    </Project>
+    <Project Include="System.Collections.NonGeneric.csproj">
+      <TargetGroup>net463</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
+++ b/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
@@ -5,17 +5,23 @@
     <ProjectGuid>{585E3764-534B-4A12-8BD5-8578CB826A45}</ProjectGuid>
     <RootNamespace>System.Collections.NonGeneric</RootNamespace>
     <AssemblyName>System.Collections.NonGeneric</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
-    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.3</PackageTargetFramework>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">4.0.2.0</AssemblyVersion>
+    <ContractProject Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">../ref/4.0.1/System.Collections.NonGeneric.depproj</ContractProject>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetGroup)' != 'net463'">
     <Compile Include="System\Collections\ArrayList.cs" />
     <Compile Include="System\Collections\CaseInsensitiveComparer.cs" />
     <Compile Include="System\Collections\CaseInsensitiveHashCodeProvider.cs" />
@@ -32,7 +38,7 @@
     <Compile Include="System\Collections\Stack.cs" />
     <Compile Include="System\Collections\Specialized\CollectionsUtil.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="mscorlib" />
   </ItemGroup>

--- a/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
+++ b/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
@@ -10,7 +10,7 @@
     <ContractProject Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">../ref/4.0.1/System.Collections.NonGeneric.depproj</ContractProject>
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Collections.NonGeneric/src/project.json
+++ b/src/System.Collections.NonGeneric/src/project.json
@@ -16,6 +16,22 @@
         "dotnet5.4"
       ]
     },
+    "netstandard1.7": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.Globalization": "4.0.10",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Threading": "4.0.10"
+      },
+      "imports": [
+        "dotnet5.8"
+      ]
+    },
     "net46": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"

--- a/src/System.Collections.NonGeneric/src/project.json
+++ b/src/System.Collections.NonGeneric/src/project.json
@@ -20,6 +20,11 @@
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
+    },
+    "net463": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
     }
   }
 }

--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -20,7 +20,7 @@ namespace System.Collections.Tests
             var hash = new ComparableHashtable();
             VerifyHashtable(hash, null, null);
         }
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public static void Ctor_HashCodeProvider_Comparer()
         {
@@ -42,7 +42,7 @@ namespace System.Collections.Tests
                 nullComparer ? null : StringComparer.OrdinalIgnoreCase);
             VerifyHashtable(hash, null, hash.EqualityComparer);
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         [Fact]
         public static void Ctor_IDictionary()
@@ -66,7 +66,7 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentNullException>("d", () => new Hashtable((IDictionary)null)); // Dictionary is null
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public static void Ctor_IDictionary_HashCodeProvider_Comparer()
         {
@@ -88,7 +88,7 @@ namespace System.Collections.Tests
         {
             Assert.Throws<ArgumentNullException>("d", () => new Hashtable(null, CaseInsensitiveHashCodeProvider.Default, StringComparer.OrdinalIgnoreCase)); // Dictionary is null
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         [Fact]
         public static void Ctor_IEqualityComparer()
@@ -116,7 +116,7 @@ namespace System.Collections.Tests
             VerifyHashtable(hash, null, null);
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Theory]
         [InlineData(0)]
         [InlineData(10)]
@@ -126,7 +126,7 @@ namespace System.Collections.Tests
             var hash = new ComparableHashtable(capacity, CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
             VerifyHashtable(hash, null, hash.EqualityComparer);
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         [Fact]
         public static void Ctor_Int_Invalid()
@@ -135,7 +135,7 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentException>("capacity", () => new Hashtable(int.MaxValue)); // Capacity / load factor > int.MaxValue
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public static void Ctor_IDictionary_Int()
         {
@@ -152,7 +152,7 @@ namespace System.Collections.Tests
 
             VerifyHashtable(hash1, hash2, hash1.EqualityComparer);
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         [Fact]
         public static void Ctor_IDictionary_Int_Invalid()
@@ -225,7 +225,7 @@ namespace System.Collections.Tests
             VerifyHashtable(hash, null, null);
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Theory]
         [InlineData(0, 0.1)]
         [InlineData(10, 0.2)]
@@ -236,7 +236,7 @@ namespace System.Collections.Tests
             var hash = new ComparableHashtable(capacity, loadFactor, CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
             VerifyHashtable(hash, null, hash.EqualityComparer);
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         [Fact]
         public static void Ctor_Int_Int_GenerateNewPrime()
@@ -803,7 +803,7 @@ namespace System.Collections.Tests
             }
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public static void HashCodeProvider_Set_ImpactsSearch()
         {
@@ -885,7 +885,7 @@ namespace System.Collections.Tests
             public int FixedHashCode;
             public int GetHashCode(object obj) => FixedHashCode;
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         private static void VerifyHashtable(ComparableHashtable hash1, Hashtable hash2, IEqualityComparer ikc)
         {
@@ -936,15 +936,15 @@ namespace System.Collections.Tests
 
             public ComparableHashtable(int capacity, float loadFactor) : base(capacity, loadFactor) { }
 
-#if FEATURE_NS_1_7
+#if netstandard17
             public ComparableHashtable(int capacity, IHashCodeProvider hcp, IComparer comparer) : base(capacity, hcp, comparer) { }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
             public ComparableHashtable(int capacity, IEqualityComparer ikc) : base(capacity, ikc) { }
 
-#if FEATURE_NS_1_7
+#if netstandard17
             public ComparableHashtable(IHashCodeProvider hcp, IComparer comparer) : base(hcp, comparer) { }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
             public ComparableHashtable(IEqualityComparer ikc) : base(ikc) { }
 
@@ -952,29 +952,29 @@ namespace System.Collections.Tests
 
             public ComparableHashtable(IDictionary d, float loadFactor) : base(d, loadFactor) { }
 
-#if FEATURE_NS_1_7
+#if netstandard17
             public ComparableHashtable(IDictionary d, IHashCodeProvider hcp, IComparer comparer) : base(d, hcp, comparer) { }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
             public ComparableHashtable(IDictionary d, IEqualityComparer ikc) : base(d, ikc) { }
 
-#if FEATURE_NS_1_7
+#if netstandard17
             public ComparableHashtable(IDictionary d, float loadFactor, IHashCodeProvider hcp, IComparer comparer) : base(d, loadFactor, hcp, comparer) { }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
             public ComparableHashtable(IDictionary d, float loadFactor, IEqualityComparer ikc) : base(d, loadFactor, ikc) { }
 
-#if FEATURE_NS_1_7
+#if netstandard17
             public ComparableHashtable(int capacity, float loadFactor, IHashCodeProvider hcp, IComparer comparer) : base(capacity, loadFactor, hcp, comparer) { }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
             public ComparableHashtable(int capacity, float loadFactor, IEqualityComparer ikc) : base(capacity, loadFactor, ikc) { }
 
             public new IEqualityComparer EqualityComparer => base.EqualityComparer;
-#if FEATURE_NS_1_7
+#if netstandard17
             public IHashCodeProvider HashCodeProvider { get { return hcp; } set { hcp = value; } }
             public IComparer Comparer { get { return comparer; } set { comparer = value; } }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
         }
 
         private class BadHashCode

--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -20,7 +20,7 @@ namespace System.Collections.Tests
             var hash = new ComparableHashtable();
             VerifyHashtable(hash, null, null);
         }
-
+#if FEATURE_NS_1_7
         [Fact]
         public static void Ctor_HashCodeProvider_Comparer()
         {
@@ -42,6 +42,7 @@ namespace System.Collections.Tests
                 nullComparer ? null : StringComparer.OrdinalIgnoreCase);
             VerifyHashtable(hash, null, hash.EqualityComparer);
         }
+#endif //FEATURE_NS_1_7
 
         [Fact]
         public static void Ctor_IDictionary()
@@ -65,6 +66,7 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentNullException>("d", () => new Hashtable((IDictionary)null)); // Dictionary is null
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public static void Ctor_IDictionary_HashCodeProvider_Comparer()
         {
@@ -86,6 +88,7 @@ namespace System.Collections.Tests
         {
             Assert.Throws<ArgumentNullException>("d", () => new Hashtable(null, CaseInsensitiveHashCodeProvider.Default, StringComparer.OrdinalIgnoreCase)); // Dictionary is null
         }
+#endif //FEATURE_NS_1_7
 
         [Fact]
         public static void Ctor_IEqualityComparer()
@@ -113,6 +116,7 @@ namespace System.Collections.Tests
             VerifyHashtable(hash, null, null);
         }
 
+#if FEATURE_NS_1_7
         [Theory]
         [InlineData(0)]
         [InlineData(10)]
@@ -122,6 +126,7 @@ namespace System.Collections.Tests
             var hash = new ComparableHashtable(capacity, CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
             VerifyHashtable(hash, null, hash.EqualityComparer);
         }
+#endif //FEATURE_NS_1_7
 
         [Fact]
         public static void Ctor_Int_Invalid()
@@ -130,6 +135,7 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentException>("capacity", () => new Hashtable(int.MaxValue)); // Capacity / load factor > int.MaxValue
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public static void Ctor_IDictionary_Int()
         {
@@ -146,6 +152,7 @@ namespace System.Collections.Tests
 
             VerifyHashtable(hash1, hash2, hash1.EqualityComparer);
         }
+#endif //FEATURE_NS_1_7
 
         [Fact]
         public static void Ctor_IDictionary_Int_Invalid()
@@ -218,6 +225,7 @@ namespace System.Collections.Tests
             VerifyHashtable(hash, null, null);
         }
 
+#if FEATURE_NS_1_7
         [Theory]
         [InlineData(0, 0.1)]
         [InlineData(10, 0.2)]
@@ -228,6 +236,7 @@ namespace System.Collections.Tests
             var hash = new ComparableHashtable(capacity, loadFactor, CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
             VerifyHashtable(hash, null, hash.EqualityComparer);
         }
+#endif //FEATURE_NS_1_7
 
         [Fact]
         public static void Ctor_Int_Int_GenerateNewPrime()
@@ -794,6 +803,7 @@ namespace System.Collections.Tests
             }
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public static void HashCodeProvider_Set_ImpactsSearch()
         {
@@ -875,6 +885,7 @@ namespace System.Collections.Tests
             public int FixedHashCode;
             public int GetHashCode(object obj) => FixedHashCode;
         }
+#endif //FEATURE_NS_1_7
 
         private static void VerifyHashtable(ComparableHashtable hash1, Hashtable hash2, IEqualityComparer ikc)
         {
@@ -925,11 +936,15 @@ namespace System.Collections.Tests
 
             public ComparableHashtable(int capacity, float loadFactor) : base(capacity, loadFactor) { }
 
+#if FEATURE_NS_1_7
             public ComparableHashtable(int capacity, IHashCodeProvider hcp, IComparer comparer) : base(capacity, hcp, comparer) { }
+#endif //FEATURE_NS_1_7
 
             public ComparableHashtable(int capacity, IEqualityComparer ikc) : base(capacity, ikc) { }
 
+#if FEATURE_NS_1_7
             public ComparableHashtable(IHashCodeProvider hcp, IComparer comparer) : base(hcp, comparer) { }
+#endif //FEATURE_NS_1_7
 
             public ComparableHashtable(IEqualityComparer ikc) : base(ikc) { }
 
@@ -937,21 +952,29 @@ namespace System.Collections.Tests
 
             public ComparableHashtable(IDictionary d, float loadFactor) : base(d, loadFactor) { }
 
+#if FEATURE_NS_1_7
             public ComparableHashtable(IDictionary d, IHashCodeProvider hcp, IComparer comparer) : base(d, hcp, comparer) { }
+#endif //FEATURE_NS_1_7
 
             public ComparableHashtable(IDictionary d, IEqualityComparer ikc) : base(d, ikc) { }
 
+#if FEATURE_NS_1_7
             public ComparableHashtable(IDictionary d, float loadFactor, IHashCodeProvider hcp, IComparer comparer) : base(d, loadFactor, hcp, comparer) { }
+#endif //FEATURE_NS_1_7
 
             public ComparableHashtable(IDictionary d, float loadFactor, IEqualityComparer ikc) : base(d, loadFactor, ikc) { }
 
+#if FEATURE_NS_1_7
             public ComparableHashtable(int capacity, float loadFactor, IHashCodeProvider hcp, IComparer comparer) : base(capacity, loadFactor, hcp, comparer) { }
+#endif //FEATURE_NS_1_7
 
             public ComparableHashtable(int capacity, float loadFactor, IEqualityComparer ikc) : base(capacity, loadFactor, ikc) { }
 
             public new IEqualityComparer EqualityComparer => base.EqualityComparer;
+#if FEATURE_NS_1_7
             public IHashCodeProvider HashCodeProvider { get { return hcp; } set { hcp = value; } }
             public IComparer Comparer { get { return comparer; } set { comparer = value; } }
+#endif //FEATURE_NS_1_7
         }
 
         private class BadHashCode

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.builds
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.builds
@@ -4,6 +4,10 @@
   <ItemGroup>
     <Project Include="System.Collections.NonGeneric.Tests.csproj"/>
     <Project Include="System.Collections.NonGeneric.Tests.csproj">
+      <TargetGroup>netstandard1.7</TargetGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+    </Project>
+    <Project Include="System.Collections.NonGeneric.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -8,7 +8,9 @@
     <RootNamespace>System.Collections.NonGeneric.Tests</RootNamespace>
     <AssemblyName>System.Collections.NonGeneric.Tests</AssemblyName>
     <ProjectGuid>{EE95AE39-845A-42D3-86D0-8065DBE56612}</ProjectGuid>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);FEATURE_NS_1_7</DefineConstants>
+    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7'">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -37,7 +39,7 @@
     </Compile>
     <Compile Include="ArrayListTests.cs" />
     <Compile Include="ArrayList\ArrayList.IList.Tests.cs" />
-    <Compile Include="CaseInsensitiveHashCodeProviderTests.cs" />
+    <Compile Include="CaseInsensitiveHashCodeProviderTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="Hashtable\Hashtable.Values.Tests.cs" />
     <Compile Include="Hashtable\Hashtable.Keys.Tests.cs" />
     <Compile Include="Hashtable\Hashtable.IDictionary.Tests.cs" />

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -8,9 +8,8 @@
     <RootNamespace>System.Collections.NonGeneric.Tests</RootNamespace>
     <AssemblyName>System.Collections.NonGeneric.Tests</AssemblyName>
     <ProjectGuid>{EE95AE39-845A-42D3-86D0-8065DBE56612}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);FEATURE_NS_1_7</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
     <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
-    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7'">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -23,7 +23,8 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {
-    "netstandard1.3": {}
+    "netstandard1.3": {},
+    "netstandard1.7": {}
   },
   "supports": {
     "coreFx.Test.netcore50": {},

--- a/src/System.Collections/pkg/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/System.Collections.pkgproj
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Version>4.0.12.0</Version>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\4.0.0\System.Collections.depproj">

--- a/src/System.Collections/pkg/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/System.Collections.pkgproj
@@ -8,8 +8,14 @@
     <ProjectReference Include="..\ref\4.0.0\System.Collections.depproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
+    <ProjectReference Include="..\ref\4.0.10\System.Collections.depproj">
+      <SupportedFramework>net46;netcore50;netcoreapp1.0</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.Collections.csproj">
-      <SupportedFramework>net46;netcore50;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>netcoreapp1.1;net463;$(AllXamarinFrameworks)</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Collections.csproj">
+      <TargetGroup>net463</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="any\System.Collections.pkgproj" />
     <ProjectReference Include="aot\System.Collections.pkgproj" />

--- a/src/System.Collections/pkg/any/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/any/System.Collections.pkgproj
@@ -9,6 +9,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Collections.csproj" />
+    <ProjectReference Include="..\..\src\System.Collections.csproj">
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\redist\System.Collections.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/src/System.Collections/pkg/aot/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/aot/System.Collections.pkgproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>4.0.12.0</Version>
     <PackageTargetRuntime>aot</PackageTargetRuntime>
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>

--- a/src/System.Collections/ref/4.0.10/System.Collections.depproj
+++ b/src/System.Collections/ref/4.0.10/System.Collections.depproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections/ref/4.0.10/project.json
+++ b/src/System.Collections/ref/4.0.10/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4"
+      ]
+    }
+  }
+}

--- a/src/System.Collections/ref/System.Collections.csproj
+++ b/src/System.Collections/ref/System.Collections.csproj
@@ -5,7 +5,7 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Collections.cs" />

--- a/src/System.Collections/ref/System.Collections.csproj
+++ b/src/System.Collections/ref/System.Collections.csproj
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Collections/ref/project.json
+++ b/src/System.Collections/ref/project.json
@@ -3,9 +3,9 @@
     "System.Runtime": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "imports": [
-        "dotnet5.4"
+        "dotnet5.8"
       ]
     }
   }

--- a/src/System.Collections/src/System.Collections.builds
+++ b/src/System.Collections/src/System.Collections.builds
@@ -3,10 +3,12 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Collections.csproj" />
-    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Collections.csproj">
-      <TargetGroup>net46</TargetGroup>
-    </Project> -->
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </Project>
+    <Project Include="System.Collections.csproj">
+      <TargetGroup>net463</TargetGroup>
+    </Project>
     <!-- NETCore50 must redistribute binaries due to shared library
     <Project Include="System.Collections.csproj">
       <TargetGroup>netcore50aot</TargetGroup>

--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -3,29 +3,34 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{D5FF747F-7A0B-9003-885A-FE9A63E755E5}</ProjectGuid>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netcore50aot'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netcore50aot' OR '$(TargetGroup)' != 'net463'">true</IsPartialFacadeAssembly>
     <AssemblyName>System.Collections</AssemblyName>
-    <AssemblyVersion>4.0.12.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3'">4.0.12.0</AssemblyVersion>
+    <ContractProject Condition="'$(TargetGroup)'=='netstandard1.3'">../ref/4.0.10/System.Collections.depproj</ContractProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.7</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.346_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aotao_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' == ''">
+  <ItemGroup Condition="'$(TargetGroup)' == '' OR '$(TargetGroup)'=='netstandard1.3'">
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj">
       <TargetGroup>netstandard1.5</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
+      <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
       <OSGroup>$(InputOSGroup)</OSGroup>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
     <Compile Include="System\Collections\Generic\BitHelper.cs" />
     <Compile Include="System\Collections\Generic\ICollectionDebugView.cs" />
     <Compile Include="System\Collections\Generic\IDictionaryDebugView.cs" />
@@ -55,7 +60,7 @@
     <Compile Include="System\Collections\Generic\EqualityComparer.cs" />
     <Compile Include="System\Collections\Generic\List.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />

--- a/src/System.Collections/src/project.json
+++ b/src/System.Collections/src/project.json
@@ -9,7 +9,16 @@
         "dotnet5.4"
       ]
     },
-    "net46": {
+    "netstandard1.7": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.2-beta-24329-03"
+      },
+      "imports": [
+        "dotnet5.6"
+      ]
+    },
+    "net463": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }

--- a/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
@@ -31,7 +31,9 @@ namespace System.Collections.Tests
                 Assert.False(bitArray[i]);
                 Assert.False(bitArray.Get(i));
             }
-            Assert.Equal(length, bitArray.Count);
+            ICollection collection = bitArray;
+            Assert.Equal(length, collection.Count);
+            Assert.False(collection.IsSynchronized);
         }
 
         [Theory]
@@ -60,7 +62,9 @@ namespace System.Collections.Tests
                 Assert.Equal(defaultValue, bitArray[i]);
                 Assert.Equal(defaultValue, bitArray.Get(i));
             }
-            Assert.Equal(length, bitArray.Count);
+            ICollection collection = bitArray;
+            Assert.Equal(length, collection.Count);
+            Assert.False(collection.IsSynchronized);
         }
 
         [Fact]
@@ -92,7 +96,9 @@ namespace System.Collections.Tests
                 Assert.Equal(values[i], bitArray[i]);
                 Assert.Equal(values[i], bitArray.Get(i));
             }
-            Assert.Equal(values.Length, bitArray.Count);
+            ICollection collection = bitArray;
+            Assert.Equal(values.Length, collection.Count);
+            Assert.False(collection.IsSynchronized);
         }
 
         public static IEnumerable<object[]> Ctor_BitArray_TestData()
@@ -135,7 +141,9 @@ namespace System.Collections.Tests
                 Assert.Equal(bits[i], bitArray[i]);
                 Assert.Equal(bits[i], bitArray.Get(i));
             }
-            Assert.Equal(bits.Length, bitArray.Count);
+            ICollection collection = bitArray;
+            Assert.Equal(bits.Length, collection.Count);
+            Assert.False(collection.IsSynchronized);
         }
 
         public static IEnumerable<object[]> Ctor_IntArray_TestData()
@@ -160,7 +168,9 @@ namespace System.Collections.Tests
                 Assert.Equal(expected[i], bitArray[i]);
                 Assert.Equal(expected[i], bitArray.Get(i));
             }
-            Assert.Equal(expected.Length, bitArray.Count);
+            ICollection collection = bitArray;
+            Assert.Equal(expected.Length, collection.Count);
+            Assert.False(collection.IsSynchronized);
         }
 
         [Fact]
@@ -203,7 +213,9 @@ namespace System.Collections.Tests
                 Assert.Equal(expected[i], bitArray[i]);
                 Assert.Equal(expected[i], bitArray.Get(i));
             }
-            Assert.Equal(expected.Length, bitArray.Count);
+            ICollection collection = bitArray;
+            Assert.Equal(expected.Length, collection.Count);
+            Assert.False(collection.IsSynchronized);
         }
 
         [Fact]
@@ -212,6 +224,7 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentNullException>("bytes", () => new BitArray((byte[])null));
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public static void Ctor_Simple_Method_Tests()
         {
@@ -223,5 +236,6 @@ namespace System.Collections.Tests
             Assert.False(bitArray.IsReadOnly);
             Assert.Equal(bitArray, bitArray.Clone());
         }
+#endif //FEATURE_NS_1_7
     }
 }

--- a/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
@@ -224,7 +224,7 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentNullException>("bytes", () => new BitArray((byte[])null));
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public static void Ctor_Simple_Method_Tests()
         {
@@ -236,6 +236,6 @@ namespace System.Collections.Tests
             Assert.False(bitArray.IsReadOnly);
             Assert.Equal(bitArray, bitArray.Clone());
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
     }
 }

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -252,7 +252,8 @@ namespace System.Collections.Tests
         public static void CopyTo<T>(BitArray bitArray, int length, int index, T[] expected, T def)
         {
             T[] array = (T[])Array.CreateInstance(typeof(T), length);
-            bitArray.CopyTo(array, index);
+            ICollection collection = bitArray;
+            collection.CopyTo(array, index);
             for (int i = 0; i < index; i++)
             {
                 Assert.Equal(def, array[i]);
@@ -270,7 +271,7 @@ namespace System.Collections.Tests
         [Fact]
         public static void CopyTo_Type_Invalid()
         {
-            BitArray bitArray = new BitArray(10);
+            ICollection bitArray = new BitArray(10);
             Assert.Throws<ArgumentNullException>("array", () => bitArray.CopyTo(null, 0));
             Assert.Throws<ArgumentException>("array", () => bitArray.CopyTo(new long[10], 0));
             Assert.Throws<ArgumentException>("array", () => bitArray.CopyTo(new int[10, 10], 0));
@@ -293,7 +294,7 @@ namespace System.Collections.Tests
         [InlineData(default(int), BitsPerInt32 * 4, 4, 1)]
         public static void CopyTo_Size_Invalid<T>(T def, int bits, int arraySize, int index)
         {
-            BitArray bitArray = new BitArray(bits);
+            ICollection bitArray = new BitArray(bits);
             T[] array = (T[])Array.CreateInstance(typeof(T), arraySize);
             Assert.Throws<ArgumentOutOfRangeException>("index", () => bitArray.CopyTo(array, -1));
             Assert.Throws<ArgumentException>(def is int ? string.Empty : null, () => bitArray.CopyTo(array, index));
@@ -302,9 +303,9 @@ namespace System.Collections.Tests
         [Fact]
         public static void SyncRoot()
         {
-            BitArray bitArray = new BitArray(10);
+            ICollection bitArray = new BitArray(10);
             Assert.Same(bitArray.SyncRoot, bitArray.SyncRoot);
-            Assert.NotSame(bitArray.SyncRoot, (new BitArray(10)).SyncRoot);
+            Assert.NotSame(bitArray.SyncRoot, ((ICollection)new BitArray(10)).SyncRoot);
         }
     }
 }

--- a/src/System.Collections/tests/System.Collections.Tests.builds
+++ b/src/System.Collections/tests/System.Collections.Tests.builds
@@ -4,6 +4,10 @@
   <ItemGroup>
     <Project Include="System.Collections.Tests.csproj"/>
     <Project Include="System.Collections.Tests.csproj">
+      <TargetGroup>netstandard1.7</TargetGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+    </Project>
+    <Project Include="System.Collections.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -8,9 +8,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Tests</AssemblyName>
     <RootNamespace>System.Collections.Tests</RootNamespace>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);FEATURE_NS_1_7</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
     <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
-    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7'">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -8,7 +8,9 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Tests</AssemblyName>
     <RootNamespace>System.Collections.Tests</RootNamespace>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);FEATURE_NS_1_7</DefineConstants>
+    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7'">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -124,7 +126,7 @@
     <Compile Include="Generic\List\List.Generic.Tests.AddRange.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.BinarySearch.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.Constructor.cs" />
-    <Compile Include="Generic\List\List.Generic.Tests.ConvertAll.cs" />
+    <Compile Include="Generic\List\List.Generic.Tests.ConvertAll.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="Generic\List\List.Generic.Tests.Find.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.Remove.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.Sort.cs" />

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -21,7 +21,8 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {
-    "netstandard1.3": {}
+    "netstandard1.3": {},
+    "netstandard1.7": {}
   },
   "supports": {
     "coreFx.Test.netcore50": {},

--- a/src/System.Console/pkg/System.Console.pkgproj
+++ b/src/System.Console/pkg/System.Console.pkgproj
@@ -2,11 +2,17 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Console.depproj">
+      <SupportedFramework>net46;netcore50;netcoreapp1.0</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.Console.csproj">
-      <SupportedFramework>net46;netcore50;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Console.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Console.csproj">
+      <AdditionalProperties>TargetGroup=net463</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="win\System.Console.pkgproj" />
     <ProjectReference Include="unix\System.Console.pkgproj" />

--- a/src/System.Console/pkg/ValidationSuppression.txt
+++ b/src/System.Console/pkg/ValidationSuppression.txt
@@ -1,0 +1,1 @@
+PermitHigherCompatibleImplementationVersion

--- a/src/System.Console/pkg/unix/System.Console.pkgproj
+++ b/src/System.Console/pkg/unix/System.Console.pkgproj
@@ -10,6 +10,10 @@
     <ProjectReference Include="..\..\src\System.Console.csproj" >
       <OSGroup>Unix</OSGroup>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\System.Console.csproj" >
+      <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </ProjectReference>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Console/pkg/win/System.Console.pkgproj
+++ b/src/System.Console/pkg/win/System.Console.pkgproj
@@ -13,6 +13,10 @@
     </ProjectReference>
     <ProjectReference Include="..\..\src\System.Console.csproj" >
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\System.Console.csproj" >
+      <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>
     <ExternalOnTargetFramework Include="net" />

--- a/src/System.Console/ref/4.0.0/System.Console.depproj
+++ b/src/System.Console/ref/4.0.0/System.Console.depproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Console/ref/4.0.0/System.Console.depproj
+++ b/src/System.Console/ref/4.0.0/System.Console.depproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.Console/ref/4.0.0/project.json
+++ b/src/System.Console/ref/4.0.0/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Console": "4.0.0"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4"
+      ]
+    }
+  }
+}

--- a/src/System.Console/ref/System.Console.csproj
+++ b/src/System.Console/ref/System.Console.csproj
@@ -5,7 +5,7 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Console.cs" />

--- a/src/System.Console/ref/System.Console.csproj
+++ b/src/System.Console/ref/System.Console.csproj
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Console/ref/project.json
+++ b/src/System.Console/ref/project.json
@@ -5,9 +5,9 @@
     "System.Text.Encoding":  "4.0.0"
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "imports": [
-        "dotnet5.4"
+        "dotnet5.8"
       ]
     }
   }

--- a/src/System.Console/src/System.Console.builds
+++ b/src/System.Console/src/System.Console.builds
@@ -9,7 +9,18 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.Console.csproj">
+      <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </Project>
+    <Project Include="System.Console.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </Project>
+    <Project Include="System.Console.csproj">
       <TargetGroup>net46</TargetGroup>
+    </Project>
+    <Project Include="System.Console.csproj">
+      <TargetGroup>net463</TargetGroup>
     </Project>
     <Project Include="System.Console.csproj">
       <OSGroup>Windows_NT</OSGroup>

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -14,7 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.3'">
     <AdditionalFiles Include="$(ToolsDir)PinvokeAnalyzer_OneCoreApis.txt" />
@@ -170,7 +170,7 @@
     </Compile>
   </ItemGroup>
   <!-- Unix -->
-  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And '$(TargetGroup)' != 'net46' And '$(TargetGroup)' != 'net463'">
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And ('$(TargetGroup)' == '' OR '$(TargetGroup)'=='netstandard1.3')">
     <Compile Include="System\ConsolePal.Unix.cs" />
     <Compile Include="System\TermInfo.cs" />
     <Compile Include="System\IO\StdInReader.cs" />

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -1,29 +1,40 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'=='' AND '$(TargetGroup)' == ''">Windows_Debug</Configuration>
+    <Configuration Condition="'$(Configuration)'=='' AND ('$(TargetGroup)' == '' OR '$(TargetGroup)' == 'netstandard1.3')">Windows_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{F9DF2357-81B4-4317-908E-512DA9395583}</ProjectGuid>
     <RootNamespace>System.Console</RootNamespace>
     <AssemblyName>System.Console</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46' OR '$(TargetGroup)'=='netcore50'">4.0.1.0</AssemblyVersion>
+    <ContractProject Condition="'$(AssemblyVersion)'=='4.0.1.0'">../ref/4.0.0/System.Console.depproj</ContractProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.3'">
+    <AdditionalFiles Include="$(ToolsDir)PinvokeAnalyzer_OneCoreApis.txt" />
+  </ItemGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard1.3_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard1.3_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard1.3_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard1.3_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetGroup)' != 'net463'">
     <Compile Include="System\Console.cs" />
     <Compile Include="System\ConsoleCancelEventArgs.cs" />
     <Compile Include="System\ConsoleColor.cs" />
@@ -47,7 +58,7 @@
     <Compile Include="System\ConsolePal.WinRT.cs" />
   </ItemGroup>
   <!-- Windows : Win32 -->
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == ''">
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And ('$(TargetGroup)' == '' OR '$(TargetGroup)'=='netstandard1.3')">
     <Compile Include="System\ConsolePal.Windows.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
@@ -159,7 +170,7 @@
     </Compile>
   </ItemGroup>
   <!-- Unix -->
-  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And '$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And '$(TargetGroup)' != 'net46' And '$(TargetGroup)' != 'net463'">
     <Compile Include="System\ConsolePal.Unix.cs" />
     <Compile Include="System\TermInfo.cs" />
     <Compile Include="System\IO\StdInReader.cs" />
@@ -255,7 +266,7 @@
       <Link>Common\Interop\Unix\Interop.StdinReady.cs"</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Console/src/project.json
+++ b/src/System.Console/src/project.json
@@ -22,6 +22,28 @@
         "dotnet5.4"
       ]
     },
+    "netstandard1.7": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Collections": "4.0.0",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.IO": "4.0.10",
+        "System.IO.FileSystem.Primitives": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Text.Encoding": "4.0.10",
+        "System.Text.Encoding.Extensions": "4.0.10",
+        "System.Threading": "4.0.10",
+        "System.Threading.Tasks": "4.0.10"
+      },
+      "imports": [
+        "dotnet5.8"
+      ]
+    },
     "net46": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"

--- a/src/System.Console/src/project.json
+++ b/src/System.Console/src/project.json
@@ -27,6 +27,11 @@
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
     },
+    "net463": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    },
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",

--- a/src/System.Globalization/ref/System.Globalization.csproj
+++ b/src/System.Globalization/ref/System.Globalization.csproj
@@ -5,7 +5,7 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Globalization.cs" />

--- a/src/System.Globalization/ref/System.Globalization.csproj
+++ b/src/System.Globalization/ref/System.Globalization.csproj
@@ -5,7 +5,7 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Globalization.cs" />

--- a/src/System.Globalization/src/System.Globalization.builds
+++ b/src/System.Globalization/src/System.Globalization.builds
@@ -9,10 +9,6 @@
     <Project Include="System.Globalization.csproj">
       <TargetGroup>net463</TargetGroup>
     </Project>
-    <!-- Net46 facade is currently inbox for 4.0
-    <Project Include="System.Globalization.csproj">
-      <TargetGroup>net46</TargetGroup>
-    </Project> -->
     <Project Include="System.Globalization.csproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/src/System.Globalization/src/System.Globalization.csproj
+++ b/src/System.Globalization/src/System.Globalization.csproj
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <AssemblyName>System.Globalization</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3' Or '$(TargetGroup)'=='netcore50' Or '$(TargetGroup)'=='netcore50aot'">4.0.12.0</AssemblyVersion>
-    <ContractProject Condition="'$(AssemblyVersion)'=='4.0.12.0'">../ref/4.0.10/System.Globalization.depproj</ContractProject>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='netcore50' OR '$(TargetGroup)'=='netcore50aot'">4.0.12.0</AssemblyVersion>
+    <ContractProject Condition="'$(AssemblyVersion)'!='4.1.0.0'">../ref/4.0.10/System.Globalization.depproj</ContractProject>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.Globalization/src/System.Globalization.csproj
+++ b/src/System.Globalization/src/System.Globalization.csproj
@@ -8,7 +8,7 @@
     <ContractProject Condition="'$(AssemblyVersion)'!='4.1.0.0'">../ref/4.0.10/System.Globalization.depproj</ContractProject>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Globalization/src/project.json
+++ b/src/System.Globalization/src/project.json
@@ -8,6 +8,14 @@
         "dotnet5.4"
       ]
     },
+    "netstandard1.7": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.2-beta-24329-03"
+      },
+      "imports": [
+        "dotnet5.8"
+      ]
+    },
     "netcore50": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.CoreCLR": "1.0.2-beta-24329-03"

--- a/src/System.Globalization/src/project.json
+++ b/src/System.Globalization/src/project.json
@@ -13,7 +13,7 @@
         "Microsoft.TargetingPack.Private.CoreCLR": "1.0.2-beta-24329-03"
       }
     },
-    "net46": {
+    "net463": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }

--- a/src/System.IO.Compression/pkg/System.IO.Compression.pkgproj
+++ b/src/System.IO.Compression/pkg/System.IO.Compression.pkgproj
@@ -5,8 +5,11 @@
     <ProjectReference Include="..\ref\4.0.0\System.IO.Compression.depproj">
       <SupportedFramework>net45;netcore45;wpa81</SupportedFramework>
     </ProjectReference>
+    <ProjectReference Include="..\ref\4.1.0\System.IO.Compression.depproj">
+      <SupportedFramework>net46;netcore50;netcoreapp1.0</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.IO.Compression.csproj">
-      <SupportedFramework>net46;netcore50;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>netcoreapp1.1;net463;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Compression.builds" />
     <InboxOnTargetFramework Include="net45">

--- a/src/System.IO.Compression/pkg/ValidationSuppression.txt
+++ b/src/System.IO.Compression/pkg/ValidationSuppression.txt
@@ -1,0 +1,1 @@
+PermitHigherCompatibleImplementationVersion

--- a/src/System.IO.Compression/ref/4.1.0/System.IO.Compression.depproj
+++ b/src/System.IO.Compression/ref/4.1.0/System.IO.Compression.depproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.2.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.IO.Compression/ref/4.1.0/System.IO.Compression.depproj
+++ b/src/System.IO.Compression/ref/4.1.0/System.IO.Compression.depproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.Compression/ref/4.1.0/project.json
+++ b/src/System.IO.Compression/ref/4.1.0/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.IO.Compression": "4.1.0"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  }
+}

--- a/src/System.IO.Compression/ref/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/ref/System.IO.Compression.csproj
@@ -3,9 +3,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <UseECMAKey Condition="'$(UseECMAKey)' == ''">true</UseECMAKey>
-    <AssemblyVersion>4.1.2.0</AssemblyVersion>
+    <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.IO.Compression/ref/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/ref/System.IO.Compression.csproj
@@ -6,7 +6,7 @@
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.IO.Compression.cs" />

--- a/src/System.IO.Compression/ref/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/ref/System.IO.Compression.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <UseECMAKey Condition="'$(UseECMAKey)' == ''">true</UseECMAKey>
+    <UseECMAKey>true</UseECMAKey>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>

--- a/src/System.IO.Compression/ref/project.json
+++ b/src/System.IO.Compression/ref/project.json
@@ -6,9 +6,9 @@
     "System.Threading.Tasks": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.6": {
+    "netstandard1.7": {
       "imports": [
-        "dotnet5.6"
+        "dotnet5.8"
       ]
     }
   }

--- a/src/System.IO.Compression/src/System.IO.Compression.builds
+++ b/src/System.IO.Compression/src/System.IO.Compression.builds
@@ -9,7 +9,18 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.IO.Compression.csproj">
+      <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </Project>
+    <Project Include="System.IO.Compression.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </Project>
+    <Project Include="System.IO.Compression.csproj">
       <TargetGroup>net46</TargetGroup>
+    </Project>
+    <Project Include="System.IO.Compression.csproj">
+      <TargetGroup>net463</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -12,7 +12,7 @@
     <OutputType>Library</OutputType>
     <ProjectGuid>{5471BFE8-8071-466F-838E-5ADAA779E742}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <UseECMAKey Condition="'$(UseECMAKey)'==''">true</UseECMAKey>
+    <UseECMAKey>true</UseECMAKey>
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
     <DefineConstants Condition="'$(TargetGroup)' != 'net46' And '$(TargetGroup)' != 'net463'">$(DefineConstants);FEATURE_ZLIB</DefineConstants>
     <DefineConstants Condition="'$(AssemblyVersion)'!='4.1.2.0'">$(DefineConstants);FEATURE_NS_1_7</DefineConstants>

--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -15,9 +15,9 @@
     <UseECMAKey>true</UseECMAKey>
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
     <DefineConstants Condition="'$(TargetGroup)' != 'net46' And '$(TargetGroup)' != 'net463'">$(DefineConstants);FEATURE_ZLIB</DefineConstants>
-    <DefineConstants Condition="'$(AssemblyVersion)'!='4.1.2.0'">$(DefineConstants);FEATURE_NS_1_7</DefineConstants>
+    <DefineConstants Condition="'$(AssemblyVersion)'!='4.1.2.0'">$(DefineConstants);netstandard17</DefineConstants>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' Or '$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.6</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />

--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -6,14 +6,17 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.IO.Compression</AssemblyName>
-    <AssemblyVersion>4.1.2.0</AssemblyVersion>
+    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">4.1.2.0</AssemblyVersion>
+    <ContractProject Condition="'$(AssemblyVersion)'=='4.1.2.0'">../ref/4.1.0/System.IO.Compression.depproj</ContractProject>
     <OutputType>Library</OutputType>
     <ProjectGuid>{5471BFE8-8071-466F-838E-5ADAA779E742}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseECMAKey Condition="'$(UseECMAKey)'==''">true</UseECMAKey>
-    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.3</PackageTargetFramework>
-    <DefineConstants Condition="'$(TargetGroup)' != 'net46'">$(DefineConstants);FEATURE_ZLIB</DefineConstants>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
+    <DefineConstants Condition="'$(TargetGroup)' != 'net46' And '$(TargetGroup)' != 'net463'">$(DefineConstants);FEATURE_ZLIB</DefineConstants>
+    <DefineConstants Condition="'$(AssemblyVersion)'!='4.1.2.0'">$(DefineConstants);FEATURE_NS_1_7</DefineConstants>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' Or '$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
@@ -21,8 +24,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard1.3_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard1.3_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard1.3_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard1.3_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
   <!-- Files shared between net46 and core -->
   <ItemGroup>
     <Compile Include="$(SharedOpenSourcePath)System\IO\Compression\Crc32Helper.cs" />
@@ -38,7 +47,7 @@
     </Compile>
   </ItemGroup>
   <!-- Files exclusive to Core -->
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46' And '$(TargetGroup)' != 'net463'">
     <Compile Include="System\IO\Compression\CompressionLevel.cs" />
     <Compile Include="System\IO\Compression\CompressionMode.cs" />
     <Compile Include="System\IO\Compression\Deflater.cs" />
@@ -59,7 +68,7 @@
     </Compile>
   </ItemGroup>
   <!-- Windows specific files exclusive to Core -->
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'net46' And '$(TargetGroup)' != 'net463'">
     <Compile Include="System\IO\Compression\ZLibNative.Windows.cs" />
     <Compile Include="Interop\Interop.zlib.Windows.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
@@ -82,7 +91,7 @@
     </Compile>
   </ItemGroup>
   <!-- Files exclusive to net46 -->
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46' Or '$(TargetGroup)' == 'net463'">
     <Compile Include="AssemblyInfo.cs" />
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
@@ -346,7 +346,7 @@ namespace System.IO.Compression
             throw new InvalidOperationException(SR.CannotWriteToDeflateStream);
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
             TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
 
@@ -596,7 +596,7 @@ namespace System.IO.Compression
             }
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         public override IAsyncResult BeginWrite(byte[] array, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
             TaskToApm.Begin(WriteAsync(array, offset, count, CancellationToken.None), asyncCallback, asyncState);
 

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
@@ -346,11 +346,13 @@ namespace System.IO.Compression
             throw new InvalidOperationException(SR.CannotWriteToDeflateStream);
         }
 
+#if FEATURE_NS_1_7
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
             TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
 
         public override int EndRead(IAsyncResult asyncResult) =>
             TaskToApm.End<int>(asyncResult);
+#endif
 
         public override Task<int> ReadAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
@@ -594,11 +596,13 @@ namespace System.IO.Compression
             }
         }
 
+#if FEATURE_NS_1_7
         public override IAsyncResult BeginWrite(byte[] array, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
             TaskToApm.Begin(WriteAsync(array, offset, count, CancellationToken.None), asyncCallback, asyncState);
 
         public override void EndWrite(IAsyncResult asyncResult) =>
             TaskToApm.End(asyncResult);
+#endif
 
         public override Task WriteAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
         {

--- a/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
@@ -116,7 +116,7 @@ namespace System.IO.Compression
             return _deflateStream.ReadByte();
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         public override IAsyncResult BeginRead(byte[] array, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
             TaskToApm.Begin(WriteAsync(array, offset, count, CancellationToken.None), asyncCallback, asyncState);
 
@@ -130,7 +130,7 @@ namespace System.IO.Compression
             return _deflateStream.Read(array, offset, count);
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         public override IAsyncResult BeginWrite(byte[] array, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
             TaskToApm.Begin(WriteAsync(array, offset, count, CancellationToken.None), asyncCallback, asyncState);
 

--- a/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
@@ -116,12 +116,13 @@ namespace System.IO.Compression
             return _deflateStream.ReadByte();
         }
 
-        // Uncomment once Stream Begin/End Read are available.
-        //public override IAsyncResult BeginRead(byte[] array, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
-        //    TaskToApm.Begin(WriteAsync(array, offset, count, CancellationToken.None), asyncCallback, asyncState);
+#if FEATURE_NS_1_7
+        public override IAsyncResult BeginRead(byte[] array, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
+            TaskToApm.Begin(WriteAsync(array, offset, count, CancellationToken.None), asyncCallback, asyncState);
 
-        //public override int EndRead(IAsyncResult asyncResult) =>
-        //    TaskToApm.End<int>(asyncResult);
+        public override int EndRead(IAsyncResult asyncResult) =>
+            TaskToApm.End<int>(asyncResult);
+#endif
 
         public override int Read(byte[] array, int offset, int count)
         {
@@ -129,12 +130,13 @@ namespace System.IO.Compression
             return _deflateStream.Read(array, offset, count);
         }
 
-        // Uncomment once Stream Begin/End Write are available.
-        //public override IAsyncResult BeginWrite(byte[] array, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
-        //    TaskToApm.Begin(WriteAsync(array, offset, count, CancellationToken.None), asyncCallback, asyncState);
+#if FEATURE_NS_1_7
+        public override IAsyncResult BeginWrite(byte[] array, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
+            TaskToApm.Begin(WriteAsync(array, offset, count, CancellationToken.None), asyncCallback, asyncState);
 
-        //public override void EndWrite(IAsyncResult asyncResult) =>
-        //    TaskToApm.End(asyncResult);
+        public override void EndWrite(IAsyncResult asyncResult) =>
+            TaskToApm.End(asyncResult);
+#endif            
 
         public override void Write(byte[] array, int offset, int count)
         {

--- a/src/System.IO.Compression/src/project.json
+++ b/src/System.IO.Compression/src/project.json
@@ -21,6 +21,27 @@
         "dotnet5.6"
       ]
     },
+    "netstandard1.7": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Collections": "4.0.10",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.IO": "4.2.0-beta-devapi-24401-01",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Runtime.Handles": "4.0.0",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Text.Encoding": "4.0.10",
+        "System.Threading": "4.0.0",
+        "System.Threading.Tasks": "4.0.10"
+      },
+      "imports": [
+        "dotnet5.8"
+      ]
+    },
     "netstandard1.3": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",

--- a/src/System.IO.Compression/src/project.json
+++ b/src/System.IO.Compression/src/project.json
@@ -21,7 +21,33 @@
         "dotnet5.6"
       ]
     },
+    "netstandard1.3": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Collections": "4.0.10",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.IO": "4.0.10",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Runtime.Handles": "4.0.0",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Text.Encoding": "4.0.10",
+        "System.Threading": "4.0.0",
+        "System.Threading.Tasks": "4.0.10"
+      },
+      "imports": [
+        "dotnet5.4"
+      ]
+    },
     "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    },
+    "net463": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }

--- a/src/System.IO.FileSystem/pkg/System.IO.FileSystem.pkgproj
+++ b/src/System.IO.FileSystem/pkg/System.IO.FileSystem.pkgproj
@@ -2,11 +2,17 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.1\System.IO.FileSystem.depproj">
+      <SupportedFramework>net46;netcore50;netcoreapp1.0</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.IO.FileSystem.csproj">
-      <SupportedFramework>net46;netcore50;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>netcoreapp1.1;net463;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.FileSystem.csproj">
       <TargetGroup>net46</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.IO.FileSystem.csproj">
+      <TargetGroup>net463</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="win\System.IO.FileSystem.pkgproj" />
     <ProjectReference Include="unix\System.IO.FileSystem.pkgproj" />

--- a/src/System.IO.FileSystem/pkg/ValidationSuppression.txt
+++ b/src/System.IO.FileSystem/pkg/ValidationSuppression.txt
@@ -1,0 +1,1 @@
+PermitHigherCompatibleImplementationVersion

--- a/src/System.IO.FileSystem/pkg/unix/System.IO.FileSystem.pkgproj
+++ b/src/System.IO.FileSystem/pkg/unix/System.IO.FileSystem.pkgproj
@@ -11,6 +11,10 @@
     <ProjectReference Include="..\..\src\System.IO.FileSystem.csproj">
       <OSGroup>Unix</OSGroup>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\System.IO.FileSystem.csproj">
+      <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </ProjectReference>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.IO.FileSystem/pkg/win/System.IO.FileSystem.pkgproj
+++ b/src/System.IO.FileSystem/pkg/win/System.IO.FileSystem.pkgproj
@@ -13,6 +13,10 @@
     </ProjectReference>
     <ProjectReference Include="..\..\src\System.IO.FileSystem.csproj">
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\System.IO.FileSystem.csproj">
+      <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>
 

--- a/src/System.IO.FileSystem/ref/4.0.1/System.IO.FileSystem.depproj
+++ b/src/System.IO.FileSystem/ref/4.0.1/System.IO.FileSystem.depproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.FileSystem/ref/4.0.1/System.IO.FileSystem.depproj
+++ b/src/System.IO.FileSystem/ref/4.0.1/System.IO.FileSystem.depproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.IO.FileSystem/ref/4.0.1/project.json
+++ b/src/System.IO.FileSystem/ref/4.0.1/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.IO.FileSystem": "4.0.1"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  }
+}

--- a/src/System.IO.FileSystem/ref/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/ref/System.IO.FileSystem.csproj
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.IO.FileSystem/ref/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/ref/System.IO.FileSystem.csproj
@@ -5,7 +5,7 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.IO.FileSystem.cs" />

--- a/src/System.IO.FileSystem/ref/project.json
+++ b/src/System.IO.FileSystem/ref/project.json
@@ -8,9 +8,9 @@
     "System.Threading.Tasks": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "imports": [
-        "dotnet5.4"
+        "dotnet5.8"
       ]
     }
   }

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.builds
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.builds
@@ -9,7 +9,18 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.IO.FileSystem.csproj">
+      <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </Project>
+    <Project Include="System.IO.FileSystem.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </Project>
+    <Project Include="System.IO.FileSystem.csproj">
       <TargetGroup>net46</TargetGroup>
+    </Project>
+    <Project Include="System.IO.FileSystem.csproj">
+      <TargetGroup>net463</TargetGroup>
     </Project>
     <Project Include="System.IO.FileSystem.csproj">
       <OSGroup>Windows_NT</OSGroup>

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -15,7 +15,7 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' Or '$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46' Or '$(TargetGroup)' == 'net463'">None</ResourcesSourceOutputDirectory>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsUnix)' == 'true'">
     <NoWarn>$(NoWarn);414</NoWarn>

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -1,24 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'=='' AND '$(TargetGroup)' == ''">Windows_Debug</Configuration>
+    <Configuration Condition="'$(Configuration)'=='' AND ('$(TargetGroup)' == '' Or '$(TargetGroup)' == 'netstandard1.3')">Windows_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{879C23DC-D828-4DFB-8E92-ABBC11B71035}</ProjectGuid>
     <AssemblyName>System.IO.FileSystem</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3' Or '$(TargetGroup)'=='net46' Or '$(TargetGroup)'=='netcore50'">4.0.2.0</AssemblyVersion>
+    <ContractProject Condition="'$(AssemblyVersion)'=='4.0.2.0'">../ref/4.0.1/System.IO.FileSystem.depproj</ContractProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableWinRT Condition="'$(PackageTargetFramework)' == 'netcore50'">true</EnableWinRT>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
-    <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' Or '$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
+    <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46' Or '$(TargetGroup)' == 'net463'">None</ResourcesSourceOutputDirectory>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsUnix)' == 'true'">
     <NoWarn>$(NoWarn);414</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetsWindows)' == 'true' AND '$(TargetGroup)' == ''">
+  <PropertyGroup Condition="'$(TargetsWindows)' == 'true' AND ('$(TargetGroup)' == '' Or '$(TargetGroup)' == 'netstandard1.3')">
     <ProjectJson>win/project.json</ProjectJson>
     <ProjectLockJson>win/project.lock.json</ProjectLockJson>
   </PropertyGroup>
@@ -27,15 +29,24 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard1.3_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard1.3_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard1.3_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard1.3_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.3'">
+    <AdditionalFiles Include="$(ToolsDir)PinvokeAnalyzer_OneCoreApis.txt" />
+  </ItemGroup>
   <ItemGroup Condition="'$(EnableWinRT)' == 'true'">
     <TargetingPackReference Include="Windows" />
     <ProjectReference Include="$(SourceDir)/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46' And '$(TargetGroup)' != 'net463'">
     <Compile Include="System\IO\Error.cs" />
     <Compile Include="System\IO\Directory.cs" />
     <Compile Include="System\IO\DirectoryInfo.cs" />
@@ -67,7 +78,7 @@
     </Compile>
   </ItemGroup>
   <!-- Windows -->
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'net46' And '$(TargetGroup)' != 'net463'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeFileHandle.Windows.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" />
     <Compile Include="System\IO\DirectoryInfo.Windows.cs" />
@@ -198,7 +209,7 @@
     </Compile>
   </ItemGroup>
   <!-- Windows : Win32 only -->
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(EnableWinRT)' != 'true' And '$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(EnableWinRT)' != 'true' And '$(TargetGroup)' != 'net46' And '$(TargetGroup)' != 'net463'">
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.UnsafeCreateFile.cs">
       <Link>Common\Interop\Windows\Interop.UnsafeCreateFile.cs</Link>
     </Compile>
@@ -375,7 +386,7 @@
       <Link>Common\System\IO\DriveInfoInternal.Unix.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46' Or '$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.IO.FileSystem/src/project.json
+++ b/src/System.IO.FileSystem/src/project.json
@@ -23,6 +23,29 @@
         "dotnet5.4"
       ]
     },
+    "netstandard1.7": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Collections": "4.0.10",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.IO": "4.0.10",
+        "System.IO.FileSystem.Primitives": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Runtime.Handles": "4.0.0",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Text.Encoding": "4.0.10",
+        "System.Text.Encoding.Extensions": "4.0.10",
+        "System.Threading": "4.0.10",
+        "System.Threading.Tasks": "4.0.10"
+      },
+      "imports": [
+        "dotnet5.8"
+      ]
+    },
     "net46": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"

--- a/src/System.IO.FileSystem/src/project.json
+++ b/src/System.IO.FileSystem/src/project.json
@@ -27,6 +27,11 @@
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
+    },
+    "net463": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
     }
   }
 }

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -131,7 +132,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void ValidExtendedPathWithTrailingSlash()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
@@ -224,7 +225,7 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void PathWithInvalidColons_ThrowsNotSupportedException()
         {
             var paths = IOInputs.GetPathsWithInvalidColons();
@@ -235,7 +236,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void DirectoryLongerThanMaxPath_Succeeds()
         {
             var paths = IOInputs.GetPathsLongerThanMaxPath(GetTestFilePath());
@@ -247,7 +248,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void DirectoryLongerThanMaxLongPath_ThrowsPathTooLongException()
         {
             var paths = IOInputs.GetPathsLongerThanMaxLongPath(GetTestFilePath());
@@ -258,7 +259,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsPathTooLongException()
         {
             var paths = IOInputs.GetPathsLongerThanMaxLongPath(GetTestFilePath(), useExtendedSyntax: true);
@@ -270,7 +271,7 @@ namespace System.IO.Tests
 
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void ExtendedDirectoryLongerThanLegacyMaxPath_Succeeds()
         {
             var paths = IOInputs.GetPathsLongerThanMaxPath(GetTestFilePath(), useExtendedSyntax: true);
@@ -281,7 +282,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void DirectoryLongerThanMaxDirectoryAsPath_Succeeds()
         {
             var paths = IOInputs.GetPathsLongerThanMaxDirectory(GetTestFilePath());
@@ -293,7 +294,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixPathLongerThan256_Allowed()
         {
             DirectoryInfo testDir = Create(GetTestFilePath());
@@ -304,7 +305,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixPathWithDeeplyNestedDirectories()
         {
             DirectoryInfo parent = Create(GetTestFilePath());
@@ -316,7 +317,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsWhiteSpaceAsPath_ThrowsArgumentException()
         {
             var paths = IOInputs.GetWhiteSpace();
@@ -327,7 +328,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixWhiteSpaceAsPath_Allowed()
         {
             var paths = IOInputs.GetWhiteSpace();
@@ -339,7 +340,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsTrailingWhiteSpace()
         {
             // Windows will remove all non-significant whitespace in a path
@@ -357,7 +358,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsExtendedSyntaxWhiteSpace()
         {
             var paths = IOInputs.GetSimpleWhiteSpace();
@@ -373,7 +374,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixNonSignificantTrailingWhiteSpace()
         {
             // Unix treats trailing/prename whitespace as significant and a part of the name.
@@ -391,7 +392,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // alternate data streams
+        [PlatformSpecific(XunitPlatformID.Windows)] // alternate data streams
         public void PathWithAlternateDataStreams_ThrowsNotSupportedException()
         {
             var paths = IOInputs.GetPathsWithAlternativeDataStreams();
@@ -402,7 +403,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // device name prefixes
+        [PlatformSpecific(XunitPlatformID.Windows)] // device name prefixes
         public void PathWithReservedDeviceNameAsPath_ThrowsDirectoryNotFoundException()
         {   // Throws DirectoryNotFoundException, when the behavior really should be an invalid path
             var paths = IOInputs.GetPathsWithReservedDeviceNames();
@@ -413,7 +414,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // device name prefixes
+        [PlatformSpecific(XunitPlatformID.Windows)] // device name prefixes
         public void PathWithReservedDeviceNameAsExtendedPath()
         {
             var paths = IOInputs.GetReservedDeviceNames();
@@ -427,7 +428,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // UNC shares
+        [PlatformSpecific(XunitPlatformID.Windows)] // UNC shares
         public void UncPathWithoutShareNameAsPath_ThrowsArgumentException()
         {
             var paths = IOInputs.GetUncPathsWithoutShareName();
@@ -438,14 +439,14 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // UNC shares
+        [PlatformSpecific(XunitPlatformID.Windows)] // UNC shares
         public void UNCPathWithOnlySlashes()
         {
             Assert.Throws<ArgumentException>(() => Create("//"));
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // drive labels
+        [PlatformSpecific(XunitPlatformID.Windows)] // drive labels
         public void CDriveCase()
         {
             DirectoryInfo dir = Create("c:\\");
@@ -454,7 +455,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void DriveLetter_Windows()
         {
             // On Windows, DirectoryInfo will replace "<DriveLetter>:" with "."
@@ -465,7 +466,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void DriveLetter_Unix()
         {
             // On Unix, there's no special casing for drive letters, which are valid file names
@@ -484,7 +485,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // testing drive labels
+        [PlatformSpecific(XunitPlatformID.Windows)] // testing drive labels
         public void NonExistentDriveAsPath_ThrowsDirectoryNotFoundException()
         {
             Assert.Throws<DirectoryNotFoundException>(() =>
@@ -494,7 +495,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // testing drive labels
+        [PlatformSpecific(XunitPlatformID.Windows)] // testing drive labels
         public void SubdirectoryOnNonExistentDriveAsPath_ThrowsDirectoryNotFoundException()
         {
             Assert.Throws<DirectoryNotFoundException>(() =>
@@ -505,7 +506,7 @@ namespace System.IO.Tests
 
         [Fact]
         [ActiveIssue(1221)]
-        [PlatformSpecific(PlatformID.Windows)] // testing drive labels
+        [PlatformSpecific(XunitPlatformID.Windows)] // testing drive labels
         public void NotReadyDriveAsPath_ThrowsDirectoryNotFoundException()
         {   // Behavior is suspect, should really have thrown IOException similar to the SubDirectory case
             var drive = IOServices.GetNotReadyDrive();
@@ -522,7 +523,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // testing drive labels
+        [PlatformSpecific(XunitPlatformID.Windows)] // testing drive labels
         [ActiveIssue(1221)]
         public void SubdirectoryOnNotReadyDriveAsPath_ThrowsIOException()
         {

--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -113,7 +114,7 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsExtendedDirectoryWithSubdirectories()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + GetTestFilePath());
@@ -123,7 +124,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsLongPathExtendedDirectory()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(IOServices.GetPath(IOInputs.ExtendedPrefix + TestDirectory, characterCount: 500).FullPath);
@@ -132,7 +133,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsDeleteReadOnlyDirectory()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
@@ -143,7 +144,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsDeleteExtendedReadOnlyDirectory()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + GetTestFilePath());
@@ -154,7 +155,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixDeleteReadOnlyDirectory()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
@@ -164,7 +165,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsShouldBeAbleToDeleteHiddenDirectory()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
@@ -174,7 +175,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsShouldBeAbleToDeleteExtendedHiddenDirectory()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + GetTestFilePath());
@@ -184,7 +185,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixShouldBeAbleToDeleteHiddenDirectory()
         {
             string testDir = "." + GetTestFileName();
@@ -232,7 +233,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void RecursiveDelete_ShouldThrowIOExceptionIfContainedFileInUse()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/Directory/Delete_MountVolume.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete_MountVolume.cs
@@ -23,7 +23,7 @@ public class Directory_Delete_MountVolume
 
     [Fact]
     [ActiveIssue(1221)]
-    [PlatformSpecific(PlatformID.Windows)] // testing volumes / mounts / drive letters
+    [PlatformSpecific(Xunit.PlatformID.Windows)] // testing volumes / mounts / drive letters
     public static void RunTest()
     {
         try

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -5,6 +5,7 @@
 using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -180,7 +181,7 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void ValidExtendedPathExists_ReturnsTrue()
         {
             Assert.All((IOInputs.GetValidPathComponentNames()), (component) =>
@@ -192,7 +193,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void ExtendedPathAlreadyExistsAsFile()
         {
             string path = IOInputs.ExtendedPrefix + GetTestFilePath();
@@ -204,7 +205,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void ExtendedPathAlreadyExistsAsDirectory()
         {
             string path = IOInputs.ExtendedPrefix + GetTestFilePath();
@@ -216,7 +217,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void DirectoryLongerThanMaxDirectoryAsPath_DoesntThrow()
         {
             Assert.All((IOInputs.GetPathsLongerThanMaxDirectory(GetTestFilePath())), (path) =>
@@ -226,7 +227,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // Unix equivalent tested already in CreateDirectory
+        [PlatformSpecific(XunitPlatformID.Windows)] // Unix equivalent tested already in CreateDirectory
         public void WindowsWhiteSpaceAsPath_ReturnsFalse()
         {
             // Checks that errors aren't thrown when calling Exists() on impossible paths
@@ -257,7 +258,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // In Windows, trailing whitespace in a path is trimmed appropriately
+        [PlatformSpecific(XunitPlatformID.Windows)] // In Windows, trailing whitespace in a path is trimmed appropriately
         public void TrailingWhitespaceExistence()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
@@ -278,7 +279,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // alternate data stream
+        [PlatformSpecific(XunitPlatformID.Windows)] // alternate data stream
         public void PathWithAlternateDataStreams_ReturnsFalse()
         {
             Assert.All(IOInputs.GetWhiteSpace(), (component) =>
@@ -289,7 +290,7 @@ namespace System.IO.Tests
 
         [Fact]
         [OuterLoop]
-        [PlatformSpecific(PlatformID.Windows)] // device names
+        [PlatformSpecific(XunitPlatformID.Windows)] // device names
         public void PathWithReservedDeviceNameAsPath_ReturnsFalse()
         {
             Assert.All((IOInputs.GetPathsWithReservedDeviceNames()), (component) =>
@@ -299,7 +300,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // UNC paths
+        [PlatformSpecific(XunitPlatformID.Windows)] // UNC paths
         public void UncPathWithoutShareNameAsPath_ReturnsFalse()
         {
             Assert.All((IOInputs.GetUncPathsWithoutShareName()), (component) =>
@@ -309,7 +310,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // max directory length not fixed on Unix
+        [PlatformSpecific(XunitPlatformID.Windows)] // max directory length not fixed on Unix
         public void DirectoryEqualToMaxDirectory_ReturnsTrue()
         {
             // Creates directories up to the maximum directory length all at once
@@ -320,7 +321,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // max directory length not fixed on Unix
+        [PlatformSpecific(XunitPlatformID.Windows)] // max directory length not fixed on Unix
         public void DirectoryWithComponentLongerThanMaxComponentAsPath_ReturnsFalse()
         {
             Assert.All((IOInputs.GetPathsWithComponentLongerThanMaxComponent()), (component) =>
@@ -331,7 +332,7 @@ namespace System.IO.Tests
 
         [Fact]
         [ActiveIssue(1221)]
-        [PlatformSpecific(PlatformID.Windows)] // drive labels
+        [PlatformSpecific(XunitPlatformID.Windows)] // drive labels
         public void NotReadyDriveAsPath_ReturnsFalse()
         {
             var drive = IOServices.GetNotReadyDrive();
@@ -348,7 +349,7 @@ namespace System.IO.Tests
 
         [Fact]
         [ActiveIssue(1221)]
-        [PlatformSpecific(PlatformID.Windows)] // drive labels
+        [PlatformSpecific(XunitPlatformID.Windows)] // drive labels
         public void SubdirectoryOnNotReadyDriveAsPath_ReturnsFalse()
         {
             var drive = IOServices.GetNotReadyDrive();
@@ -364,21 +365,21 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // drive labels
+        [PlatformSpecific(XunitPlatformID.Windows)] // drive labels
         public void NonExistentDriveAsPath_ReturnsFalse()
         {
             Assert.False(Exists(IOServices.GetNonExistentDrive()));
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // drive labels
+        [PlatformSpecific(XunitPlatformID.Windows)] // drive labels
         public void SubdirectoryOnNonExistentDriveAsPath_ReturnsFalse()
         {
             Assert.False(Exists(Path.Combine(IOServices.GetNonExistentDrive(), "nonexistentsubdir")));
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void FalseForNonRegularFile()
         {
             string fileName = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot.cs
@@ -50,7 +50,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void UNCShares()
         {
             string root = Directory.GetDirectoryRoot(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Test1", "test2", "test3"));

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -182,7 +183,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsInvalidCharsPath()
         {
             Assert.All(WindowsInvalidUnixValid, invalid =>
@@ -190,7 +191,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixValidCharsFilePath()
         {
             if (TestFiles)
@@ -206,7 +207,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixValidCharsDirectoryPath()
         {
             if (TestDirectories)

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -209,7 +210,7 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsSearchPatternLongSegment()
         {
             // Create a path segment longer than the normal max of 255
@@ -242,7 +243,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsSearchPatternWithDoubleDots()
         {
             Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, Path.Combine("..ab ab.. .. abc..d", "abc..")));
@@ -251,7 +252,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsSearchPatternInvalid()
         {
             Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, "\0"));
@@ -294,7 +295,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixSearchPatternInvalid()
         {
             Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, "\0"));
@@ -302,7 +303,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public virtual void WindowsSearchPatternQuestionMarks()
         {
             string testDir1Str = GetTestFileName();
@@ -321,7 +322,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsSearchPatternWhitespace()
         {
             Assert.Empty(GetEntries(TestDirectory, "           "));
@@ -375,7 +376,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixSearchPatternFileValidChar()
         {
             if (TestFiles)
@@ -390,7 +391,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixSearchPatternDirectoryValidChar()
         {
             if (TestDirectories)
@@ -405,7 +406,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixSearchPatternWithDoubleDots()
         {
             // search pattern is valid but directory doesn't exist

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str_so.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str_so.cs
@@ -28,7 +28,7 @@ namespace System.IO.Tests
         #endregion
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public override void WindowsSearchPatternQuestionMarks()
         {
             string testDir1Str = GetTestFileName();

--- a/src/System.IO.FileSystem/tests/Directory/GetLogicalDrives.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetLogicalDrives.cs
@@ -5,13 +5,14 @@
 using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
     public class Directory_GetLogicalDrives
     {
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void GetsValidDriveStrings_Unix()
         {
             string[] drives = Directory.GetLogicalDrives();
@@ -21,7 +22,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void GetsValidDriveStrings_Windows()
         {
             string[] drives = Directory.GetLogicalDrives();

--- a/src/System.IO.FileSystem/tests/Directory/GetParent.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetParent.cs
@@ -39,7 +39,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void UNCShares()
         {
             Assert.Null(GetParent(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")));

--- a/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -120,7 +121,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void Windows_DirectoryDoesntExist_ReturnDefaultValues()
         {
             string path = GetTestFilePath();
@@ -149,7 +150,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void Unix_DirectoryDoesntExist_Throws()
         {
             string path = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -144,7 +145,7 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void Path_With_Longer_Than_MaxDirectory_Succeeds()
         {
             string testDir = GetTestFilePath();
@@ -169,7 +170,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsWildCharacterPath()
         {
             Assert.Throws<ArgumentException>(() => Move("*", GetTestFilePath()));
@@ -179,7 +180,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixWildCharacterPath()
         {
             // Wildcards are allowed in paths for Unix move commands as literals as well as functional wildcards,
@@ -205,7 +206,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsWhitespacePath()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
@@ -219,7 +220,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixWhitespacePath()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
@@ -234,7 +235,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsExistingDirectory()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
@@ -249,7 +250,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void BetweenDriveLabels()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
@@ -261,7 +262,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixExistingDirectory()
         {
             // Moving to an-empty directory is supported on Unix, but moving to a non-empty directory is not

--- a/src/System.IO.FileSystem/tests/Directory/ReparsePoints_MountVolume.cs
+++ b/src/System.IO.FileSystem/tests/Directory/ReparsePoints_MountVolume.cs
@@ -20,7 +20,7 @@ public class Directory_ReparsePoints_MountVolume
 
     [Fact]
     [ActiveIssue(1221)]
-    [PlatformSpecific(PlatformID.Windows)] // testing mounting volumes and reparse points
+    [PlatformSpecific(Xunit.PlatformID.Windows)] // testing mounting volumes and reparse points
     public static void runTest()
     {
         try

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -20,7 +21,7 @@ namespace System.IO.Tests
         #endregion
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // UNC shares for constructor
+        [PlatformSpecific(XunitPlatformID.Windows)] // UNC shares for constructor
         public void NetworkShare()
         {
             string dirName = new string(Path.DirectorySeparatorChar, 2) + Path.Combine("contoso", "amusement", "device");
@@ -42,7 +43,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(".")]
         [InlineData("............")]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsInvalidExtensionsAreRemoved(string extension)
         {
             string testDir = GetTestFilePath();
@@ -53,7 +54,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(".s", ".")]
         [InlineData(".s", ".s....")]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsCurtailTrailingDots(string extension, string trailing)
         {
             string testDir = GetTestFilePath();
@@ -65,7 +66,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(".s", ".")]
         [InlineData(".s.s....", ".ls")]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixLastDotIsExtension(string extension, string trailing)
         {
             string testDir = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -144,7 +145,7 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsControWhiteSpace()
         {
             // CreateSubdirectory will throw when passed a path with control whitespace e.g. "\t"
@@ -157,7 +158,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsSimpleWhiteSpace()
         {
             // CreateSubdirectory trims all simple whitespace, returning us the parent directory
@@ -175,7 +176,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixWhiteSpaceAsPath_Allowed()
         {
             var paths = IOInputs.GetWhiteSpace();
@@ -187,7 +188,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixNonSignificantTrailingWhiteSpace()
         {
             // Unix treats trailing/prename whitespace as significant and a part of the name.
@@ -205,7 +206,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void ExtendedPathSubdirectory()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + GetTestFilePath());
@@ -216,7 +217,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // UNC shares
+        [PlatformSpecific(XunitPlatformID.Windows)] // UNC shares
         public void UNCPathWithOnlySlashes()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -98,7 +98,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(Xunit.PlatformID.AnyUnix)]
         public void FalseForNonRegularFile()
         {
             string fileName = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetAttributes.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -48,7 +49,7 @@ namespace System.IO.Tests
 
         [Theory]
         [InlineData(FileAttributes.ReadOnly)]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixAttributeSetting(FileAttributes attr)
         {
             var test = new DirectoryInfo(GetTestFilePath());
@@ -64,7 +65,7 @@ namespace System.IO.Tests
         [InlineData(FileAttributes.System)]
         [InlineData(FileAttributes.Archive)]
         [InlineData(FileAttributes.ReadOnly | FileAttributes.Hidden)]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsAttributeSetting(FileAttributes attr)
         {
             var test = new DirectoryInfo(GetTestFilePath());
@@ -81,7 +82,7 @@ namespace System.IO.Tests
         [InlineData(FileAttributes.SparseFile)]
         [InlineData(FileAttributes.ReparsePoint)]
         [InlineData(FileAttributes.Compressed)]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixInvalidAttributes(FileAttributes attr)
         {
             var path = GetTestFilePath();
@@ -96,7 +97,7 @@ namespace System.IO.Tests
         [InlineData(FileAttributes.SparseFile)]
         [InlineData(FileAttributes.ReparsePoint)]
         [InlineData(FileAttributes.Compressed)]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsInvalidAttributes(FileAttributes attr)
         {
             var path = GetTestFilePath();
@@ -108,7 +109,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(~FileAttributes.ReadOnly)]
         [InlineData(-1)]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixInvalidAttributes_ThrowArgumentException(FileAttributes attr)
         {
             var test = new DirectoryInfo(GetTestFilePath());
@@ -120,7 +121,7 @@ namespace System.IO.Tests
         [InlineData(FileAttributes.Temporary)]
         [InlineData(~FileAttributes.ReadOnly)]
         [InlineData(-1)]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsInvalidAttributes_ThrowArgumentException(FileAttributes attr)
         {
             var test = new DirectoryInfo(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Root.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Root.cs
@@ -32,7 +32,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void UNCShares()
         {
             string root = Path.GetPathRoot(Directory.GetCurrentDirectory());

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
@@ -38,7 +38,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void DriveOnlyReturnsPeriod_Windows()
         {
             string path = @"C:";

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -169,7 +170,7 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsWhitespacePath()
         {
             string testFile = GetTestFilePath();
@@ -182,7 +183,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixWhitespacePath()
         {
             string testFile = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -57,7 +58,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void ValidCreation_ExtendedSyntax()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + GetTestFilePath());
@@ -72,7 +73,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void ValidCreation_LongPathExtendedSyntax()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(IOServices.GetPath(IOInputs.ExtendedPrefix + TestDirectory, characterCount: 500).FullPath);
@@ -195,7 +196,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsWildCharacterPath()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
@@ -206,7 +207,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsWhitespacePath()
         {
             Assert.Throws<ArgumentException>(() => Create("         "));
@@ -219,7 +220,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixWhitespacePath()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/System.IO.FileSystem/tests/File/Delete.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -108,21 +109,21 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void Windows_NonExistentPath_Throws_DirectoryNotFoundException()
         {
             Assert.Throws<DirectoryNotFoundException>(() => Delete(Path.Combine(TestDirectory, GetTestFileName(), "C")));
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void Unix_NonExistentPath_Nop()
         {
             Delete(Path.Combine(TestDirectory, GetTestFileName(), "C"));
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void Windows_File_Already_Open_Throws_IOException()
         {
             string path = GetTestFilePath();
@@ -133,7 +134,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void Unix_File_Already_Open_Allowed()
         {
             string path = GetTestFilePath();
@@ -146,7 +147,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsDeleteReadOnlyFile()
         {
             string path = GetTestFilePath();
@@ -158,7 +159,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixDeleteReadOnlyFile()
         {
             FileInfo testFile = Create(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -140,7 +141,7 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // Unix equivalent tested already in CreateDirectory
+        [PlatformSpecific(XunitPlatformID.Windows)] // Unix equivalent tested already in CreateDirectory
         public void WindowsNonSignificantWhiteSpaceAsPath_ReturnsFalse()
         {
             // Checks that errors aren't thrown when calling Exists() on impossible paths
@@ -173,7 +174,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // In Windows, trailing whitespace in a path is trimmed
+        [PlatformSpecific(XunitPlatformID.Windows)] // In Windows, trailing whitespace in a path is trimmed
         public void TrimTrailingWhitespacePath()
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());
@@ -185,7 +186,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // alternate data stream
+        [PlatformSpecific(XunitPlatformID.Windows)] // alternate data stream
         public void PathWithAlternateDataStreams_ReturnsFalse()
         {
             Assert.All((IOInputs.GetPathsWithAlternativeDataStreams()), (component) =>
@@ -196,7 +197,7 @@ namespace System.IO.Tests
 
         [Fact]
         [OuterLoop]
-        [PlatformSpecific(PlatformID.Windows)] // device names
+        [PlatformSpecific(XunitPlatformID.Windows)] // device names
         public void PathWithReservedDeviceNameAsPath_ReturnsFalse()
         {
             Assert.All((IOInputs.GetPathsWithReservedDeviceNames()), (component) =>
@@ -206,7 +207,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // UNC paths
+        [PlatformSpecific(XunitPlatformID.Windows)] // UNC paths
         public void UncPathWithoutShareNameAsPath_ReturnsFalse()
         {
             Assert.All((IOInputs.GetUncPathsWithoutShareName()), (component) =>
@@ -216,7 +217,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // max directory length not fixed on Unix
+        [PlatformSpecific(XunitPlatformID.Windows)] // max directory length not fixed on Unix
         public void DirectoryWithComponentLongerThanMaxComponentAsPath_ReturnsFalse()
         {
             Assert.All((IOInputs.GetPathsWithComponentLongerThanMaxComponent()), (component) =>
@@ -226,7 +227,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void FalseForNonRegularFile()
         {
             string fileName = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/File/GetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetAttributes.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -46,7 +47,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(FileAttributes.ReadOnly)]
         [InlineData(FileAttributes.Normal)]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixAttributeSetting(FileAttributes attr)
         {
             var path = GetTestFilePath();
@@ -64,7 +65,7 @@ namespace System.IO.Tests
         [InlineData(FileAttributes.Normal)]
         [InlineData(FileAttributes.Temporary)]
         [InlineData(FileAttributes.ReadOnly | FileAttributes.Hidden)]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsAttributeSetting(FileAttributes attr)
         {
             var path = GetTestFilePath();
@@ -80,7 +81,7 @@ namespace System.IO.Tests
         [InlineData(FileAttributes.ReparsePoint)]
         [InlineData(FileAttributes.Compressed)]
         [InlineData(FileAttributes.Encrypted)]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixInvalidAttributes(FileAttributes attr)
         {
             var path = GetTestFilePath();
@@ -95,7 +96,7 @@ namespace System.IO.Tests
         [InlineData(FileAttributes.SparseFile)]
         [InlineData(FileAttributes.ReparsePoint)]
         [InlineData(FileAttributes.Compressed)]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsInvalidAttributes(FileAttributes attr)
         {
             var path = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -121,7 +122,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void Windows_FileDoesntExist_ReturnDefaultValues()
         {
             string path = GetTestFilePath();
@@ -150,7 +151,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void Unix_FileDoesntExist_Throws_FileNotFoundException()
         {
             string path = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -148,7 +149,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void MaxPath_Windows()
         {
             // Create a destination path longer than the traditional Windows limit of 256 characters,
@@ -177,7 +178,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void LongPath()
         {
             //Create a destination path longer than the traditional Windows limit of 256 characters
@@ -197,7 +198,7 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsPathWithIllegalColons()
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());
@@ -209,7 +210,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsWildCharacterPath()
         {
             Assert.Throws<ArgumentException>(() => Move("*", GetTestFilePath()));
@@ -219,7 +220,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixWildCharacterPath()
         {
             string testDir = GetTestFilePath();
@@ -243,7 +244,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsWhitespacePath()
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());
@@ -254,7 +255,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixWhitespacePath()
         {
             FileInfo testFileSource = new FileInfo(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/FileInfo/Directory.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Directory.cs
@@ -48,7 +48,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void UNCShares()
         {
             var directory = Directory(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File"));

--- a/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
@@ -83,7 +83,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(Xunit.PlatformID.AnyUnix)]
         public void TrueForNonRegularFile()
         {
             string fileName = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/FileInfo/Extension.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Extension.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -24,7 +25,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(".")]
         [InlineData("............")]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsInvalidExtensionsAreRemoved(string extension)
         {
             string testFile = GetTestFilePath();
@@ -35,7 +36,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(".s", ".")]
         [InlineData(".s", ".s....")]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsCurtailTrailingDots(string extension, string trailing)
         {
             string testFile = GetTestFilePath();
@@ -47,7 +48,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(".s", ".")]
         [InlineData(".s.s....", ".ls")]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixLastDotIsExtension(string extension, string trailing)
         {
             string testFile = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetAttributes.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -63,7 +64,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(FileAttributes.ReadOnly)]
         [InlineData(FileAttributes.Normal)]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixAttributeSetting(FileAttributes attr)
         {
             var test = new FileInfo(GetTestFilePath());
@@ -82,7 +83,7 @@ namespace System.IO.Tests
         [InlineData(FileAttributes.Normal)]
         [InlineData(FileAttributes.Temporary)]
         [InlineData(FileAttributes.ReadOnly | FileAttributes.Hidden)]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsAttributeSetting(FileAttributes attr)
         {
             var test = new FileInfo(GetTestFilePath());
@@ -99,7 +100,7 @@ namespace System.IO.Tests
         [InlineData(FileAttributes.SparseFile)]
         [InlineData(FileAttributes.ReparsePoint)]
         [InlineData(FileAttributes.Compressed)]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public void UnixInvalidAttributes(FileAttributes attr)
         {
             var path = GetTestFilePath();
@@ -114,7 +115,7 @@ namespace System.IO.Tests
         [InlineData(FileAttributes.SparseFile)]
         [InlineData(FileAttributes.ReparsePoint)]
         [InlineData(FileAttributes.Compressed)]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(XunitPlatformID.Windows)]
         public void WindowsInvalidAttributes(FileAttributes attr)
         {
             var path = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
@@ -7,6 +7,7 @@ using System.IO.Pipes;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -41,7 +42,7 @@ namespace System.IO.Tests
             }
         }
 
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(XunitPlatformID.AnyUnix)]
         public async Task FifoReadWriteViaFileStream()
         {
             string fifoPath = GetTestFilePath();
@@ -90,7 +91,7 @@ namespace System.IO.Tests
             }
         }
 
-        [PlatformSpecific(PlatformID.Windows)] // Uses P/Invokes to create async pipe handle
+        [PlatformSpecific(XunitPlatformID.Windows)] // Uses P/Invokes to create async pipe handle
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -124,7 +125,7 @@ namespace System.IO.Tests
             }
         }
 
-        [PlatformSpecific(PlatformID.Windows)] // Uses P/Invokes to create async pipe handle
+        [PlatformSpecific(XunitPlatformID.Windows)] // Uses P/Invokes to create async pipe handle
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
@@ -199,7 +199,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void RawLongPathAccess_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => CreateFileStream("\\\\.\\disk\\access\\", FileMode.Open));

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.delete.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.delete.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -85,7 +86,7 @@ namespace System.IO.Tests
             }
         }
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // file sharing restriction limitations on Unix
+        [PlatformSpecific(XunitPlatformID.Windows)] // file sharing restriction limitations on Unix
         public void FileShareDeleteExistingMultipleClients()
         {
             // create the file
@@ -119,7 +120,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // file sharing restriction limitations on Unix
+        [PlatformSpecific(XunitPlatformID.Windows)] // file sharing restriction limitations on Unix
         public void FileShareWithoutDeleteThrows()
         {
             string fileName = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.read.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.read.cs
@@ -41,7 +41,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // file sharing restriction limitations on Unix
+        [PlatformSpecific(Xunit.PlatformID.Windows)] // file sharing restriction limitations on Unix
         public void FileShareWithoutReadThrows()
         {
             string fileName = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
 
 namespace System.IO.Tests
 {
@@ -11,8 +12,8 @@ namespace System.IO.Tests
     {
         public static readonly byte[] TestBuffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
 
-        protected const PlatformID CaseInsensitivePlatforms = PlatformID.Windows | PlatformID.OSX;
-        protected const PlatformID CaseSensitivePlatforms = PlatformID.AnyUnix & ~PlatformID.OSX;
+        protected const XunitPlatformID CaseInsensitivePlatforms = XunitPlatformID.Windows | XunitPlatformID.OSX;
+        protected const XunitPlatformID CaseSensitivePlatforms = XunitPlatformID.AnyUnix & ~XunitPlatformID.OSX;
 
         /// <summary>
         /// In some cases (such as when running without elevated privileges),

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.builds
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.builds
@@ -9,6 +9,16 @@
       <TestTFMs>netcoreapp1.0;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
+    <Project Include="System.IO.FileSystem.Tests.csproj">
+      <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.7</TargetGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+    </Project>
+    <Project Include="System.IO.FileSystem.Tests.csproj">
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.7</TargetGroup>
+    </Project>
     <Project Include="Performance\System.IO.FileSystem.Performance.Tests.csproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -11,8 +11,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
-    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7'">.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7'">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -29,6 +30,7 @@
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.IO.FileSystem.pkgproj">
       <Project>{879c23dc-d828-4dfb-8e92-abbc11b71035}</Project>
+      <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
       <Name>System.IO.FileSystem</Name>
       <Private>True</Private>
     </ProjectReference>
@@ -43,7 +45,7 @@
     <Compile Include="DirectoryInfo\Root.cs" />
     <Compile Include="Directory\EnumerableAPIs.cs" />
     <Compile Include="Directory\GetFileSystemEntries_str_str_so.cs" />
-    <Compile Include="Directory\GetLogicalDrives.cs" />
+    <Compile Include="Directory\GetLogicalDrives.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="Directory\GetParent.cs" />
     <Compile Include="FileInfo\GetSetAttributes.cs" />
     <Compile Include="FileInfo\Length.cs" />
@@ -160,6 +162,7 @@
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
+      <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -30,7 +30,8 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {
-    "netstandard1.3": {}
+    "netstandard1.3": {},
+    "netstandard1.7": {}
   },
   "supports": {
     "coreFx.Test.netcoreapp1.0": {},

--- a/src/System.IO/pkg/System.IO.pkgproj
+++ b/src/System.IO/pkg/System.IO.pkgproj
@@ -9,10 +9,10 @@
       <SupportedFramework>net46;netcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\4.1\System.IO.depproj">
-      <SupportedFramework>net462</SupportedFramework>
+      <SupportedFramework>net462;netcoreapp1.0</SupportedFramework>
     </ProjectReference>	
     <ProjectReference Include="..\ref\System.IO.csproj">
-      <SupportedFramework>net463;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.csproj">
       <TargetGroup>net462</TargetGroup>

--- a/src/System.IO/pkg/any/System.IO.pkgproj
+++ b/src/System.IO/pkg/any/System.IO.pkgproj
@@ -8,6 +8,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.IO.csproj" />
+    <ProjectReference Include="..\..\src\System.IO.csproj">
+      <TargetGroup>netstandard1.6</TargetGroup>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\redist\System.IO.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/src/System.IO/ref/System.IO.csproj
+++ b/src/System.IO/ref/System.IO.csproj
@@ -5,7 +5,7 @@
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.IO.cs" />

--- a/src/System.IO/ref/System.IO.csproj
+++ b/src/System.IO/ref/System.IO.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.6</PackageTargetFramework>
+    <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.IO/ref/project.json
+++ b/src/System.IO/ref/project.json
@@ -5,9 +5,9 @@
     "System.Threading.Tasks": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.6": { 
+    "netstandard1.7": { 
       "imports": [
-        "dotnet5.7"
+        "dotnet5.8"
       ]
     }
   }

--- a/src/System.IO/ref/project.json
+++ b/src/System.IO/ref/project.json
@@ -5,7 +5,7 @@
     "System.Threading.Tasks": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.6": {
+    "netstandard1.6": { 
       "imports": [
         "dotnet5.7"
       ]

--- a/src/System.IO/src/System.IO.builds
+++ b/src/System.IO/src/System.IO.builds
@@ -4,6 +4,9 @@
   <ItemGroup>
     <Project Include="System.IO.csproj" />
     <Project Include="System.IO.csproj">
+      <TargetGroup>netstandard1.6</TargetGroup>
+    </Project>
+    <Project Include="System.IO.csproj">
       <TargetGroup>net462</TargetGroup>
     </Project>
     <Project Include="System.IO.csproj">

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -9,7 +9,7 @@
     <ContractProject Condition="'$(AssemblyVersion)' == '4.1.0.0'">..\ref\4.1\System.IO.depproj</ContractProject>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.6</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -5,10 +5,10 @@
     <AssemblyName>System.IO</AssemblyName>
     <ProjectGuid>{07390899-C8F6-4e83-A3A9-6867B8CB46A0}</ProjectGuid>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(TargetGroup)' == 'net462'">4.1.0.0</AssemblyVersion>
-    <ContractProject Condition="'$(TargetGroup)' == 'net462'">..\ref\4.1\System.IO.depproj</ContractProject>
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'net462' Or '$(TargetGroup)' == 'netstandard1.6' Or '$(TargetGroup)'=='netstandard13aot'">4.1.0.0</AssemblyVersion>
+    <ContractProject Condition="'$(AssemblyVersion)' == '4.1.0.0'">..\ref\4.1\System.IO.depproj</ContractProject>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.6</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
@@ -29,11 +29,12 @@
     <ExcludeAssemblyInfoPartialFile>true</ExcludeAssemblyInfoPartialFile>
     <StringResourcesPath>Resources/Strings.netcore50aot.resx</StringResourcesPath>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == ''">
+  <ItemGroup Condition="'$(TargetGroup)' == '' Or '$(TargetGroup)'=='netstandard1.6'">
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
       <Project>{E7E8DE8A-9EC1-46A8-A6EE-727DB32DBEB8}</Project>
       <Name>System.Diagnostics.Debug</Name>
       <OSGroup>$(InputOSGroup)</OSGroup>
+      <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net462' and '$(TargetGroup)' != 'net463'">

--- a/src/System.IO/src/project.json
+++ b/src/System.IO/src/project.json
@@ -2,7 +2,6 @@
   "frameworks": {
     "netstandard1.6": {
       "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.TargetingPack.Private.CoreCLR": "1.0.2-beta-24329-03"
       },
       "imports": [
@@ -11,7 +10,6 @@
     },
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.TargetingPack.Private.CoreCLR": "1.0.2-beta-24329-03"
       },
       "imports": [

--- a/src/System.IO/src/project.json
+++ b/src/System.IO/src/project.json
@@ -9,6 +9,15 @@
         "dotnet5.7"
       ]
     },
+    "netstandard1.7": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.2-beta-24329-03"
+      },
+      "imports": [
+        "dotnet5.8"
+      ]
+    },
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",

--- a/src/System.IO/tests/BinaryWriter/BinaryWriterTests.cs
+++ b/src/System.IO/tests/BinaryWriter/BinaryWriterTests.cs
@@ -316,7 +316,7 @@ namespace System.IO.Tests
             }
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public void BinaryWriter_CloseTests()
         {
@@ -329,7 +329,7 @@ namespace System.IO.Tests
                 binaryWriter.Close();
             }
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         [Fact]
         public void BinaryWriter_DisposeTests_Negative()
@@ -342,7 +342,7 @@ namespace System.IO.Tests
             }
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public void BinaryWriter_CloseTests_Negative()
         {
@@ -353,7 +353,7 @@ namespace System.IO.Tests
                 ValidateDisposedExceptions(binaryWriter);
             }
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         private void ValidateDisposedExceptions(BinaryWriter binaryWriter)
         {

--- a/src/System.IO/tests/BinaryWriter/BinaryWriterTests.cs
+++ b/src/System.IO/tests/BinaryWriter/BinaryWriterTests.cs
@@ -316,6 +316,7 @@ namespace System.IO.Tests
             }
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public void BinaryWriter_CloseTests()
         {
@@ -328,6 +329,7 @@ namespace System.IO.Tests
                 binaryWriter.Close();
             }
         }
+#endif //FEATURE_NS_1_7
 
         [Fact]
         public void BinaryWriter_DisposeTests_Negative()
@@ -340,6 +342,7 @@ namespace System.IO.Tests
             }
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public void BinaryWriter_CloseTests_Negative()
         {
@@ -350,6 +353,7 @@ namespace System.IO.Tests
                 ValidateDisposedExceptions(binaryWriter);
             }
         }
+#endif //FEATURE_NS_1_7
 
         private void ValidateDisposedExceptions(BinaryWriter binaryWriter)
         {

--- a/src/System.IO/tests/Stream/Stream.TestLeaveOpen.cs
+++ b/src/System.IO/tests/Stream/Stream.TestLeaveOpen.cs
@@ -22,14 +22,9 @@ namespace System.IO.Tests
             ms.Position = 0;
             Assert.True(ms.CanRead, "ERROR: Before testing, MemoryStream's CanRead property was false!  What?");
 
-            // Test leaveOpen with calling Dispose
+            // Test leaveOpen.
             StreamReader sr = new StreamReader(ms, System.Text.Encoding.UTF8, true, 1000, true);
             sr.Dispose();
-            Assert.True(ms.CanRead, "ERROR: After disposing a StreamReader with leaveOpen bool set, MemoryStream's CanRead property was false!");
-
-            // Test leaveOpen with calling Close
-            sr = new StreamReader(ms, System.Text.Encoding.UTF8, true, 1000, true);
-            sr.Close();
             Assert.True(ms.CanRead, "ERROR: After closing a StreamReader with leaveOpen bool set, MemoryStream's CanRead property was false!");
 
             // Test not leaving open
@@ -37,22 +32,10 @@ namespace System.IO.Tests
             sr.Dispose();
             Assert.False(ms.CanRead, "ERROR: After closing a StreamReader with leaveOpen bool not set, MemoryStream's CanRead property was true!");
 
-            // Test not leaving open
-            ms = CreateStream();
-            sr = new StreamReader(ms, System.Text.Encoding.UTF8, true, 1000, false);
-            sr.Close();
-            Assert.False(ms.CanRead, "ERROR: After closing a StreamReader with leaveOpen bool not set, MemoryStream's CanRead property was true!");
-
             // Test default
             ms = CreateStream();
             sr = new StreamReader(ms);
             sr.Dispose();
-            Assert.False(ms.CanRead, "ERROR: After disposing a StreamReader with the default value for leaveOpen, MemoryStream's CanRead property was true!");
-
-            // Test default
-            ms = CreateStream();
-            sr = new StreamReader(ms);
-            sr.Close();
             Assert.False(ms.CanRead, "ERROR: After closing a StreamReader with the default value for leaveOpen, MemoryStream's CanRead property was true!");
         }
 
@@ -64,37 +47,20 @@ namespace System.IO.Tests
             ms.Position = 0;
             Assert.True(ms.CanRead, "ERROR: Before testing, MemoryStream's CanRead property was false!  What?");
 
-            // Test leaveOpen with calling Dispose
+            // Test leaveOpen.
             BinaryReader br = new BinaryReader(ms, System.Text.Encoding.UTF8, true);
             br.Dispose();
-            Assert.True(ms.CanRead, "ERROR: After disposing a BinaryReader with leaveOpen bool set, MemoryStream's CanRead property was false!");
-
-            // Test leaveOpen with calling Close
-            br = new BinaryReader(ms, System.Text.Encoding.UTF8, true);
-            br.Close();
             Assert.True(ms.CanRead, "ERROR: After closing a BinaryReader with leaveOpen bool set, MemoryStream's CanRead property was false!");
 
-            // Test not leaving open with calling Dispose
+            // Test not leaving open
             br = new BinaryReader(ms, System.Text.Encoding.UTF8, false);
             br.Dispose();
-            Assert.False(ms.CanRead, "ERROR: After disposing a BinaryReader with leaveOpen bool not set, MemoryStream's CanRead property was true!");
-
-            // Test not leaving open with calling Close
-            ms = CreateStream();
-            br = new BinaryReader(ms, System.Text.Encoding.UTF8, false);
-            br.Close();
             Assert.False(ms.CanRead, "ERROR: After closing a BinaryReader with leaveOpen bool not set, MemoryStream's CanRead property was true!");
 
-            // Test default with calling Dispose
+            // Test default
             ms = CreateStream();
             br = new BinaryReader(ms);
             br.Dispose();
-            Assert.False(ms.CanRead, "ERROR: After disposing a BinaryReader with the default value for leaveOpen, MemoryStream's CanRead property was true!");
-
-            // Test default with calling Close
-            ms = CreateStream();
-            br = new BinaryReader(ms);
-            br.Close();
             Assert.False(ms.CanRead, "ERROR: After closing a BinaryReader with the default value for leaveOpen, MemoryStream's CanRead property was true!");
         }
 
@@ -104,37 +70,20 @@ namespace System.IO.Tests
             Stream ms = CreateStream();
             Assert.True(ms.CanWrite, "ERROR: Before testing, MemoryStream's CanWrite property was false!  What?");
 
-            // Test leaveOpen with calling Dispose
+            // Test leaveOpen.
             StreamWriter sw = new StreamWriter(ms, System.Text.Encoding.UTF8, 1000, true);
             sw.Dispose();
-            Assert.True(ms.CanWrite, "ERROR: After disposing a StreamWriter with leaveOpen bool set, MemoryStream's CanWrite property was false!");
-
-            // Test leaveOpen with calling Close
-            sw = new StreamWriter(ms, System.Text.Encoding.UTF8, 1000, true);
-            sw.Close();
             Assert.True(ms.CanWrite, "ERROR: After closing a StreamWriter with leaveOpen bool set, MemoryStream's CanWrite property was false!");
 
-            // Test not leaving open with calling Dispose
+            // Test not leaving open
             sw = new StreamWriter(ms, System.Text.Encoding.UTF8, 1000, false);
             sw.Dispose();
-            Assert.False(ms.CanWrite, "ERROR: After disposing a StreamWriter with leaveOpen bool not set, MemoryStream's CanWrite property was true!");
-
-            // Test not leaving open with calling Close
-            ms = CreateStream();
-            sw = new StreamWriter(ms, System.Text.Encoding.UTF8, 1000, false);
-            sw.Close();
             Assert.False(ms.CanWrite, "ERROR: After closing a StreamWriter with leaveOpen bool not set, MemoryStream's CanWrite property was true!");
 
-            // Test default with calling Dispose
+            // Test default
             ms = CreateStream();
             sw = new StreamWriter(ms);
             sw.Dispose();
-            Assert.False( ms.CanWrite, "ERROR: After disposing a StreamWriter with the default value for leaveOpen, MemoryStream's CanWrite property was true!");
-
-            // Test default with calling Close
-            ms = CreateStream();
-            sw = new StreamWriter(ms);
-            sw.Close();
             Assert.False(ms.CanWrite, "ERROR: After closing a StreamWriter with the default value for leaveOpen, MemoryStream's CanWrite property was true!");
         }
 
@@ -145,37 +94,20 @@ namespace System.IO.Tests
             Stream ms = CreateStream();
             Assert.True(ms.CanWrite, "ERROR: Before testing, MemoryStream's CanWrite property was false!  What?");
 
-            // Test leaveOpen with calling Dispose
+            // Test leaveOpen.
             BinaryWriter bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, true);
             bw.Dispose();
-            Assert.True(ms.CanWrite, "ERROR: After disposing a BinaryWriterwith leaveOpen bool set, MemoryStream's CanWrite property was false!");
-
-            // Test leaveOpen with calling Close
-            bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, true);
-            bw.Close();
             Assert.True(ms.CanWrite, "ERROR: After closing a BinaryWriterwith leaveOpen bool set, MemoryStream's CanWrite property was false!");
 
-            // Test not leaving open with calling Dispose
+            // Test not leaving open
             bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, false);
             bw.Dispose();
-            Assert.False(ms.CanWrite, "ERROR: After disposing a BinaryWriterwith leaveOpen bool not set, MemoryStream's CanWrite property was true!");
-
-            // Test not leaving open with calling Close
-            ms = CreateStream();
-            bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, false);
-            bw.Close();
             Assert.False(ms.CanWrite, "ERROR: After closing a BinaryWriterwith leaveOpen bool not set, MemoryStream's CanWrite property was true!");
 
-            // Test default with calling Dispose
+            // Test default
             ms = CreateStream();
             bw = new BinaryWriter(ms);
             bw.Dispose();
-            Assert.False(ms.CanWrite, "ERROR: After disposing a BinaryWriterwith the default value for leaveOpen, MemoryStream's CanWrite property was true!");
-
-            // Test default with calling Close
-            ms = CreateStream();
-            bw = new BinaryWriter(ms);
-            bw.Close();
             Assert.False(ms.CanWrite, "ERROR: After closing a BinaryWriterwith the default value for leaveOpen, MemoryStream's CanWrite property was true!");
         }
     }

--- a/src/System.IO/tests/StreamReader/StreamReaderTests.cs
+++ b/src/System.IO/tests/StreamReader/StreamReaderTests.cs
@@ -280,6 +280,7 @@ namespace System.IO.Tests
             Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public void ObjectClosedReadLine()
         {
@@ -289,6 +290,7 @@ namespace System.IO.Tests
             sr.Close();
             Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
         }
+#endif //FEATURE_NS_1_7
 
         [Fact]
         public void ObjectDisposedReadLineBaseStream()
@@ -300,6 +302,7 @@ namespace System.IO.Tests
             Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public void ObjectClosedReadLineBaseStream()
         {
@@ -309,6 +312,7 @@ namespace System.IO.Tests
             ms.Close();
             Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
         }
+#endif //FEATURE_NS_1_7
 
         [Fact]
         public void VanillaReadLines()

--- a/src/System.IO/tests/StreamReader/StreamReaderTests.cs
+++ b/src/System.IO/tests/StreamReader/StreamReaderTests.cs
@@ -280,7 +280,7 @@ namespace System.IO.Tests
             Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public void ObjectClosedReadLine()
         {
@@ -290,7 +290,7 @@ namespace System.IO.Tests
             sr.Close();
             Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         [Fact]
         public void ObjectDisposedReadLineBaseStream()
@@ -302,7 +302,7 @@ namespace System.IO.Tests
             Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public void ObjectClosedReadLineBaseStream()
         {
@@ -312,7 +312,7 @@ namespace System.IO.Tests
             ms.Close();
             Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         [Fact]
         public void VanillaReadLines()

--- a/src/System.IO/tests/StreamWriter/StreamWriter.CloseTests.cs
+++ b/src/System.IO/tests/StreamWriter/StreamWriter.CloseTests.cs
@@ -27,7 +27,7 @@ namespace System.IO.Tests
             ValidateDisposedExceptions(sw2);
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public void AfterCloseThrows()
         {
@@ -39,7 +39,7 @@ namespace System.IO.Tests
             sw2.Close();
             ValidateDisposedExceptions(sw2);
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         private void ValidateDisposedExceptions(StreamWriter sw)
         {
@@ -80,7 +80,7 @@ namespace System.IO.Tests
             Assert.Throws<ObjectDisposedException>(() => sw2.Flush());
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public void CantFlushAfterClose()
         {
@@ -93,6 +93,6 @@ namespace System.IO.Tests
             sw2.Close();
             Assert.Throws<ObjectDisposedException>(() => sw2.Flush());
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
     }
 }

--- a/src/System.IO/tests/StreamWriter/StreamWriter.CloseTests.cs
+++ b/src/System.IO/tests/StreamWriter/StreamWriter.CloseTests.cs
@@ -27,6 +27,7 @@ namespace System.IO.Tests
             ValidateDisposedExceptions(sw2);
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public void AfterCloseThrows()
         {
@@ -38,6 +39,7 @@ namespace System.IO.Tests
             sw2.Close();
             ValidateDisposedExceptions(sw2);
         }
+#endif //FEATURE_NS_1_7
 
         private void ValidateDisposedExceptions(StreamWriter sw)
         {
@@ -78,6 +80,7 @@ namespace System.IO.Tests
             Assert.Throws<ObjectDisposedException>(() => sw2.Flush());
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public void CantFlushAfterClose()
         {
@@ -90,5 +93,6 @@ namespace System.IO.Tests
             sw2.Close();
             Assert.Throws<ObjectDisposedException>(() => sw2.Flush());
         }
+#endif //FEATURE_NS_1_7
     }
 }

--- a/src/System.IO/tests/StringReader/StringReader.CtorTests.cs
+++ b/src/System.IO/tests/StringReader/StringReader.CtorTests.cs
@@ -156,7 +156,7 @@ namespace System.IO.Tests
             Assert.Equal(str1, sr.ReadToEnd());
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public static void Closed_DisposedExceptions()
         {
@@ -164,7 +164,7 @@ namespace System.IO.Tests
             sr.Close();
             ValidateDisposedExceptions(sr);
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         [Fact]
         public static void Disposed_DisposedExceptions()

--- a/src/System.IO/tests/StringReader/StringReader.CtorTests.cs
+++ b/src/System.IO/tests/StringReader/StringReader.CtorTests.cs
@@ -156,6 +156,7 @@ namespace System.IO.Tests
             Assert.Equal(str1, sr.ReadToEnd());
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public static void Closed_DisposedExceptions()
         {
@@ -163,6 +164,7 @@ namespace System.IO.Tests
             sr.Close();
             ValidateDisposedExceptions(sr);
         }
+#endif //FEATURE_NS_1_7
 
         [Fact]
         public static void Disposed_DisposedExceptions()

--- a/src/System.IO/tests/StringWriter/StringWriterTests.cs
+++ b/src/System.IO/tests/StringWriter/StringWriterTests.cs
@@ -235,7 +235,7 @@ namespace System.IO.Tests
             Assert.Equal(sb.ToString(), sw.GetStringBuilder().ToString());
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Fact]
         public static void Closed_DisposedExceptions()
         {
@@ -243,7 +243,7 @@ namespace System.IO.Tests
             sw.Close();
             ValidateDisposedExceptions(sw);
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         [Fact]
         public static void Disposed_DisposedExceptions()

--- a/src/System.IO/tests/StringWriter/StringWriterTests.cs
+++ b/src/System.IO/tests/StringWriter/StringWriterTests.cs
@@ -235,6 +235,7 @@ namespace System.IO.Tests
             Assert.Equal(sb.ToString(), sw.GetStringBuilder().ToString());
         }
 
+#if FEATURE_NS_1_7
         [Fact]
         public static void Closed_DisposedExceptions()
         {
@@ -242,6 +243,7 @@ namespace System.IO.Tests
             sw.Close();
             ValidateDisposedExceptions(sw);
         }
+#endif //FEATURE_NS_1_7
 
         [Fact]
         public static void Disposed_DisposedExceptions()

--- a/src/System.IO/tests/System.IO.Tests.builds
+++ b/src/System.IO/tests/System.IO.Tests.builds
@@ -4,7 +4,16 @@
   <ItemGroup>
     <Project Include="System.IO.Tests.csproj"/>
     <Project Include="System.IO.Tests.csproj">
-      <TestTFMs>net462;net463</TestTFMs>
+      <TestTFMs>net462</TestTFMs>
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.IO.Tests.csproj">
+      <TargetGroup>netstandard1.7</TargetGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+    </Project>
+    <Project Include="System.IO.Tests.csproj">
+      <TargetGroup>netstandard1.7</TargetGroup>
+      <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -8,8 +8,7 @@
     <RootNamespace>System.IO</RootNamespace>
     <AssemblyName>System.IO.Tests</AssemblyName>
     <ProjectGuid>{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);FEATURE_NS_1_7</DefineConstants>
-    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7'">.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -8,12 +8,14 @@
     <RootNamespace>System.IO</RootNamespace>
     <AssemblyName>System.IO.Tests</AssemblyName>
     <ProjectGuid>{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}</ProjectGuid>
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);FEATURE_NS_1_7</DefineConstants>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7'">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="BinaryReader\BinaryReaderTests.cs" />
+    <Compile Include="BinaryReader\BinaryReaderTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="BinaryWriter\BinaryWriter.WriteByteCharTests.cs" />
     <Compile Include="BinaryWriter\BinaryWriter.WriteTests.cs" />
     <Compile Include="BinaryWriter\BinaryWriterTests.cs" />

--- a/src/System.IO/tests/project.json
+++ b/src/System.IO/tests/project.json
@@ -15,7 +15,8 @@
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
   },
   "frameworks": {
-    "netstandard1.5": {}
+    "netstandard1.5": {},
+    "netstandard1.7": {}
   },
   "supports": {
     "coreFx.Test.netcoreapp1.0": {},

--- a/src/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
+++ b/src/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
@@ -8,8 +8,11 @@
     <ProjectReference Include="..\ref\4.0.10\System.Linq.Expressions.depproj">
       <SupportedFramework>net46;netcore50</SupportedFramework>
     </ProjectReference>
+    <ProjectReference Include="..\ref\4.1.0\System.Linq.Expressions.depproj">
+      <SupportedFramework>netcoreapp1.0</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.Linq.Expressions.csproj">
-      <SupportedFramework>net463;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Linq.Expressions.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
+++ b/src/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <version>4.2.0.0</version>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\4.0.0\System.Linq.Expressions.depproj">

--- a/src/System.Linq.Expressions/ref/4.1.0/System.Linq.Expressions.depproj
+++ b/src/System.Linq.Expressions/ref/4.1.0/System.Linq.Expressions.depproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.6</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>

--- a/src/System.Linq.Expressions/ref/4.1.0/System.Linq.Expressions.depproj
+++ b/src/System.Linq.Expressions/ref/4.1.0/System.Linq.Expressions.depproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.6</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Linq.Expressions/ref/4.1.0/project.json
+++ b/src/System.Linq.Expressions/ref/4.1.0/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Linq.Expressions": "4.1.0"
+  },
+  "frameworks": {
+    "netstandard1.6": { }
+  }
+}

--- a/src/System.Linq.Expressions/ref/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/ref/System.Linq.Expressions.csproj
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.6</PackageTargetFramework>
+    <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Linq.Expressions/ref/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/ref/System.Linq.Expressions.csproj
@@ -5,7 +5,7 @@
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Linq.Expressions.cs" />

--- a/src/System.Linq.Expressions/ref/project.json
+++ b/src/System.Linq.Expressions/ref/project.json
@@ -4,9 +4,9 @@
     "System.Reflection": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.6": {
+    "netstandard1.7": {
       "imports": [
-        "dotnet5.7"
+        "dotnet5.8"
       ]
     }
   }

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.builds
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.builds
@@ -4,6 +4,9 @@
   <ItemGroup>
     <Project Include="System.Linq.Expressions.csproj" />
     <Project Include="System.Linq.Expressions.csproj">
+      <TargetGroup>netstandard1.6</TargetGroup>
+    </Project>
+    <Project Include="System.Linq.Expressions.csproj">
        <TargetGroup>net463</TargetGroup>
     </Project>
     <!-- NETCore50 must redistribute binaries due to shared library

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -18,7 +18,7 @@
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net463'">None</ResourcesSourceOutputDirectory>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.6</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -9,8 +9,10 @@
     <ProjectGuid>{AEF718E9-D4FC-418F-A7AE-ED6B2C7B3787}</ProjectGuid>
     <AssemblyName>System.Linq.Expressions</AssemblyName>
     <RootNamespace>System.Linq.Expressions</RootNamespace>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.6</PackageTargetFramework>
+    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.6' Or '$(TargetGroup)'=='netstandard1.6'">4.1.1.0</AssemblyVersion>
+    <ContractProject Condition="'$(AssemblyVersion)'=='4.1.1.0'">../ref/4.1.0/System.Linq.Expressions.depproj</ContractProject>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.7</PackageTargetFramework>
     <IsInterpreting Condition="'$(PackageTargetFramework)' == 'netcore50'">true</IsInterpreting>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
@@ -21,6 +23,8 @@
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.6_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.6_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />

--- a/src/System.Linq.Expressions/src/project.json
+++ b/src/System.Linq.Expressions/src/project.json
@@ -28,6 +28,34 @@
         "dotnet5.7"
       ]
     },
+    "netstandard1.7": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Collections": "4.0.10",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.Globalization": "4.0.10",
+        "System.IO": "4.0.10",
+        "System.Linq": "4.0.0",
+        "System.ObjectModel": "4.0.10",
+        "System.Reflection": "4.0.10",
+        "System.Reflection.Emit": "4.0.0",
+        "System.Reflection.Emit.ILGeneration": "4.0.0",
+        "System.Reflection.Emit.Lightweight": "4.0.0",
+        "System.Reflection.Extensions": "4.0.0",
+        "System.Reflection.Primitives": "4.0.0",
+        "System.Reflection.TypeExtensions": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Threading": "4.0.10",
+        "System.Threading.Tasks": "4.0.10"
+      },
+      "imports": [
+        "dotnet5.8"
+      ]
+    },
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",

--- a/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
+++ b/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
@@ -8,11 +8,17 @@
     <ProjectReference Include="..\ref\4.0.10\System.Runtime.Extensions.depproj">
       <SupportedFramework>net46;netcore50</SupportedFramework>
     </ProjectReference>
+    <ProjectReference Include="..\ref\4.1.0\System.Runtime.Extensions.depproj">
+      <SupportedFramework>netcoreapp1.0;net462</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.Runtime.Extensions.csproj">
-      <SupportedFramework>netcoreapp1.0;net462;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>netcoreapp1.1;net463;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Extensions.csproj">
       <TargetGroup>net462</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Runtime.Extensions.csproj">
+      <TargetGroup>net463</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="win\System.Runtime.Extensions.pkgproj" />
     <ProjectReference Include="unix\System.Runtime.Extensions.pkgproj" />

--- a/src/System.Runtime.Extensions/pkg/ValidationSuppression.txt
+++ b/src/System.Runtime.Extensions/pkg/ValidationSuppression.txt
@@ -1,0 +1,1 @@
+PermitHigherCompatibleImplementationVersion

--- a/src/System.Runtime.Extensions/pkg/unix/System.Runtime.Extensions.pkgproj
+++ b/src/System.Runtime.Extensions/pkg/unix/System.Runtime.Extensions.pkgproj
@@ -11,6 +11,10 @@
     <ProjectReference Include="..\..\src\System.Runtime.Extensions.csproj">
       <OSGroup>Unix</OSGroup>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\System.Runtime.Extensions.csproj">
+      <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.5</TargetGroup>
+    </ProjectReference>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Runtime.Extensions/pkg/win/System.Runtime.Extensions.pkgproj
+++ b/src/System.Runtime.Extensions/pkg/win/System.Runtime.Extensions.pkgproj
@@ -11,6 +11,10 @@
     <ProjectReference Include="..\..\src\System.Runtime.Extensions.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\System.Runtime.Extensions.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.5</TargetGroup>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\redist\System.Runtime.Extensions.depproj">
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50</TargetGroup>

--- a/src/System.Runtime.Extensions/ref/4.1.0/System.Runtime.Extensions.depproj
+++ b/src/System.Runtime.Extensions/ref/4.1.0/System.Runtime.Extensions.depproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.5</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>

--- a/src/System.Runtime.Extensions/ref/4.1.0/System.Runtime.Extensions.depproj
+++ b/src/System.Runtime.Extensions/ref/4.1.0/System.Runtime.Extensions.depproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.5</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Extensions/ref/4.1.0/project.json
+++ b/src/System.Runtime.Extensions/ref/4.1.0/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Runtime.Extensions": "4.1.0"
+  },
+  "frameworks": {
+    "netstandard1.5": { }
+  }
+}

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.csproj
@@ -5,7 +5,7 @@
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.Extensions.cs" />

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.csproj
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.5</PackageTargetFramework>
+    <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Runtime.Extensions/ref/project.json
+++ b/src/System.Runtime.Extensions/ref/project.json
@@ -3,9 +3,9 @@
     "System.Runtime": "4.0.20"
   },
   "frameworks": {
-    "netstandard1.5": {
+    "netstandard1.7": {
       "imports": [
-        "dotnet5.6"
+        "dotnet5.8"
       ]
     }
   }

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.builds
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.builds
@@ -9,7 +9,18 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.Runtime.Extensions.csproj">
+      <TargetGroup>netstandard1.5</TargetGroup>
+      <OSGroup>Unix</OSGroup>
+    </Project>
+    <Project Include="System.Runtime.Extensions.csproj">
+      <TargetGroup>netstandard1.5</TargetGroup>
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.Runtime.Extensions.csproj">
       <TargetGroup>net462</TargetGroup>
+    </Project>
+    <Project Include="System.Runtime.Extensions.csproj">
+      <TargetGroup>net463</TargetGroup>
     </Project>
     <!-- NETCore50 must redistribute binaries due to shared library
     <Project Include="System.Runtime.Extensions.csproj">

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -1,40 +1,52 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'=='' AND '$(TargetGroup)' == ''">Windows_Debug</Configuration>
+    <Configuration Condition="'$(Configuration)'=='' AND ('$(TargetGroup)' == '' Or '$(TargetGroup)' == 'netstandard1.5')">Windows_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}</ProjectGuid>
     <AssemblyName>System.Runtime.Extensions</AssemblyName>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.5' Or '$(TargetGroup)'=='net462' Or '$(TargetGroup)'=='netcore50' Or '$(TargetGroup)'=='netcore50aot' Or '$(TargetGroup)'=='netstandard15aot'">4.1.1.0</AssemblyVersion>
+    <ContractProject Condition="'$(AssemblyVersion)'=='4.1.1.0'">../ref/4.1.0/System.Runtime.Extensions.depproj</ContractProject>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <!-- System.IO.Path conflicts between type in partial facade and in mscorlib -->
     <NoWarn>0436</NoWarn>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.5</PackageTargetFramework>
-    <CoreClrOrCorRt Condition="'$(TargetGroup)' == '' Or '$(TargetGroup)' == 'netstandard15aot'">true</CoreClrOrCorRt>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.7</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.5'">.NETCoreApp,Version=v1.0</NuGetTargetMoniker>
+    <CoreClrOrCorRt Condition="'$(TargetGroup)' == '' Or '$(TargetGroup)' == 'netstandard1.5' Or '$(TargetGroup)' == 'netstandard15aot'">true</CoreClrOrCorRt>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard1.5_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard1.5_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard1.5_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard1.5_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50aot_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard15aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard15aot_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard15aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard15aot_Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.5'">
+    <AdditionalFiles Include="$(ToolsDir)PinvokeAnalyzer_OneCoreApis.txt" />
+  </ItemGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot' Or '$(TargetGroup)' == 'netstandard15aot'">
     <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
     <ExcludeAssemblyInfoPartialFile>true</ExcludeAssemblyInfoPartialFile>
   </PropertyGroup>
   <!-- Shared CoreCLR and .NET Native -->
-  <ItemGroup Condition="'$(TargetGroup)' != 'net462'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net462' And '$(TargetGroup)' != 'net463'">
     <Compile Include="System\BitConverter.cs" />
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
     <Compile Include="System\Environment.cs" />
@@ -72,7 +84,7 @@
     </Compile>
   </ItemGroup>
   <!-- WINDOWS: Shared CoreCLR and .NET Native -->
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'net462'">
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'net462' And '$(TargetGroup)' != 'net463'">
     <Compile Include="System\Environment.Windows.cs" />
     <Compile Include="System\Diagnostics\Stopwatch.Windows.cs" />
     <Compile Include="System\IO\Path.Windows.cs" />
@@ -250,11 +262,15 @@
     <Compile Include="$(CommonPath)\System\SR.Core.cs" Condition="'$(TargetGroup)' == 'netcore50aot' And '$(TargetsWindows)'=='true'" />
     <Compile Include="$(CommonPath)\System\SR.CoreRT.cs" Condition="'$(TargetGroup)' == 'netstandard15aot' Or '$(TargetsUnix)'=='true'" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == ''">
-    <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />
-    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
+  <ItemGroup Condition="'$(TargetGroup)' == '' Or '$(TargetGroup)' == 'netstandard1.5'">
+    <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj">
+      <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
+      <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
+    </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net462'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net462' Or '$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />
   </ItemGroup>

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -13,6 +13,11 @@
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
     },
+    "net463": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    },
     "netcore50": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24401-00",

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.builds
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.builds
@@ -9,6 +9,16 @@
       <TestTFMs>netcoreapp1.0;net462</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
+    <Project Include="System.Runtime.Extensions.Tests.csproj">
+      <TargetGroup>netstandard1.7</TargetGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <OSGroup>Unix</OSGroup>
+    </Project>
+    <Project Include="System.Runtime.Extensions.Tests.csproj">
+      <TargetGroup>netstandard1.7</TargetGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
     <Project Include="Performance\System.Runtime.Extensions.Performance.Tests.csproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -12,7 +12,9 @@
     <RootNamespace>System.Runtime.Extensions.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Extensions.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NugetTargetMoniker>.NETStandard,Version=v1.5</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);FEATURE_NS_1_7</DefineConstants>
+    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.5</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7'">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -21,7 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
-    <Compile Include="System\EnvironmentTests.cs" />
+    <Compile Include="System\EnvironmentTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="System\Environment.MachineName.cs" />
     <Compile Include="System\IO\Path.Combine.cs" />
     <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -12,9 +12,8 @@
     <RootNamespace>System.Runtime.Extensions.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Extensions.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);FEATURE_NS_1_7</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
     <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.5</NugetTargetMoniker>
-    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7'">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -39,6 +39,7 @@ namespace System.Tests
             }
         }
 
+#if FEATURE_NS_1_7
         [Theory]
         [MemberData(nameof(ExitCodeValues))]
         public static void ExitCode_Roundtrips(int exitCode)
@@ -48,6 +49,7 @@ namespace System.Tests
 
             Environment.ExitCode = 0; // in case the test host has a void returning Main
         }
+#endif //FEATURE_NS_1_7
 
         [ActiveIssue("https://github.com/dotnet/coreclr/issues/6206")]
         [Theory]

--- a/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -39,7 +39,7 @@ namespace System.Tests
             }
         }
 
-#if FEATURE_NS_1_7
+#if netstandard17
         [Theory]
         [MemberData(nameof(ExitCodeValues))]
         public static void ExitCode_Roundtrips(int exitCode)
@@ -49,7 +49,7 @@ namespace System.Tests
 
             Environment.ExitCode = 0; // in case the test host has a void returning Main
         }
-#endif //FEATURE_NS_1_7
+#endif //netstandard17
 
         [ActiveIssue("https://github.com/dotnet/coreclr/issues/6206")]
         [Theory]

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetCommandLineArgs.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetCommandLineArgs.cs
@@ -78,7 +78,6 @@ namespace System.Tests
         public static int CheckCommandLineArgs(string[] args)
         {
             string[] cmdLineArgs = Environment.GetCommandLineArgs();
-            string cmdLine = Environment.CommandLine;
 
             Assert.InRange(cmdLineArgs.Length, 4, int.MaxValue); /*AppName, AssemblyName, TypeName, MethodName*/
             Assert.True(cmdLineArgs[0].Contains(TestConsoleApp)); /*The host returns the fullName*/

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -23,7 +23,8 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {
-    "netstandard1.5": {}
+    "netstandard1.5": {},
+    "netstandard1.7": {}
   },
   "supports": {
     "coreFx.Test.netcoreapp1.0": {},

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.2-beta-devapi-24401-01",
+    "System.Console": "4.0.1-beta-devapi-24401-01",
     "System.Diagnostics.Process": "4.1.1-beta-devapi-24401-01",
     "System.Globalization": "4.0.12-beta-devapi-24401-01",
     "System.IO.FileSystem": "4.0.2-beta-devapi-24401-01",


### PR DESCRIPTION
Update package and assemblies that are targetting netstandard1.7

cc: @weshaggard @danmosemsft @stephentoub @ericstj 

This change includes:
- Building a new set of contract and implementations for netstandard1.7 for the assemblies where we have added API.
- Include those new assemblies in the packages.
- Separate tests for the new surface area into an itemgroup that will only be compiled when `$(TargetGroup)=='netstandard1.7'`