### PR TITLE
Remove buildtools myget feed

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -4,7 +4,6 @@
   <!-- The command-line doesn't need it, but the IDE does.                    -->
   <packageSources>
     <clear/>
-    <add key="myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>

--- a/src/System.Net.Primitives/tests/FunctionalTests/project.json
+++ b/src/System.Net.Primitives/tests/FunctionalTests/project.json
@@ -7,10 +7,6 @@
     "System.Runtime": "4.3.0-beta-24512-01",
     "System.Text.RegularExpressions": "4.3.0-beta-24512-01",
     "System.Threading.Tasks": "4.3.0-beta-24512-01",
-    "System.Net.Primitives": {
-      "version": "4.0.11",
-      "exclude": "compile"
-    },
     "test-runtime": {
       "target": "project",
       "exclude": "compile"


### PR DESCRIPTION
Remove special compilation rule for System.Net.NameResolution PalTests

Addresses #9428 now that TestSuite is just a metapackage on dotnet-core feed along with Microsoft.xunit.netcore.extensions.

Also addresses #10600 by removing the exclude compile.

/cc @weshaggard 