### PR TITLE
Setting TCP as default for Azure endpoint

### DIFF
--- a/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.Windows.cs
+++ b/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Data.Common;
 using System.Data.SqlClient;
 using System.Runtime.InteropServices;
 
@@ -326,6 +327,10 @@ namespace System.Data.SqlClient
                 clientConsumerInfo.fSynchronousConnection = fSync;
                 clientConsumerInfo.timeout = timeout;
                 clientConsumerInfo.fParallel = fParallel;
+
+                clientConsumerInfo.transparentNetworkResolution = TransparentNetworkResolutionMode.DisabledMode;
+                clientConsumerInfo.totalTimeout = SniOpenTimeOut;
+                clientConsumerInfo.isAzureSqlServerEndpoint = ADP.IsAzureSqlServerEndpoint(constring);
 
                 if (spnBuffer != null)
                 {

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1047,4 +1047,16 @@
   <data name="SNI_PN9" xml:space="preserve">
     <value>SQL Network Interfaces</value>
   </data>
+  <data name="AZURESQL_GenericEndpoint" xml:space="preserve">
+    <value>.database.windows.net</value>
+  </data>
+  <data name="AZURESQL_GermanEndpoint" xml:space="preserve">
+    <value>.database.cloudapi.de</value>
+  </data>
+  <data name="AZURESQL_UsGovEndpoint" xml:space="preserve">
+    <value>.database.usgovcloudapi.net</value>
+  </data>
+  <data name="AZURESQL_ChinaEndpoint" xml:space="preserve">
+    <value>.database.chinacloudapi.cn</value>
+  </data>
 </root>

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
@@ -1071,5 +1071,43 @@ namespace System.Data.Common
 
             return s_systemDataVersion;
         }
