### PR TITLE
Improve test coverage for some string.Compare overloads

### DIFF
--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -572,7 +572,7 @@ namespace System.Tests
                 {
                     // Use Compare(string, int, string, int, int) or Compare(string, int, string, int, int, false)
                     Assert.Equal(expected, Math.Sign(string.Compare(strA, indexA, strB, indexB, length)));
-                    // Uncomment when this is exposed in .NET Core
+                    // Uncomment when this is exposed in .NET Core (dotnet/corefx#10963)
                     // Assert.Equal(expected, Math.Sign(string.Compare(strA, indexA, strB, indexB, length, ignoreCase: false)));
                 }
             }
@@ -584,7 +584,7 @@ namespace System.Tests
                 if (!skipNonComparisonOverloads)
                 {
                     // Use Compare(string, int, string, int, int, true)
-                    // Uncomment when this is exposed in .NET Core
+                    // Uncomment when this is exposed in .NET Core (dotnet/corefx#10963)
                     // Assert.Equal(expected, Math.Sign(string.Compare(strA, indexA, strB, indexB, length, ignoreCase: true)));
                 }
             }
@@ -634,8 +634,8 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>("length", () => string.Compare("a", 0, "bb", 0, -1, StringComparison.CurrentCulture));
 
             // There is a subtle behavior difference between the string.Compare that accepts a StringComparison parameter,
-            // and the one that does not. The former originally included short-circuiting logic for nulls BEFORE the length/
-            // index parameters were validated (but after the StringComparison was), while the latter did not. As a result,
+            // and the one that does not. The former includes short-circuiting logic for nulls BEFORE the length/
+            // index parameters are validated (but after the StringComparison is), while the latter does not. As a result,
             // this will not throw:
             // string.Compare(null, -1, null, -1, -1, StringComparison.CurrentCulture)
             // but this will:

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -680,6 +680,7 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>("indexB", () => string.CompareOrdinal("foo", 0, "foo", -1, 0)); // then indexB
             Assert.Throws<ArgumentOutOfRangeException>("indexA", () => string.CompareOrdinal("foo", 4, "foo", 4, 0)); // indexA > strA.Length first
             Assert.Throws<ArgumentOutOfRangeException>("indexB", () => string.CompareOrdinal("foo", 3, "foo", 4, 0)); // then indexB > strB.Length
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => string.CompareOrdinal("foo", 0, "foo", 0, -1)); // early return should not kick in if count is invalid
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -572,7 +572,7 @@ namespace System.Tests
                 {
                     // Use Compare(string, int, string, int, int) or Compare(string, int, string, int, int, false)
                     Assert.Equal(expected, Math.Sign(string.Compare(strA, indexA, strB, indexB, length)));
-                    // Uncomment when this is exposed in .NET Core (dotnet/corefx#10963)
+                    // Uncomment when this is exposed in .NET Core (dotnet/corefx#10066)
                     // Assert.Equal(expected, Math.Sign(string.Compare(strA, indexA, strB, indexB, length, ignoreCase: false)));
                 }
             }
@@ -584,7 +584,7 @@ namespace System.Tests
                 if (!skipNonComparisonOverloads)
                 {
                     // Use Compare(string, int, string, int, int, true)
-                    // Uncomment when this is exposed in .NET Core (dotnet/corefx#10963)
+                    // Uncomment when this is exposed in .NET Core (dotnet/corefx#10066)
                     // Assert.Equal(expected, Math.Sign(string.Compare(strA, indexA, strB, indexB, length, ignoreCase: true)));
                 }
             }

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -423,8 +423,14 @@ namespace System.Tests
         [InlineData(null, 0, null, 0, 0, StringComparison.CurrentCulture, 0)]
         [InlineData("Hello", 0, null, 0, 0, StringComparison.CurrentCulture, 1)]
         [InlineData(null, 0, "Hello", 0, 0, StringComparison.CurrentCulture, -1)]
+        [InlineData(null, -1, null, -1, -1, StringComparison.CurrentCulture, 0)]
+        [InlineData("foo", -1, null, -1, -1, StringComparison.CurrentCulture, 1)]
+        [InlineData(null, -1, "foo", -1, -1, StringComparison.CurrentCulture, -1)]
         // CurrentCultureIgnoreCase
         [InlineData("HELLO", 0, "hello", 0, 5, StringComparison.CurrentCultureIgnoreCase, 0)]
