### PR TITLE
Cross compile System.Net.Http for Desktop

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -19,6 +19,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <Import Project="System.Net.Http.WinHttpHandler.msbuild" Condition="'$(TargetsWindows)' == 'true'" />
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+    <!-- Need to compile it here since the NET46 target here is building against System.Runtime whereas the
+         the list of other files in System.Net.Http.WinHttpHandler.msbuild is also used by System.Net.Http
+         library and the NET46 target there uses framework assembly references instead. -->
+    <CompileItem Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs" />
+    <CompileItem Include="$(CommonPath)\System\Net\HttpStatusDescription.cs" />
+    <CompileItem Include="$(CommonPath)\System\Net\HttpVersion.cs" />
+  </ItemGroup>
   <!--  For source files to be shown within the visual tree in Solution Explorer, the items must be
          included directly in the project file. We have the *.msbuild define the Compile items in a made
          up item called CompileItem and then just include it here. -->

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -13,14 +13,11 @@
     <CompileItem Include="$(CommonPath)\Interop\Windows\winhttp\Interop.SafeWinHttpHandle.cs" />
     <CompileItem Include="$(CommonPath)\Interop\Windows\winhttp\Interop.winhttp_types.cs" />
     <CompileItem Include="$(CommonPath)\Interop\Windows\winhttp\Interop.winhttp.cs" />
-    <CompileItem Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs" />
     <CompileItem Include="$(CommonPath)\System\CharArrayHelpers.cs" />
     <CompileItem Include="$(CommonPath)\System\StringExtensions.cs" />
     <CompileItem Include="$(CommonPath)\System\Diagnostics\ExceptionExtensions.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs" />
