### PR TITLE
Fix the conditional for building System.Security.Cryptography.Native.Apple

### DIFF
--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -232,6 +232,6 @@ add_subdirectory(System.Net.Http.Native)
 add_subdirectory(System.Net.Security.Native)
 add_subdirectory(System.Security.Cryptography.Native)
 
-if(OSX)
+if(APPLE)
     add_subdirectory(System.Security.Cryptography.Native.Apple)
 endif()


### PR DESCRIPTION
#10653 didn't actually produce the new library.  The CMakeLists change had accidentally gotten clobbered on my machine and I rebuilt it by hand.  Since I hadn't done a clean build the expected dylib was already present, so I didn't notice that the trigger is APPLE, not OSX.

After merging I remembered to check the CI build output and the new library was not present.  Now it should be there.