### PR TITLE
Use the CommonCrypto CSPRNG on macOS

### DIFF
--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -22,6 +22,7 @@
     <NativePackage Include="runtime.native.System" />
     <NativePackage Include="runtime.native.System.Net.Http" />
     <NativePackage Include="runtime.native.System.Security.Cryptography" />
+    <NativePackage Include="runtime.native.System.Security.Cryptography.Apple" />
     <NativePackage Include="runtime.native.System.Net.Security" />
   </ItemGroup>
 

--- a/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
@@ -423,6 +423,9 @@
     <BaseLinePackage Include="runtime.native.System.Security.Cryptography">
       <Version>4.0.0</Version>
     </BaseLinePackage>
+    <BaseLinePackage Include="runtime.native.System.Security.Cryptography.Apple">
+      <Version>4.0.1</Version>
+    </BaseLinePackage>
     <BaseLinePackage Include="System.Private.DataContractSerialization">
       <Version>4.1.1</Version>
     </BaseLinePackage>

--- a/pkg/Microsoft.Private.PackageBaseline/native.library.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/native.library.packages.props
@@ -35,5 +35,10 @@
     <NativeLibrary Include="System.Security.Cryptography.Native">
       <Package>runtime.native.System.Security.Cryptography</Package>
     </NativeLibrary>
+
+    <!-- runtime.native.System.Security.Cryptography.Apple -->
+    <NativeLibrary Include="System.Security.Cryptography.Native.Apple">
+      <Package>runtime.native.System.Security.Cryptography.Apple</Package>
+    </NativeLibrary>
   </ItemGroup>
 </Project>

--- a/src/Common/src/Interop/OSX/Interop.Libraries.cs
+++ b/src/Common/src/Interop/OSX/Interop.Libraries.cs
@@ -11,5 +11,6 @@ internal static partial class Interop
         internal const string libproc = "libproc";
         internal const string LibSystemKernel = "/usr/lib/system/libsystem_kernel";
         internal const string SystemConfigurationLibrary = "/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration";
+        internal const string AppleCryptoNative = "System.Security.Cryptography.Native.Apple";
     }
 }

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Err.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Err.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security.Cryptography;
+
+internal static partial class Interop
+{
+    internal static partial class AppleCrypto
+    {
+        internal const string CCRNGStatus = "CCRNGStatus";
+
+        internal static Exception CreateExceptionForCCError(int errorCode, string errorType)
+        {
+            return new AppleCommonCryptoCryptographicException(
+                errorCode,
+                SR.Format(
+                    SR.Cryptography_Unmapped_System_Typed_Error,
+                    errorCode,
+                    errorType));
+        }
+
+        private sealed class AppleCommonCryptoCryptographicException : CryptographicException
+        {
+            internal AppleCommonCryptoCryptographicException(int errorCode, string message)
+                : base(message)
+            {
+                HResult = errorCode;
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Random.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Random.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+internal static partial class Interop
+{
+    internal static partial class AppleCrypto
+    {
+        internal static unsafe void GetRandomBytes(byte[] buf, int num)
+        {
+            Debug.Assert(buf != null);
+            Debug.Assert(num >= 0 && num <= buf.Length);
+
+            fixed (byte* pBuf = buf)
+            {
+                int errorCode;
+                int ret = AppleCryptoNative_GetRandomBytes(pBuf, num, out errorCode);
+
+                if (ret == 0)
+                {
+                    throw CreateExceptionForCCError(errorCode, CCRNGStatus);
+                }
+
+                if (ret != 1)
+                {
+                    throw new CryptographicException();
+                }
+            }
+        }
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static unsafe extern int AppleCryptoNative_GetRandomBytes(byte* buf, int num, out int errorCode);
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -231,6 +231,9 @@
   <data name="Cryptography_UnexpectedTransformTruncation" xml:space="preserve">
     <value>CNG provider unexpectedly terminated encryption or decryption prematurely.</value>
   </data>
+  <data name="Cryptography_Unmapped_System_Typed_Error" xml:space="preserve">
+    <value>The system cryptographic library returned error '{0}' of type '{1}'</value>
+  </data>
   <data name="Cryptography_UnsupportedPaddingMode" xml:space="preserve">
     <value>The specified PaddingMode is not supported.</value>
   </data>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.builds
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.builds
@@ -6,6 +6,9 @@
       <OSGroup>Unix</OSGroup>
     </Project>
     <Project Include="System.Security.Cryptography.Algorithms.csproj">
+      <OSGroup>OSX</OSGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.Algorithms.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.Security.Cryptography.Algorithms.csproj">

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -236,9 +236,23 @@
       <Link>Common\System\Security\Cryptography\RSACng.SignVerify.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' AND '$(TargetsOSX)' != 'true' ">
+    <Compile Include="System\Security\Cryptography\RNGCryptoServiceProvider.Unix.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+      <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs</Link>
+    </Compile>
+    <Compile Include="System\Security\Cryptography\RNGCryptoServiceProvider.OSX.cs" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Security\Cryptography\ECDsaOpenSsl.cs" />
-    <Compile Include="System\Security\Cryptography\RNGCryptoServiceProvider.Unix.cs" />
     <Compile Include="Internal\Cryptography\AesImplementation.Unix.cs" />
     <Compile Include="Internal\Cryptography\HashProviderDispenser.Unix.cs" />
     <Compile Include="Internal\Cryptography\OpenSslCipher.cs" />

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RNGCryptoServiceProvider.OSX.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RNGCryptoServiceProvider.OSX.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography
+{
+    internal sealed class RNGCryptoServiceProvider : RandomNumberGenerator
+    {
+        public sealed override void GetBytes(byte[] data)
+        {
+            ValidateGetBytesArgs(data);
+            if (data.Length > 0)
+            {
+                Interop.AppleCrypto.GetRandomBytes(data, data.Length);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Instead of calling into OpenSSL for random numbers, we will use CommonCrypto's
CCRandomGenerateBytes.

There are consumers of the CSPRNG which can't, due to layering, reference
this library, and they will have to get switched to use the new shim; but that
is a followup change.

The first big step for #9394.
cc: @ellismg @stephentoub @weshaggard 