### PR TITLE
Fix for Issue#10155 & #10217

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -268,7 +268,11 @@ namespace System.Runtime.Serialization
             set { _helper.UnderlyingType = value; }
         }
 
-        public Type OriginalUnderlyingType { get; set; }
+        public Type OriginalUnderlyingType
+        {
+            [SecuritySafeCritical]
+            get { return _helper.OriginalUnderlyingType; }
+        }
 
         public virtual bool IsBuiltInDataContract
         {
@@ -522,6 +526,7 @@ namespace System.Runtime.Serialization
             private static object s_clrTypeStringsLock = new object();
 
             private Type _underlyingType;
+            Type _originalUnderlyingType;
             private bool _isReference;
             private bool _isValueType;
             private XmlQualifiedName _stableName;
@@ -760,6 +765,16 @@ namespace System.Runtime.Serialization
                 return type;
             }
 
+            // Maps adapted types back to the original type
+            // Any change to this method should be reflected in GetDataContractAdapterType
+            internal static Type GetDataContractOriginalType(Type type)
+            {
+                if (type == Globals.TypeOfDateTimeOffsetAdapter)
+                {
+                    return Globals.TypeOfDateTimeOffset;
+                }
+                return type;
+            }
             private static RuntimeTypeHandle GetDataContractAdapterTypeHandle(RuntimeTypeHandle typeHandle)
             {
                 if (Globals.TypeOfDateTimeOffset.TypeHandle.Equals(typeHandle))
@@ -1061,6 +1076,17 @@ namespace System.Runtime.Serialization
                 set { _underlyingType = value; }
             }
 
+            internal Type OriginalUnderlyingType
+            {
+                get
+                {
+                    if (this._originalUnderlyingType == null)
+                    {
+                        this._originalUnderlyingType = GetDataContractOriginalType(this._underlyingType);
+                    }
+                    return this._originalUnderlyingType;
+                }
+            }
             internal virtual bool IsBuiltInDataContract
             {
                 get

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -270,7 +270,6 @@ namespace System.Runtime.Serialization
 
         public Type OriginalUnderlyingType
         {
-            [SecuritySafeCritical]
             get { return _helper.OriginalUnderlyingType; }
         }
 
@@ -526,7 +525,7 @@ namespace System.Runtime.Serialization
             private static object s_clrTypeStringsLock = new object();
 
             private Type _underlyingType;
-            Type _originalUnderlyingType;
+            private Type _originalUnderlyingType;
             private bool _isReference;
             private bool _isValueType;
             private XmlQualifiedName _stableName;
@@ -1080,11 +1079,11 @@ namespace System.Runtime.Serialization
             {
                 get
                 {
-                    if (this._originalUnderlyingType == null)
+                    if (_originalUnderlyingType == null)
                     {
-                        this._originalUnderlyingType = GetDataContractOriginalType(this._underlyingType);
+                        _originalUnderlyingType = GetDataContractOriginalType(this._underlyingType);
                     }
-                    return this._originalUnderlyingType;
+                    return _originalUnderlyingType;
                 }
             }
             internal virtual bool IsBuiltInDataContract

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerWriteContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerWriteContext.cs
@@ -621,20 +621,20 @@ namespace System.Runtime.Serialization
 
         protected virtual bool WriteTypeInfo(XmlWriterDelegator writer, DataContract contract, DataContract declaredContract)
         {
-            if (XmlObjectSerializer.IsContractDeclared(contract, declaredContract))
+            if (!XmlObjectSerializer.IsContractDeclared(contract, declaredContract))
             {
-                return false;
+                if (DataContractResolver == null)
+                {
+                    WriteTypeInfo(writer, contract.Name, contract.Namespace);
+                    return true;
+                }
+                else
+                {
+                    WriteResolvedTypeInfo(writer, contract.OriginalUnderlyingType, declaredContract.OriginalUnderlyingType);
+                    return false;
+                }
             }
-            bool hasResolver = DataContractResolver != null;
-            if (hasResolver)
-            {
-                WriteResolvedTypeInfo(writer, contract.UnderlyingType, declaredContract.UnderlyingType);
-            }
-            else
-            {
-                WriteTypeInfo(writer, contract.Name, contract.Namespace);
-            }
-            return hasResolver;
+            return false;
         }
 
         protected virtual void WriteTypeInfo(XmlWriterDelegator writer, string dataContractName, string dataContractNamespace)


### PR DESCRIPTION
Fix two issues.

Fix #10155.  When serialize a object with unknown type, if the serializer contains a DataContractResolver, it will end up with SerializationException. However, no exception thrown from Desktop Version. This is because, in core version, it always verify knowtype if there's resolver. Change the code to match the desktop version. 

Fix #10217. When serialize a object with DateTimeOffset property, the OriginalUnderlyType of DataContract is always DateTimeOffsetAgent type, which should be DateTimeOffset based on Desktop version. This is because it is missing GetDataContractOriginalType method in DataContractCriticalHelper.


@shmao @mconnew @zhenlan 