### PR TITLE
Update SNI package used for testing SqlClient

### DIFF
--- a/pkg/ExternalPackages/versions.props
+++ b/pkg/ExternalPackages/versions.props
@@ -8,13 +8,16 @@
     <ExternalPackage Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
     </ExternalPackage>
-    <ExternalPackage Include="runtime.win10-amd64.runtime.native.System.IO.Compression">
+    <ExternalPackage Include="runtime.win10-arm64.runtime.native.System.Data.SqlClient.sni">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
     </ExternalPackage>
-    <ExternalPackage Include="runtime.win10-arm.runtime.native.System.IO.Compression">
+    <ExternalPackage Include="runtime.win10-amd64-aot.runtime.native.System.IO.Compression">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
     </ExternalPackage>
-    <ExternalPackage Include="runtime.win10-x86.runtime.native.System.IO.Compression">
+    <ExternalPackage Include="runtime.win10-arm-aot.runtime.native.System.IO.Compression">
+      <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
+    </ExternalPackage>
+    <ExternalPackage Include="runtime.win10-x86-aot.runtime.native.System.IO.Compression">
       <Version>4.0.1-$(ExternalExpectedPrerelease)</Version>
     </ExternalPackage>
   </ItemGroup>

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.CSharp": "4.0.2-beta-24418-01",
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24418-01",
+    "runtime.native.System.Data.SqlClient.sni": "4.0.2-beta-24418-01",
     "System.Data.Common": "4.1.1-beta-24418-01",
     "System.Data.SqlClient": "4.1.1-beta-24418-01",
     "System.Text.Encoding.CodePages": "4.0.2-beta-24418-01",


### PR DESCRIPTION
The sqlclient src package uses the last stable version of the runtime sni package, so I updated the hard-coded SNI versions used in testing to be the latest prerelease version. This way we're actually testing the latest SNI version that we're publishing. I also updated the ExternalPackages props to be correct for clrcompression and updated them for the new SNI package.

@jhendrixMSFT @chcosta 