### PR TITLE
Produce System.Security.Cryptography.Native.OpenSsl library and package

### DIFF
--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -23,6 +23,7 @@
     <NativePackage Include="runtime.native.System.Net.Http" />
     <NativePackage Include="runtime.native.System.Security.Cryptography" />
     <NativePackage Include="runtime.native.System.Security.Cryptography.Apple" />
+    <NativePackage Include="runtime.native.System.Security.Cryptography.OpenSsl" />
     <NativePackage Include="runtime.native.System.Net.Security" />
   </ItemGroup>
 

--- a/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
@@ -426,6 +426,9 @@
     <BaseLinePackage Include="runtime.native.System.Security.Cryptography.Apple">
       <Version>4.0.1</Version>
     </BaseLinePackage>
+    <BaseLinePackage Include="runtime.native.System.Security.Cryptography.OpenSsl">
+      <Version>4.0.1</Version>
+    </BaseLinePackage>
     <BaseLinePackage Include="System.Private.DataContractSerialization">
       <Version>4.1.1</Version>
     </BaseLinePackage>

--- a/pkg/Microsoft.Private.PackageBaseline/native.library.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/native.library.packages.props
@@ -40,5 +40,10 @@
     <NativeLibrary Include="System.Security.Cryptography.Native.Apple">
       <Package>runtime.native.System.Security.Cryptography.Apple</Package>
     </NativeLibrary>
+
+    <!-- runtime.native.System.Security.Cryptography.OpenSsl -->
+    <NativeLibrary Include="System.Security.Cryptography.Native.OpenSsl">
+      <Package>runtime.native.System.Security.Cryptography.OpenSsl</Package>
+    </NativeLibrary>
   </ItemGroup>
 </Project>

--- a/src/Common/src/Interop/Unix/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Unix/Interop.Libraries.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
         internal const string SystemNative = "System.Native";
         internal const string HttpNative = "System.Net.Http.Native";
         internal const string NetSecurityNative = "System.Net.Security.Native";
-        internal const string CryptoNative = "System.Security.Cryptography.Native";
+        internal const string CryptoNative = "System.Security.Cryptography.Native.OpenSsl";
         internal const string GlobalizationNative = "System.Globalization.Native";
         internal const string CompressionNative = "System.IO.Compression.Native";
     }

--- a/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -43,16 +43,28 @@ set(NATIVECRYPTO_SOURCES
     pal_x509ext.cpp
 )
 
+add_library(objlib OBJECT ${NATIVECRYPTO_SOURCES} ${VERSION_FILE_PATH})
+
 add_library(System.Security.Cryptography.Native
     SHARED
-    ${NATIVECRYPTO_SOURCES}
-    ${VERSION_FILE_PATH}
+    $<TARGET_OBJECTS:objlib>
+)
+
+add_library(System.Security.Cryptography.Native.OpenSsl
+    SHARED
+    $<TARGET_OBJECTS:objlib>
 )
 
 # Disable the "lib" prefix.
 set_target_properties(System.Security.Cryptography.Native PROPERTIES PREFIX "")
+set_target_properties(System.Security.Cryptography.Native.OpenSsl PROPERTIES PREFIX "")
 
 target_link_libraries(System.Security.Cryptography.Native
+  ${OPENSSL_CRYPTO_LIBRARY}
+  ${OPENSSL_SSL_LIBRARY}
+)
+
+target_link_libraries(System.Security.Cryptography.Native.OpenSsl
   ${OPENSSL_CRYPTO_LIBRARY}
   ${OPENSSL_SSL_LIBRARY}
 )
@@ -71,8 +83,15 @@ if (APPLE)
         COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
         COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native>
         )
+
+    add_custom_command(TARGET System.Security.Cryptography.Native.OpenSsl POST_BUILD
+        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
+        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
+        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
+        )
 endif()
 
 include(configure.cmake)
 
 install_library_and_symbols (System.Security.Cryptography.Native)
+install_library_and_symbols (System.Security.Cryptography.Native.OpenSsl)

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/debian/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/debian/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <PackageTargetRuntime>debian.8-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(DebianNativePath)System.Security.Cryptography.Native.OpenSsl.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/23/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/23/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Fedora23NativePath)System.Security.Cryptography.Native.OpenSsl.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/13.2/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/13.2/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(OpenSuse132NativePath)System.Security.Cryptography.Native.OpenSsl.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/osx/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/osx/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(OSXNativePath)System.Security.Cryptography.Native.OpenSsl.dylib">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/rhel/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/rhel/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <PackageTargetRuntime>rhel.7-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(RHELNativePath)System.Security.Cryptography.Native.OpenSsl.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.builds
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="runtime.native.System.Security.Cryptography.OpenSsl.pkgproj"/>
+    <Project Include="rhel\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>rhel.7</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="debian\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>debian.8</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="fedora\23\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>fedora.23</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="ubuntu\14.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>ubuntu.14.04</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="ubuntu\16.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>ubuntu.16.04</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="osx\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>osx.10</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="opensuse\13.2\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>opensuse.13.2</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <SkipValidatePackage>true</SkipValidatePackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- make this package installable and noop in a packages.config-based project -->
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>lib/netstandard1.0</TargetPath>
+    </File>
+    <ProjectReference Include="rhel\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="debian\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="fedora\23\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="osx\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="opensuse\13.2\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/14.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/14.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Ubuntu1404NativePath)System.Security.Cryptography.Native.OpenSsl.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/16.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/16.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Ubuntu1604NativePath)System.Security.Cryptography.Native.OpenSsl.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
The current package and library claim a fairly generic name, which recognizes that the original
intent of the library was to provide an abstraction. That abstraction was lost long ago, it
really is just our controlled ABI into OpenSSL (libcrypto, libssl).

With the effort to have mainline scenarios on macOS not need OpenSSL, but to still allow the
RSAOpenSsl (etc) types to continue to function (both during the rolling upgrade and beyond)
either everything in the current library needs to move to dynamic function binding, or the
library needs to be split between the Apple CommonCrypto (et al) dependencies and the
OpenSSL dependencies.

Next steps:
* Change current callers of S.S.C.Native.[so|dylib] to S.S.C.Native.OpenSsl.[so|dylib] and replace which package is consumed.
* Stop producing the S.S.C.Native library and packages (possibly the same PR as the previous bullet)
* Introduce the S.S.C.Native.Apple library and package
* Separate the managed crypto libraries from Windows|Unix to Windows|OSX|Unix (still Unix vs Linux because of OpenBSD, NetBSD, etc) and all the work of actually switching.

@ericstj @weshaggard PTAL.  I feel like there's supposed to be some extra metadata somewhere, but none of where runtime.native.System.Security.Cryptography is referenced seemed right (e.g. the stable packages list).

Step 1 of N for #9394.