### PR TITLE
Disable three failing JSON serialization tests

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1894,6 +1894,7 @@ public static partial class DataContractJsonSerializerTests
         Assert.StrictEqual(x.P2, y.P2);
     }
 
+    [ActiveIssue(10852, PlatformID.Linux)]
     [Fact]
     public static void DCJS_TypeWithAllPrimitiveProperties()
     {
@@ -1935,6 +1936,7 @@ public static partial class DataContractJsonSerializerTests
         Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
     }
 
+    [ActiveIssue(10852, PlatformID.Linux)]
     [Fact]
     public static void DCJS_ArrayOfDateTime()
     {

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2268,6 +2268,7 @@ public static partial class DataContractSerializerTests
         Assert.StrictEqual(true, Enumerable.SequenceEqual(value, deserialized));
     }
 
+    [ActiveIssue(10852, PlatformID.Linux)]
     [Fact]
     public static void DCS_ArrayOfDateTime()
     {


### PR DESCRIPTION
These are causing the main builds to fail after https://github.com/dotnet/corefx/pull/10798.
cc: @shmao 