### PR TITLE
Support metadata from certificates with no Algorithm.Parameters values

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -235,6 +235,14 @@ extern int32_t CryptoNative_GetX509PublicKeyParameterBytes(X509* x509, uint8_t* 
     }
 
     ASN1_TYPE* parameter = x509->cert_info->key->algor->parameter;
+
+    if (!parameter)
+    {
+        // If pBuf is NULL we're asking for the length, so return 0 (which is negative-zero)
+        // If pBuf is non-NULL we're asking to fill the data, in which case we return 1.
+        return pBuf != NULL;
+    }
+    
     int len = i2d_ASN1_TYPE(parameter, NULL);
 
     if (cBuf < len)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
@@ -148,6 +148,11 @@ namespace Internal.Cryptography.Pal.Native
 
         public byte[] ToByteArray()
         {
+            if (cbData == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
             byte[] array = new byte[cbData];
             Marshal.Copy((IntPtr)pbData, array, 0, cbData);
             return array;
@@ -252,6 +257,11 @@ namespace Internal.Cryptography.Pal.Native
 
         public byte[] ToByteArray()
         {
+            if (cbData == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
             byte[] array = new byte[cbData];
             Marshal.Copy((IntPtr)pbData, array, 0, cbData);
             return array;

--- a/src/System.Security.Cryptography.X509Certificates/tests/InteropTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/InteropTests.cs
@@ -245,6 +245,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
             public byte[] ToByteArray()
             {
+                if (cbData == 0)
+                {
+                    return Array.Empty<byte>();
+                }
+
                 byte[] array = new byte[cbData];
                 Marshal.Copy((IntPtr)pbData, array, 0, cbData);
                 return array;
@@ -301,6 +306,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
             public byte[] ToByteArray()
             {
+                if (cbData == 0)
+                {
+                    return Array.Empty<byte>();
+                }
+
                 byte[] array = new byte[cbData];
                 Marshal.Copy((IntPtr)pbData, array, 0, cbData);
                 return array;

--- a/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -139,6 +139,60 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        public static void GetPublicKey_X509Signature_NoParameters()
+        {
+            // Normally RSA signature AlgorithmIdentifiers get represented as
+            //
+            // SEQUENCE(
+            //    algorithm: OID(1.2.840.113549.1.1.5),
+            //    parameters: NULL)
+            //
+            // where parameters: NULL is the byte sequence 05 00.
+            //
+            // This certificate has omitted the parameters section completely,
+            // which while RFC compliant (it's labelled OPTIONAL) isn't what everyone
+            // else does.  So this test ensures that we can read such a cert.
+            const string PemEncodedCert = @"
+-----BEGIN CERTIFICATE-----
+MIIE4jCCAsygAwIBAgIEMTI0NjALBgkqhkiG9w0BAQUwgZgxCzAJBgNVBAYTAlVT
+MQswCQYDVQQIDAJOWTEbMBkGA1UECgwSUVogSW5kdXN0cmllcywgTExDMRswGQYD
+VQQLDBJRWiBJbmR1c3RyaWVzLCBMTEMxGTAXBgNVBAMMEHF6aW5kdXN0cmllcy5j
+b20xJzAlBgkqhkiG9w0BCQEWGHN1cHBvcnRAcXppbmR1c3RyaWVzLmNvbTAeFw0x
+NjA0MDYyMTAwMDBaFw0xNzA0MDcyMTAwMDBaMIGtMQswCQYDVQQGDAJDWjEXMBUG
+A1UECAwOQ3plY2ggUmVwdWJsaWMxDTALBgNVBAcMBEJybm8xGTAXBgNVBAoMEHNt
+c3RpY2tldCBzLnIuby4xGTAXBgNVBAsMEHNtc3RpY2tldCBzLnIuby4xHjAcBgNV
+BAMMFXBva2xhZG5hLnNtc3RpY2tldC5jejEgMB4GCSqGSIb3DQEJAQwRaW5mb0Bz
+bXN0aWNrZXQuY3owggEgMAsGCSqGSIb3DQEBAQOCAQ8AMIIBCgKCAQEAsDh05CAX
+Wp29GTbjk3gzeCCe/1t7V3aNTwbtzkUtLZnbS9tge/+Iaqsz10IOWk3SndLhPIfa
+KUvX/pnkq5CXIVyTTyRoFpyYrDfNoRmZ/3uTmMG50urk0Rg/+e4f2k32BfFTfB0W
+3V169+QQ6Xvvuoyh62cppfi1msgFJ6WGmEF1r73Q6tK1vxfuA9wJfMWTl4Sg8nEf
+9NXsTc9VAwGKRJbmTUN1b0xsqFvlFbxvaxPGwxNM29lXWlez5KEsh0sfUyTGQuTB
+tu5JMC57TGvL0/TwgwrtOxQL5+N4lJAWnUQ+z3XXL694eSsuKlgw2yasO2ZwWnyz
+eap2vnN/CifUgwIDAQABoyMwITAfBgNVHSMEGDAWgBSQplC3hNS56l/yBYQTeEXo
+qXVUXDALBgkqhkiG9w0BAQUDggIBAHMNLagyKZYla3gR0KOhxiUWuFG2gU7uB2v+
+zeqmIh6XxG4/39r6SJgUIimZ2aVQjYLa/fgrn5FRXhDqMumLJ3rWp8GB05evmdWl
+WMQrb6E39jsFXuCzev6mCjiHxzGC2I7SRvFmnCj5fvOF81V5dLjU2PnCNqPym9Aw
+XbEHVXTxpM9okSeq/EoeuTA5NHl/EySwYiGoexz0Ia51M5cw5W5go2Abmtqs4bbz
+7OFeZKP9fd1p+C/ZnekgKq+3SJ9qbEiJxoPir3rG2N0mw7iI5pwvbCixY9irZh5o
+Lrc5RvH4hdpygNSm4MYEuBykEW0tizkcVanGCUmGdjxM22Y9XdPgKitS04rVk/2U
+C1Gszv9KvtmQ2P3/HWWWiOQgljc3SFqBltt6TqJTGCtLEbWRw6V+sw3SALoafvLg
+tIsyWUsjM5LunRkUQ+HIsmKo42943TmgUvgRuuo0nsEFI5TS7Jh0iC/2gQEt7XGh
+wzOTZ0HzM3oNnTphlXFLBwL9MUgWKbhu5Fg486dDMeQmZmhztW/+F/uHHYFisk+1
+tmr2prSh5i4fD71t4p+EGJJQxM4wCiXRLzggIVGUAIrzynxO2vjYiMQxAUH3tdsX
+JI6fq+e/mFZOE2XQmYu3/hQEw8/2F6usF1lyvwMZt2TgQZF1/g8gFVQUY2mGLM1z
+Wry5FNNo
+-----END CERTIFICATE-----";
+
+            byte[] bytes = System.Text.Encoding.ASCII.GetBytes(PemEncodedCert);
+
+            using (X509Certificate2 cert = new X509Certificate2(bytes))
+            {
+                Assert.Equal(Array.Empty<byte>(), cert.GetKeyAlgorithmParameters());
+                Assert.Equal("1.2.840.113549.1.1.1", cert.GetKeyAlgorithm());
+            }
+        }
+
+        [Fact]
         public static void TestNotBefore()
         {
             DateTime expected = new DateTime(2013, 1, 24, 22, 33, 39, DateTimeKind.Utc).ToLocalTime();


### PR DESCRIPTION
RSA has no algorithm parameters. Most implementations set the parameters
value to DER-NULL (0x05 0x00), including both Windows and OpenSSL.

At least one CA has been found to omit this optional value instead of
declaring it to be NULL, and when it was missing we had failed reads in
both Windows and the Unix implementations.

To quote [RFC 4055](https://tools.ietf.org/html/rfc4055#section-2.1):
> There are two possible encodings for the AlgorithmIdentifier
   parameters field associated with these object identifiers.  The two
   alternatives arise from the loss of the OPTIONAL associated with the
   algorithm identifier parameters when the 1988 syntax for
   AlgorithmIdentifier was translated into the 1997 syntax.  Later the
   OPTIONAL was recovered via a defect report, but by then many people
   thought that algorithm parameters were mandatory.  Because of this
   history some implementations encode parameters as a NULL element
   while others omit them entirely. 

Fixes #9792.
cc: @AtsushiKan @stephentoub 