### PR TITLE
Fix running src/Native/build-native scripts by themselves

### DIFF
--- a/config.json
+++ b/config.json
@@ -208,7 +208,7 @@
       "description": "Sets the value of the build configuration.",
       "valueType": "passThrough",
       "values": [],
-      "defaultValue": "DEBUG"
+      "defaultValue": "Debug"
     },
     "HostOs": {
       "description": "OS for result binaries.",

--- a/config.json
+++ b/config.json
@@ -220,7 +220,7 @@
       "description": "Sets the value of the number of processors available.",
       "valueType": "passThrough",
       "values": ["NUmeric values"],
-      "defaultValue": "${ProcessorCount}"
+      "defaultValue": "--numproc ${ProcessorCount}"
     },
     "Project": {
       "description": "Project where the commands are going to be applied.",

--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -14,7 +14,7 @@ set CMAKE_BUILD_TYPE=Debug
 set "__LinkArgs= "
 set "__LinkLibraries= "
 
-call %__rootDir%/run.cmd build-managed -GenerateVersion
+call %__rootDir%/run.cmd build-managed -GenerateVersion -project=%__rootDir%/build.proj
 
 :Arg_Loop
 :: Since the native build requires some configuration information before msbuild is called, we have to do some manual args parsing
@@ -55,7 +55,7 @@ exit /b 1
 :VS2015
 :: Setup vars for VS2015
 set __VSVersion=vs2015
-set __PlatformToolset="v140"
+set __PlatformToolset=v140
 if NOT "%__BuildArch%" == "arm64" ( 
     :: Set the environment for the native build
     call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %__VCBuildArch%
@@ -111,16 +111,13 @@ goto :Failure
 
 :BuildNativeProj
 :: Build the project created by Cmake
-set __msbuildArgs="%__IntermediatesDir%\install.vcxproj" /t:rebuild /nologo /p:Configuration=%CMAKE_BUILD_TYPE% 
 if "%__BuildArch%" == "arm64" (
-    set __msbuildArgs=%__msbuildArgs% /p:UseEnv=true
+    set __msbuildArgs=/p:UseEnv=true
 ) else (
-    set __msbuildArgs=%__msbuildArgs% /p:Platform=%__BuildArch% /p:PlatformToolset="%__PlatformToolset%"
+    set __msbuildArgs=/p:Platform=%__BuildArch% /p:PlatformToolset="%__PlatformToolset%"
 )
-set __msbuildArgs=%__msbuildArgs% /maxcpucount /nodeReuse:false  /fileloggerparameters:Verbosity=normal
 
-msbuild %__msbuildArgs%
-
+call %__rootDir%/run.cmd build-managed -project="%__IntermediatesDir%\install.vcxproj" -- /t:rebuild /p:Configuration=%CMAKE_BUILD_TYPE% %__msbuildArgs%
 IF ERRORLEVEL 1 (
     goto :Failure
 )

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -2,11 +2,13 @@
 
 usage()
 {
-    echo "Our parameters changed! The parameters: buildArch, buildType and HostOS"
-    echo "are passes by the Run Command Tool."
+    echo "Our parameters changed! The parameters: buildArch, buildType, buildOS, numProc"
+    echo "are passed by the Run Command Tool."
+    echo "If you plan to only run this script, be sure to pass those parameters in the stated order."
     echo "For more information type build-native.sh -? at the root of the repo."
     echo
-    echo "Usage: $0 [verbose] [clangx.y] [cross] [staticLibLink] [cmakeargs] [makeargs]"
+    echo "Usage: $0 [runParameters][verbose] [clangx.y] [cross] [staticLibLink] [cmakeargs] [makeargs]"
+    echo "runParameters: buildArch, buildType, buildOS, numProc"
     echo "verbose - optional argument to enable verbose build output."
     echo "clangx.y - optional argument to build using clang version x.y."
     echo "cross - optional argument to signify cross compilation,"
@@ -95,20 +97,15 @@ __nativeroot=$__scriptpath/Unix
 __rootRepo="$__scriptpath/../.."
 __rootbinpath="$__scriptpath/../../bin"
 
-#This parameters are handled and passed by the Run Command Tool
-#For more information: 'link to documentation'
-__BuildArch=$1
-__BuildType=$2
-__HostOS=$3
-__NumProc=$4
-
-__BuildOS=$__HostOS
-__CMakeArgs=$__BuildType
+# Set the various build properties here so that CMake and MSBuild can pick them up
 __CMakeExtraArgs=""
 __MakeExtraArgs=""
 __generateversionsource=false
-
-# Set the various build properties here so that CMake and MSBuild can pick them up
+__BuildArch=x64
+__BuildType=Debug
+__CMakeArgs=DEBUG
+__BuildOS=Linux
+__NumProc=$4
 __UnprocessedBuildArgs=
 __CrossBuild=0
 __ServerGC=0
@@ -127,6 +124,40 @@ while :; do
             usage
             exit 1
             ;;
+        x86)
+            __BuildArch=x86
+            ;;
+        x64)
+            __BuildArch=x64
+            ;;
+        arm)
+            __BuildArch=arm
+            ;;
+        arm-softfp)
+            __BuildArch=arm-softfp
+            ;;
+        arm64)
+            __BuildArch=arm64
+            ;;
+        debug)
+            __BuildType=Debug
+            ;;
+        release)
+            __BuildType=Release
+            __CMakeArgs=RELEASE 
+	    ;;
+        freebsd)
+            __BuildOS=FreeBSD
+            ;;
+        linux)
+            __BuildOS=Linux
+            ;;
+        netbsd)
+            __BuildOS=NetBSD
+            ;;
+        osx)
+            __BuildOS=OSX
+            ;;       
         verbose)
             __VerboseBuild=1
             ;;

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -4,11 +4,11 @@ usage()
 {
     echo "Our parameters changed! The parameters: buildArch, buildType, buildOS, numProc"
     echo "are passed by the Run Command Tool."
-    echo "If you plan to only run this script, be sure to pass those parameters in the stated order."
+    echo "If you plan to only run this script, be sure to pass those parameters."
     echo "For more information type build-native.sh -? at the root of the repo."
     echo
     echo "Usage: $0 [runParameters][verbose] [clangx.y] [cross] [staticLibLink] [cmakeargs] [makeargs]"
-    echo "runParameters: buildArch, buildType, buildOS, numProc"
+    echo "runParameters: buildArch, buildType, buildOS, --numProc <numproc value>"
     echo "verbose - optional argument to enable verbose build output."
     echo "clangx.y - optional argument to build using clang version x.y."
     echo "cross - optional argument to signify cross compilation,"
@@ -105,7 +105,7 @@ __BuildArch=x64
 __BuildType=Debug
 __CMakeArgs=DEBUG
 __BuildOS=Linux
-__NumProc=$4
+__NumProc=1
 __UnprocessedBuildArgs=
 __CrossBuild=0
 __ServerGC=0
@@ -157,7 +157,11 @@ while :; do
             ;;
         osx)
             __BuildOS=OSX
-            ;;       
+            ;;
+        --numproc)
+            shift
+            __NumProc=$1
+            ;;         
         verbose)
             __VerboseBuild=1
             ;;


### PR DESCRIPTION
The native scripts under `src/Native` only worked when called from `build-native` at the root of the repo.
With this change, we don't force people to run the scripts from the root.

Fix: #10533 

cc: @joperezr @ianhays 