### PR TITLE
Revert "Add StreamingContext public APIs back to contract"

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/project.json
+++ b/src/System.Data.SqlClient/tests/ManualTests/project.json
@@ -35,7 +35,7 @@
     "System.Runtime.Extensions": "4.1.1-beta-24411-04",
     "System.Runtime.Handles": "4.0.2-beta-24411-04",
     "System.Runtime.InteropServices": "4.2.0-beta-24411-04",
-    "System.Runtime.Serialization.Primitives": "4.2.0-beta-24411-04",
+    "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Security.Principal": "4.0.2-beta-24411-04",
     "System.Security.Principal.Windows": "4.0.1-beta-24411-04",
     "System.Text.Encoding": "4.0.12-beta-24411-04",

--- a/src/System.Runtime.Serialization.Formatters/tests/project.json
+++ b/src/System.Runtime.Serialization.Formatters/tests/project.json
@@ -7,7 +7,7 @@
     "System.Reflection.TypeExtensions": "4.1.1-beta-24411-04",
     "System.Runtime": "4.1.1-beta-24411-04",
     "System.Runtime.Extensions": "4.1.1-beta-24411-04",
-    "System.Runtime.Serialization.Primitives": "4.2.0-beta-24411-04",
+    "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Text.RegularExpressions": "4.2.0-beta-24411-04",
     "test-runtime": {
       "target": "project",

--- a/src/System.Runtime.Serialization.Json/tests/Performance/ContractReferences/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/ContractReferences/project.json
@@ -14,7 +14,7 @@
     "System.ObjectModel": "4.0.13-beta-24411-04",
     "System.Runtime": "4.1.1-beta-24411-04",
     "System.Runtime.Extensions": "4.1.1-beta-24411-04",
-    "System.Runtime.Serialization.Primitives": "4.2.0-beta-24411-04",
+    "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Runtime.Serialization.Json": "4.0.3-beta-24411-04",
     "System.Runtime.Serialization.Xml": "4.1.2-beta-24411-04",
     "System.Threading.Tasks": "4.0.12-beta-24411-04",

--- a/src/System.Runtime.Serialization.Primitives/ref/System.Runtime.Serialization.Primitives.cs
+++ b/src/System.Runtime.Serialization.Primitives/ref/System.Runtime.Serialization.Primitives.cs
@@ -114,24 +114,7 @@ namespace System.Runtime.Serialization
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct StreamingContext
     {
-        public StreamingContext(System.Runtime.Serialization.StreamingContextStates state) { }
-        public StreamingContext(System.Runtime.Serialization.StreamingContextStates state, object additional) { }
         public override bool Equals(object obj) { return default(bool); }
         public override int GetHashCode() { return default(int); }
-        public System.Runtime.Serialization.StreamingContextStates State { get { return default(System.Runtime.Serialization.StreamingContextStates); } }
-        public object Context { get { return default(object); } }
-    }
-    [Flags]
-    public enum StreamingContextStates
-    {
-        CrossProcess = 0x01,
-        CrossMachine = 0x02,
-        File = 0x04,
-        Persistence = 0x08,
-        Remoting = 0x10,
-        Other = 0x20,
-        Clone = 0x40,
-        CrossAppDomain = 0x80,
-        All = 0xFF,
     }
 }

--- a/src/System.Runtime.Serialization.Primitives/ref/System.Runtime.Serialization.Primitives.csproj
+++ b/src/System.Runtime.Serialization.Primitives/ref/System.Runtime.Serialization.Primitives.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.Runtime.Serialization.Primitives/src/System.Runtime.Serialization.Primitives.csproj
+++ b/src/System.Runtime.Serialization.Primitives/src/System.Runtime.Serialization.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Runtime.Serialization.Primitives</AssemblyName>
-    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <RootNamespace>System.Runtime.Serialization.Primitives</RootNamespace>
     <NoWarn>$(NoWarn);1634;1691;649</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.Runtime.Serialization.Primitives/src/System/Runtime/Serialization/StreamingContext.cs
+++ b/src/System.Runtime.Serialization.Primitives/src/System/Runtime/Serialization/StreamingContext.cs
@@ -21,18 +21,18 @@ namespace System.Runtime.Serialization
         internal Object m_additionalContext;
         internal StreamingContextStates m_state;
 
-        public StreamingContext(StreamingContextStates state)
+        internal StreamingContext(StreamingContextStates state)
             : this(state, null)
         {
         }
 
-        public StreamingContext(StreamingContextStates state, Object additional)
+        internal StreamingContext(StreamingContextStates state, Object additional)
         {
             m_state = state;
             m_additionalContext = additional;
         }
 
-        public Object Context
+        internal Object Context
         {
             get { return m_additionalContext; }
         }
@@ -52,7 +52,7 @@ namespace System.Runtime.Serialization
             return (int)m_state;
         }
 
-        public StreamingContextStates State
+        internal StreamingContextStates State
         {
             get { return m_state; }
         }
@@ -62,7 +62,7 @@ namespace System.Runtime.Serialization
     // Keep these in sync with the version in vm\runtimehandles.h
     // **********************************************************
     [Flags]
-    public enum StreamingContextStates
+    internal enum StreamingContextStates
     {
         CrossProcess = 0x01,
         CrossMachine = 0x02,

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/ContractReferences/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/ContractReferences/project.json
@@ -13,7 +13,7 @@
     "System.ObjectModel": "4.0.13-beta-24411-04",
     "System.Runtime": "4.1.1-beta-24411-04",
     "System.Runtime.Extensions": "4.1.1-beta-24411-04",
-    "System.Runtime.Serialization.Primitives": "4.2.0-beta-24411-04",
+    "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Runtime.Serialization.Json": "4.0.3-beta-24411-04",
     "System.Runtime.Serialization.Xml": "4.1.2-beta-24411-04",
     "System.Text.Encoding": "4.0.12-beta-24411-04",

--- a/src/System.Xml.XmlSerializer/tests/Performance/ContractReferences/project.json
+++ b/src/System.Xml.XmlSerializer/tests/Performance/ContractReferences/project.json
@@ -12,7 +12,7 @@
     "System.Reflection": "4.1.1-beta-24411-04",
     "System.Runtime": "4.1.1-beta-24411-04",
     "System.Runtime.Extensions": "4.1.1-beta-24411-04",
-    "System.Runtime.Serialization.Primitives": "4.2.0-beta-24411-04",
+    "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Runtime.Serialization.Json": "4.0.3-beta-24411-04",
     "System.Runtime.Serialization.Xml": "4.1.2-beta-24411-04",
     "System.Text.Encoding": "4.0.12-beta-24411-04",


### PR DESCRIPTION
Reverts dotnet/corefx#10036

These APIs modified APIs in a frozen netstandard (see https://github.com/dotnet/corefx/issues/10426). In particular it added APIs to the ref targeting netstandard1.3 which isn't compatible. If we want to add these we need to correctly version them and put them in a new netstandard. For now I don't believe we need them so I'm reverting this change. We can include as part of the work we are doing in dev/api. See PR https://github.com/dotnet/corefx/pull/10667.

FYI @joperezr @stephentoub @danmosemsft 