### PR TITLE
Reducing array allocations in expression interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -18,52 +18,6 @@ namespace System.Linq.Expressions.Interpreter
         private const int MaxHelpers = 3;
         private const int MaxArgs = 3;
 
-        public virtual object InvokeInstance(object instance, params object[] args)
-        {
-            switch (args.Length)
-            {
-                case 0: return Invoke(instance);
-                case 1: return Invoke(instance, args[0]);
-                case 2: return Invoke(instance, args[0], args[1]);
-                case 3: return Invoke(instance, args[0], args[1], args[2]);
-                case 4: return Invoke(instance, args[0], args[1], args[2], args[3]);
-                case 5: return Invoke(instance, args[0], args[1], args[2], args[3], args[4]);
-                case 6: return Invoke(instance, args[0], args[1], args[2], args[3], args[4], args[5]);
-                case 7: return Invoke(instance, args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
-                case 8: return Invoke(instance, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
-                default: throw new InvalidOperationException();
-            }
-        }
-
-        public virtual object Invoke(params object[] args)
-        {
-            switch (args.Length)
-            {
-                case 0: return Invoke();
-                case 1: return Invoke(args[0]);
-                case 2: return Invoke(args[0], args[1]);
-                case 3: return Invoke(args[0], args[1], args[2]);
-                case 4: return Invoke(args[0], args[1], args[2], args[3]);
-                case 5: return Invoke(args[0], args[1], args[2], args[3], args[4]);
-                case 6: return Invoke(args[0], args[1], args[2], args[3], args[4], args[5]);
-                case 7: return Invoke(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
-                case 8: return Invoke(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
-                case 9: return Invoke(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]);
-                default: throw new InvalidOperationException();
-            }
-        }
-
-        public virtual object Invoke() { throw new InvalidOperationException(); }
-        public virtual object Invoke(object arg0) { throw new InvalidOperationException(); }
-        public virtual object Invoke(object arg0, object arg1) { throw new InvalidOperationException(); }
-        public virtual object Invoke(object arg0, object arg1, object arg2) { throw new InvalidOperationException(); }
-        public virtual object Invoke(object arg0, object arg1, object arg2, object arg3) { throw new InvalidOperationException(); }
-        public virtual object Invoke(object arg0, object arg1, object arg2, object arg3, object arg4) { throw new InvalidOperationException(); }
-        public virtual object Invoke(object arg0, object arg1, object arg2, object arg3, object arg4, object arg5) { throw new InvalidOperationException(); }
-        public virtual object Invoke(object arg0, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6) { throw new InvalidOperationException(); }
-        public virtual object Invoke(object arg0, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7) { throw new InvalidOperationException(); }
-        public virtual object Invoke(object arg0, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8) { throw new InvalidOperationException(); }
-
 #if FEATURE_FAST_CREATE
         /// <summary>
         /// Fast creation works if we have a known primitive types for the entire
@@ -250,12 +204,6 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Action)target.CreateDelegate(typeof(Action), target);
         }
 
-        public override object Invoke()
-        {
-            _target();
-            return null;
-        }
-
         public override int Run(InterpretedFrame frame)
         {
             _target();
@@ -278,12 +226,6 @@ namespace System.Linq.Expressions.Interpreter
         public ActionCallInstruction(MethodInfo target)
         {
             _target = (Action<T0>)target.CreateDelegate(typeof(Action<T0>), target);
-        }
-
-        public override object Invoke(object arg0)
-        {
-            _target(arg0 != null ? (T0)arg0 : default(T0));
-            return null;
         }
 
         public override int Run(InterpretedFrame frame)
@@ -310,12 +252,6 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Action<T0, T1>)target.CreateDelegate(typeof(Action<T0, T1>), target);
         }
 
-        public override object Invoke(object arg0, object arg1)
-        {
-            _target(arg0 != null ? (T0)arg0 : default(T0), arg1 != null ? (T1)arg1 : default(T1));
-            return null;
-        }
-
         public override int Run(InterpretedFrame frame)
         {
             _target((T0)frame.Data[frame.StackIndex - 2], (T1)frame.Data[frame.StackIndex - 1]);
@@ -338,11 +274,6 @@ namespace System.Linq.Expressions.Interpreter
         public FuncCallInstruction(MethodInfo target)
         {
             _target = (Func<TRet>)target.CreateDelegate(typeof(Func<TRet>), target);
-        }
-
-        public override object Invoke()
-        {
-            return _target();
         }
 
         public override int Run(InterpretedFrame frame)
@@ -369,11 +300,6 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Func<T0, TRet>)target.CreateDelegate(typeof(Func<T0, TRet>), target);
         }
 
