### PR TITLE
Fix a Bug with Serializing Types with Non-Public Default Ctor.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -872,7 +872,7 @@ namespace System.Runtime.Serialization
                   return Activator.CreateInstance(type);
             }
 
-            const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance;
+            const BindingFlags Flags = BindingFlags.Public | BindingFlags.Instance;
             bool hasDefaultConstructor = s_typeHasDefaultConstructorMap.GetOrAdd(type, t => t.GetConstructor(Flags, Array.Empty<Type>()) != null);
             return hasDefaultConstructor ? Activator.CreateInstance(type) : TryGetUninitializedObjectWithFormatterServices(type) ?? Activator.CreateInstance(type);
 #else

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1825,6 +1825,30 @@ public static partial class DataContractJsonSerializerTests
         });
     }
 
+    [Fact]
+    public static void DCJS_TypeWithInternalDefaultConstructor()
+    {
+        var value = TypeWithInternalDefaultConstructor.CreateInstance();
+
+        value.Name = "foo";
+        var actual = SerializeAndDeserialize(value, "{\"Name\":\"foo\"}");
+
+        Assert.NotNull(actual);
+        Assert.Equal(value.Name, actual.Name);
+    }
+
+    [Fact]
+    public static void DCJS_TypeWithInternalDefaultConstructorWithoutDataContractAttribute()
+    {
+        var value = TypeWithInternalDefaultConstructorWithoutDataContractAttribute.CreateInstance();
+
+        value.Name = "foo";
+        var actual = SerializeAndDeserialize(value, "{\"Name\":\"foo\"}");
+
+        Assert.NotNull(actual);
+        Assert.Equal(value.Name, actual.Name);
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractJsonSerializer dcjs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2920,3 +2920,34 @@ public class TypeOfReferenceChild
     [DataMember]
     public string Name { get; set; }
 }
+
+[DataContract]
+public sealed class TypeWithInternalDefaultConstructor
+{
+    internal TypeWithInternalDefaultConstructor()
+    {
+    }
+
+    internal static TypeWithInternalDefaultConstructor CreateInstance()
+    {
+        return new TypeWithInternalDefaultConstructor();
+    }
+
+    [DataMember]
+    public string Name { get; set; }
+}
+
+public sealed class TypeWithInternalDefaultConstructorWithoutDataContractAttribute
+{
+    internal TypeWithInternalDefaultConstructorWithoutDataContractAttribute()
+    {
+    }
+
+    internal static TypeWithInternalDefaultConstructorWithoutDataContractAttribute CreateInstance()
+    {
+        return new TypeWithInternalDefaultConstructorWithoutDataContractAttribute();
+    }
+
+    [DataMember]
+    public string Name { get; set; }
+}


### PR DESCRIPTION
If a type is marked with [DataContract], but it has no public default constructor, an instance of the type cannot be de-serialized. The PR is to fix this issue.

Fix #10374 