### PR TITLE
Glibc readdir_r() deprecated use readdir()

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -5,6 +5,7 @@
 #cmakedefine01 HAVE_PIPE2
 #cmakedefine01 HAVE_STAT_BIRTHTIME
 #cmakedefine01 HAVE_GNU_STRERROR_R
+#cmakedefine01 HAVE_GNU_READDIR_R
 #cmakedefine01 HAVE_DIRENT_NAME_LEN
 #cmakedefine01 HAVE_MNTINFO
 #cmakedefine01 HAVE_STATFS_FSTYPENAME

--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -5,7 +5,7 @@
 #cmakedefine01 HAVE_PIPE2
 #cmakedefine01 HAVE_STAT_BIRTHTIME
 #cmakedefine01 HAVE_GNU_STRERROR_R
-#cmakedefine01 HAVE_GNU_READDIR_R
+#cmakedefine01 HAVE_READDIR_R
 #cmakedefine01 HAVE_DIRENT_NAME_LEN
 #cmakedefine01 HAVE_MNTINFO
 #cmakedefine01 HAVE_STATFS_FSTYPENAME

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -339,9 +339,9 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
         return ERANGE;
     }
 
-#if defined HAVE_GNU_READDIR_R
     dirent* result = nullptr;
     dirent* entry = static_cast<dirent*>(buffer);
+#if defined HAVE_GNU_READDIR_R
     int error = readdir_r(dir, entry, &result);
 
     // positive error number returned -> failure
@@ -353,7 +353,6 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     }
 
     // 0 returned with null result -> end-of-stream
-    if (result == nullptr)
     {
         *outputEntry = {}; // managed out param must be initialized
         return -1;         // shim convention for end-of-stream
@@ -363,7 +362,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     assert(result == entry);
 #else
     errno = 0;
-    dirent* entry = readdir(dir);
+    result = readdir(dir);
 
     //  kernel set errno -> failure
     if (errno != 0)
@@ -374,16 +373,16 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     }
 
     // 0 returned with null result -> end-of-stream
-    if (entry == nullptr)
+    if (result == nullptr)
     {
         *outputEntry = {}; // managed out param must be initialized
         return -1;         // shim convention for end-of-stream
     }
 
-    assert(entry->d_reclen <= bufferSize);
-    memcpy(buffer, entry, static_cast<size_t>(entry->d_reclen));
+    assert(result->d_reclen <= bufferSize);
+    memcpy(entry, result, static_cast<size_t>(result->d_reclen));
 #endif
-    ConvertDirent(static_cast<dirent*>(buffer), outputEntry);
+    ConvertDirent(*entry, outputEntry);
     return 0;
 }
 

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -316,7 +316,6 @@ extern "C" int32_t SystemNative_GetDirentSize()
     return sizeof(dirent);
 }
 
-#if defined HAVE_GNU_READDIR_R
 // To reduce the number of string copies, this function calling pattern works as follows:
 // 1) The managed code calls GetDirentSize() to get the platform-specific
 //    size of the dirent struct.
@@ -340,6 +339,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
         return ERANGE;
     }
 
+#if defined HAVE_GNU_READDIR_R
     dirent* result = nullptr;
     dirent* entry = static_cast<dirent*>(buffer);
     int error = readdir_r(dir, entry, &result);
@@ -361,41 +361,8 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
 
     // 0 returned with non-null result (guaranteed to be set to entry arg) -> success
     assert(result == entry);
-    ConvertDirent(*entry, outputEntry);
-    return 0;
-}
-
 #else
-// To reduce the number of string copies, this function calling pattern works as follows:
-// 1) The managed code calls GetDirentSize() to get the platform-specific
-//    size of the dirent struct.
-// 2) The managed code creates a byte[] buffer of the size of the native dirent
-//    and passes a pointer to this buffer to this function.
-// 3) This function gets a pointer to the possibly statically allocated directory entry.
-// 4) Then, byte[] entry is copied into the byte[] buffer for bufferSize bytes.
-//    This makes the 1st strcpy.
-// 5) The ConvertDirent function will set a pointer to the start of the inode name
-//    in the byte[] buffer so the managed code can find it and copy it out of the
-//    buffer into a managed string that the caller of the framework can use, making
-//    the 2nd and final strcpy.
-//
-//    To make this function thread safe ensure calls on the same DIR* dir never happen concurrently.
-extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* outputEntry)
-{
-    assert(buffer != nullptr);
-    assert(dir != nullptr);
-    assert(outputEntry != nullptr);
-
-    if (bufferSize < static_cast<int32_t>(sizeof(dirent)))
-    {
-        assert(false && "Buffer size too small; use GetDirentSize to get required buffer size");
-        return ERANGE;
-    }
-
     errno = 0;
-    // Returns a pointer to memory that may be statically allocated by glibc.
-    // Data returned by readdir may be overwritten by other readdir calls 
-    // on the same directory stream.
     dirent* entry = readdir(dir);
 
     // positive error number returned -> failure
@@ -414,10 +381,10 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     }
 
     memcpy(buffer,entry,static_cast<size_t>(bufferSize));
