### PR TITLE
Improve code coverage of System.Linq.Expressions.CoalesceConversionBinaryExpression

### DIFF
--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -995,13 +995,18 @@ namespace System.Linq.Expressions.Tests
             double? d = 0;
             var left = Expression.Constant(d, typeof(double?));
             var right = Expression.Constant(i, typeof(int?));
-            Expression<Func<double?, int?>> conversion = x => (int?)x;
+            Expression<Func<double?, int?>> conversion = x => 1 + (int?)x;
 
-            BinaryExpression exp = Expression.Coalesce(left, right, conversion);
+            BinaryExpression actual = Expression.Coalesce(left, right, conversion);
 
-            Assert.Equal(conversion, exp.Conversion);
-            Assert.Equal(exp.Right.Type, exp.Type);
-            Assert.Equal(ExpressionType.Coalesce, exp.NodeType);
+            Assert.Equal(conversion, actual.Conversion);
+            Assert.Equal(actual.Right.Type, actual.Type);
+            Assert.Equal(ExpressionType.Coalesce, actual.NodeType);
+
+            // Compile and evaluate with interpretation flag and without
+            // in case there are bugs in the compiler/interpreter. 
+            Assert.Equal(2, conversion.Compile(false).Invoke(1.1));
+            Assert.Equal(2, conversion.Compile(true).Invoke(1.1));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -989,6 +989,22 @@ namespace System.Linq.Expressions.Tests
         #endregion
 
         [Fact]
+        public static void BasicCoalesceExpressionTest()
+        {
+            int? i = 0;
+            double? d = 0;
+            var left = Expression.Constant(d, typeof(double?));
+            var right = Expression.Constant(i, typeof(int?));
+            Expression<Func<double?, int?>> conversion = x => (int?)x;
+
+            BinaryExpression exp = Expression.Coalesce(left, right, conversion);
+
+            Assert.Equal(exp.Conversion, conversion);
+            Assert.Equal(exp.Type, exp.Right.Type);
+            Assert.Equal(exp.NodeType, ExpressionType.Coalesce);
+        }
+
+        [Fact]
         public static void CannotReduce()
         {
             Expression exp = Expression.Coalesce(Expression.Constant(0, typeof(int?)), Expression.Constant(0));

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -999,9 +999,9 @@ namespace System.Linq.Expressions.Tests
 
             BinaryExpression exp = Expression.Coalesce(left, right, conversion);
 
-            Assert.Equal(exp.Conversion, conversion);
-            Assert.Equal(exp.Type, exp.Right.Type);
-            Assert.Equal(exp.NodeType, ExpressionType.Coalesce);
+            Assert.Equal(conversion, exp.Conversion);
+            Assert.Equal(exp.Right.Type, exp.Type);
+            Assert.Equal(ExpressionType.Coalesce, exp.NodeType);
         }
 
         [Fact]


### PR DESCRIPTION
Code coverage of internal class System.Linq.Expressions.CoalesceConversionBinaryExpression increase from 44.4% up to 100%.

Contributes to #1198

сс @VSadov @stephentoub 