### PR TITLE
Fix minor bug in `clean.sh`

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -8,15 +8,19 @@ usage()
     echo "  -b         Delete the binary output directory."
     echo "  -p         Delete the repo-local NuGet package directory."
     echo "  -c         Delete the user-local NuGet package caches."
-    echo "  --all      Cleans the root directory."
+    echo "  -all       Cleans the root directory."
     echo
     echo "If no option is specified, then \"clean.sh -b\" is implied."
     exit 1
 }
 
+if [ "$1" == "-?" ] || [ "$1" == "-h" ]; then
+    usage
+fi
+
 __working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ $* == -all ]
+if [ "$*" == "-all" ]
 then
    echo "Removing all untracked files in the working tree"
    git clean -xdf $__working_tree_root


### PR DESCRIPTION
* add '-?' and '-h' option processing for usage.
* fix 'line 19: [: ==: unary operator expected' when running without option.
* fix typo '-all' to '--all'.