### PR TITLE
Seed System.Security.Cryptography.Native.Apple.dylib and package

### DIFF
--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -231,3 +231,7 @@ add_subdirectory(System.Native)
 add_subdirectory(System.Net.Http.Native)
 add_subdirectory(System.Net.Security.Native)
 add_subdirectory(System.Security.Cryptography.Native)
+
+if(OSX)
+    add_subdirectory(System.Security.Cryptography.Native.Apple)
+endif()

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -1,0 +1,24 @@
+
+project(System.Security.Cryptography.Native.Apple)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+add_definitions(-DPIC=1)
+
+set(NATIVECRYPTO_SOURCES
+    pal_random.cpp
+)
+
+add_library(System.Security.Cryptography.Native.Apple
+    SHARED
+    ${NATIVECRYPTO_SOURCES}
+    ${VERSION_FILE_PATH}
+)
+
+# Disable the "lib" prefix.
+set_target_properties(System.Security.Cryptography.Native.Apple PROPERTIES PREFIX "")
+
+target_link_libraries(System.Security.Cryptography.Native.Apple
+)
+
+install_library_and_symbols (System.Security.Cryptography.Native.Apple)

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_random.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_random.cpp
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_random.h"
+
+#include <CommonCrypto/CommonCrypto.h>
+#include <CommonCrypto/CommonRandom.h>
+
+extern "C" int AppleCryptoNative_GetRandomBytes(uint8_t* pBuf, uint32_t cbBuf, int32_t* pkCCStatus)
+{
+    if (pBuf == nullptr || pkCCStatus == nullptr)
+        return -1;
+
+    CCRNGStatus status = CCRandomGenerateBytes(pBuf, cbBuf);
+    *pkCCStatus = status;
+    return status == kCCSuccess;
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_random.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_random.h
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "pal_types.h"
+
+/*
+Shims CCRandomGenerateBytes, putting the resulting CCRNGStatus value in pkCCStatus.
+
+Returns 1 on success, 0 on system error (see pkCCStatus), -1 on input error.
+*/
+extern "C" int AppleCryptoNative_GetRandomBytes(uint8_t* pBuf, uint32_t cbBuf, int32_t* pkCCStatus);

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.Apple/osx/runtime.native.System.Security.Cryptography.Apple.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.Apple/osx/runtime.native.System.Security.Cryptography.Apple.pkgproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(OSXNativePath)System.Security.Cryptography.Native.Apple.dylib">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.Apple/runtime.native.System.Security.Cryptography.Apple.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.Apple/runtime.native.System.Security.Cryptography.Apple.builds
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="runtime.native.System.Security.Cryptography.Apple.pkgproj"/>
+    <Project Include="osx\runtime.native.System.Security.Cryptography.Apple.pkgproj">
+      <OSGroup>osx.10</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.Apple/runtime.native.System.Security.Cryptography.Apple.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.Apple/runtime.native.System.Security.Cryptography.Apple.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <SkipValidatePackage>true</SkipValidatePackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- make this package installable and noop in a packages.config-based project -->
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>lib/netstandard1.0</TargetPath>
+    </File>
+    <ProjectReference Include="osx\runtime.native.System.Security.Cryptography.Apple.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
At this stage the shim is only capable of performing CSPRNG duties, the purpose here is to
ensure that the library is getting built and to seed in the package for dependencies.

Other functional behaviors in the shim will be added along with the managed caller so it can
be better reviewed.

cc: @weshaggard @ericstj @ellismg