### PR TITLE
Fix processing misaligned floats and doubles in System.Reflection.Metadata

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BlobUtilities.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BlobUtilities.cs
@@ -49,15 +49,16 @@ namespace System.Reflection
         {
             fixed (byte* ptr = &buffer[start])
             {
-                *(double*)ptr = value;
+                *(long*)ptr = *(long*)&value;
             }
         }
 
         public static void WriteSingle(this byte[] buffer, int start, float value)
         {
+
             fixed (byte* ptr = &buffer[start])
             {
-                *(float*)ptr = value;
+                *(int*)ptr = *(int*)&value;
             }
         }
 
@@ -318,9 +319,9 @@ namespace System.Reflection
         internal static byte GetUserStringTrailingByte(string str)
         {
             // ECMA-335 II.24.2.4:
-            // This final byte holds the value 1 if and only if any UTF16 character within 
+            // This final byte holds the value 1 if and only if any UTF16 character within
             // the string has any bit set in its top byte, or its low byte is any of the following:
-            // 0x01–0x08, 0x0E–0x1F, 0x27, 0x2D, 0x7F.  Otherwise, it holds 0. 
+            // 0x01–0x08, 0x0E–0x1F, 0x27, 0x2D, 0x7F.  Otherwise, it holds 0.
             // The 1 signifies Unicode characters that require handling beyond that normally provided for 8-bit encoding sets.
 
             foreach (char ch in str)

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
@@ -284,12 +284,14 @@ namespace System.Reflection.Metadata
 
         public float ReadSingle()
         {
-            return *(float*)GetCurrentPointerAndAdvance(sizeof(float));
+            int val = ReadInt32();
+            return *(float*)&val;
         }
 
         public double ReadDouble()
         {
-            return *(double*)GetCurrentPointerAndAdvance(sizeof(double));
+            long val = ReadInt64();
+            return *(double*)&val;
         }
 
         public Guid ReadGuid()


### PR DESCRIPTION
Fix processing misaligned floats and doubles in System.Reflection.Metadata    
- WriteDouble(), WriteSingle() in BlobUtilities.cs
- ReadDouble(), ReadSingle() in BlobReader.cs