+        [InlineData("Hello", 0, "Hello", 0, 5, StringComparison.CurrentCultureIgnoreCase, 0)]
+        [InlineData("Hello", 2, "Hello", 2, 3, StringComparison.CurrentCultureIgnoreCase, 0)]
+        [InlineData("Hello", 2, "Yellow", 2, 3, StringComparison.CurrentCultureIgnoreCase, 0)]
         [InlineData("Hello", 0, "Goodbye", 0, 5, StringComparison.CurrentCultureIgnoreCase, 1)]
         [InlineData("Goodbye", 0, "Hello", 0, 5, StringComparison.CurrentCultureIgnoreCase, -1)]
         [InlineData("HELLO", 2, "hello", 2, 3, StringComparison.CurrentCultureIgnoreCase, 0)]
@@ -432,6 +438,9 @@ namespace System.Tests
         [InlineData(null, 0, null, 0, 0, StringComparison.CurrentCultureIgnoreCase, 0)]
         [InlineData("Hello", 0, null, 0, 0, StringComparison.CurrentCultureIgnoreCase, 1)]
         [InlineData(null, 0, "Hello", 0, 0, StringComparison.CurrentCultureIgnoreCase, -1)]
+        [InlineData(null, -1, null, -1, -1, StringComparison.CurrentCultureIgnoreCase, 0)]
+        [InlineData("foo", -1, null, -1, -1, StringComparison.CurrentCultureIgnoreCase, 1)]
+        [InlineData(null, -1, "foo", -1, -1, StringComparison.CurrentCultureIgnoreCase, -1)]
         // InvariantCulture (not exposed as enum case, but is valid)
         [InlineData("Hello", 0, "Hello", 0, 5, (StringComparison)2, 0)]
         [InlineData("Hello", 0, "Goodbye", 0, 5, (StringComparison)2, 1)]
@@ -443,6 +452,9 @@ namespace System.Tests
         [InlineData(null, 0, "Hello", 0, 5, (StringComparison)2, -1)]
         // InvariantCultureIgnoreCase (not exposed as enum case, but is valid)
         [InlineData("HELLO", 0, "hello", 0, 5, (StringComparison)3, 0)]
+        [InlineData("Hello", 0, "Hello", 0, 5, (StringComparison)3, 0)]
+        [InlineData("Hello", 2, "Hello", 2, 3, (StringComparison)3, 0)]
+        [InlineData("Hello", 2, "Yellow", 2, 3, (StringComparison)3, 0)]
         [InlineData("Hello", 0, "Goodbye", 0, 5, (StringComparison)3, 1)]
         [InlineData("Goodbye", 0, "Hello", 0, 5, (StringComparison)3, -1)]
         [InlineData("HELLO", 2, "hello", 2, 3, (StringComparison)3, 0)]
@@ -496,8 +508,14 @@ namespace System.Tests
         [InlineData(null, 0, null, 0, 0, StringComparison.Ordinal, 0)]
         [InlineData("Hello", 0, null, 0, 5, StringComparison.Ordinal, 1)]
         [InlineData(null, 0, "Hello", 0, 5, StringComparison.Ordinal, -1)]
+        [InlineData(null, -1, null, -1, -1, StringComparison.Ordinal, 0)]
+        [InlineData("foo", -1, null, -1, -1, StringComparison.Ordinal, 1)]
+        [InlineData(null, -1, "foo", -1, -1, StringComparison.Ordinal, -1)]
         // OrdinalIgnoreCase
         [InlineData("HELLO", 0, "hello", 0, 5, StringComparison.OrdinalIgnoreCase, 0)]
+        [InlineData("Hello", 0, "Hello", 0, 5, StringComparison.OrdinalIgnoreCase, 0)]
+        [InlineData("Hello", 2, "Hello", 2, 3, StringComparison.OrdinalIgnoreCase, 0)]
+        [InlineData("Hello", 2, "Yellow", 2, 3, StringComparison.OrdinalIgnoreCase, 0)]
         [InlineData("Hello", 0, "Goodbye", 0, 5, StringComparison.OrdinalIgnoreCase, 1)]
         [InlineData("Goodbye", 0, "Hello", 0, 5, StringComparison.OrdinalIgnoreCase, -1)]
         [InlineData("HELLO", 2, "hello", 2, 3, StringComparison.OrdinalIgnoreCase, 0)]
