### PR TITLE
Adding the SqlClient Stress Test execution engine

### DIFF
--- a/src/System.Data.SqlClient/System.Data.SqlClient.sln
+++ b/src/System.Data.SqlClient/System.Data.SqlClient.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SqlClient", "src\System.Data.SqlClient.csproj", "{D4550556-4745-457F-BA8F-3EBF3836D6B4}"
 EndProject
@@ -9,6 +9,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SqlClient.Tests", "tests\FunctionalTests\System.Data.SqlClient.Tests.csproj", "{F3E72F35-0351-4D67-9388-725BCAD807BA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SqlClient.ManualTesting.Tests", "tests\ManualTests\System.Data.SqlClient.ManualTesting.Tests.csproj", "{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "stresstest", "tests\stress\StressTest\stresstest.csproj", "{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -52,6 +54,18 @@ Global
 		{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Unix_Release|Any CPU.Build.0 = Unix_Release|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/IMonitorLoader.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/IMonitorLoader.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Monitoring;
+
+namespace Monitoring
+{
+    public interface IMonitorLoader
+    {
+        string HostMachine { get; set; }
+        string AssemblyPath { get; set; }
+        string TestName { get; set; }
+        bool Enabled { get; set; }
+
+        void Action(MonitorLoaderUtils.MonitorAction monitoraction);
+        void AddPerfData(MonitorMetrics data);
+        Dictionary<string, MonitorMetrics> GetPerfData();
+    }
+
+    public class MonitorLoaderUtils
+    {
+        public enum MonitorAction
+        {
+            Initialize,
+            Start,
+            Stop,
+            DoNothing
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/IMonitorLoader.csproj
+++ b/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/IMonitorLoader.csproj
@@ -1,0 +1,16 @@
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{AF78BA88-6428-47EA-8682-442DAF8E9656}</ProjectGuid>
+    <RootNamespace>Monitoring</RootNamespace>
+    <AssemblyName>Monitoring</AssemblyName>
+    <OutputType>Library</OutputType>
+    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="IMonitorLoader.cs" />
+    <Compile Include="MonitorMetrics.cs" />
+  </ItemGroup>
+  <!--Import the targets-->
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/MonitorMetrics.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/MonitorMetrics.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Monitoring
+{
+    public class MonitorMetrics
+    {
+        private string _name;
+        private string _strValue;
+        private string _unit;
+        private bool _isPrimary;
+        private bool _isHigherBetter;
+        private double _dblValue;
+        private long _lngValue;
+        private char _valueType; // D=double, L=long, S=String
+
+        public MonitorMetrics(string name, string value, string unit, bool HigherIsBetter, bool Primary)
+        {
+            _name = name;
+            _strValue = value;
+            _unit = unit;
+            _valueType = 'S';
+            _isHigherBetter = HigherIsBetter;
+            _isPrimary = Primary;
+        }
+
+        public MonitorMetrics(string name, double value, string unit, bool HigherIsBetter, bool Primary)
+        {
+            _name = name;
+            _dblValue = value;
+            _unit = unit;
+            _valueType = 'D';
+            _isHigherBetter = HigherIsBetter;
+            _isPrimary = Primary;
+        }
+
+        public MonitorMetrics(string name, long value, string unit, bool HigherIsBetter, bool Primary)
+        {
+            _name = name;
+            _lngValue = value;
+            _unit = unit;
+            _valueType = 'L';
+            _isHigherBetter = HigherIsBetter;
+            _isPrimary = Primary;
+        }
+
+        public string GetName()
+        {
+            return _name;
+        }
+
+        public string GetUnit()
+        {
+            return _unit;
+        }
+
+        public bool GetPrimary()
+        {
+            return _isPrimary;
+        }
+
+        public bool GetHigherIsBetter()
+        {
+            return _isHigherBetter;
+        }
+
+        public char GetValueType()
+        {
+            return _valueType;
+        }
+
+        public string GetStringValue()
+        {
+            if (_valueType == 'S')
+                return _strValue;
+            throw new Exception("Value is not a string");
+        }
+
+        public double GetDoubleValue()
+        {
+            if (_valueType == 'D')
+                return _dblValue;
+            throw new Exception("Value is not a double");
+        }
+
+        public long GetLongValue()
+        {
+            if (_valueType == 'L')
+                return _lngValue;
+            throw new Exception("Value is not a long");
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/project.json
+++ b/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/project.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.2-beta-24416-03",
+    "System.Collections": "4.0.12-beta-24416-03"
+  },
+  "frameworks": {
+    "netstandard1.3": {}
+  }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/Constants.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/Constants.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DPStressHarness
+{
+    public static class Constants
+    {
+        public const string XML_ELEM_RESULTS = "PerfResults";
+        public const string XML_ELEM_RUN = "Run";
+        public const string XML_ELEM_RUN_METRIC = "RunMetric";
+        public const string XML_ELEM_TEST = "Test";
+        public const string XML_ELEM_TEST_METRIC = "TestMetric";
+        public const string XML_ELEM_EXCEPTION = "Exception";
+
+        public const string XML_ATTR_RUN_LABEL = "label";
+        public const string XML_ATTR_RUN_START_TIME = "startTime";
+        public const string XML_ATTR_RUN_OFFICIAL = "official";
+        public const string XML_ATTR_RUN_MILESTONE = "milestone";
+        public const string XML_ATTR_RUN_BRANCH = "branch";
+        public const string XML_ATTR_RUN_UPLOADED = "uploaded";
+        public const string XML_ATTR_RUN_METRIC_NAME = "name";
+        public const string XML_ATTR_TEST_NAME = "name";
+        public const string XML_ATTR_TEST_METRIC_NAME = "name";
+        public const string XML_ATTR_TEST_METRIC_UNITS = "units";
+        public const string XML_ATTR_TEST_METRIC_ISHIGHERBETTER = "isHigherBetter";
+
+        public const string XML_ATTR_VALUE_TRUE = "true";
+        public const string XML_ATTR_VALUE_FALSE = "false";
+
+        public const string RUN_METRIC_PROCESSOR_COUNT = "Processor Count";
+        public const string RUN_DNS_HOST_NAME = "DNS Host Name";
+        public const string RUN_IDENTITY_NAME = "Identity Name";
+        public const string RUN_PROCESS_MACHINE_NAME = "Process Machine Name";
+
+        public const string TEST_METRIC_TEST_ASSEMBLY = "Test Assembly";
+        public const string TEST_METRIC_TEST_IMPROVEMENT = "Improvement";
+        public const string TEST_METRIC_TEST_OWNER = "Owner";
+        public const string TEST_METRIC_TEST_CATEGORY = "Category";
+        public const string TEST_METRIC_TEST_PRIORITY = "Priority";
+        public const string TEST_METRIC_APPLICATION_NAME = "Application Name";
+        public const string TEST_METRIC_TARGET_ASSEMBLY_NAME = "Target Assembly Name";
+        public const string TEST_METRIC_ELAPSED_SECONDS = "Elapsed Seconds";
+        public const string TEST_METRIC_RPS = "Requests Per Second";
+        public const string TEST_METRIC_PEAK_WORKING_SET = "Peak Working Set";
+        public const string TEST_METRIC_WORKING_SET = "Working Set";
+        public const string TEST_METRIC_PRIVATE_BYTES = "Private Bytes";
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/DeadlockDetection.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/DeadlockDetection.cs
@@ -1,0 +1,192 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DPStressHarness
+{
+    public class DeadlockDetection
+    {
+        /// <summary>
+        /// Information for a thread relating to deadlock detection. All of its information is stored in a reference object to make updating it easier.
+        /// </summary>
+        private class ThreadInfo
+        {
+            public ThreadInfo(long dueTime)
+            {
+                this.DueTime = dueTime;
+            }
+
+            /// <summary>
+            /// The time (in ticks) when the thread should be completed
+            /// </summary>
+            public long DueTime;
+
+            /// <summary>
+            /// True if the thread should not be aborted
+            /// </summary>
+            public bool DisableAbort;
+
+            /// <summary>
+            /// The time when DisableAbort was set to true
+            /// </summary>
+            public long DisableAbortTime;
+        }
+
+        /// <summary>
+        /// Maximum time that a test thread (i.e. a thread that is directly executing a [StressTest] method) can
+        /// execute before it is considered to be deadlocked. This should be longer than the 
+        /// TaskThreadDeadlockTimeoutTicks because if the test is waiting for a task then the test will always
+        /// take longer to execute than the task.
+        /// </summary>
+        public const long TestThreadDeadlockTimeoutTicks = 20 * 60 * TimeSpan.TicksPerSecond;
+
+        /// <summary>
+        /// Maximum time that any Task can execute before it is considered to be deadlocked
+        /// </summary>
+        public const long TaskThreadDeadlockTimeoutTicks = 10 * 60 * TimeSpan.TicksPerSecond;
+
+        /// <summary>
+        /// Dictionary that maps Threads to the time (in ticks) when they should be completed. If they are not completed by that time then
+        /// they are considered to be deadlocked.
+        /// </summary>
+        private static ConcurrentDictionary<Thread, ThreadInfo> s_threadDueTimes = null;
+
+        /// <summary>
+        /// Timer that scans through _threadDueTimes to find deadlocked threads
+        /// </summary>
+        private static Timer s_deadlockWatchdog = null;
+
+        /// <summary>
+        /// Interval of _deadlockWatchdog, in milliseconds
+        /// </summary>
+        private const int _watchdogIntervalMs = 60 * 1000;
+
+        /// <summary>
+        /// true if deadlock detection is enabled, otherwise false. Should be set only at process startup.
+        /// </summary>
+        private static bool s_isEnabled = false;
+
+        /// <summary>
+        /// Enables deadlock detection.
+        /// </summary>
+        public static void Enable()
+        {
+            // Switch out the default TaskScheduler. We must use reflection because it is private.
+            FieldInfo defaultTaskScheduler = typeof(TaskScheduler).GetField("s_defaultTaskScheduler", BindingFlags.NonPublic | BindingFlags.Static);
+            DeadlockDetectionTaskScheduler newTaskScheduler = new DeadlockDetectionTaskScheduler();
+            defaultTaskScheduler.SetValue(null, newTaskScheduler);
+
+            s_threadDueTimes = new ConcurrentDictionary<Thread, ThreadInfo>();
+            s_deadlockWatchdog = new Timer(CheckForDeadlocks, null, _watchdogIntervalMs, _watchdogIntervalMs);
+
+            s_isEnabled = true;
+        }
+
+        /// <summary>
+        /// Adds the current Task execution thread to the tracked thread collection.
+        /// </summary>
+        public static void AddTaskThread()
+        {
+            if (s_isEnabled)
+            {
+                long dueTime = DateTime.UtcNow.Ticks + TaskThreadDeadlockTimeoutTicks;
+                AddThread(dueTime);
+            }
+        }
+
+        /// <summary>
+        /// Adds the current Test execution thread (i.e. a thread that is directly executing a [StressTest] method) to the tracked thread collection.
+        /// </summary>
+        public static void AddTestThread()
+        {
+            if (s_isEnabled)
+            {
+                long dueTime = DateTime.UtcNow.Ticks + TestThreadDeadlockTimeoutTicks;
+                AddThread(dueTime);
+            }
+        }
+
+        private static void AddThread(long dueTime)
+        {
+            s_threadDueTimes.TryAdd(Thread.CurrentThread, new ThreadInfo(dueTime));
+        }
+
+        /// <summary>
+        /// Removes the current thread from the tracked thread collection
+        /// </summary>
+        public static void RemoveThread()
+        {
+            if (s_isEnabled)
+            {
+                ThreadInfo unused;
+                s_threadDueTimes.TryRemove(Thread.CurrentThread, out unused);
+            }
+        }
+
+        /// <summary>
+        /// Disables abort of current thread. Call this when the current thread is waiting on a task.
+        /// </summary>
+        public static void DisableThreadAbort()
+        {
+            if (s_isEnabled)
+            {
+                ThreadInfo threadInfo;
+                if (s_threadDueTimes.TryGetValue(Thread.CurrentThread, out threadInfo))
+                {
+                    threadInfo.DisableAbort = true;
+                    threadInfo.DisableAbortTime = DateTime.UtcNow.Ticks;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Enables abort of current thread after calling DisableThreadAbort(). The elapsed time since calling DisableThreadAbort() is added to the due time.
+        /// </summary>
+        public static void EnableThreadAbort()
+        {
+            if (s_isEnabled)
+            {
+                ThreadInfo threadInfo;
+                if (s_threadDueTimes.TryGetValue(Thread.CurrentThread, out threadInfo))
+                {
+                    threadInfo.DueTime += DateTime.UtcNow.Ticks - threadInfo.DisableAbortTime;
+                    threadInfo.DisableAbort = false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Looks through the tracked thread collection and aborts any thread that is past its due time
+        /// </summary>
+        /// <param name="state">unused</param>
+        private static void CheckForDeadlocks(object state)
+        {
+            if (s_isEnabled)
+            {
+                long now = DateTime.UtcNow.Ticks;
+
+                // Find candidate threads
+                foreach (var threadDuePair in s_threadDueTimes)
+                {
+                    if (!threadDuePair.Value.DisableAbort && now > threadDuePair.Value.DueTime)
+                    {
+                        // Abort the misbehaving thread and the return
+                        // NOTE: We only want to abort a single thread at a time to allow the other thread in the deadlock pair to continue
+                        Thread t = threadDuePair.Key;
+                        Console.WriteLine("Deadlock detected on thread with managed thread id {0}", t.ManagedThreadId);
+                        Debugger.Break();
+                        t.Join();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/DeadlockDetectionTaskScheduler.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/DeadlockDetectionTaskScheduler.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DPStressHarness
+{
+    public class DeadlockDetectionTaskScheduler : TaskScheduler
+    {
+        private readonly WaitCallback _runTaskCallback;
+        private readonly ParameterizedThreadStart _runTaskThreadStart;
+#if DEBUG
+        private readonly ConcurrentDictionary<Task, object> _queuedItems = new ConcurrentDictionary<Task, object>();
+#endif
+
+        public DeadlockDetectionTaskScheduler()
+        {
+            _runTaskCallback = new WaitCallback(RunTask);
+            _runTaskThreadStart = new ParameterizedThreadStart(RunTask);
+        }
+
+        // This is only used for debugging, so for retail we'd prefer the perf
+        protected override IEnumerable<Task> GetScheduledTasks()
+        {
+#if DEBUG
+            return _queuedItems.Keys;
+#else
+            return new Task[0];
+#endif
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            if ((task.CreationOptions & TaskCreationOptions.LongRunning) == TaskCreationOptions.LongRunning)
+            {
+                // Create a new background thread for long running tasks
+                Thread thread = new Thread(_runTaskThreadStart) { IsBackground = true };
+                thread.Start(task);
+            }
+            else
+            {
+                // Otherwise queue the work on the threadpool
+#if DEBUG
+                _queuedItems.TryAdd(task, null);
+#endif
+
+                ThreadPool.QueueUserWorkItem(_runTaskCallback, task);
+            }
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            if (!taskWasPreviouslyQueued)
+            {
+                // Run the task inline
+                RunTask(task);
+                return true;
+            }
+
+            // Couldn't run the task
+            return false;
+        }
+
+        private void RunTask(object state)
+        {
+            Task inTask = state as Task;
+
+#if DEBUG
+            // Remove from the dictionary of queued items
+            object ignored;
+            _queuedItems.TryRemove(inTask, out ignored);
+#endif
+
+            // Note when the thread started work
+            DeadlockDetection.AddTaskThread();
+
+            try
+            {
+                // Run the task
+                base.TryExecuteTask(inTask);
+            }
+            finally
+            {
+                // Remove the thread from the list when complete
+                DeadlockDetection.RemoveThread();
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/FakeConsole.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/FakeConsole.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DPStressHarness
+{
+    public static class FakeConsole
+    {
+        public static void Write(string value)
+        {
+#if DEBUG
+            Console.Write(value);
+#endif
+        }
+
+        public static void WriteLine(string value)
+        {
+#if DEBUG
+            Console.WriteLine(value);
+#endif
+        }
+
+        public static void WriteLine(string format, params object[] arg)
+        {
+#if DEBUG
+            Console.WriteLine(format, arg);
+#endif
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/GlobalExceptionHandlerAttribute.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/GlobalExceptionHandlerAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace DPStressHarness
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
+    public class GlobalExceptionHandlerAttribute : Attribute
+    {
+        public GlobalExceptionHandlerAttribute()
+        {
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/GlobalTestCleanupAttribute.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/GlobalTestCleanupAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace DPStressHarness
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
+    public class GlobalTestCleanupAttribute : Attribute
+    {
+        public GlobalTestCleanupAttribute()
+        {
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/GlobalTestSetupAttribute.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/GlobalTestSetupAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace DPStressHarness
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
+    public class GlobalTestSetupAttribute : Attribute
+    {
+        public GlobalTestSetupAttribute()
+        {
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/ITestAttributeFilter.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/ITestAttributeFilter.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace DPStressHarness
+{
+    public interface ITestAttributeFilter
+    {
+        bool MatchFilter(string filterString);
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/Logger.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/Logger.cs
@@ -1,0 +1,227 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Xml;
+using System.Diagnostics;
+
+namespace DPStressHarness
+{
+    public class Logger
+    {
+        private const string _resultDocumentName = "perfout.xml";
+
+        private XmlDocument _doc;
+        private XmlElement _runElem;
+        private XmlElement _testElem;
+
+        public Logger(string runLabel, bool isOfficial, string milestone, string branch)
+        {
+            _doc = GetTestResultDocument();
+
+            _runElem = GetRunElement(_doc, runLabel, DateTime.Now.ToString(), isOfficial, milestone, branch);
+
+            Process currentProcess = Process.GetCurrentProcess();
+            AddRunMetric(Constants.RUN_PROCESS_MACHINE_NAME, currentProcess.MachineName);
+            AddRunMetric(Constants.RUN_DNS_HOST_NAME, System.Net.Dns.GetHostName());
+            AddRunMetric(Constants.RUN_IDENTITY_NAME, System.Security.Principal.WindowsIdentity.GetCurrent().Name);
+            AddRunMetric(Constants.RUN_METRIC_PROCESSOR_COUNT, Environment.ProcessorCount.ToString());
+
+        }
+
+        public void AddRunMetric(string metricName, string metricValue)
+        {
+            Debug.Assert(_runElem != null);
+
+            if (metricValue.Equals(String.Empty))
+                return;
+
+            AddRunMetricElement(_runElem, metricName, metricValue);
+        }
+
+        public void AddTest(string testName)
+        {
+            Debug.Assert(_runElem != null);
+
+            _testElem = AddTestElement(_runElem, testName);
+        }
+
+        public void AddTestMetric(string metricName, string metricValue, string metricUnits)
+        {
+            AddTestMetric(metricName, metricValue, metricUnits, null);
+        }
+
+        public void AddTestMetric(string metricName, string metricValue, string metricUnits, bool? isHigherBetter)
+        {
+            Debug.Assert(_runElem != null);
+            Debug.Assert(_testElem != null);
+
+            if (metricValue.Equals(String.Empty))
+                return;
+
+            AddTestMetricElement(_testElem, metricName, metricValue, metricUnits, isHigherBetter);
+        }
+
+        public void AddTestException(string exceptionData)
+        {
+            Debug.Assert(_runElem != null);
+            Debug.Assert(_testElem != null);
+
+            AddTestExceptionElement(_testElem, exceptionData);
+        }
+
+        public void Save()
+        {
+            FileStream resultDocumentStream = new FileStream(_resultDocumentName, FileMode.Create);
+            _doc.Save(resultDocumentStream);
+            resultDocumentStream.Dispose();
+        }
+
+        private static XmlDocument GetTestResultDocument()
+        {
+            if (File.Exists(_resultDocumentName))
+            {
+                XmlDocument doc = new XmlDocument();
+                FileStream resultDocumentStream = new FileStream(_resultDocumentName, FileMode.Open, FileAccess.Read);
+                doc.Load(resultDocumentStream);
+                resultDocumentStream.Dispose();
+                return doc;
+            }
+            else
+            {
+                XmlDocument doc = new XmlDocument();
+                doc.LoadXml("<?xml version=\"1.0\" encoding=\"utf-8\" ?><PerfResults></PerfResults>");
+                FileStream resultDocumentStream = new FileStream(_resultDocumentName, FileMode.CreateNew);
+                doc.Save(resultDocumentStream);
+                resultDocumentStream.Dispose();
+                return doc;
+            }
+        }
+
+
+        private static XmlElement GetRunElement(XmlDocument doc, string label, string startTime, bool isOfficial, string milestone, string branch)
+        {
+            foreach (XmlNode node in doc.DocumentElement.ChildNodes)
+            {
+                if (node.NodeType == XmlNodeType.Element &&
+                     node.Name.Equals(Constants.XML_ELEM_RUN) &&
+                     ((XmlElement)node).GetAttribute(Constants.XML_ATTR_RUN_LABEL).Equals(label))
+                {
+                    return (XmlElement)node;
+                }
+            }
+
+            XmlElement runElement = doc.CreateElement(Constants.XML_ELEM_RUN);
+
+            XmlAttribute attrLabel = doc.CreateAttribute(Constants.XML_ATTR_RUN_LABEL);
+            attrLabel.Value = label;
+            runElement.Attributes.Append(attrLabel);
+
+            XmlAttribute attrStartTime = doc.CreateAttribute(Constants.XML_ATTR_RUN_START_TIME);
+            attrStartTime.Value = startTime;
+            runElement.Attributes.Append(attrStartTime);
+
+            XmlAttribute attrOfficial = doc.CreateAttribute(Constants.XML_ATTR_RUN_OFFICIAL);
+            attrOfficial.Value = isOfficial.ToString();
+            runElement.Attributes.Append(attrOfficial);
+
+            if (milestone != null)
+            {
+                XmlAttribute attrMilestone = doc.CreateAttribute(Constants.XML_ATTR_RUN_MILESTONE);
+                attrMilestone.Value = milestone;
+                runElement.Attributes.Append(attrMilestone);
+            }
+
+            if (branch != null)
+            {
+                XmlAttribute attrBranch = doc.CreateAttribute(Constants.XML_ATTR_RUN_BRANCH);
+                attrBranch.Value = branch;
+                runElement.Attributes.Append(attrBranch);
+            }
+
+            doc.DocumentElement.AppendChild(runElement);
+
+            return runElement;
+        }
+
+
+        private static void AddRunMetricElement(XmlElement runElement, string name, string value)
+        {
+            // First check and make sure the metric hasn't already been added.
+            // If it has, it's from a previous test in the same run, so just return.
+            foreach (XmlNode node in runElement.ChildNodes)
+            {
+                if (node.NodeType == XmlNodeType.Element && node.Name.Equals(Constants.XML_ELEM_RUN_METRIC))
+                {
+                    if (node.Attributes[Constants.XML_ATTR_RUN_METRIC_NAME].Value.Equals(name))
+                        return;
+                }
+            }
+
+            XmlElement runMetricElement = runElement.OwnerDocument.CreateElement(Constants.XML_ELEM_RUN_METRIC);
+
+            XmlAttribute attrName = runElement.OwnerDocument.CreateAttribute(Constants.XML_ATTR_RUN_METRIC_NAME);
+            attrName.Value = name;
+            runMetricElement.Attributes.Append(attrName);
+
+            XmlText nodeValue = runElement.OwnerDocument.CreateTextNode(value);
+            runMetricElement.AppendChild(nodeValue);
+
+            runElement.AppendChild(runMetricElement);
+        }
+
+
+        private static XmlElement AddTestElement(XmlElement runElement, string name)
+        {
+            XmlElement testElement = runElement.OwnerDocument.CreateElement(Constants.XML_ELEM_TEST);
+
+            XmlAttribute attrName = runElement.OwnerDocument.CreateAttribute(Constants.XML_ATTR_TEST_NAME);
+            attrName.Value = name;
+            testElement.Attributes.Append(attrName);
+
+            runElement.AppendChild(testElement);
+
+            return testElement;
+        }
+
+
+        private static void AddTestMetricElement(XmlElement testElement, string name, string value, string units, bool? isHigherBetter)
+        {
+            XmlElement testMetricElement = testElement.OwnerDocument.CreateElement(Constants.XML_ELEM_TEST_METRIC);
+
+            XmlAttribute attrName = testElement.OwnerDocument.CreateAttribute(Constants.XML_ATTR_TEST_METRIC_NAME);
+            attrName.Value = name;
+            testMetricElement.Attributes.Append(attrName);
+
+            if (units != null)
+            {
+                XmlAttribute attrUnits = testElement.OwnerDocument.CreateAttribute(Constants.XML_ATTR_TEST_METRIC_UNITS);
+                attrUnits.Value = units;
+                testMetricElement.Attributes.Append(attrUnits);
+            }
+
+            if (isHigherBetter.HasValue)
+            {
+                XmlAttribute attrIsHigherBetter = testElement.OwnerDocument.CreateAttribute(Constants.XML_ATTR_TEST_METRIC_ISHIGHERBETTER);
+                attrIsHigherBetter.Value = isHigherBetter.ToString();
+                testMetricElement.Attributes.Append(attrIsHigherBetter);
+            }
+
+            XmlText nodeValue = testElement.OwnerDocument.CreateTextNode(value);
+            testMetricElement.AppendChild(nodeValue);
+
+            testElement.AppendChild(testMetricElement);
+        }
+
+        private static void AddTestExceptionElement(XmlElement testElement, string exceptionData)
+        {
+            XmlElement testFailureElement = testElement.OwnerDocument.CreateElement(Constants.XML_ELEM_EXCEPTION);
+            XmlText txtNode = testFailureElement.OwnerDocument.CreateTextNode(exceptionData);
+            testFailureElement.AppendChild(txtNode);
+
+            testElement.AppendChild(testFailureElement);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/MemApi.Unix.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/MemApi.Unix.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace DPStressHarness
+{
+    internal static class MemApi
+    {
+        public static IntPtr GetCurrentProcess()
+        {
+            return IntPtr.Zero;
+        }
+
+        public static bool SetProcessWorkingSetSize(IntPtr hProcess, int dwMinimumWorkingSetSize, int dwMaximumWorkingSetSize)
+        {
+            return true;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/MemApi.Windows.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/MemApi.Windows.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace DPStressHarness
+{
+    static class MemApi
+    {
+#pragma warning disable BCL0015 // Invalid Pinvoke call
+        [DllImport("KERNEL32")]
+        public static extern IntPtr GetCurrentProcess();
+#pragma warning restore BCL0015 // Invalid Pinvoke call
+
+#pragma warning disable BCL0015 // Invalid Pinvoke call
+        [DllImport("KERNEL32")]
+        public static extern bool SetProcessWorkingSetSize(IntPtr hProcess, int dwMinimumWorkingSetSize, int dwMaximumWorkingSetSize);
+#pragma warning restore BCL0015 // Invalid Pinvoke call
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/MonitorLoadUtils.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/MonitorLoadUtils.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Monitoring;
+using System.Reflection;
+
+namespace DPStressHarness
+{
+    public static class MonitorLoader
+    {
+        public static IMonitorLoader LoadMonitorLoaderAssembly()
+
+        {
+            IMonitorLoader monitorloader = null;
+            const string classname = "Monitoring.MonitorLoader";
+            const string interfacename = "IMonitorLoader";
+            Assembly mainAssembly = typeof(Monitoring.IMonitorLoader).GetTypeInfo().Assembly;
+
+            Type t = mainAssembly.GetType(classname);
+            //make sure the the type is derived from IMonitorLoader
+            Type[] interfaces = t.GetInterfaces();
+            bool derivedFromIMonitorLoader = false;
+            if (interfaces != null)
+            {
+                foreach (Type intrface in interfaces)
+                {
+                    if (intrface.Name == interfacename)
+                    {
+                        derivedFromIMonitorLoader = true;
+                    }
+                }
+            }
+            if (derivedFromIMonitorLoader)
+
+            {
+                monitorloader = (IMonitorLoader)Activator.CreateInstance(t);
+
+                monitorloader.AssemblyPath = mainAssembly.FullName;
+            }
+            else
+            {
+                throw new Exception("The specified assembly does not implement " + interfacename + "!!");
+            }
+            return monitorloader;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/MultithreadedTest.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/MultithreadedTest.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Diagnostics;
+using System.Threading;
+
+namespace DPStressHarness
+{
+    internal class MultiThreadedTest : TestBase
+    {
+        private MultiThreadedTestAttribute _attr;
+        public static bool _continue;
+        public static int _threadsRunning;
+        public static int _rps;
+        public static Exception _firstException = null;
+
+        private struct TestInfo
+        {
+            public object _instance;
+            public TestMethodDelegate _delegateTest;
+        }
+
+        public MultiThreadedTest(MultiThreadedTestAttribute attr,
+                                 MethodInfo testMethodInfo,
+                                 Type type,
+                                 List<MethodInfo> setupMethods,
+                                 List<MethodInfo> cleanupMethods)
+            : base(attr, testMethodInfo, type, setupMethods, cleanupMethods)
+
+        {
+            _attr = attr;
+        }
+
+        public override void Run()
+        {
+            try
+            {
+                Stopwatch timer = new Stopwatch();
+                long warmupDuration = (long)_attr.WarmupDuration * Stopwatch.Frequency;
+                long testDuration = (long)_attr.TestDuration * Stopwatch.Frequency;
+                int threads = _attr.Threads;
+
+                TestInfo[] info = new TestInfo[threads];
+                ConstructorInfo targetConstructor = _type.GetConstructor(Type.EmptyTypes);
+
+                for (int i = 0; i < threads; i++)
+                {
+                    info[i] = new TestInfo();
+                    info[i]._instance = targetConstructor.Invoke(null);
+                    info[i]._delegateTest = CreateTestMethodDelegate();
+
+                    SetVariations(info[i]._instance);
+                    ExecuteSetupPhase(info[i]._instance);
+                }
+
+                _firstException = null;
+                _continue = true;
+                _rps = 0;
+
+                for (int i = 0; i < threads; i++)
+                {
+                    Interlocked.Increment(ref _threadsRunning);
+                    Thread t = new Thread(new ParameterizedThreadStart(MultiThreadedTest.RunThread));
+                    t.Start(info[i]);
+                }
+
+                timer.Reset();
+                timer.Start();
+
+                while (timer.ElapsedTicks < warmupDuration)
+                {
+                    Thread.Sleep(1000);
+                }
+
+                int warmupRequests = Interlocked.Exchange(ref _rps, 0);
+                timer.Reset();
+                timer.Start();
+                TestMetrics.StartCollection();
+
+                while (timer.ElapsedTicks < testDuration)
+                {
+                    Thread.Sleep(1000);
+                }
+
+                int requests = Interlocked.Exchange(ref _rps, 0);
+                double elapsedSeconds = timer.ElapsedTicks / Stopwatch.Frequency;
+                TestMetrics.StopCollection();
+                _continue = false;
+
+                while (_threadsRunning > 0)
+                {
+                    Thread.Sleep(1000);
+                }
+
+                for (int i = 0; i < threads; i++)
+                {
+                    ExecuteCleanupPhase(info[i]._instance);
+                }
+
+                double rps = (double)requests / elapsedSeconds;
+
+                if (_firstException == null)
+                {
+                    LogTest(rps);
+                }
+                else
+                {
+                    LogTestFailure(_firstException.ToString());
+                }
+            }
+            catch (TargetInvocationException e)
+            {
+                LogTestFailure(e.InnerException.ToString());
+            }
+            catch (Exception e)
+            {
+                LogTestFailure(e.ToString());
+            }
+        }
+
+
+        public static void RunThread(Object state)
+        {
+            try
+            {
+                while (_continue)
+                {
+                    TestInfo info = (TestInfo)state;
+                    info._delegateTest(info._instance);
+                    Interlocked.Increment(ref _rps);
+                }
+            }
+            catch (Exception e)
+            {
+                if (_firstException == null)
+                {
+                    _firstException = e;
+                }
+                _continue = false;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _threadsRunning);
+            }
+        }
+
+        protected void LogTest(double rps)
+        {
+            Logger logger = new Logger(TestMetrics.RunLabel, TestMetrics.IsOfficial, TestMetrics.Milestone, TestMetrics.Branch);
+            logger.AddTest(this.Title);
+
+            LogStandardMetrics(logger);
+
+            logger.AddTestMetric(Constants.TEST_METRIC_RPS, String.Format("{0:F2}", rps), "rps", true);
+
+            logger.Save();
+
+            Console.WriteLine("{0}: Requests per Second={1:F2}, Working Set={2}, Peak Working Set={3}, Private Bytes={4}",
+                              this.Title,
+                              rps,
+                              TestMetrics.WorkingSet,
+                              TestMetrics.PeakWorkingSet,
+                              TestMetrics.PrivateBytes);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/PerfCounters.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/PerfCounters.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace DPStressHarness
+{
+    public class PerfCounters
+    {
+        private long _requestsCounter;
+        //private long rpsCounter;
+
+        private long _exceptionsCounter;
+        //private long epsCounter;
+
+        public PerfCounters()
+        {
+
+        }
+
+        public void IncrementRequestsCounter()
+        {
+            _requestsCounter++;
+        }
+
+        public void IncrementExceptionsCounter()
+        {
+            _exceptionsCounter++;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/Program.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/Program.cs
@@ -1,0 +1,277 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Text;
+using System.Reflection;
+
+
+namespace DPStressHarness
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Init(args);
+            Run();
+        }
+        public enum RunMode
+        {
+            RunAll,
+            RunVerify,
+            Help,
+            ExitWithError
+        };
+
+        private static RunMode s_mode = RunMode.RunAll;
+        private static IEnumerable<TestBase> s_tests;
+        private static StressEngine s_eng;
+        private static string s_error;
+
+
+        public static void Init(string[] args)
+        {
+            for (int i = 0; i < args.Length; i++)
+            {
+                switch (args[i])
+                {
+                    case "-a":
+                        string assemblyName = args[++i];
+                        TestFinder.AssemblyName = new AssemblyName(assemblyName);
+                        break;
+
+                    case "-all":
+                        s_mode = RunMode.RunAll;
+                        break;
+
+                    case "-override":
+                        TestMetrics.Overrides.Add(args[++i], args[++i]);
+                        break;
+
+                    case "-variation":
+                        TestMetrics.Variations.Add(args[++i]);
+                        break;
+
+                    case "-test":
+                        TestMetrics.SelectedTests.Add(args[++i]);
+                        break;
+
+                    case "-duration":
+                        TestMetrics.StressDuration = Int32.Parse(args[++i]);
+                        break;
+
+                    case "-threads":
+                        TestMetrics.StressThreads = Int32.Parse(args[++i]);
+                        break;
+
+                    case "-verify":
+                        s_mode = RunMode.RunVerify;
+                        break;
+
+                    case "-debug":
+                        if (System.Diagnostics.Debugger.IsAttached)
+                        {
+                            System.Diagnostics.Debugger.Break();
+                        }
+                        else
+                        {
+                            Console.WriteLine("Current PID: {0}, attach the debugger and press Enter to continue the execution...", System.Diagnostics.Process.GetCurrentProcess().Id);
+                            Console.ReadLine();
+                        }
+                        break;
+
+                    case "-exceptionThreshold":
+                        TestMetrics.ExceptionThreshold = Int32.Parse(args[++i]);
+                        break;
+
+                    case "-monitorenabled":
+                        TestMetrics.MonitorEnabled = bool.Parse(args[++i]);
+                        break;
+
+                    case "-randomSeed":
+                        TestMetrics.RandomSeed = Int32.Parse(args[++i]);
+                        break;
+
+                    case "-filter":
+                        TestMetrics.Filter = args[++i];
+                        break;
+
+                    case "-printMethodName":
+                        TestMetrics.PrintMethodName = true;
+                        break;
+
+                    case "-deadlockdetection":
+                        if (bool.Parse(args[++i]))
+                        {
+                            DeadlockDetection.Enable();
+                        }
+                        break;
+
+                    default:
+                        s_mode = RunMode.Help;
+                        break;
+                }
+            }
+
+            if (TestFinder.AssemblyName != null)
+            {
+                Console.WriteLine("Assembly Found for the Assembly Name " + TestFinder.AssemblyName);
+                
+                if (TestFinder.AssemblyName != null)
+                {
+                    // get and load all the tests
+                    s_tests = TestFinder.GetTests(Assembly.Load(TestFinder.AssemblyName));
+
+                    // instantiate the stress engine
+                    s_eng = new StressEngine(TestMetrics.StressThreads, TestMetrics.StressDuration, s_tests, TestMetrics.RandomSeed);
+                }
+                else
+                {
+                    Program.s_error = string.Format("Assembly {0} cannot be found.", TestFinder.AssemblyName);
+                    s_mode = RunMode.ExitWithError;
+                }
+            }
+        }
+
+        public static void TestCase(Assembly assembly,
+                                    RunMode mode,
+                                    int duration,
+                                    int threads,
+                                    int? exceptionThreshold = null,
+                                    bool printMethodName = false,
+                                    bool deadlockDetection = false,
+                                    int randomSeed = 0,
+                                    string[] selectedTests = null,
+                                    string[] overrides = null,
+                                    string[] variations = null,
+                                    string filter = null,
+                                    bool monitorEnabled = false,
+                                    string monitorMachineName = "localhost")
+        {
+            TestMetrics.Reset();
+            TestFinder.AssemblyName = assembly.GetName();
+            mode = RunMode.RunAll;
+
+            for (int i = 0; overrides != null && i < overrides.Length; i++)
+            {
+                TestMetrics.Overrides.Add(overrides[i], overrides[++i]);
+            }
+
+            for (int i = 0; variations != null && i < variations.Length; i++)
+            {
+                TestMetrics.Variations.Add(variations[i]);
+            }
+
+            for (int i = 0; selectedTests != null && i < selectedTests.Length; i++)
+            {
+                TestMetrics.SelectedTests.Add(selectedTests[i]);
+            }
+
+            TestMetrics.StressDuration = duration;
+            TestMetrics.StressThreads = threads;
+            TestMetrics.ExceptionThreshold = exceptionThreshold;
+            TestMetrics.MonitorEnabled = monitorEnabled;
+            TestMetrics.MonitorMachineName = monitorMachineName;
+            TestMetrics.RandomSeed = randomSeed;
+            TestMetrics.Filter = filter;
+            TestMetrics.PrintMethodName = printMethodName;
+
+            if (deadlockDetection)
+            {
+                DeadlockDetection.Enable();
+            }
+
+            // get and load all the tests
+            s_tests = TestFinder.GetTests(assembly);
+
+            // instantiate the stress engine
+            s_eng = new StressEngine(TestMetrics.StressThreads, TestMetrics.StressDuration, s_tests, TestMetrics.RandomSeed);
+        }
+
+        public static void Run()
+        {
+            if (TestFinder.AssemblyName == null)
+            {
+                s_mode = RunMode.Help;
+            }
+            switch (s_mode)
+            {
+                case RunMode.RunAll:
+                    RunStress();
+                    break;
+
+                case RunMode.RunVerify:
+                    RunVerify();
+                    break;
+
+                case RunMode.ExitWithError:
+                    ExitWithError();
+                    break;
+
+                case RunMode.Help:
+                    PrintHelp();
+                    break;
+            }
+        }
+
+        static private void PrintHelp()
+        {
+            Console.WriteLine("stresstest.exe [-a <module name>] <arguments>");
+            Console.WriteLine();
+            Console.WriteLine("   -a <module name> should specify path to the assembly containing the tests.");
+            Console.WriteLine();
+            Console.WriteLine("Supported options are:");
+            Console.WriteLine();
+            Console.WriteLine("   -all                        Run all tests - best for debugging, not perf measurements.");
+            Console.WriteLine();
+            Console.WriteLine("   -verify                     Run in functional verification mode.");
+            Console.WriteLine();
+            Console.WriteLine("   -duration <n>               Duration of the test in seconds.");
+            Console.WriteLine();
+            Console.WriteLine("   -threads <n>                Number of threads to use.");
+            Console.WriteLine();
+            Console.WriteLine("   -override <name> <value>    Override the value of a test property.");
+            Console.WriteLine();
+            Console.WriteLine("   -test <name>                Run specific test(s) using their name.");
+            Console.WriteLine();
+            Console.WriteLine("   -debug                      Print process ID in the beginning and wait for Enter (to give your time to attach the debugger).");
+            Console.WriteLine();
+            Console.WriteLine("   -exceptionThreshold <n>     An optional limit on exceptions which will be caught. When reached, test will halt.");
+            Console.WriteLine();
+            Console.WriteLine("   -monitorenabled             True or False to enable monitoring. Default is false");
+            Console.WriteLine();
+            Console.WriteLine("   -randomSeed                 Enables setting of the random number generator used internally.  This serves both the purpose");
+            Console.WriteLine("                               of helping to improve reproducibility and making it deterministic from Chess's perspective");
+            Console.WriteLine("                               for a given schedule. Default is " + TestMetrics.RandomSeed + ".");
+            Console.WriteLine();
+            Console.WriteLine("   -filter                     Run tests whose stress test attributes match the given filter. Filter is not applied if attribute");
+            Console.WriteLine("                               does not implement ITestAttributeFilter. Example: -filter TestType=Query,Update;IsServerTest=True ");
+            Console.WriteLine();
+            Console.WriteLine("   -printMethodName            Print tests' title in console window");
+            Console.WriteLine();
+            Console.WriteLine("   -deadlockdetection          True or False to enable deadlock detection. Default is false");
+            Console.WriteLine();
+        }
+
+        static private int ExitWithError()
+        {
+            Environment.FailFast("Exit with error(s).");
+            return 1;
+        }
+
+        static private int RunVerify()
+        {
+            throw new NotImplementedException();
+        }
+
+        static private int RunStress()
+        {
+            return s_eng.Run();
+        }
+    }
+
+}
+

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/RecordedExceptions.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/RecordedExceptions.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+
+namespace DPStressHarness
+{
+    public class RecordedExceptions
+    {
+        // Reference wrapper around an integer which is used in order to make updating a little easier & more efficient
+        public class ExceptionCount
+        {
+            public int Count = 0;
+        }
+
+        private ConcurrentDictionary<string, ConcurrentDictionary<string, ExceptionCount>> _exceptions = new ConcurrentDictionary<string, ConcurrentDictionary<string, ExceptionCount>>();
+
+        /// <summary>
+        /// Records an exception and returns true if the threshold is exceeded for that exception
+        /// </summary>
+        public bool Record(string testName, Exception ex)
+        {
+            // Converting from exception to string can be expensive so only do it once and cache the string
+            string exceptionString = ex.ToString();
+            TraceException(testName, exceptionString);
+
+            // Get the exceptions for the current test case
+            ConcurrentDictionary<string, ExceptionCount> exceptionsForTest = _exceptions.GetOrAdd(testName, _ => new ConcurrentDictionary<string, ExceptionCount>());
+
+            // Get the count for the current exception
+            ExceptionCount exCount = exceptionsForTest.GetOrAdd(exceptionString, _ => new ExceptionCount());
+
+            // Increment the count
+            Interlocked.Increment(ref exCount.Count);
+
+            // If the count is over the threshold, return true
+            return TestMetrics.ExceptionThreshold.HasValue && (exCount.Count > TestMetrics.ExceptionThreshold);
+        }
+
+        private void TraceException(string testName, string exceptionString)
+        {
+            StringBuilder status = new StringBuilder();
+            status.AppendLine("========================================================================");
+            status.AppendLine("Exception Report");
+            status.AppendLine("========================================================================");
+
+            status.AppendLine(string.Format("Test: {0}", testName));
+            status.AppendLine(exceptionString);
+
+            status.AppendLine("========================================================================");
+            status.AppendLine("End of Exception Report");
+            status.AppendLine("========================================================================");
+            Trace.WriteLine(status.ToString());
+        }
+
+        public void TraceAllExceptions()
+        {
+            StringBuilder status = new StringBuilder();
+            status.AppendLine("========================================================================");
+            status.AppendLine("All Exceptions Report");
+            status.AppendLine("========================================================================");
+
+            foreach (string testName in _exceptions.Keys)
+            {
+                ConcurrentDictionary<string, ExceptionCount> exceptionsForTest = _exceptions[testName];
+
+                status.AppendLine(string.Format("Test: {0}", testName));
+                foreach (var exceptionString in exceptionsForTest.Keys)
+                {
+                    status.AppendLine(string.Format("Count: {0}", exceptionsForTest[exceptionString].Count));
+                    status.AppendLine(string.Format("Exception: {0}", exceptionString));
+                    status.AppendLine();
+                }
+
+                status.AppendLine();
+                status.AppendLine();
+            }
+
+            status.AppendLine("========================================================================");
+            status.AppendLine("End of All Exceptions Report");
+            status.AppendLine("========================================================================");
+            Trace.WriteLine(status.ToString());
+        }
+
+        public int GetExceptionsCount()
+        {
+            int count = 0;
+
+            foreach (string testName in _exceptions.Keys)
+            {
+                ConcurrentDictionary<string, ExceptionCount> exceptionsForTest = _exceptions[testName];
+
+                foreach (var exceptionString in exceptionsForTest.Keys)
+                {
+                    count += exceptionsForTest[exceptionString].Count;
+                }
+            }
+
+            return count;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/SqlScript.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/SqlScript.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.Text.RegularExpressions;
+
+namespace DPStressHarness
+{
+    /// <summary>
+    /// Use SqlScript.Execute to run sql scripts prior to test execution.
+    /// Recommended practice is to store the sql scripts as a resource in your dll (if it's complicated),
+    /// or just as a string in your assembly.
+    /// </summary>
+    public static class SqlScript
+    {
+        public static void Execute(string script, string connectionString)
+        {
+            //script = Regex.Replace(script, @"/\*((?!\*/)(.|\n)*?)\*/", "", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+
+            //Regex re = new Regex(@"(?<GO>^GO)|(?<COMMAND>((?!^GO)(.|\n))+)", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
+
+            //MatchCollection matches = re.Matches(script);
+
+            //foreach (Match m in matches)
+            //{
+            //    Console.WriteLine(m.Groups["GO"]);
+            //    Console.WriteLine(m.Groups["COMMAND"]);
+            //}
+
+            //Console.WriteLine();
+
+
+            SqlConnection conn = new SqlConnection(connectionString);
+            conn.Open();
+
+            try
+            {
+                script = Regex.Replace(script, @"/\*((?!\*/)(.|\n)*?)\*/", "", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+
+                Regex re = new Regex(@"(?<GO>^GO)|(?<COMMAND>((?!^GO)(.|\n))+)", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
+                MatchCollection matches = re.Matches(script);
+
+                foreach (Match m in matches)
+                {
+                    string cmdText = m.Groups["COMMAND"].Value.Trim();
+
+                    if (cmdText == String.Empty)
+                        continue;
+
+                    SqlCommand cmd = new SqlCommand(cmdText, conn);
+                    cmd.CommandTimeout = 300;
+                    cmd.ExecuteNonQuery();
+                }
+            }
+            finally
+            {
+                conn.Close();
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/StressEngine.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/StressEngine.cs
@@ -1,0 +1,209 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Diagnostics;
+using Monitoring;
+
+namespace DPStressHarness
+{
+    public class StressEngine
+    {
+        private Random _rnd;
+        private int _threads;
+        private int _duration;
+        private int _threadsRunning;
+        private bool _continue;
+        private List<StressTest> _allTests;
+        private RecordedExceptions _exceptions = new RecordedExceptions();
+        private PerfCounters _perfcounters = null;
+        private static long s_globalRequestsCounter = 0;
+
+        public StressEngine(int threads, int duration, IEnumerable<TestBase> allTests, int seed)
+        {
+            if (seed != 0)
+            {
+                _rnd = new Random(seed);
+            }
+            else
+            {
+                Random rndBootstrap = new Random();
+
+                seed = rndBootstrap.Next();
+
+                _rnd = new Random(seed);
+            }
+
+            Console.WriteLine("Seeding stress engine random number generator with {0}\n", seed);
+
+
+            _threads = threads;
+            _duration = duration;
+            _allTests = new List<StressTest>();
+
+            List<StressTest> tmpWeightedLookup = new List<StressTest>();
+
+            foreach (TestBase t in allTests)
+            {
+                if (t is StressTest)
+                {
+                    _allTests.Add(t as StressTest);
+                }
+            }
+
+            try
+            {
+                _perfcounters = new PerfCounters();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Warning: An error ocurred initializing performance counters. Performance counters can only be initialized when running with Administrator privileges. Error Message: " + e.Message);
+            }
+        }
+
+        public int Run()
+        {
+            TraceListener listener = new TextWriterTraceListener(Console.Out);
+            Trace.Listeners.Add(listener);
+            Trace.UseGlobalLock = true;
+
+            _threadsRunning = 0;
+            _continue = true;
+
+            if (_allTests.Count == 0)
+            {
+                throw new ArgumentException("The specified assembly doesn't contain any tests to run. Test methods must be decorated with a Test, StressTest, MultiThreadedTest, or ThreadPoolTest attribute.");
+            }
+
+            // Run any global setup
+            StressTest firstStressTest = _allTests.Find(t => t is StressTest);
+            if (null != firstStressTest)
+            {
+                firstStressTest.RunGlobalSetup();
+            }
+
+            //Monitoring Start
+            IMonitorLoader _monitorloader = null;
+            if (TestMetrics.MonitorEnabled)
+            {
+                _monitorloader = MonitorLoader.LoadMonitorLoaderAssembly();
+                if (_monitorloader != null)
+                {
+                    _monitorloader.Enabled = TestMetrics.MonitorEnabled;
+                    _monitorloader.HostMachine = TestMetrics.MonitorMachineName;
+                    _monitorloader.TestName = firstStressTest.Title;
+                    _monitorloader.Action(MonitorLoaderUtils.MonitorAction.Start);
+                }
+            }
+
+            for (int i = 0; i < _threads; i++)
+            {
+                Interlocked.Increment(ref _threadsRunning);
+                Thread t = new Thread(new ThreadStart(this.RunStressThread));
+                t.Start();
+            }
+
+            while (_threadsRunning > 0)
+            {
+                Thread.Sleep(1000);
+            }
+
+            //Monitoring Stop
+            if (TestMetrics.MonitorEnabled)
+            {
+                if (_monitorloader != null)
+                    _monitorloader.Action(MonitorLoaderUtils.MonitorAction.Stop);
+            }
+
+            // Run any global cleanup
+            if (null != firstStressTest)
+            {
+                firstStressTest.RunGlobalCleanup();
+            }
+
+            // Write out all exceptions
+            _exceptions.TraceAllExceptions();
+            return _exceptions.GetExceptionsCount();
+        }
+
+
+        public void RunStressThread()
+        {
+            try
+            {
+                StressTest[] tests = new StressTest[_allTests.Count];
+                List<int> tmpWeightedLookup = new List<int>();
+
+                for (int i = 0; i < tests.Length; i++)
+                {
+                    tests[i] = _allTests[i].Clone();
+                    tests[i].RunSetup();
+
+                    for (int j = 0; j < tests[i].Weight; j++)
+                    {
+                        tmpWeightedLookup.Add(i);
+                    }
+                }
+
+                int[] weightedLookup = tmpWeightedLookup.ToArray();
+
+                Stopwatch timer = new Stopwatch();
+                long testDuration = (long)_duration * Stopwatch.Frequency;
+
+                timer.Reset();
+                timer.Start();
+
+                while (_continue && timer.ElapsedTicks < testDuration)
+                {
+                    int n = _rnd.Next(0, weightedLookup.Length);
+                    StressTest t = tests[weightedLookup[n]];
+
+                    if (TestMetrics.PrintMethodName)
+                    {
+                        FakeConsole.WriteLine("{0}: {1}", ++s_globalRequestsCounter, t.Title);
+                    }
+
+                    try
+                    {
+                        DeadlockDetection.AddTestThread();
+                        t.Run();
+                        if (_perfcounters != null)
+                            _perfcounters.IncrementRequestsCounter();
+                    }
+                    catch (Exception e)
+                    {
+                        if (_perfcounters != null)
+                            _perfcounters.IncrementExceptionsCounter();
+
+                        t.HandleException(e);
+
+                        bool thresholdExceeded = _exceptions.Record(t.Title, e);
+                        if (thresholdExceeded)
+                        {
+                            FakeConsole.WriteLine("Exception Threshold of {0} has been exceeded on {1} - Halting!\n",
+                                TestMetrics.ExceptionThreshold, t.Title);
+                            break;
+                        }
+                    }
+                    finally
+                    {
+                        DeadlockDetection.RemoveThread();
+                    }
+                }
+
+                foreach (StressTest t in tests)
+                {
+                    t.RunCleanup();
+                }
+            }
+            finally
+            {
+                _continue = false;
+                Interlocked.Decrement(ref _threadsRunning);
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/StressTest.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/StressTest.cs
@@ -1,0 +1,155 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace DPStressHarness
+{
+    internal class StressTest : TestBase
+    {
+        private StressTestAttribute _attr;
+        private object _targetInstance;
+        private TestMethodDelegate _tmd;
+
+        // TODO: MethodInfo objects below can have associated delegates to improve
+        // runtime performance.
+        protected MethodInfo _globalSetupMethod;
+        protected MethodInfo _globalCleanupMethod;
+
+        public delegate void ExceptionHandler(Exception e);
+
+        /// <summary>
+        /// Cache the global exception handler method reference. It is
+        /// recommended not to actually use this reference to call the
+        /// method. Use the delegate instead.
+        /// </summary>
+        protected MethodInfo _globalExceptionHandlerMethod;
+
+        /// <summary>
+        /// Create a delegate to call global exception handler method.
+        /// Use this delegate to call test assembly's exception handler.
+        /// </summary>
+        protected ExceptionHandler _globalExceptionHandlerDelegate;
+
+        public StressTest(StressTestAttribute attr,
+                    MethodInfo testMethodInfo,
+                    MethodInfo globalSetupMethod,
+                    MethodInfo globalCleanupMethod,
+                    Type type,
+                    List<MethodInfo> setupMethods,
+                    List<MethodInfo> cleanupMethods,
+                    MethodInfo globalExceptionHandlerMethod)
+            : base(attr, testMethodInfo, type, setupMethods, cleanupMethods)
+        {
+            _attr = attr;
+            _globalSetupMethod = globalSetupMethod;
+            _globalCleanupMethod = globalCleanupMethod;
+            _globalExceptionHandlerMethod = globalExceptionHandlerMethod;
+        }
+
+        public StressTest Clone()
+        {
+            StressTest t = new StressTest(_attr, this._testMethod, this._globalSetupMethod, this._globalCleanupMethod, this._type, this._setupMethods, this._cleanupMethods, this._globalExceptionHandlerMethod);
+            return t;
+        }
+
+        private void InitTargetInstance()
+        {
+            _targetInstance = _type.GetConstructor(Type.EmptyTypes).Invoke(null);
+
+            // Create a delegate for exception handling on _targetInstance
+            if (_globalExceptionHandlerMethod != null)
+            {
+                _globalExceptionHandlerDelegate = (ExceptionHandler)_globalExceptionHandlerMethod.CreateDelegate(
+                    typeof(ExceptionHandler),
+                    _targetInstance
+                    );
+            }
+        }
+
+        /// <summary>
+        /// Perform any global initialization for the test assembly. For example, make the connection to the database, load a workspace, etc.
+        /// </summary>
+        public void RunGlobalSetup()
+        {
+            if (null == _targetInstance)
+            {
+                InitTargetInstance();
+            }
+
+            if (null != _globalSetupMethod)
+            {
+                _globalSetupMethod.Invoke(_targetInstance, null);
+            }
+        }
+
+        /// <summary>
+        /// Run any per-thread setup needed
+        /// </summary>
+        public void RunSetup()
+        {
+            // create an instance of the class that defines the test method.
+            if (null == _targetInstance)
+            {
+                InitTargetInstance();
+            }
+            _tmd = CreateTestMethodDelegate();
+
+            // Set variation fields on the target instance
+            SetVariations(_targetInstance);
+
+            // Execute the setup phase for this thread.
+            ExecuteSetupPhase(_targetInstance);
+        }
+
+        /// <summary>
+        /// Execute the test method(s)
+        /// </summary>
+        public override void Run()
+        {
+            _tmd(_targetInstance);
+        }
+
+        /// <summary>
+        /// Provide an opportunity to handle the exception
+        /// </summary>
+        /// <param name="e"></param>
+        public void HandleException(Exception e)
+        {
+            if (null != _globalExceptionHandlerDelegate)
+            {
+                _globalExceptionHandlerDelegate(e);
+            }
+        }
+
+        /// <summary>
+        /// Run any per-thread cleanup for the test
+        /// </summary>
+        public void RunCleanup()
+        {
+            ExecuteCleanupPhase(_targetInstance);
+        }
+
+        /// <summary>
+        /// Run final global cleanup for the test assembly. Could be used to release resources or for reporting, etc.
+        /// </summary>
+        public void RunGlobalCleanup()
+        {
+            if (null != _globalCleanupMethod)
+            {
+                _globalCleanupMethod.Invoke(_targetInstance, null);
+            }
+        }
+
+        public int Weight
+        {
+            get { return _attr.Weight; }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/System.Data.StressRunner.csproj
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/System.Data.StressRunner.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}</ProjectGuid>
+    <RootNamespace>DPStressHarness</RootNamespace>
+    <AssemblyName>System.Data.StressRunner</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\IMonitorLoader\IMonitorLoader.csproj" />
+  </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
+    <Compile Include="MemApi.Unix.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
+    <Compile Include="MemApi.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DeadlockDetection.cs" />
+    <Compile Include="DeadlockDetectionTaskScheduler.cs" />
+    <Compile Include="ITestAttributeFilter.cs" />
+    <Compile Include="MonitorLoadUtils.cs" />
+    <Compile Include="Constants.cs" />
+    <Compile Include="FakeConsole.cs" />
+    <Compile Include="GlobalTestCleanupAttribute.cs" />
+    <Compile Include="GlobalTestSetupAttribute.cs" />
+    <Compile Include="GlobalExceptionHandlerAttribute.cs" />
+    <Compile Include="Logger.cs" />
+    <Compile Include="MultithreadedTest.cs" />
+    <Compile Include="PerfCounters.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="RecordedExceptions.cs" />
+    <Compile Include="SqlScript.cs" />
+    <Compile Include="StressEngine.cs" />
+    <Compile Include="StressTest.cs" />
+    <Compile Include="Test.cs" />
+    <Compile Include="TestAttribute.cs" />
+    <Compile Include="TestBase.cs" />
+    <Compile Include="TestCleanupAttribute.cs" />
+    <Compile Include="TestFinder.cs" />
+    <Compile Include="TestMetrics.cs" />
+    <Compile Include="TestSetupAttribute.cs" />
+    <Compile Include="TestVariationAttribute.cs" />
+    <Compile Include="ThreadPoolTest.cs" />
+    <Compile Include="VersionUtil.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <!--Import the targets-->
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/Test.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/Test.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+
+namespace DPStressHarness
+{
+    internal class Test : TestBase
+    {
+        private TestAttribute _attr;
+        private int _overrideIterations = -1;
+        private int _overrideWarmup = -1;
+
+        public Test(TestAttribute attr,
+                    MethodInfo testMethodInfo,
+                    Type type,
+                    List<MethodInfo> setupMethods,
+                    List<MethodInfo> cleanupMethods)
+            : base(attr, testMethodInfo, type, setupMethods, cleanupMethods)
+        {
+            _attr = attr;
+        }
+
+
+        public override void Run()
+        {
+            try
+            {
+                // create an instance of the class that defines the test method.
+                object targetInstance = _type.GetConstructor(Type.EmptyTypes).Invoke(null);
+
+                SetVariations(targetInstance);
+
+                ExecuteSetupPhase(targetInstance);
+
+                TestMethodDelegate tmd = CreateTestMethodDelegate();
+
+                ExecuteTest(targetInstance, tmd);
+
+                ExecuteCleanupPhase(targetInstance);
+
+                LogTest();
+            }
+            catch (TargetInvocationException e)
+            {
+                LogTestFailure(e.InnerException.ToString());
+            }
+            catch (Exception e)
+            {
+                LogTestFailure(e.ToString());
+            }
+        }
+
+        protected void LogTest()
+        {
+            Logger logger = new Logger(TestMetrics.RunLabel, TestMetrics.IsOfficial, TestMetrics.Milestone, TestMetrics.Branch);
+            logger.AddTest(this.Title);
+
+            LogStandardMetrics(logger);
+
+            logger.AddTestMetric(Constants.TEST_METRIC_ELAPSED_SECONDS, String.Format("{0:F2}", TestMetrics.ElapsedSeconds), "sec", false);
+
+            logger.Save();
+
+            Console.WriteLine("{0}: Elapsed Seconds={1:F2}, Working Set={2}, Peak Working Set={3}, Private Bytes={4}",
+                              this.Title,
+                              TestMetrics.ElapsedSeconds,
+                              TestMetrics.WorkingSet,
+                              TestMetrics.PeakWorkingSet,
+                              TestMetrics.PrivateBytes);
+        }
+
+
+        private void ExecuteTest(Object targetInstance, TestMethodDelegate tmd)
+        {
+            int warmupIterations = _attr.WarmupIterations;
+            int testIterations = _attr.TestIterations;
+
+            if (_overrideIterations >= 0)
+            {
+                testIterations = _overrideIterations;
+            }
+            if (_overrideWarmup >= 0)
+            {
+                warmupIterations = _overrideWarmup;
+            }
+
+            /** do some cleanup to make memory tests more accurate **/
+            System.GC.Collect();
+            System.GC.WaitForPendingFinalizers();
+            System.GC.Collect();
+
+            IntPtr h = MemApi.GetCurrentProcess();
+            bool fRes = MemApi.SetProcessWorkingSetSize(h, -1, -1);
+            /****/
+
+            System.Threading.Thread.Sleep(10000);
+
+            for (int i = 0; i < warmupIterations; i++)
+            {
+                tmd(targetInstance);
+            }
+
+            TestMetrics.StartCollection();
+            for (int i = 0; i < testIterations; i++)
+            {
+                tmd(targetInstance);
+            }
+            TestMetrics.StopCollection();
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestAttribute.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestAttribute.cs
@@ -1,0 +1,272 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace DPStressHarness
+{
+    public enum TestPriority
+    {
+        BVT = 0,
+        High = 1,
+        Medium = 2,
+        Low = 3
+    }
+
+    public class TestAttributeBase : Attribute
+    {
+        private string _title;
+        private string _description = "none provided";
+        private string _applicationName = "unknown";
+        private string _improvement = "ADONETV3";
+        private string _owner = "unknown";
+        private string _category = "unknown";
+        private TestPriority _priority = TestPriority.BVT;
+
+        public TestAttributeBase(string title)
+        {
+            _title = title;
+        }
+
+        public string Title
+        {
+            get { return _title; }
+            set { _title = value; }
+        }
+
+        public string Description
+        {
+            get { return _description; }
+            set { _description = value; }
+        }
+
+        public string Improvement
+        {
+            get { return _improvement; }
+            set { _improvement = value; }
+        }
+
+        public string Owner
+        {
+            get { return _owner; }
+            set { _owner = value; }
+        }
+
+        public string ApplicationName
+        {
+            get { return _applicationName; }
+            set { _applicationName = value; }
+        }
+
+        public TestPriority Priority
+        {
+            get { return _priority; }
+            set { _priority = value; }
+        }
+
+        public string Category
+        {
+            get { return _category; }
+            set { _category = value; }
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class TestAttribute : TestAttributeBase
+    {
+        private int _warmupIterations = 0;
+        private int _testIterations = 1;
+
+        public TestAttribute(string title) : base(title)
+        {
+        }
+
+        public int WarmupIterations
+        {
+            get
+            {
+                string propName = "WarmupIterations";
+
+                if (TestMetrics.Overrides.ContainsKey(propName))
+                {
+                    return Int32.Parse(TestMetrics.Overrides[propName]);
+                }
+                else
+                {
+                    return _warmupIterations;
+                }
+            }
+            set { _warmupIterations = value; }
+        }
+
+        public int TestIterations
+        {
+            get
+            {
+                string propName = "TestIterations";
+
+                if (TestMetrics.Overrides.ContainsKey(propName))
+                {
+                    return Int32.Parse(TestMetrics.Overrides[propName]);
+                }
+                else
+                {
+                    return _testIterations;
+                }
+            }
+            set { _testIterations = value; }
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class StressTestAttribute : TestAttributeBase
+    {
+        private int _weight = 1;
+
+        public StressTestAttribute(string title)
+            : base(title)
+        {
+        }
+
+        public int Weight
+        {
+            get { return _weight; }
+            set { _weight = value; }
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class MultiThreadedTestAttribute : TestAttributeBase
+    {
+        private int _warmupDuration = 60;
+        private int _testDuration = 60;
+        private int _threads = 16;
+
+        public MultiThreadedTestAttribute(string title)
+            : base(title)
+        {
+        }
+
+        public int WarmupDuration
+        {
+            get
+            {
+                string propName = "WarmupDuration";
+
+                if (TestMetrics.Overrides.ContainsKey(propName))
+                {
+                    return Int32.Parse(TestMetrics.Overrides[propName]);
+                }
+                else
+                {
+                    return _warmupDuration;
+                }
+            }
+            set { _warmupDuration = value; }
+        }
+
+        public int TestDuration
+        {
+            get
+            {
+                string propName = "TestDuration";
+
+                if (TestMetrics.Overrides.ContainsKey(propName))
+                {
+                    return Int32.Parse(TestMetrics.Overrides[propName]);
+                }
+                else
+                {
+                    return _testDuration;
+                }
+            }
+            set { _testDuration = value; }
+        }
+
+        public int Threads
+        {
+            get
+            {
+                string propName = "Threads";
+
+                if (TestMetrics.Overrides.ContainsKey(propName))
+                {
+                    return Int32.Parse(TestMetrics.Overrides[propName]);
+                }
+                else
+                {
+                    return _threads;
+                }
+            }
+            set { _threads = value; }
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class ThreadPoolTestAttribute : TestAttributeBase
+    {
+        private int _warmupDuration = 60;
+        private int _testDuration = 60;
+        private int _threads = 64;
+
+        public ThreadPoolTestAttribute(string title)
+            : base(title)
+        {
+        }
+
+        public int WarmupDuration
+        {
+            get
+            {
+                string propName = "WarmupDuration";
+
+                if (TestMetrics.Overrides.ContainsKey(propName))
+                {
+                    return Int32.Parse(TestMetrics.Overrides[propName]);
+                }
+                else
+                {
+                    return _warmupDuration;
+                }
+            }
+            set { _warmupDuration = value; }
+        }
+
+        public int TestDuration
+        {
+            get
+            {
+                string propName = "TestDuration";
+
+                if (TestMetrics.Overrides.ContainsKey(propName))
+                {
+                    return Int32.Parse(TestMetrics.Overrides[propName]);
+                }
+                else
+                {
+                    return _testDuration;
+                }
+            }
+            set { _testDuration = value; }
+        }
+
+        public int Threads
+        {
+            get
+            {
+                string propName = "Threads";
+
+                if (TestMetrics.Overrides.ContainsKey(propName))
+                {
+                    return Int32.Parse(TestMetrics.Overrides[propName]);
+                }
+                else
+                {
+                    return _threads;
+                }
+            }
+            set { _threads = value; }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestBase.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestBase.cs
@@ -1,0 +1,173 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace DPStressHarness
+{
+    public abstract class TestBase
+    {
+        private TestAttributeBase _attr;
+        private string _variationSuffix = "";
+
+        [System.CLSCompliantAttribute(false)]
+        protected MethodInfo _testMethod;
+        [System.CLSCompliantAttribute(false)]
+        protected Type _type;
+
+        [System.CLSCompliantAttribute(false)]
+        protected List<MethodInfo> _setupMethods;
+
+        [System.CLSCompliantAttribute(false)]
+        protected List<MethodInfo> _cleanupMethods;
+
+        protected delegate void TestMethodDelegate(object t);
+
+        public TestBase(TestAttributeBase attr,
+                        MethodInfo testMethodInfo,
+                        Type type,
+                        List<MethodInfo> setupMethods,
+                        List<MethodInfo> cleanupMethods)
+        {
+            _attr = attr;
+            _testMethod = testMethodInfo;
+            _type = type;
+            _setupMethods = setupMethods;
+            _cleanupMethods = cleanupMethods;
+        }
+
+        public string Title
+        {
+            get { return _attr.Title + _variationSuffix; }
+        }
+
+        public string Description
+        {
+            get { return _attr.Description; }
+        }
+
+        public string Category
+        {
+            get { return _attr.Category; }
+        }
+
+        public TestPriority Priority
+        {
+            get { return _attr.Priority; }
+        }
+
+        public List<string> GetVariations()
+        {
+            FieldInfo[] fields = _type.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
+
+            List<string> variations = new List<string>(10);
+            foreach (FieldInfo fi in fields)
+            {
+                TestVariationAttribute[] attrs = (TestVariationAttribute[])fi.GetCustomAttributes(typeof(TestVariationAttribute), false);
+
+                foreach (TestVariationAttribute testVarAttr in attrs)
+                {
+                    if (!variations.Contains(testVarAttr.VariationName))
+                    {
+                        variations.Add(testVarAttr.VariationName);
+                    }
+                }
+            }
+
+            return variations;
+        }
+
+        public abstract void Run();
+
+
+        protected void ExecuteSetupPhase(Object targetInstance)
+        {
+            if (_setupMethods != null)
+            {
+                foreach (MethodInfo setupMthd in _setupMethods)
+                {
+                    setupMthd.Invoke(targetInstance, null);
+                }
+            }
+        }
+
+        protected void ExecuteCleanupPhase(Object targetInstance)
+        {
+            if (_cleanupMethods != null)
+            {
+                foreach (MethodInfo cleanupMethod in _cleanupMethods)
+                {
+                    cleanupMethod.Invoke(targetInstance, null);
+                }
+            }
+        }
+
+        protected void SetVariations(Object targetInstance)
+        {
+            FieldInfo[] fields = targetInstance.GetType().GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
+
+            foreach (FieldInfo fi in fields)
+            {
+                TestVariationAttribute[] attrs = (TestVariationAttribute[])fi.GetCustomAttributes(typeof(TestVariationAttribute), false);
+
+                foreach (TestVariationAttribute testVarAttr in attrs)
+                {
+                    foreach (string specifiedVariation in TestMetrics.Variations)
+                    {
+                        if (specifiedVariation.Equals(testVarAttr.VariationName))
+                        {
+                            fi.SetValue(targetInstance, testVarAttr.VariationValue);
+                            _variationSuffix += "_" + testVarAttr.VariationName;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        protected TestMethodDelegate CreateTestMethodDelegate()
+        {
+            Type[] args = { typeof(object) };
+            return new TestMethodDelegate((instance) => _testMethod.Invoke(instance, null));
+        }
+
+
+        protected void LogTestFailure(string exceptionData)
+        {
+            Console.WriteLine("{0}: Failed", this.Title);
+            Console.WriteLine(exceptionData);
+
+            Logger logger = new Logger(TestMetrics.RunLabel, false, TestMetrics.Milestone, TestMetrics.Branch);
+            logger.AddTest(this.Title);
+            logger.AddTestMetric("Test Assembly", _testMethod.Module.FullyQualifiedName, null);
+            logger.AddTestException(exceptionData);
+            logger.Save();
+        }
+
+        protected void LogStandardMetrics(Logger logger)
+        {
+            logger.AddTestMetric(Constants.TEST_METRIC_TEST_ASSEMBLY, _testMethod.Module.FullyQualifiedName, null);
+            logger.AddTestMetric(Constants.TEST_METRIC_TEST_IMPROVEMENT, _attr.Improvement, null);
+            logger.AddTestMetric(Constants.TEST_METRIC_TEST_OWNER, _attr.Owner, null);
+            logger.AddTestMetric(Constants.TEST_METRIC_TEST_CATEGORY, _attr.Category, null);
+            logger.AddTestMetric(Constants.TEST_METRIC_TEST_PRIORITY, _attr.Priority.ToString(), null);
+            logger.AddTestMetric(Constants.TEST_METRIC_APPLICATION_NAME, _attr.Improvement, null);
+
+            if (TestMetrics.TargetAssembly != null)
+            {
+                logger.AddTestMetric(Constants.TEST_METRIC_TARGET_ASSEMBLY_NAME, (new AssemblyName(TestMetrics.TargetAssembly.FullName)).Name, null);
+            }
+
+            logger.AddTestMetric(Constants.TEST_METRIC_PEAK_WORKING_SET, String.Format("{0}", TestMetrics.PeakWorkingSet), "bytes");
+            logger.AddTestMetric(Constants.TEST_METRIC_WORKING_SET, String.Format("{0}", TestMetrics.WorkingSet), "bytes");
+            logger.AddTestMetric(Constants.TEST_METRIC_PRIVATE_BYTES, String.Format("{0}", TestMetrics.PrivateBytes), "bytes");
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestCleanupAttribute.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestCleanupAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace DPStressHarness
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
+    public class TestCleanupAttribute : Attribute
+    {
+        public TestCleanupAttribute()
+        {
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestFinder.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestFinder.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.IO;
+
+namespace DPStressHarness
+{
+    internal class TestFinder
+    {
+        private static AssemblyName s_assemblyName;
+
+        public static AssemblyName AssemblyName
+        {
+            get { return s_assemblyName; }
+            set { s_assemblyName = value; }
+        }
+
+        public static IEnumerable<TestBase> GetTests(Assembly assembly)
+        {
+            List<TestBase> tests = new List<TestBase>();
+
+
+            Type[] typesInModule = null;
+            try
+            {
+                typesInModule = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                Console.WriteLine("ReflectionTypeLoadException Errors");
+                foreach (Exception loadEx in ex.LoaderExceptions)
+                {
+                    Console.WriteLine("\t" + loadEx.Message);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error." + ex.Message);
+            }
+
+            foreach (Type t in typesInModule)
+            {
+                MethodInfo[] methods = t.GetMethods(BindingFlags.Instance | BindingFlags.Public);
+                List<MethodInfo> setupMethods = new List<MethodInfo>();
+                List<MethodInfo> cleanupMethods = new List<MethodInfo>();
+
+                MethodInfo globalSetupMethod = null;
+                MethodInfo globalCleanupMethod = null;
+                MethodInfo globalExceptionHandlerMethod = null;
+
+                foreach (MethodInfo m in methods)
+                {
+                    GlobalTestSetupAttribute[] globalSetupAttributes = (GlobalTestSetupAttribute[])m.GetCustomAttributes(typeof(GlobalTestSetupAttribute), true);
+                    if (globalSetupAttributes.Length > 0)
+                    {
+                        if (null == globalSetupMethod)
+                        {
+                            globalSetupMethod = m;
+                        }
+                        else
+                        {
+                            throw new NotSupportedException("Only one GlobalTestSetup method may be specified per type.");
+                        }
+                    }
+
+                    GlobalTestCleanupAttribute[] globalCleanupAttributes = (GlobalTestCleanupAttribute[])m.GetCustomAttributes(typeof(GlobalTestCleanupAttribute), true);
+                    if (globalCleanupAttributes.Length > 0)
+                    {
+                        if (null == globalCleanupMethod)
+                        {
+                            globalCleanupMethod = m;
+                        }
+                        else
+                        {
+                            throw new NotSupportedException("Only one GlobalTestCleanup method may be specified per type.");
+                        }
+                    }
+
+                    GlobalExceptionHandlerAttribute[] globalExceptionHandlerAttributes = (GlobalExceptionHandlerAttribute[])m.GetCustomAttributes(typeof(GlobalExceptionHandlerAttribute), true);
+                    if (globalExceptionHandlerAttributes.Length > 0)
+                    {
+                        if (null == globalExceptionHandlerMethod)
+                        {
+                            globalExceptionHandlerMethod = m;
+                        }
+                        else
+                        {
+                            throw new NotSupportedException("Only one GlobalExceptionHandler method may be specified.");
+                        }
+                    }
+
+                    TestSetupAttribute[] testSetupAttrs = (TestSetupAttribute[])m.GetCustomAttributes(typeof(TestSetupAttribute), true);
+                    if (testSetupAttrs.Length > 0)
+                    {
+                        setupMethods.Add(m); ;
+                    }
+
+                    TestCleanupAttribute[] testCleanupAttrs = (TestCleanupAttribute[])m.GetCustomAttributes(typeof(TestCleanupAttribute), true);
+                    if (testCleanupAttrs.Length > 0)
+                    {
+                        cleanupMethods.Add(m); ;
+                    }
+                }
+
+                foreach (MethodInfo m in methods)
+                {
+                    // add single-threaded tests to the list
+                    TestAttribute[] testAttrs = (TestAttribute[])m.GetCustomAttributes(typeof(TestAttribute), true);
+                    foreach (TestAttribute attr in testAttrs)
+                    {
+                        tests.Add(new Test(attr, m, t, setupMethods, cleanupMethods));
+                    }
+
+                    // add any declared stress tests.
+                    StressTestAttribute[] stressTestAttrs = (StressTestAttribute[])m.GetCustomAttributes(typeof(StressTestAttribute), true);
+                    foreach (StressTestAttribute attr in stressTestAttrs)
+                    {
+                        if (TestMetrics.IncludeTest(attr) && MatchFilter(attr))
+                            tests.Add(new StressTest(attr, m, globalSetupMethod, globalCleanupMethod, t, setupMethods, cleanupMethods, globalExceptionHandlerMethod));
+                    }
+
+                    // add multi-threaded (non thread pool) tests to the list
+                    MultiThreadedTestAttribute[] multiThreadedTestAttrs = (MultiThreadedTestAttribute[])m.GetCustomAttributes(typeof(MultiThreadedTestAttribute), true);
+                    foreach (MultiThreadedTestAttribute attr in multiThreadedTestAttrs)
+                    {
+                        if (TestMetrics.IncludeTest(attr))
+                            tests.Add(new MultiThreadedTest(attr, m, t, setupMethods, cleanupMethods));
+                    }
+
+                    // add multi-threaded (with thread pool) tests to the list
+                    ThreadPoolTestAttribute[] threadPoolTestAttrs = (ThreadPoolTestAttribute[])m.GetCustomAttributes(typeof(ThreadPoolTestAttribute), true);
+                    foreach (ThreadPoolTestAttribute attr in threadPoolTestAttrs)
+                    {
+                        if (TestMetrics.IncludeTest(attr))
+                            tests.Add(new ThreadPoolTest(attr, m, t, setupMethods, cleanupMethods));
+                    }
+                }
+            }
+
+            return tests;
+        }
+
+        private static bool MatchFilter(StressTestAttribute attr)
+        {
+            // This change should not have impacts on any existing tests. 
+            //    1. If filter is not provided in command line, we do not apply filter and select all the tests.
+            //    2. If current test attribute (such as StressTestAttribute) does not implement ITestAttriuteFilter, it is not affected and still selected.
+
+            if (string.IsNullOrEmpty(TestMetrics.Filter))
+            {
+                return true;
+            }
+
+            var filter = attr as ITestAttributeFilter;
+            if (filter == null)
+            {
+                return true;
+            }
+
+            return filter.MatchFilter(TestMetrics.Filter);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestMetrics.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestMetrics.cs
@@ -1,0 +1,362 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Globalization;
+
+namespace DPStressHarness
+{
+    public static class TestMetrics
+    {
+        private const string _defaultValue = "unknown";
+
+        private static bool s_valid = false;
+        private static bool s_reset = true;
+        private static Stopwatch s_stopwatch = new Stopwatch();
+        private static long s_workingSet;
+        private static long s_peakWorkingSet;
+        private static long s_privateBytes;
+        private static Assembly s_targetAssembly;
+        private static string s_fileVersion = _defaultValue;
+        private static string s_privateBuild = _defaultValue;
+        private static string s_runLabel = DateTime.Now.ToString();
+        private static Dictionary<string, string> s_overrides;
+        private static List<string> s_variations = null;
+        private static List<string> s_selectedTests = null;
+        private static bool s_isOfficial = false;
+        private static string s_milestone = _defaultValue;
+        private static string s_branch = _defaultValue;
+        private static List<string> s_categories = null;
+        private static bool s_profileMeasuredCode = false;
+        private static int s_stressThreads = 16;
+        private static int s_stressDuration = -1;
+        private static int? s_exceptionThreshold = null;
+        private static bool s_monitorenabled = false;
+        private static string s_monitormachinename = "localhost";
+        private static int s_randomSeed = 0;
+        private static string s_filter = null;
+        private static bool s_printMethodName = false;
+
+        /// <summary>Starts the sample profiler.</summary>
+        /// <remarks>
+        /// Do not inline to avoid errors when the functionality is not used 
+        /// and the profiling DLL is not available.
+        /// </remarks>
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static void InternalStartProfiling()
+        {
+            //            Microsoft.VisualStudio.Profiler.DataCollection.StartProfile(
+            //                Microsoft.VisualStudio.Profiler.ProfileLevel.Global, 
+            //                Microsoft.VisualStudio.Profiler.DataCollection.CurrentId);
+        }
+
+        /// <summary>Stops the sample profiler.</summary>
+        /// <remarks>
+        /// Do not inline to avoid errors when the functionality is not used 
+        /// and the profiling DLL is not available.
+        /// </remarks>
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static void InternalStopProfiling()
+        {
+            //            Microsoft.VisualStudio.Profiler.DataCollection.StopProfile(
+            //                Microsoft.VisualStudio.Profiler.ProfileLevel.Global, 
+            //                Microsoft.VisualStudio.Profiler.DataCollection.CurrentId);
+        }
+
+        public static void StartCollection()
+        {
+            s_valid = false;
+
+            s_stopwatch.Reset();
+            s_stopwatch.Start();
+            s_reset = true;
+        }
+
+        public static void StartProfiling()
+        {
+            if (s_profileMeasuredCode)
+            {
+                InternalStartProfiling();
+            }
+        }
+
+        public static void StopProfiling()
+        {
+            if (s_profileMeasuredCode)
+            {
+                InternalStopProfiling();
+            }
+        }
+
+        public static void StopCollection()
+        {
+            s_stopwatch.Stop();
+
+            Process p = Process.GetCurrentProcess();
+            s_workingSet = p.WorkingSet64;
+            s_peakWorkingSet = p.PeakWorkingSet64;
+            s_privateBytes = p.PrivateMemorySize64;
+
+            s_valid = true;
+        }
+
+        public static void PauseTimer()
+        {
+            s_stopwatch.Stop();
+        }
+
+        public static void UnPauseTimer()
+        {
+            if (s_reset)
+            {
+                s_stopwatch.Reset();
+                s_reset = false;
+            }
+
+            s_stopwatch.Start();
+        }
+
+        private static void ThrowIfInvalid()
+        {
+            if (!s_valid) throw new InvalidOperationException("Collection must be stopped before accessing this metric.");
+        }
+
+        public static void Reset()
+        {
+            s_valid = false;
+            s_reset = true;
+            s_stopwatch = new Stopwatch();
+            s_workingSet = new long();
+            s_peakWorkingSet = new long();
+            s_privateBytes = new long();
+            s_targetAssembly = null;
+            s_fileVersion = _defaultValue;
+            s_privateBuild = _defaultValue;
+            s_runLabel = DateTime.Now.ToString();
+            s_overrides = null;
+            s_variations = null;
+            s_selectedTests = null;
+            s_isOfficial = false;
+            s_milestone = _defaultValue;
+            s_branch = _defaultValue;
+            s_categories = null;
+            s_profileMeasuredCode = false;
+            s_stressThreads = 16;
+            s_stressDuration = -1;
+            s_exceptionThreshold = null;
+            s_monitorenabled = false;
+            s_monitormachinename = "localhost";
+            s_randomSeed = 0;
+            s_filter = null;
+            s_printMethodName = false;
+        }
+
+        public static string FileVersion
+        {
+            get { return s_fileVersion; }
+            set { s_fileVersion = value; }
+        }
+
+        public static string PrivateBuild
+        {
+            get { return s_privateBuild; }
+            set { s_privateBuild = value; }
+        }
+
+        public static Assembly TargetAssembly
+        {
+            get { return s_targetAssembly; }
+
+            set
+            {
+                s_targetAssembly = value;
+                s_fileVersion = VersionUtil.GetFileVersion(s_targetAssembly.ManifestModule.FullyQualifiedName);
+                s_privateBuild = VersionUtil.GetPrivateBuild(s_targetAssembly.ManifestModule.FullyQualifiedName);
+            }
+        }
+
+        public static string RunLabel
+        {
+            get { return s_runLabel; }
+            set { s_runLabel = value; }
+        }
+
+        public static string Milestone
+        {
+            get { return s_milestone; }
+            set { s_milestone = value; }
+        }
+
+        public static string Branch
+        {
+            get { return s_branch; }
+            set { s_branch = value; }
+        }
+
+        public static bool IsOfficial
+        {
+            get { return s_isOfficial; }
+            set { s_isOfficial = value; }
+        }
+
+        public static bool IsDefaultValue(string val)
+        {
+            return val.Equals(_defaultValue);
+        }
+
+        public static double ElapsedSeconds
+        {
+            get
+            {
+                ThrowIfInvalid();
+                return s_stopwatch.ElapsedMilliseconds / 1000.0;
+            }
+        }
+
+        public static long WorkingSet
+        {
+            get
+            {
+                ThrowIfInvalid();
+                return s_workingSet;
+            }
+        }
+
+        public static long PeakWorkingSet
+        {
+            get
+            {
+                ThrowIfInvalid();
+                return s_peakWorkingSet;
+            }
+        }
+
+        public static long PrivateBytes
+        {
+            get
+            {
+                ThrowIfInvalid();
+                return s_privateBytes;
+            }
+        }
+
+
+        public static Dictionary<string, string> Overrides
+        {
+            get
+            {
+                if (s_overrides == null)
+                {
+                    s_overrides = new Dictionary<string, string>(8);
+                }
+                return s_overrides;
+            }
+        }
+
+        public static List<string> Variations
+        {
+            get
+            {
+                if (s_variations == null)
+                {
+                    s_variations = new List<string>(8);
+                }
+
+                return s_variations;
+            }
+        }
+
+        public static List<string> SelectedTests
+        {
+            get
+            {
+                if (s_selectedTests == null)
+                {
+                    s_selectedTests = new List<string>(8);
+                }
+
+                return s_selectedTests;
+            }
+        }
+
+        public static bool IncludeTest(TestAttributeBase test)
+        {
+            if (s_selectedTests == null || s_selectedTests.Count == 0)
+                return true; // user has no selection - run all
+            else
+                return s_selectedTests.Contains(test.Title);
+        }
+
+        public static List<string> Categories
+        {
+            get
+            {
+                if (s_categories == null)
+                {
+                    s_categories = new List<string>(8);
+                }
+
+                return s_categories;
+            }
+        }
+
+        public static bool ProfileMeasuredCode
+        {
+            get { return s_profileMeasuredCode; }
+            set { s_profileMeasuredCode = value; }
+        }
+
+        public static int StressDuration
+        {
+            get { return s_stressDuration; }
+            set { s_stressDuration = value; }
+        }
+
+        public static int StressThreads
+        {
+            get { return s_stressThreads; }
+            set { s_stressThreads = value; }
+        }
+
+        public static int? ExceptionThreshold
+        {
+            get { return s_exceptionThreshold; }
+            set { s_exceptionThreshold = value; }
+        }
+
+        public static bool MonitorEnabled
+        {
+            get { return s_monitorenabled; }
+            set { s_monitorenabled = value; }
+        }
+
+
+        public static string MonitorMachineName
+        {
+            get { return s_monitormachinename; }
+            set { s_monitormachinename = value; }
+        }
+
+        public static int RandomSeed
+        {
+            get { return s_randomSeed; }
+            set { s_randomSeed = value; }
+        }
+
+        public static string Filter
+        {
+            get { return s_filter; }
+            set { s_filter = value; }
+        }
+
+        public static bool PrintMethodName
+        {
+            get { return s_printMethodName; }
+            set { s_printMethodName = value; }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestSetupAttribute.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestSetupAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace DPStressHarness
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
+    public class TestSetupAttribute : Attribute
+    {
+        public TestSetupAttribute()
+        {
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestVariationAttribute.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/TestVariationAttribute.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DPStressHarness
+{
+    [AttributeUsage(AttributeTargets.Field, Inherited = true, AllowMultiple = true)]
+    public class TestVariationAttribute : Attribute
+    {
+        private string _variationName;
+        private object _variationValue;
+
+        public TestVariationAttribute(string variationName, object variationValue)
+        {
+            _variationName = variationName;
+            _variationValue = variationValue;
+        }
+
+        public string VariationName
+        {
+            get { return _variationName; }
+            set { _variationName = value; }
+        }
+
+        public object VariationValue
+        {
+            get { return _variationValue; }
+            set { _variationValue = value; }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/ThreadPoolTest.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/ThreadPoolTest.cs
@@ -1,0 +1,174 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace DPStressHarness
+{
+    internal class ThreadPoolTest : TestBase
+    {
+        private ThreadPoolTestAttribute _attr;
+        public static bool _continue;
+        public static int _threadsRunning;
+        public static int _rps;
+        public static WaitCallback _waitCallback = new WaitCallback(RunThreadPool);
+        public static Exception _firstException = null;
+
+        private struct TestInfo
+        {
+            public object _instance;
+            public TestMethodDelegate _delegateTest;
+        }
+
+        public ThreadPoolTest(ThreadPoolTestAttribute attr,
+                                 MethodInfo testMethodInfo,
+                                 Type type,
+                                 List<MethodInfo> setupMethods,
+                                 List<MethodInfo> cleanupMethods)
+            : base(attr, testMethodInfo, type, setupMethods, cleanupMethods)
+        {
+            _attr = attr;
+        }
+
+        public override void Run()
+        {
+            try
+            {
+                Stopwatch timer = new Stopwatch();
+                long warmupDuration = (long)_attr.WarmupDuration * Stopwatch.Frequency;
+                long testDuration = (long)_attr.TestDuration * Stopwatch.Frequency;
+                int threads = _attr.Threads;
+
+                TestInfo[] info = new TestInfo[threads];
+                ConstructorInfo targetConstructor = _type.GetConstructor(Type.EmptyTypes);
+
+                for (int i = 0; i < threads; i++)
+                {
+                    info[i] = new TestInfo();
+                    info[i]._instance = targetConstructor.Invoke(null);
+                    info[i]._delegateTest = CreateTestMethodDelegate();
+
+                    ExecuteSetupPhase(info[i]._instance);
+                }
+
+                _firstException = null;
+                _continue = true;
+                _rps = 0;
+
+                for (int i = 0; i < threads; i++)
+                {
+                    Interlocked.Increment(ref _threadsRunning);
+                    ThreadPool.QueueUserWorkItem(_waitCallback, info[i]);
+                }
+
+                timer.Reset();
+                timer.Start();
+
+                while (timer.ElapsedTicks < warmupDuration)
+                {
+                    Thread.Sleep(1000);
+                }
+
+                int warmupRequests = Interlocked.Exchange(ref _rps, 0);
+                timer.Reset();
+                timer.Start();
+                TestMetrics.StartCollection();
+
+                while (timer.ElapsedTicks < testDuration)
+                {
+                    Thread.Sleep(1000);
+                }
+
+                int requests = Interlocked.Exchange(ref _rps, 0);
+                double elapsedSeconds = timer.ElapsedTicks / Stopwatch.Frequency;
+                TestMetrics.StopCollection();
+                _continue = false;
+
+                while (_threadsRunning > 0)
+                {
+                    Thread.Sleep(1000);
+                }
+
+                for (int i = 0; i < threads; i++)
+                {
+                    ExecuteCleanupPhase(info[i]._instance);
+                }
+
+                double rps = (double)requests / elapsedSeconds;
+
+                if (_firstException == null)
+                {
+                    LogTest(rps);
+                }
+                else
+                {
+                    LogTestFailure(_firstException.ToString());
+                }
+            }
+            catch (TargetInvocationException e)
+            {
+                LogTestFailure(e.InnerException.ToString());
+            }
+            catch (Exception e)
+            {
+                LogTestFailure(e.ToString());
+            }
+        }
+
+
+        public static void RunThreadPool(Object state)
+        {
+            try
+            {
+                TestInfo info = (TestInfo)state;
+                info._delegateTest(info._instance);
+                Interlocked.Increment(ref _rps);
+            }
+            catch (Exception e)
+            {
+                if (_firstException == null)
+                {
+                    _firstException = e;
+                }
+                _continue = false;
+            }
+            finally
+            {
+                if (_continue)
+                {
+                    ThreadPool.QueueUserWorkItem(_waitCallback, state);
+                }
+                else
+                {
+                    Interlocked.Decrement(ref _threadsRunning);
+                }
+            }
+        }
+
+        protected void LogTest(double rps)
+        {
+            Logger logger = new Logger(TestMetrics.RunLabel, TestMetrics.IsOfficial, TestMetrics.Milestone, TestMetrics.Branch);
+            logger.AddTest(this.Title);
+
+            LogStandardMetrics(logger);
+
+            logger.AddTestMetric(Constants.TEST_METRIC_RPS, String.Format("{0:F2}", rps), "rps", true);
+
+            logger.Save();
+
+            Console.WriteLine("{0}: Requests per Second={1:F2}, Working Set={2}, Peak Working Set={3}, Private Bytes={4}",
+                              this.Title,
+                              rps,
+                              TestMetrics.WorkingSet,
+                              TestMetrics.PeakWorkingSet,
+                              TestMetrics.PrivateBytes);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/VersionUtil.cs
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/VersionUtil.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+using System.Reflection;
+
+#pragma warning disable 618
+
+namespace DPStressHarness
+{
+    public class VersionUtil
+    {
+        public static string GetFileVersion(string moduleName)
+        {
+            FileVersionInfo info = GetFileVersionInfo(moduleName);
+            return info.FileVersion;
+        }
+
+        public static string GetPrivateBuild(string moduleName)
+        {
+            FileVersionInfo info = GetFileVersionInfo(moduleName);
+            return info.PrivateBuild;
+        }
+
+        private static FileVersionInfo GetFileVersionInfo(string moduleName)
+        {
+            if (File.Exists(moduleName))
+            {
+                return FileVersionInfo.GetVersionInfo(Path.GetFullPath(moduleName));
+            }
+            else
+            {
+                string moduleInRuntimeDir = AppContext.BaseDirectory + moduleName;
+                return FileVersionInfo.GetVersionInfo(moduleInRuntimeDir);
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/project.json
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/project.json
@@ -1,0 +1,47 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.1.1-beta-24416-03",
+    "Microsoft.NETCore.Platforms": "1.0.2-beta-24416-03",
+    "System.AppContext": "4.1.1-beta-24416-03",
+    "System.Console": "4.0.1-beta-24416-03",
+    "System.Collections": "4.0.12-beta-24416-03",
+    "System.Collections.Concurrent": "4.0.13-beta-24416-03",
+    "System.Data.Common": "4.1.1-beta-24416-03",
+    "System.Data.SqlClient": "4.1.1-beta-24416-03",
+    "System.Diagnostics.Debug": "4.0.12-beta-24416-03",
+    "System.Diagnostics.DiagnosticSource": "4.0.1-beta-24416-03",
+    "System.Diagnostics.FileVersionInfo": "4.0.1-beta-24416-03",
+    "System.Diagnostics.Process": "4.1.1-beta-24416-03",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.1-beta-24416-03",
+    "System.Diagnostics.TraceSource": "4.0.1-beta-24416-03",
+    "System.IO.FileSystem": "4.0.2-beta-24416-03",
+    "System.Net.NameResolution": "4.0.1-beta-24416-03",
+    "System.Security.Principal": "4.0.2-beta-24416-03",
+    "System.Security.Principal.Windows": "4.0.1-beta-24416-03",
+    "System.Threading.Thread": "4.0.0",
+    "System.Threading": "4.0.12-beta-24416-03",
+    "System.Threading.Timer": "4.0.2-beta-24416-03",
+    "System.Reflection.Extensions": "4.0.2-beta-24416-03",
+    "System.Reflection": "4.1.1-beta-24416-03",
+    "System.Reflection.Emit": "4.0.2-beta-24416-03",
+    "System.Reflection.TypeExtensions": "4.1.1-beta-24416-03",
+    "System.Runtime.InteropServices": "4.2.0-beta-24416-03",
+    "System.Threading.ThreadPool": "4.0.11-beta-24416-03",
+    "System.Runtime.Extensions": "4.1.1-beta-24416-03",
+    "System.Text.RegularExpressions": "4.2.0-beta-24416-03",
+    "System.Xml.ReaderWriter": "4.1.0-beta-24416-03",
+    "System.Xml.XmlDocument": "4.0.2-beta-24416-03",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50"
+      ]
+    },
+    "netstandard1.3": {}
+  }
+}


### PR DESCRIPTION
This pull request adds the SqlClient Reliability test execution engine for .Net core. 
The tests to be executed with this engine will follow. 

