### PR TITLE
Remove P2P reference from System.Globalization

### DIFF
--- a/src/System.Globalization/ref/System.Globalization.csproj
+++ b/src/System.Globalization/ref/System.Globalization.csproj
@@ -14,9 +14,5 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj">
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
This was required before because System.Runtime package didn't have the pushed down types yet, but it does now, so this is not necessary any more.

cc: @weshaggard @sokket 