### PR TITLE
HttpClient: Use string.Concat over string.Format

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -988,11 +988,7 @@ namespace System.Net.Http
                         {
                             proxyInfo.AccessType = Interop.WinHttp.WINHTTP_ACCESS_TYPE_NAMED_PROXY;
                             Uri proxyUri = state.Proxy.GetProxy(uri);
-                            string proxyString = string.Format(
-                                CultureInfo.InvariantCulture,
-                                "{0}://{1}",
-                                proxyUri.Scheme,
-                                proxyUri.Authority);
+                            string proxyString = proxyUri.Scheme + "://" + proxyUri.Authority;
                             proxyInfo.Proxy = Marshal.StringToHGlobalUni(proxyString);
                         }
                     }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
@@ -344,8 +344,7 @@ namespace System.Net.Http.Headers
             else
             {
                 // Must always be quoted.
-                string dateString = string.Format(CultureInfo.InvariantCulture, "\"{0}\"",
-                    HttpRuleParser.DateToString(date.Value));
+                string dateString = "\"" + HttpRuleParser.DateToString(date.Value) + "\"";
                 if (dateParameter != null)
                 {
                     dateParameter.Value = dateString;
@@ -452,7 +451,7 @@ namespace System.Net.Http.Headers
             if (needsQuotes)
             {
                 // Re-add quotes "value".
-                result = string.Format(CultureInfo.InvariantCulture, "\"{0}\"", result);
+                result = "\"" + result + "\"";
             }
             return result;
         }
@@ -486,7 +485,7 @@ namespace System.Net.Http.Headers
         {
             byte[] buffer = Encoding.UTF8.GetBytes(input);
             string encodedName = Convert.ToBase64String(buffer);
-            return string.Format(CultureInfo.InvariantCulture, "=?utf-8?B?{0}?=", encodedName);
+            return "=?utf-8?B?" + encodedName + "?=";
         }
 
         // Attempt to decode MIME encoded strings.

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -543,7 +543,7 @@ namespace System.Net.Http
                     // Unlike normal credentials, proxy credentials are URL decoded by libcurl, so we URL encode 
                     // them in order to allow, for example, a colon in the username.
                     string credentialText = string.IsNullOrEmpty(credentials.Domain) ?
-                        string.Format("{0}:{1}", WebUtility.UrlEncode(credentials.UserName), WebUtility.UrlEncode(credentials.Password)) :
+                        WebUtility.UrlEncode(credentials.UserName) + ":" + WebUtility.UrlEncode(credentials.Password) :
                         string.Format("{2}\\{0}:{1}", WebUtility.UrlEncode(credentials.UserName), WebUtility.UrlEncode(credentials.Password), WebUtility.UrlEncode(credentials.Domain));
 
                     EventSourceTrace("Proxy credentials set.");
@@ -565,7 +565,7 @@ namespace System.Net.Http
                 CURLAUTH authScheme = credentialSchemePair.Value;
                 string userName = string.IsNullOrEmpty(credentials.Domain) ?
                     credentials.UserName :
-                    string.Format("{0}\\{1}", credentials.Domain, credentials.UserName);
+                    credentials.Domain + "\\" + credentials.UserName;
 
                 SetCurlOption(CURLoption.CURLOPT_USERNAME, userName);
                 SetCurlOption(CURLoption.CURLOPT_HTTPAUTH, (long)authScheme);

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -663,7 +663,7 @@ namespace System.Net.Http
             {
                 if (!string.IsNullOrEmpty(creds.Domain))
                 {
-                    rtCreds.UserName = string.Format(CultureInfo.InvariantCulture, "{0}\\{1}", creds.Domain, creds.UserName);
+                    rtCreds.UserName = creds.Domain + "\\" + creds.UserName;
                 }
                 else
                 {


### PR DESCRIPTION
`Concat` is cheaper than `Format` (~2x faster in 1,000,000 iteration microbenchmark on x64).