### PR TITLE
Enable reading loaded PE file using a stream

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
@@ -166,6 +166,8 @@ namespace System.Reflection.PortableExecutable
                 throw new ArgumentOutOfRangeException(nameof(options));
             }
 
+            IsLoadedImage = (options & PEStreamOptions.IsLoadedImage) != 0;
+
             long start = peStream.Position;
             int actualSize = StreamExtensions.GetAndValidateSize(peStream, size, nameof(peStream));
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEStreamOptions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEStreamOptions.cs
@@ -35,13 +35,18 @@ namespace System.Reflection.PortableExecutable
         /// <see cref="PEReader"/> closes the stream automatically by the time the constructor returns unless <see cref="LeaveOpen"/> is specified.
         /// </remarks>
         PrefetchEntireImage = 1 << 2,
+
+        /// <summary>
+        /// Indicates that the underlying PE image has been loaded into memory by the OS loader.
+        /// </summary>
+        IsLoadedImage = 1 << 3,
     }
 
     internal static class PEStreamOptionsExtensions
     {
         public static bool IsValid(this PEStreamOptions options)
         {
-            return (options & ~(PEStreamOptions.LeaveOpen | PEStreamOptions.PrefetchEntireImage | PEStreamOptions.PrefetchMetadata)) == 0;
+            return (options & ~(PEStreamOptions.LeaveOpen | PEStreamOptions.PrefetchEntireImage | PEStreamOptions.PrefetchMetadata | PEStreamOptions.IsLoadedImage)) == 0;
         }
     }
 }

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/DebugDirectoryTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/DebugDirectoryTests.cs
@@ -39,6 +39,13 @@ namespace System.Reflection.PortableExecutable.Tests
             LoaderUtilities.LoadPEAndValidate(Misc.Debug, ValidateCodeView);
         }
 
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void CodeView_Loaded_FromStream()
+        {
+            LoaderUtilities.LoadPEAndValidate(Misc.Debug, ValidateCodeView, useStream: true);
+        }
+
         private void ValidateCodeView(PEReader reader)
         {
             // dumpbin:

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
@@ -76,6 +76,8 @@ namespace System.Reflection.PortableExecutable.Tests
             byte b = 1;
             Assert.True(new PEReader(&b, 1, isLoadedImage: true).IsLoadedImage);
             Assert.False(new PEReader(&b, 1, isLoadedImage: false).IsLoadedImage);
+
+            Assert.True(new PEReader(new MemoryStream(), PEStreamOptions.IsLoadedImage).IsLoadedImage);
             Assert.False(new PEReader(new MemoryStream()).IsLoadedImage);
         }
 

--- a/src/System.Reflection.Metadata/tests/TestUtilities/LoaderUtilities.cs
+++ b/src/System.Reflection.Metadata/tests/TestUtilities/LoaderUtilities.cs
@@ -6,12 +6,13 @@ using Microsoft.Win32.SafeHandles;
 using System.IO;
 using System.Reflection.PortableExecutable;
 using Xunit;
+using System.Reflection.Internal;
 
 namespace System.Reflection.Metadata.Tests
 {
     internal unsafe static class LoaderUtilities
     {
-        public static void LoadPEAndValidate(byte[] peImage, Action<PEReader> validator)
+        public static void LoadPEAndValidate(byte[] peImage, Action<PEReader> validator, bool useStream = false)
         {
             string tempFile = Path.GetTempFileName();
             File.WriteAllBytes(tempFile, peImage);
@@ -24,7 +25,9 @@ namespace System.Reflection.Metadata.Tests
                 Assert.Equal('M', (char)peImagePtr[0]);
                 Assert.Equal('Z', (char)peImagePtr[1]);
 
-                using (var peReader = new PEReader(peImagePtr, int.MaxValue, isLoadedImage: true))
+                using (var peReader = useStream ?
+                    new PEReader(new ReadOnlyUnmanagedMemoryStream(peImagePtr, int.MaxValue), PEStreamOptions.IsLoadedImage) : 
+                    new PEReader(peImagePtr, int.MaxValue, isLoadedImage: true))
                 {
                     validator(peReader);
                 }


### PR DESCRIPTION
Addresses scenario where the PE file is loaded into a different process (a debuggee, for example) and the stream implements remote memory reading.