@@ -508,14 +526,15 @@ namespace System.Tests
         public static void Compare(string strA, int indexA, string strB, int indexB, int length, StringComparison comparisonType, int expected)
         {
             bool hasNullInputs = (strA == null || strB == null);
-            bool indexesReferToEntireString = (strA != null && strB != null && indexA == 0 && indexB == 0 && (length == strB.Length || length == strA.Length));
-            if (hasNullInputs || indexesReferToEntireString)
+            bool indicesReferToEntireString = (strA != null && strB != null && indexA == 0 && indexB == 0 && (length == strB.Length || length == strA.Length));
+            bool skipNonComparisonOverloads = length != 0 && ((strA == null && indexA != 0) || (strB == null && indexB != 0));
+            if (hasNullInputs || indicesReferToEntireString)
             {
                 if (comparisonType == StringComparison.CurrentCulture)
                 {
                     // Use Compare(string, string) or Compare(string, string, false) or CompareTo(string)
                     Assert.Equal(expected, Math.Sign(string.Compare(strA, strB)));
-                    Assert.Equal(expected, Math.Sign(string.Compare(strA, strB, false)));
+                    Assert.Equal(expected, Math.Sign(string.Compare(strA, strB, ignoreCase: false)));
                     if (strA != null)
                     {
                         Assert.Equal(expected, Math.Sign(strA.CompareTo(strB)));
@@ -523,31 +542,58 @@ namespace System.Tests
                         IComparable iComparable = strA;
                         Assert.Equal(expected, Math.Sign(iComparable.CompareTo(strB)));
                     }
+                    if (strB != null)
+                    {
+                        Assert.Equal(expected, -Math.Sign(strB.CompareTo(strA)));
+
+                        IComparable iComparable = strB;
+                        Assert.Equal(expected, -Math.Sign(iComparable.CompareTo(strA)));
+                    }
                 }
                 else if (comparisonType == StringComparison.CurrentCultureIgnoreCase)
                 {
                     // Use Compare(string, string, true)
-                    Assert.Equal(expected, Math.Sign(string.Compare(strA, strB, true)));
+                    Assert.Equal(expected, Math.Sign(string.Compare(strA, strB, ignoreCase: true)));
                 }
                 else if (comparisonType == StringComparison.Ordinal)
                 {
                     // Use CompareOrdinal(string, string)
                     Assert.Equal(expected, Math.Sign(string.CompareOrdinal(strA, strB)));
                 }
-                // Use CompareOrdinal(string, string, StringComparisonType)
+                // Use CompareOrdinal(string, string, StringComparison)
                 Assert.Equal(expected, Math.Sign(string.Compare(strA, strB, comparisonType)));
             }
             if (comparisonType == StringComparison.CurrentCulture)
             {
-                // Use Compare(string, int, string, int, int)
-                Assert.Equal(expected, Math.Sign(string.Compare(strA, indexA, strB, indexB, length)));
+                // This may have different behavior than the overload accepting a StringComparison
+                // for a combination of null/invalid inputs; see notes in Compare_Invalid for more
+
+                if (!skipNonComparisonOverloads)
+                {
+                    // Use Compare(string, int, string, int, int) or Compare(string, int, string, int, int, false)
+                    Assert.Equal(expected, Math.Sign(string.Compare(strA, indexA, strB, indexB, length)));
+                    // Uncomment when this is exposed in .NET Core
+                    // Assert.Equal(expected, Math.Sign(string.Compare(strA, indexA, strB, indexB, length, ignoreCase: false)));
+                }
+            }
+            else if (comparisonType == StringComparison.CurrentCultureIgnoreCase)
+            {
+                // This may have different behavior than the overload accepting a StringComparison
+                // for a combination of null/invalid inputs; see notes in Compare_Invalid for more
+
+                if (!skipNonComparisonOverloads)
+                {
+                    // Use Compare(string, int, string, int, int, true)
+                    // Uncomment when this is exposed in .NET Core
+                    // Assert.Equal(expected, Math.Sign(string.Compare(strA, indexA, strB, indexB, length, ignoreCase: true)));
+                }
             }
             else if (comparisonType == StringComparison.Ordinal)
             {
                 // Use CompareOrdinal(string, int, string, int, int)
                 Assert.Equal(expected, Math.Sign(string.CompareOrdinal(strA, indexA, strB, indexB, length)));
             }
-            // Use Compare(string, int, string, int, int, StringComparisonType)
+            // Use Compare(string, int, string, int, int, StringComparison)
             Assert.Equal(expected, Math.Sign(string.Compare(strA, indexA, strB, indexB, length, comparisonType)));
         }
 