+#endif
     ConvertDirent(*entry, outputEntry);
     return 0;
 }
-#endif
 
 extern "C" DIR* SystemNative_OpenDir(const char* path)
 {

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -371,7 +371,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
 //    size of the dirent struct.
 // 2) The managed code creates a byte[] buffer of the size of the native dirent
 //    and passes a pointer to this buffer to this function.
-// 3) This function gets a pointer to the possibly staticly allocated directory entry.
+// 3) This function gets a pointer to the possibly statically allocated directory entry.
 // 4) Then, byte[] entry is copied into the byte[] buffer for bufferSize bytes.
 //    This makes the 1st strcpy.
 // 5) The ConvertDirent function will set a pointer to the start of the inode name
@@ -393,7 +393,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     }
 
     errno = 0;
-    // returns a pointer to memory that may be staticly allocated by glibc.
+    // Returns a pointer to memory that may be statically allocated by glibc.
     // Data returned by readdir may be overwritten by other readdir calls 
     // on the same directory stream.
     dirent* entry = readdir(dir);
@@ -401,7 +401,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     // positive error number returned -> failure
     if (errno != 0)
     {
-        assert(errno == EBADF); // Invalid directory stream discriptor dir.
+        assert(errno == EBADF); // Invalid directory stream descriptor dir.
         *outputEntry = {}; // managed out param must be initialized
         return errno;
     }

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -353,6 +353,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     }
 
     // 0 returned with null result -> end-of-stream
+    if (result == nullptr)
     {
         *outputEntry = {}; // managed out param must be initialized
         return -1;         // shim convention for end-of-stream

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -380,9 +380,10 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
         return -1;         // shim convention for end-of-stream
     }
 
-    memcpy(buffer,entry,static_cast<size_t>(bufferSize));
+    assert(entry->d_reclen <= bufferSize);
+    memcpy(buffer, entry, static_cast<size_t>(entry->d_reclen));
 #endif
-    ConvertDirent(*entry, outputEntry);
+    ConvertDirent(static_cast<dirent*>(buffer), outputEntry);
     return 0;
 }
 

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -383,7 +383,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     assert(entry->d_reclen <= bufferSize);
     memcpy(buffer, entry, static_cast<size_t>(entry->d_reclen));
 #endif
-    ConvertDirent(static_cast<const dirent>(*buffer), outputEntry);
+    ConvertDirent(static_cast<dirent*>(buffer), outputEntry);
     return 0;
 }
 

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -341,7 +341,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
 
     dirent* result = nullptr;
     dirent* entry = static_cast<dirent*>(buffer);
-#if defined HAVE_GNU_READDIR_R
+#if defined HAVE_READDIR_R
     int error = readdir_r(dir, entry, &result);
 
     // positive error number returned -> failure

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -365,7 +365,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     errno = 0;
     dirent* entry = readdir(dir);
 
-    // positive error number returned -> failure
+    //  kernel set errno -> failure
     if (errno != 0)
     {
         assert(errno == EBADF); // Invalid directory stream descriptor dir.

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -383,7 +383,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     assert(entry->d_reclen <= bufferSize);
     memcpy(buffer, entry, static_cast<size_t>(entry->d_reclen));
 #endif
-    ConvertDirent(static_cast<dirent*>(buffer), outputEntry);
+    ConvertDirent(static_cast<const dirent>(*buffer), outputEntry);
     return 0;
 }
 

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -346,17 +346,18 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
 #if HAVE_READDIR_R
     int error = readdir_r(dir, entry, &result);
 
+    // positive error number returned -> failure
+    if (error != 0)
+    {
+        assert(error > 0);
+        *outputEntry = {}; // managed out param must be initialized
+        return error;
+    }
+
     // 0 returned with null result -> end-of-stream
     if (result == nullptr)
     {
         *outputEntry = {}; // managed out param must be initialized
-
-        // positive error number returned -> failure
-        if (error != 0)
-        {
-            assert(error > 0);
-            return error;
-        }
         return -1;         // shim convention for end-of-stream
     }
 

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -401,7 +401,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     // positive error number returned -> failure
     if (errno != 0)
     {
-        assert(error == EBADF); // Invalid directory stream discriptor dir.
+        assert(errno == EBADF); // Invalid directory stream discriptor dir.
         *outputEntry = {}; // managed out param must be initialized
         return errno;
     }

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -321,11 +321,13 @@ extern "C" int32_t SystemNative_GetDirentSize()
 //    size of the dirent struct.
 // 2) The managed code creates a byte[] buffer of the size of the native dirent
 //    and passes a pointer to this buffer to this function.
