### PR TITLE
Remove the warning from the test execution.

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -20,7 +20,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 
             if (!AreConnStringsSetup())
             {
-                Console.WriteLine("WARNING: Test connection strings not defined! Tests cannot be run.");
+                Console.WriteLine("INFO: Test connection strings not defined! Tests cannot be run. Refer README.md of Manual tests for more information. ");
             }
         }
 


### PR DESCRIPTION
The CoreFx shows a warning for the test execution failure for the SqlClient tests.
There is an ongoing effort to reduce the noise of warnings in the builds to make sure that the warnings are meaningful and actionable. https://github.com/dotnet/corefx/issues/9952 

For the SqlClient manual test based on the comment at https://github.com/dotnet/corefx/pull/9523/files/4dd13d11a11f2458a9de27e6c47831680b45ac83#r74627195 I am submitting this change. 

The lack of test setup can be shown as informational text more than a warning text. 

