### PR TITLE
Change caching in Environment.ProcessorCount

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
@@ -191,7 +191,7 @@ namespace System
             return num;
         }
 
-        private static int ProcessorCountCore => (int)Interop.Sys.SysConf(Interop.Sys.SysConfName._SC_NPROCESSORS_ONLN);
+        public static int ProcessorCount => (int)Interop.Sys.SysConf(Interop.Sys.SysConfName._SC_NPROCESSORS_ONLN);
 
         private static void SetEnvironmentVariableCore(string variable, string value)
         {

--- a/src/System.Runtime.Extensions/src/System/Environment.WinRT.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.WinRT.cs
@@ -40,7 +40,7 @@ namespace System
             return new OperatingSystem(PlatformID.Win32NT, new Version(0, 0));
         });
 
-        private static int ProcessorCountCore => ProcessorCountFromSystemInfo;
+        public static int ProcessorCount => ProcessorCountFromSystemInfo;
 
         private static void SetEnvironmentVariableCore(string variable, string value)
         {

--- a/src/System.Runtime.Extensions/src/System/Environment.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.cs
@@ -13,8 +13,6 @@ namespace System
 {
     public static partial class Environment
     {
-        private static readonly Lazy<int> s_processorCount = new Lazy<int>(() => ProcessorCountCore);
-
         public static string CommandLine
         {
             get
@@ -153,9 +151,7 @@ namespace System
         public static bool Is64BitProcess => IntPtr.Size == 8;
 
         public static bool Is64BitOperatingSystem => Is64BitProcess || Is64BitOperatingSystemWhen32BitProcess;
-
-        public static int ProcessorCount => s_processorCount.Value;
-
+        
         public static void SetEnvironmentVariable(string variable, string value)
         {
             ValidateVariableAndValue(variable, ref value);


### PR DESCRIPTION
When I moved Environment to corefx, I added caching for ProcessorCount, but I did so at too coarse a level.  coreclr has two different paths for getting the current processor count, one of which caches, the other doesn't.  This commit changes corefx to match.

(Most easily reviewed with whitespace-ignore: https://github.com/dotnet/corefx/pull/10865/files?w=1)

Fixes https://github.com/dotnet/corefx/issues/10484
cc: @ianhays 