@@ -586,6 +632,32 @@ namespace System.Tests
             // Length < 0
             Assert.Throws<ArgumentOutOfRangeException>("length1", () => string.Compare("a", 0, "bb", 0, -1));
             Assert.Throws<ArgumentOutOfRangeException>("length", () => string.Compare("a", 0, "bb", 0, -1, StringComparison.CurrentCulture));
+
+            // There is a subtle behavior difference between the string.Compare that accepts a StringComparison parameter,
+            // and the one that does not. The former originally included short-circuiting logic for nulls BEFORE the length/
+            // index parameters were validated (but after the StringComparison was), while the latter did not. As a result,
+            // this will not throw:
+            // string.Compare(null, -1, null, -1, -1, StringComparison.CurrentCulture)
+            // but this will:
+            // string.Compare(null, -1, null, -1, -1)
+
+            // These tests ensure that the argument validation stays in order.
+
+            // Compare accepting StringComparison
+            Assert.Throws<ArgumentException>("comparisonType", () => string.Compare(null, 0, null, 0, 0, StringComparison.CurrentCulture - 1)); // comparisonType should be validated before null short-circuiting...
+            // Tests to ensure null is short-circuited before validating the arguments are in the Compare() theory
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => string.Compare("foo", -1, "foo", -1, -1, StringComparison.CurrentCulture)); // length should be validated before indexA/indexB
+            Assert.Throws<ArgumentOutOfRangeException>("indexA", () => string.Compare("foo", -1, "foo", -1, 3, StringComparison.CurrentCulture)); // then indexA
+            Assert.Throws<ArgumentOutOfRangeException>("indexB", () => string.Compare("foo", 0, "foo", -1, 3, StringComparison.CurrentCulture)); // then indexB
+            // Then the optimization where we short-circuit if strA == strB && indexA == indexB, or length == 0, is tested in the Compare() theory.
+
+            // Compare not accepting StringComparison
+            Assert.Throws<ArgumentOutOfRangeException>("length1", () => string.Compare(null, -1, null, -1, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("length2", () => string.Compare(null, 0, "bar", 4, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("offset1", () => string.Compare(null, -1, null, -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("offset2", () => string.Compare(null, 0, null, -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("string1", () => string.Compare(null, 1, null, 1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("string2", () => string.Compare("bar", 1, null, 1, 1));
         }
 
         [Fact]
@@ -601,6 +673,13 @@ namespace System.Tests
 
             // Length < 0
             Assert.Throws<ArgumentOutOfRangeException>("count", () => string.CompareOrdinal("a", 0, "bb", 0, -1));
+
+            // We must validate arguments before any short-circuiting is done (besides for nulls)
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => string.CompareOrdinal("foo", -1, "foo", -1, -1)); // count should be validated first
+            Assert.Throws<ArgumentOutOfRangeException>("indexA", () => string.CompareOrdinal("foo", -1, "foo", -1, 0)); // then indexA
+            Assert.Throws<ArgumentOutOfRangeException>("indexB", () => string.CompareOrdinal("foo", 0, "foo", -1, 0)); // then indexB
+            Assert.Throws<ArgumentOutOfRangeException>("indexA", () => string.CompareOrdinal("foo", 4, "foo", 4, 0)); // indexA > strA.Length first
+            Assert.Throws<ArgumentOutOfRangeException>("indexB", () => string.CompareOrdinal("foo", 3, "foo", 4, 0)); // then indexB > strB.Length
         }
 
         [Theory]
@@ -917,7 +996,7 @@ namespace System.Tests
                 // Use Equals(string, string)
                 Assert.Equal(expected, string.Equals(s1, s2));
             }
-            // Use Equals(string, string, StringComparisonType)
+            // Use Equals(string, string, StringComparison)
             Assert.Equal(expected, string.Equals(s1, s2, comparisonType));
 
             // If two strings are equal ordinally, then they must have the same hash code.


### PR DESCRIPTION
I found a lot of behavior for `string.Compare` that wasn't being tested while making dotnet/coreclr#6603, so I've expanded the code coverage for these functions to test some of the edge cases I've found. In particular,

```cs
string.Compare(null, -1, null, -1, -1, StringComparison.CurrentCulture);
```

shouldn't throw, while

```cs
string.Compare(null, -1, null, -1, -1);
```

should. There are also a few other things I've added tests for, e.g. the order in which arguments are validated.

@hughbe @stephentoub PTAL