### PR TITLE
WIP: Clean up restore warnings

### DIFF
--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.csproj
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.csproj
@@ -8,6 +8,7 @@
     <AssemblyName>RemoteExecutorConsoleApp</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
+    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/project.json
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/project.json
@@ -2,11 +2,15 @@
   "dependencies": {
     "System.Runtime": "4.1.1-beta-24403-05",
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24403-05",
-    "System.Console": "4.0.1-beta-24403-05",
+    "System.Console": "4.0.0",
     "System.Diagnostics.Process": "4.1.1-beta-24403-05",
     "System.IO": "4.1.1-beta-24403-05",
     "System.Reflection": "4.1.1-beta-24403-05",
-    "System.Threading.Tasks": "4.0.12-beta-24403-05"
+    "System.Threading.Tasks": "4.0.12-beta-24403-05",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Common/tests/System/Xml/BaseLibManaged/BaseLibManaged.csproj
+++ b/src/Common/tests/System/Xml/BaseLibManaged/BaseLibManaged.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>BaseLibManaged</AssemblyName>
     <RootNamespace>WebData.BaseLib</RootNamespace>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/Common/tests/System/Xml/BaseLibManaged/project.json
+++ b/src/Common/tests/System/Xml/BaseLibManaged/project.json
@@ -1,9 +1,13 @@
 {
   "dependencies": {
     "System.Runtime": "4.1.1-beta-24403-05",
-    "System.Runtime.Extensions": "4.1.1-beta-24403-05"
+    "System.Runtime.Extensions": "4.1.1-beta-24403-05",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
   },
   "frameworks": {
-    "netstandard1.0": {}
+    "netstandard1.3": {}
   }
 }

--- a/src/Common/tests/System/Xml/ModuleCore/ModuleCore.csproj
+++ b/src/Common/tests/System/Xml/ModuleCore/ModuleCore.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>ModuleCore</AssemblyName>
     <RootNamespace>OLEDB.Test.ModuleCore</RootNamespace>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/Common/tests/System/Xml/ModuleCore/project.json
+++ b/src/Common/tests/System/Xml/ModuleCore/project.json
@@ -2,11 +2,15 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24403-05",
     "System.Collections": "4.0.12-beta-24403-05",
-    "System.Console": "4.0.1-beta-24403-05",
+    "System.Console": "4.0.0",
     "System.Diagnostics.Debug": "4.0.12-beta-24403-05",
     "System.IO": "4.1.1-beta-24403-05",
     "System.Runtime": "4.1.1-beta-24403-05",
-    "System.Text.Encoding": "4.0.12-beta-24403-05"
+    "System.Text.Encoding": "4.0.12-beta-24403-05",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Common/tests/System/Xml/XmlCoreTest/XmlCoreTest.csproj
+++ b/src/Common/tests/System/Xml/XmlCoreTest/XmlCoreTest.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>XmlCoreTest</AssemblyName>
     <RootNamespace>XmlCoreTest.Common</RootNamespace>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/Common/tests/System/Xml/XmlCoreTest/project.json
+++ b/src/Common/tests/System/Xml/XmlCoreTest/project.json
@@ -2,13 +2,18 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24403-05",
     "System.Collections": "4.0.12-beta-24403-05",
+    "System.Console" : "4.0.0",
     "System.IO": "4.1.1-beta-24403-05",
     "System.Runtime": "4.1.1-beta-24403-05",
     "System.Runtime.Extensions": "4.1.1-beta-24403-05",
     "System.Text.Encoding": "4.0.12-beta-24403-05",
     "System.Threading": "4.0.12-beta-24403-05",
     "System.Threading.Tasks": "4.0.12-beta-24403-05",
-    "System.Xml.ReaderWriter": "4.1.0-beta-24403-05"
+    "System.Xml.ReaderWriter": "4.1.0-beta-24403-05",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Common/tests/System/Xml/XmlDiff/XmlDiff.csproj
+++ b/src/Common/tests/System/Xml/XmlDiff/XmlDiff.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>XmlDiff</AssemblyName>
     <RootNamespace>System.Xml.XmlDiff</RootNamespace>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/Common/tests/System/Xml/XmlDiff/project.json
+++ b/src/Common/tests/System/Xml/XmlDiff/project.json
@@ -2,10 +2,15 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24403-05",
     "System.Collections": "4.0.12-beta-24403-05",
+    "System.Console" : "4.0.0",
     "System.Diagnostics.Debug": "4.0.12-beta-24403-05",
     "System.IO": "4.1.1-beta-24403-05",
     "System.Runtime": "4.1.1-beta-24403-05",
-    "System.Xml.ReaderWriter": "4.1.0-beta-24403-05"
+    "System.Xml.ReaderWriter": "4.1.0-beta-24403-05",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.TestAssembly/System.Diagnostics.FileVersionInfo.TestAssembly.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.TestAssembly/System.Diagnostics.FileVersionInfo.TestAssembly.csproj
@@ -10,7 +10,7 @@
     <NuGetPackageImportStamp>62805582</NuGetPackageImportStamp>
     <ProjectGuid>{28EB14BE-3BC9-4543-ABA6-A932424DFBD0}</ProjectGuid>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.TestAssembly/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.TestAssembly/project.json
@@ -1,6 +1,10 @@
 {
   "dependencies": {
-    "System.Runtime": "4.1.1-beta-24403-05"
+    "System.Runtime": "4.1.1-beta-24403-05",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Linq/tests/Performance/project.json
+++ b/src/System.Linq/tests/Performance/project.json
@@ -19,7 +19,7 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {
-    "netstandard1.5": {}
+    "netstandard1.6": {}
   },
   "supports": {
     "coreFx.Test.netcoreapp1.0": {},

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -19,7 +19,7 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {
-    "netstandard1.5": {}
+    "netstandard1.6": {}
   },
   "supports": {
     "coreFx.Test.netcoreapp1.0": {},

--- a/src/System.Reflection/tests/TestExe/System.Reflection.Tests.TestExe.csproj
+++ b/src/System.Reflection/tests/TestExe/System.Reflection.Tests.TestExe.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>System.Reflection.Tests</RootNamespace>
     <AssemblyName>System.Reflection.Tests.TestExe</AssemblyName>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Reflection/tests/TestExe/project.json
+++ b/src/System.Reflection/tests/TestExe/project.json
@@ -1,7 +1,11 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24403-05",
-    "System.Runtime": "4.1.1-beta-24403-05"
+    "System.Runtime": "4.1.1-beta-24403-05",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/System.Runtime.Loader.Noop.Assembly.csproj
+++ b/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/System.Runtime.Loader.Noop.Assembly.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>System.Runtime.Loader.Noop.Assembly</RootNamespace>
     <AssemblyName>System.Runtime.Loader.Noop.Assembly</AssemblyName>
     <ProjectGuid>{396D6EBF-60BD-4DAF-8783-FB403E070A57}</ProjectGuid>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
     <!-- Test expects an un-signed assembly --> 
     <SkipSigning>true</SkipSigning>
   </PropertyGroup>

--- a/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/project.json
+++ b/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/project.json
@@ -1,7 +1,11 @@
 {
   "dependencies": {
     "System.Runtime": "4.1.1-beta-24403-05",
-    "System.Reflection": "4.1.1-beta-24403-05"
+    "System.Reflection": "4.1.1-beta-24403-05",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24403-05",
     "System.Collections": "4.0.12-beta-24403-05",
-    "System.Console": "4.0.1-beta-24403-05",
     "System.IO": "4.1.1-beta-24403-05",
     "System.Linq": "4.1.1-beta-24403-05",
     "System.Linq.Expressions": "4.1.1-beta-24403-05",


### PR DESCRIPTION
This is more warning cleanup, mostly the ones which are because of a missing test-runtime reference and certain package version conflicts. (system.console)

/cc @ericstj @weshaggard 