-        public override object Invoke(object arg0)
-        {
-            return _target(arg0 != null ? (T0)arg0 : default(T0));
-        }
-
         public override int Run(InterpretedFrame frame)
         {
             frame.Data[frame.StackIndex - 1] = _target((T0)frame.Data[frame.StackIndex - 1]);
@@ -396,11 +322,6 @@ namespace System.Linq.Expressions.Interpreter
         public FuncCallInstruction(MethodInfo target)
         {
             _target = (Func<T0, T1, TRet>)target.CreateDelegate(typeof(Func<T0, T1, TRet>), target);
-        }
-
-        public override object Invoke(object arg0, object arg1)
-        {
-            return _target(arg0 != null ? (T0)arg0 : default(T0), arg1 != null ? (T1)arg1 : default(T1));
         }
 
         public override int Run(InterpretedFrame frame)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -309,10 +309,10 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
-    internal partial class MethodInfoCallInstruction : CallInstruction
+    internal class MethodInfoCallInstruction : CallInstruction
     {
-        private readonly MethodInfo _target;
-        private readonly int _argumentCount;
+        protected readonly MethodInfo _target;
+        protected readonly int _argumentCount;
 
         public override int ArgumentCount { get { return _argumentCount; } }
 
@@ -324,108 +324,49 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int ProducedStack { get { return _target.ReturnType == typeof(void) ? 0 : 1; } }
 
-        public override object Invoke(params object[] args)
-        {
-            return InvokeWorker(args);
-        }
-        public override object Invoke()
-        {
-            return InvokeWorker();
-        }
-        public override object Invoke(object arg0)
-        {
-            return InvokeWorker(arg0);
-        }
-        public override object Invoke(object arg0, object arg1)
-        {
-            return InvokeWorker(arg0, arg1);
-        }
-
-        public override object InvokeInstance(object instance, params object[] args)
-        {
-            if (_target.IsStatic)
-            {
-                try
-                {
-                    return _target.Invoke(null, args);
-                }
-                catch (TargetInvocationException e)
-                {
-                    throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
-                }
-            }
-
-            LightLambda targetLambda;
-            if (TryGetLightLambdaTarget(instance, out targetLambda))
-            {
-                // no need to Invoke, just interpret the lambda body
-                return InterpretLambdaInvoke(targetLambda, SkipFirstArg(args));
-            }
-
-            try
-            {
-                NullCheck(instance);
-                return _target.Invoke(instance, args);
-            }
-            catch (TargetInvocationException e)
-            {
-                throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
-            }
-        }
-
-        private object InvokeWorker(params object[] args)
-        {
-            if (_target.IsStatic)
-            {
-                try
-                {
-                    return _target.Invoke(null, args);
-                }
-                catch (TargetInvocationException e)
-                {
-                    throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
-                }
-            }
-
-            LightLambda targetLambda;
-            if (TryGetLightLambdaTarget(args[0], out targetLambda))
-            {
-                // no need to Invoke, just interpret the lambda body
-                return InterpretLambdaInvoke(targetLambda, SkipFirstArg(args));
-            }
-
-            try
-            {
-                var instance = args[0];
-                NullCheck(instance);
-                return _target.Invoke(instance, SkipFirstArg(args));
-            }
-            catch (TargetInvocationException e)
-            {
-                throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
-            }
-        }
-
-        private static object[] SkipFirstArg(object[] args)
-        {
-            object[] newArgs = new object[args.Length - 1];
-            for (int i = 0; i < newArgs.Length; i++)
-            {
-                newArgs[i] = args[i + 1];
-            }
-            return newArgs;
-        }
-
         public override int Run(InterpretedFrame frame)
         {
             int first = frame.StackIndex - _argumentCount;
-            object[] args = new object[_argumentCount];
-            for (int i = 0; i < args.Length; i++)
+
+            object ret;
+            if (_target.IsStatic)
             {
-                args[i] = frame.Data[first + i];
+                var args = GetArgs(frame, first, 0);
+                try
+                {
+                    ret = _target.Invoke(null, args);
+                }
+                catch (TargetInvocationException e)
+                {
+                    throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
+                }
+            }
+            else
+            {
+                var instance = frame.Data[first];
+                NullCheck(instance);
+
+                var args = GetArgs(frame, first, 1);
+
+                LightLambda targetLambda;
+                if (TryGetLightLambdaTarget(instance, out targetLambda))
+                {
+                    // no need to Invoke, just interpret the lambda body
+                    ret = InterpretLambdaInvoke(targetLambda, args);
+                }
+                else
+                {
+                    try
+                    {
+                        ret = _target.Invoke(instance, args);
+                    }
+                    catch (TargetInvocationException e)
+                    {
+                        throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
+                    }
+                }
             }
 
-            object ret = Invoke(args);
             if (_target.ReturnType != typeof(void))
             {
                 frame.Data[first] = ret;
@@ -435,22 +376,39 @@ namespace System.Linq.Expressions.Interpreter
             {
                 frame.StackIndex = first;
             }
+
             return 1;
+        }
+
+        protected object[] GetArgs(InterpretedFrame frame, int first, int skip)
+        {
+            var count = _argumentCount - skip;
+
+            if (count > 0)
+            {
+                var args = new object[count];
+
+                for (int i = 0; i < args.Length; i++)
+                {
+                    args[i] = frame.Data[first + i + skip];
+                }
+
+                return args;
+            }
+            else
+            {
+                return Array.Empty<object>();
+            }
         }
     }
 
-    internal partial class ByRefMethodInfoCallInstruction : CallInstruction
+    internal class ByRefMethodInfoCallInstruction : MethodInfoCallInstruction
     {
         private readonly ByRefUpdater[] _byrefArgs;
-        private readonly MethodInfo _target;
-        private readonly int _argumentCount;
-
-        public override int ArgumentCount { get { return _argumentCount; } }
 
         internal ByRefMethodInfoCallInstruction(MethodInfo target, int argumentCount, ByRefUpdater[] byrefArgs)
+            : base(target, argumentCount)
         {
-            _target = target;
-            _argumentCount = argumentCount;
             _byrefArgs = byrefArgs;
         }
 
@@ -461,16 +419,13 @@ namespace System.Linq.Expressions.Interpreter
             int first = frame.StackIndex - _argumentCount;
             object[] args = null;
             object instance = null;
+
             try
             {
                 object ret;
                 if (_target.IsStatic)
                 {
-                    args = new object[_argumentCount];
-                    for (int i = 0; i < args.Length; i++)
-                    {
-                        args[i] = frame.Data[first + i];
-                    }
+                    args = GetArgs(frame, first, 0);
                     try
                     {
                         ret = _target.Invoke(null, args);
@@ -482,13 +437,10 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    args = new object[_argumentCount - 1];
-                    for (int i = 0; i < args.Length; i++)
-                    {
-                        args[i] = frame.Data[first + i + 1];
-                    }
-
                     instance = frame.Data[first];
+                    NullCheck(instance);
+
+                    args = GetArgs(frame, first, 1);
 
                     LightLambda targetLambda;
                     if (TryGetLightLambdaTarget(instance, out targetLambda))
@@ -500,7 +452,6 @@ namespace System.Linq.Expressions.Interpreter
                     {
                         try
                         {
-                            NullCheck(instance);
                             ret = _target.Invoke(instance, args);
                         }
                         catch (TargetInvocationException e)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -857,12 +857,22 @@ namespace System.Linq.Expressions.Interpreter
 
         public void EmitNew(ConstructorInfo constructorInfo)
         {
-            Emit(new NewInstruction(constructorInfo));
+            EmitNew(constructorInfo, constructorInfo.GetParameters());
+        }
+
+        public void EmitNew(ConstructorInfo constructorInfo, ParameterInfo[] parameters)
+        {
+            Emit(new NewInstruction(constructorInfo, parameters.Length));
         }
 
         public void EmitByRefNew(ConstructorInfo constructorInfo, ByRefUpdater[] updaters)
         {
-            Emit(new ByRefNewInstruction(constructorInfo, updaters));
+            EmitByRefNew(constructorInfo, constructorInfo.GetParameters(), updaters);
+        }
+
+        public void EmitByRefNew(ConstructorInfo constructorInfo, ParameterInfo[] parameters, ByRefUpdater[] updaters)
+        {
+            Emit(new ByRefNewInstruction(constructorInfo, parameters.Length, updaters));
         }
 
         internal void EmitCreateDelegate(LightDelegateCreator creator)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2400,11 +2400,11 @@ namespace System.Linq.Expressions.Interpreter
 
                 if (updaters != null)
                 {
-                    _instructions.EmitByRefNew(node.Constructor, updaters.ToArray());
+                    _instructions.EmitByRefNew(node.Constructor, parameters, updaters.ToArray());
                 }
                 else
                 {
-                    _instructions.EmitNew(node.Constructor);
+                    _instructions.EmitNew(node.Constructor, parameters);
                 }
             }
             else


### PR DESCRIPTION
This addresses the low hanging fruit described in #10520. See the issue for a report on performance improvements.