+
+
+        static internal readonly string[] AzureSqlServerEndpoints = {Res.GetString(Res.AZURESQL_GenericEndpoint),
+                                                                     Res.GetString(Res.AZURESQL_GermanEndpoint),
+                                                                     Res.GetString(Res.AZURESQL_UsGovEndpoint),
+                                                                     Res.GetString(Res.AZURESQL_ChinaEndpoint)};
+
+        // This method assumes dataSource parameter is in TCP connection string format.
+        static internal bool IsAzureSqlServerEndpoint(string dataSource)
+        {
+            // remove server port
+            int i = dataSource.LastIndexOf(',');
+            if (i >= 0)
+            {
+                dataSource = dataSource.Substring(0, i);
+            }
+
+            // check for the instance name
+            i = dataSource.LastIndexOf('\\');
+            if (i >= 0)
+            {
+                dataSource = dataSource.Substring(0, i);
+            }
+
+            // trim redundant whitespaces
+            dataSource = dataSource.Trim();
+
+            // check if servername end with any azure endpoints
+            for (i = 0; i < AzureSqlServerEndpoints.Length; i++)
+            {
+                if (dataSource.EndsWith(AzureSqlServerEndpoints[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="SqlConnectionTest.RetrieveStatistics.cs" />
     <Compile Include="SqlErrorCollectionTest.cs" />
     <Compile Include="SqlStringTest.cs" />
+    <Compile Include="TcpDefaultForAzureTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Data.SqlClient.csproj"> 

--- a/src/System.Data.SqlClient/tests/FunctionalTests/TcpDefaultForAzureTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/TcpDefaultForAzureTest.cs
@@ -1,0 +1,135 @@
+﻿using System.Diagnostics;
+using Xunit;
+
+namespace System.Data.SqlClient.Tests
+{
+    public static class TcpDefaultForAzureTest
+    {
+        private const string NP = "Named Pipes Provider";
+        private const string TCP = "TCP Provider";
+        private const string InvalidHostname = "invalidHostname";
+        private const string ErrorMessage = "A network-related or instance-specific error occurred while establishing a connection to SQL Server.";
+
+        private static string[] AzureExtensions;
+        private static SqlConnectionStringBuilder builder;
+
+        static TcpDefaultForAzureTest()
+        {
+            AzureExtensions = new string[]
+                {
+                    ".database.windows.net",
+                    ".database.cloudapi.de",
+                    ".database.usgovcloudapi.net",
+                    ".database.chinacloudapi.cn"
+                };
+
+            builder = new SqlConnectionStringBuilder();
+            builder.ConnectTimeout = 1;
+        }
+
+
+        [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
+        public static void NonAzureNoProtocolConnectionTestOnWindows()
+        {
+            builder.DataSource = InvalidHostname;
+            Assert.True(IsConnectionFailedOn(builder.ConnectionString, NP));
+        }
+
+
+        [Fact]
+        [PlatformSpecific(Xunit.PlatformID.AnyUnix)]
+        public static void NonAzureNoProtocolConnectionTestOnUnix()
+        {
+            builder.DataSource = InvalidHostname;
+            Assert.True(IsConnectionFailedOn(builder.ConnectionString, TCP));
+        }
+
+
+        [Fact]
+        public static void NonAzureTcpConnectionTest()
+        {
+            builder.DataSource = "tcp:" + InvalidHostname;
+            Assert.True(IsConnectionFailedOn(builder.ConnectionString, TCP));
+        }
+
+
+        [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
+        public static void NonAzureNpConnectionTest()
+        {
+            builder.DataSource = "np:\\\\" + InvalidHostname + "\\pipe\\sql\\query";
+            Assert.True(IsConnectionFailedOn(builder.ConnectionString, NP));
+        }
+
+
+        [Fact]
+        public static void AzureNoProtocolConnectionTest()
+        {
+            foreach (string extension in AzureExtensions)
+            {
+                builder.DataSource = InvalidHostname + extension;
+                Assert.True(IsConnectionFailedOn(builder.ConnectionString, TCP));
+            }
+        }
+
+
+        [Fact]
+        public static void AzureTcpConnectionTest()
+        {
+            foreach (string extension in AzureExtensions)
+            {
+                builder.DataSource = "tcp:" + InvalidHostname + extension;
+                Assert.True(IsConnectionFailedOn(builder.ConnectionString, TCP));
+            }
+        }
+
+
+        [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
+        public static void AzureNpConnectionTest()
+        {
+            foreach (string extension in AzureExtensions)
+            {
+                builder.DataSource = "np:\\\\" + InvalidHostname + extension + "\\pipe\\sql\\query";
+                Assert.True(IsConnectionFailedOn(builder.ConnectionString, NP));
+            }
+        }
+
+
+        private static bool IsConnectionFailedOn(string connString, string protocol)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(connString));
+            Debug.Assert(!string.IsNullOrWhiteSpace(protocol));
+            Debug.Assert(protocol == NP || protocol == TCP);
+
+            string errorMessage = Connect(connString);
+
+            return errorMessage != null &&
+                    errorMessage.Contains(ErrorMessage) &&
+                    errorMessage.Contains(String.Format("provider: {0}, error", protocol));
+        }
+
+
+        private static string Connect(string connString)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(connString));
+
+            string errorMessage = null;
+            using (SqlConnection connection = new SqlConnection(connString))
+            {
+                try
+                {
+                    connection.Open();
+                    connection.Close();
+                }
+                catch (Exception e)
+                {
+                    errorMessage = e.Message;
+                }
+            }
+
+            return errorMessage;
+        }
+    }
+}


### PR DESCRIPTION
@saurabh500 @corivera @YoungGah 

DESCRIPTION:
This change enables a functionality that makes native SNI use TCP protocol
when no protocol specified in connection string and SQL Server is Azure
endpoint.

WHY:
Previously, native SNI tries every possible protocols (Shared Memory, TCP,
Named Pipe) to make connection when no protocol specified in connection
string.
However, since Azure SQL Server only accepts TCP for connection, there is
no need to try SM or NP when targeting server is Azure endpoint.
This change makes native SNI try TCP only when no protocol specified in
connection string and SQL Server is Azure endpoint.