### PR TITLE
Revises TestAsyncHalfCharacterAtATime test

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -143,11 +143,19 @@ namespace System.Diagnostics.Tests
             p.StartInfo.StandardOutputEncoding = Encoding.Unicode;
             p.OutputDataReceived += (s, e) =>
             {
-                if (!receivedOutput)
+                try
                 {
-                    Assert.Equal(e.Data, "a");
+                    if (!receivedOutput)
+                    {
+                        Assert.Equal(e.Data, "a");
+                    }
+                    receivedOutput = true;
                 }
-                receivedOutput = true;
+                catch (System.Exception)
+                {
+                    // This ensures that the exception in event handlers does not break
+                    // the whole unittest
+                }
             };
             p.Start();
             p.BeginOutputReadLine();


### PR DESCRIPTION
This commit introduces exception handling routine in OutputDataReceived
event handler in TestAsyncHalfCharacterAtATime unittest in order to make
an exception in the handler not to break the whole unittest.

This commit fixes #10809.