-// 3) This function passes input byte[] buffer to the OS to fill with dirent data
-//    which makes the 1st strcpy.
-// 4) The ConvertDirent function will set a pointer to the start of the inode name
-//    in the byte[] buffer so the managed code and find it and copy it out of the
-//    buffer into a managed string that the caller of the framework can use, making
+// 3) This function passes input byte[] buffer to the OS to fill with dirent
+//    data which makes the 1st strcpy.
+// 4) The ConvertDirent function will fill DirectoryEntry outputEntry with
+//    pointers from byte[] buffer.
+// 5) The managed code uses DirectoryEntry outputEntry to find start of d_name
+//    and the value of d_namelen, if avalable, to copy the name from
+//    byte[] buffer into a managed string that the caller can use; this makes
 //    the 2nd and final strcpy.
 extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* outputEntry)
 {

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -177,11 +177,11 @@ check_cxx_source_compiles(
     #include <dirent.h>
     int main(void)
     {
-	DIR* dir;
+    DIR* dir;
         struct dirent* entry;
-	struct dirent* result;
+    struct dirent* result;
         readdir_r(dir,entry,&result);
-	return 0;
+    return 0;
     }
     "
     HAVE_GNU_READDIR_R)

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -184,7 +184,7 @@ check_cxx_source_compiles(
         return 0;
     }
     "
-    HAVE_GNU_READDIR_R)
+    HAVE_READDIR_R)
 
 check_cxx_source_compiles(
     "

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -174,6 +174,20 @@ check_cxx_source_compiles(
 
 check_cxx_source_compiles(
     "
+    #include <dirent.h>
+    int main(void)
+    {
+	DIR* dir;
+        struct dirent* entry;
+	struct dirent* result;
+        readdir_r(dir,entry,&result);
+	return 0;
+    }
+    "
+    HAVE_GNU_READDIR_R)
+
+check_cxx_source_compiles(
+    "
     #include <sys/types.h>
     #include <sys/event.h>
     int main(void)

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -177,11 +177,11 @@ check_cxx_source_compiles(
     #include <dirent.h>
     int main(void)
     {
-    DIR* dir;
+        DIR* dir;
         struct dirent* entry;
-    struct dirent* result;
-        readdir_r(dir,entry,&result);
-    return 0;
+        struct dirent* result;
+        readdir_r(dir, entry, &result);
+        return 0;
     }
     "
     HAVE_GNU_READDIR_R)

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -288,12 +288,12 @@ check_cxx_source_runs(
     #include <sys/time.h>
     int main()
     {
-        int ret; 
+        int ret;
         struct timespec ts;
         ret = clock_gettime(CLOCK_MONOTONIC, &ts);
         exit(ret);
     }
-    " 
+    "
     HAVE_CLOCK_MONOTONIC)
 
 check_function_exists(
@@ -413,9 +413,9 @@ check_function_exists(
 
 set (HAVE_INOTIFY 0)
 if (HAVE_INOTIFY_INIT AND HAVE_INOTIFY_ADD_WATCH AND HAVE_INOTIFY_RM_WATCH)
-	set (HAVE_INOTIFY 1)
+    set (HAVE_INOTIFY 1)
 elseif (CMAKE_SYSTEM_NAME STREQUAL Linux)
-	message(FATAL_ERROR "Cannot find inotify functions on a Linux platform.")
+    message(FATAL_ERROR "Cannot find inotify functions on a Linux platform.")
 endif()
 
 check_cxx_source_compiles(
@@ -442,8 +442,8 @@ check_cxx_source_compiles(
 check_cxx_source_compiles(
     "
     #include <curl/curl.h>
-    int main() 
-    { 
+    int main()
+    {
         int i = CURL_SSLVERSION_TLSv1_0;
         i = CURL_SSLVERSION_TLSv1_1;
         i = CURL_SSLVERSION_TLSv1_2;


### PR DESCRIPTION
when compiling against glibc 2.24 a deprecated warning stops compilation.
This PR should fix it without changing behavior too much.

Changing to the non_reentrant version of `readdir()` does make `int32_t SystemNative_ReadDirR()` thread unsafe. The thread safety conditions documented by [glibc](https://www.gnu.org/software/libc/manual/html_node/Reading_002fClosing-Directory.html#Reading_002fClosing-Directory) says glibc's implementation of `readdir()` is thread safe _unless_ more than one thread uses same directory stream pointer as input to `readdir()` , behavior is undefined.

Is this an acceptable change, or must extra steps be taken to ensure thread safety?