-    <CompileItem Include="$(CommonPath)\System\Net\HttpStatusDescription.cs" />
-    <CompileItem Include="$(CommonPath)\System\Net\HttpVersion.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\UriScheme.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\SecurityProtocol.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs" />
@@ -41,5 +38,10 @@
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpTraceHelper.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpTransportContext.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinInetProxyHelper.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+    <CompileItem Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs" />
+    <CompileItem Include="$(CommonPath)\System\Net\HttpStatusDescription.cs" />
+    <CompileItem Include="$(CommonPath)\System\Net\HttpVersion.cs" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -16,6 +16,9 @@ namespace System.Net.Http
     {
         private const string EncodingNameDeflate = "DEFLATE";
         private const string EncodingNameGzip = "GZIP";
+#if NET46
+        private static readonly Version HttpVersionUnknown = new Version(0,0);
+#endif
 
         public static HttpResponseMessage CreateResponseMessage(
             WinHttpRequestState state,
@@ -40,7 +43,11 @@ namespace System.Net.Http
             response.Version =
                 CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase("HTTP/1.1", buffer, 0, versionLength) ? HttpVersion.Version11 :
                 CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase("HTTP/1.0", buffer, 0, versionLength) ? HttpVersion.Version10 :
+#if NET46
+                HttpVersionUnknown;
+#else
                 HttpVersion.Unknown;
+#endif
 
             response.StatusCode = (HttpStatusCode)GetResponseHeaderNumberInfo(
                 requestHandle,

--- a/src/System.Net.Http/src/System.Net.Http.builds
+++ b/src/System.Net.Http/src/System.Net.Http.builds
@@ -12,6 +12,10 @@
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50</TargetGroup>
     </Project>
+    <Project Include="System.Net.Http.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>net46</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -12,6 +12,8 @@
     <AssemblyName>System.Net.Http</AssemblyName>
     <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <WindowsRID>win</WindowsRID>
+    <!-- Suppress warnings for type conflicts between SR in partial facade and mscorlib -->
+    <NoWarn>0436</NoWarn>
     <PackageTargetFramework Condition="'$(TargetsUnix)' == 'true'">netstandard1.6</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(TargetsUnix)' == 'true'">.NETStandard,Version=v1.6</NuGetTargetMoniker>
@@ -23,12 +25,6 @@
   <ItemGroup Condition="'$(TargetGroup)' == '' AND '$(TargetsWindows)' == 'true'">
     <PackageDestination Include="runtimes/$(PackageTargetRuntime)/lib/netstandard1.3">
       <TargetFramework>netstandard1.3</TargetFramework>
-    </PackageDestination>
-    <PackageDestination Include="runtimes/$(PackageTargetRuntime)/lib/net46">
-      <TargetFramework>net46</TargetFramework>
-    </PackageDestination>
-    <PackageDestination Include="lib/net46">
-      <TargetFramework>net46</TargetFramework>
     </PackageDestination>
   </ItemGroup>
   <!-- Help VS understand available configurations -->
@@ -112,14 +108,7 @@
     <Compile Include="System\Net\Http\Headers\ViaHeaderValue.cs" />
     <Compile Include="System\Net\Http\Headers\WarningHeaderValue.cs" />
     <!-- TODO #5715: Must be moved to the Common/System/Net folder -->
-    <Compile Include="Internal\ICloneable.cs" />
-    <Compile Include="Internal\MailAddress.cs" />
-    <Compile Include="Internal\Mail\DomainLiteralReader.cs" />
     <Compile Include="Internal\Mail\DotAtomReader.cs" />
-    <Compile Include="Internal\Mail\MailAddressParser.cs" />
-    <Compile Include="Internal\Mail\MailBnfHelper.cs" />
-    <Compile Include="Internal\Mail\QuotedPairReader.cs" />
-    <Compile Include="Internal\Mail\QuotedStringFormatReader.cs" />
     <Compile Include="Internal\Mail\WhitespaceReader.cs" />
     <Compile Include="$(CommonPath)\System\Net\Logging\LoggingHash.cs">
       <Link>Common\System\Net\Logging\LoggingHash.cs</Link>
@@ -131,11 +120,25 @@
       <Link>Common\System\Net\Logging\NetEventSource.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == '' ">
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'netcore50' ">
     <Compile Include="System\Net\Http\HttpClientHandler.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)' != 'true' Or '$(TargetGroup)' != 'net46' ">
+    <!-- TODO #5715: Must be moved to the Common/System/Net folder -->
+    <Compile Include="Internal\ICloneable.cs" />
+    <Compile Include="Internal\MailAddress.cs" />
+    <Compile Include="Internal\Mail\DomainLiteralReader.cs" />
+    <Compile Include="Internal\Mail\MailAddressParser.cs" />
+    <Compile Include="Internal\Mail\MailBnfHelper.cs" />
+    <Compile Include="Internal\Mail\QuotedPairReader.cs" />
+    <Compile Include="Internal\Mail\QuotedStringFormatReader.cs" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == '' ">
     <DefineConstants>$(DefineConstants);HTTP_DLL</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'net46' ">
+    <DefineConstants>$(DefineConstants);HTTP_DLL;NET46</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Compile the WinHttpHandler implementation into the System.Net.Http.dll binary.  This is a
          temporary solution to remove the cycle dependency between HttpClient and WinHttpHandler.
@@ -144,11 +147,11 @@
          HttpMessageHandler.cs. We also use the HTTP_DLL define to change public classes into
          internal ones to remove confusion if someone looks at the implementation dlls. They are
          public in the separate WinHttpHandler.dll binary.  -->
-  <Import Project="..\..\System.Net.Http.WinHttpHandler\src\System.Net.Http.WinHttpHandler.msbuild" Condition="'$(TargetsWindows)' == 'true' And '$(TargetGroup)' == ''" />
+  <Import Project="..\..\System.Net.Http.WinHttpHandler\src\System.Net.Http.WinHttpHandler.msbuild" Condition="'$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'netcore50'" />
   <!--  For source files to be shown within the visual tree in Solution Explorer, the items must be
          included directly in the project file. We have the *.msbuild define the Compile items in a made
          up item called CompileItem and then just include it here. -->
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == '' ">
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'netcore50' ">
     <Compile Include="@(CompileItem)" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">
@@ -347,6 +350,12 @@
     <Compile Include="netcore50\System\Net\CookieHelper.cs" />
     <Compile Include="netcore50\System\Net\HttpHandlerToFilter.cs" />
     <Compile Include="netcore50\System\Net\HttpClientHandler.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+    <TargetingPackReference Include="mscorlib" />
+    <TargetingPackReference Include="System" />
+    <TargetingPackReference Include="System.Core" />
+    <TargetingPackReference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -142,6 +142,9 @@ namespace System.Net.Http
 
         internal bool TryGetBuffer(out ArraySegment<byte> buffer)
         {
+#if NET46
+            buffer = default(ArraySegment<byte>);
+#endif
             return _bufferedContent != null && _bufferedContent.TryGetBuffer(out buffer);
         }
 

--- a/src/System.Net.Http/src/project.json
+++ b/src/System.Net.Http/src/project.json
@@ -27,6 +27,11 @@
         "System.Threading": "4.0.0",
         "System.Threading.Tasks": "4.0.10"
       }
-    }
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    }    
   }
 }


### PR DESCRIPTION
This is the first part at fixing #9846 and #9884. This PR changes the compilation of System.Net.Http for NET46 target so that it builds as a "normal" .NET Framework assembly by using assembly references for mscorlib.dll, system.dll, etc.