### PR TITLE
Add full-version package dependency verification

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -60,7 +60,6 @@
 
   <PropertyGroup Condition="'$(RestoreDuringBuild)'=='true'">
     <TraversalBuildDependsOn>
-      ValidateAllProjectDependencies;
       BatchRestorePackages;
       ValidateExactRestore;
       CreateOrUpdateCurrentVersionFile;
@@ -76,7 +75,7 @@
 
   <UsingTask TaskName="GatherDirectoriesToRestore" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
-  <Target Name="BatchRestorePackages">
+  <Target Name="BatchRestorePackages" DependsOnTargets="VerifyDependencies">
     <MakeDir Directories="$(PackagesDir)" Condition="!Exists('$(PackagesDir)')" /> 
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages..." />
@@ -103,23 +102,6 @@
       <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Generating Test project.json's...done" />
   </Target>
 
-  <!-- Task from buildtools that validates dependencies contained in project.json files. -->
-  <UsingTask TaskName="ValidateProjectDependencyVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-
-  <Target Name="ValidateAllProjectDependencies"
-          Condition="'$(ValidatePackageVersions)'=='true' and '@(ProjectJsonFiles)'!=''">
-    <ValidateProjectDependencyVersions ProjectJsons="@(ProjectJsonFiles)"
-                                       ProhibitFloatingDependencies="$(ProhibitFloatingDependencies)"
-                                       ValidationPatterns="@(ValidationPattern)" />
-  </Target>
-
-  <Target Name="UpdateInvalidPackageVersions">
-    <ValidateProjectDependencyVersions ProjectJsons="@(ProjectJsonFiles)"
-                                       ProhibitFloatingDependencies="$(ProhibitFloatingDependencies)"
-                                       ValidationPatterns="@(ValidationPattern)"
-                                       UpdateInvalidDependencies="true" />
-  </Target>
-  
   <!-- Task from buildtools that uses lockfiles to validate that packages restored are exactly what were specified. -->
   <UsingTask TaskName="ValidateExactRestore" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
   

--- a/dependencies.props
+++ b/dependencies.props
@@ -1,0 +1,97 @@
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
+  <PropertyGroup>
+    <CoreFxCurrentRef>6be382282332b045c9c9532631bdc0c22925b93a</CoreFxCurrentRef>
+    <CoreClrCurrentRef>6be382282332b045c9c9532631bdc0c22925b93a</CoreClrCurrentRef>
+    <ExternalCurrentRef>d39c6fc52342a5efc925f4621683d7cdebcc3da0</ExternalCurrentRef>
+  </PropertyGroup>
+
+  <!-- Auto-upgraded properties for each build info dependency. -->
+  <PropertyGroup>
+    <CoreFxExpectedPrerelease>beta-24416-03</CoreFxExpectedPrerelease>
+    <CoreClrExpectedPrerelease>beta-24416-04</CoreClrExpectedPrerelease>
+    <ExternalExpectedPrerelease>beta-24415-00</ExternalExpectedPrerelease>
+  </PropertyGroup>
+
+  <!-- Full package version strings that are used in other parts of the build. -->
+  <PropertyGroup>
+    <AppXRunnerVersion>1.0.3-prerelease-00614-01</AppXRunnerVersion>
+  </PropertyGroup>
+
+  <!-- Package dependency verification/auto-upgrade configuration. -->
+  <PropertyGroup>
+    <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
+    <DependencyBranch>master</DependencyBranch>
+    <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <RemoteDependencyBuildInfo Include="CoreFx">
+      <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/$(DependencyBranch)</BuildInfoPath>
+      <CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
+    </RemoteDependencyBuildInfo>
+    <RemoteDependencyBuildInfo Include="CoreClr">
+      <BuildInfoPath>$(BaseDotNetBuildInfo)coreclr/$(DependencyBranch)</BuildInfoPath>
+      <CurrentRef>$(CoreClrCurrentRef)</CurrentRef>
+    </RemoteDependencyBuildInfo>
+    <RemoteDependencyBuildInfo Include="External">
+      <BuildInfoPath>$(BaseDotNetBuildInfo)projectk-tfs/$(DependencyBranch)</BuildInfoPath>
+      <CurrentRef>$(ExternalCurrentRef)</CurrentRef>
+    </RemoteDependencyBuildInfo>
+
+    <DependencyBuildInfo Include="@(RemoteDependencyBuildInfo)">
+      <RawVersionsBaseUrl>https://raw.githubusercontent.com/dotnet/versions</RawVersionsBaseUrl>
+    </DependencyBuildInfo>
+
+    <XmlUpdateStep Include="CoreFx">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>CoreFxExpectedPrerelease</ElementName>
+      <BuildInfoName>CoreFx</BuildInfoName>
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="CoreClr">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>CoreClrExpectedPrerelease</ElementName>
+      <BuildInfoName>CoreClr</BuildInfoName>
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="External">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>ExternalExpectedPrerelease</ElementName>
+      <BuildInfoName>External</BuildInfoName>
+    </XmlUpdateStep>
+  </ItemGroup>
+
+  <!-- Set up dependencies on packages that aren't found in a BuildInfo. -->
+  <ItemGroup>
+    <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.5" />
+    <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.5.1" />
+    <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.5.2" />
+    <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.6" />
+    <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.6.1" />
+    <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.6.2" />
+    <TargetingPackDependency Include="Microsoft.TargetingPack.Private.WinRT" />
+    <StaticDependency Include="@(TargetingPackDependency)">
+      <Version>1.0.1</Version>
+    </StaticDependency>
+
+    <XUnitDependency Include="xunit"/>
+    <XUnitDependency Include="xunit.runner.utility"/>
+    <XUnitDependency Include="xunit.runner.console"/>
+    <StaticDependency Include="@(XUnitDependency)">
+      <Version>2.1.0</Version>
+    </StaticDependency>
+
+    <StaticDependency Include="Microsoft.xunit.netcore.extensions;Microsoft.DotNet.BuildTools.TestSuite">
+      <Version>1.0.0-prerelease-00704-03</Version>
+    </StaticDependency>
+
+    <DependencyBuildInfo Include="@(StaticDependency)">
+      <PackageId>%(Identity)</PackageId>
+      <UpdateStableVersions>true</UpdateStableVersions>
+    </DependencyBuildInfo>
+
+    <DependencyBuildInfo Include="uwpRunnerVersion">
+      <PackageId>microsoft.xunit.runner.uwp</PackageId>
+      <Version>$(AppXRunnerVersion)</Version>
+    </DependencyBuildInfo>
+  </ItemGroup>
+</Project>

--- a/dir.props
+++ b/dir.props
@@ -85,91 +85,11 @@
     <EnableDotnetAnalyzers Condition="'$(EnableDotnetAnalyzers)'==''">true</EnableDotnetAnalyzers>
   </PropertyGroup>
 
-  <!-- Package dependency validation -->
-  <PropertyGroup>
-    <ValidatePackageVersions>true</ValidatePackageVersions>
-    <ProhibitFloatingDependencies>true</ProhibitFloatingDependencies>
-
-    <CoreFxExpectedPrerelease>beta-24416-03</CoreFxExpectedPrerelease>
-    <CoreClrExpectedPrerelease>beta-24416-04</CoreClrExpectedPrerelease>
-    <ExternalExpectedPrerelease>beta-24415-00</ExternalExpectedPrerelease>
-
-    <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore\.Targets)|(Microsoft\.NETCore\.Platforms)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)$</CoreFxVersionsIdentityRegex>
-
-    <BaseDotNetBuildInfoUrl>https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/</BaseDotNetBuildInfoUrl>
-    <DependencyBranch>master</DependencyBranch>
-  </PropertyGroup>
+  <!-- Provides package dependency version properties and verification/auto-upgrade configuration -->
+  <Import Project="$(MSBuildThisFileDirectory)dependencies.props" />
 
   <Import Project="$(MSBuildThisFileDirectory)pkg/ExternalPackages/versions.props" Condition="Exists('$(MSBuildThisFileDirectory)pkg/ExternalPackages/versions.props')" />
 
-  <!-- Dependency auto-upgrade configuration -->
-  <ItemGroup>
-    <DependencyBuildInfo Include="CoreFx">
-      <RawUrl>$(BaseDotNetBuildInfoUrl)corefx/$(DependencyBranch)</RawUrl>
-    </DependencyBuildInfo>
-    <DependencyBuildInfo Include="CoreClr">
-      <RawUrl>$(BaseDotNetBuildInfoUrl)coreclr/$(DependencyBranch)</RawUrl>
-    </DependencyBuildInfo>
-    <DependencyBuildInfo Include="External">
-      <RawUrl>$(BaseDotNetBuildInfoUrl)projectk-tfs/$(DependencyBranch)</RawUrl>
-    </DependencyBuildInfo>
-
-    <XmlUpdateStep Include="CoreFx">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>CoreFxExpectedPrerelease</ElementName>
-      <BuildInfoName>CoreFx</BuildInfoName>
-    </XmlUpdateStep>
-    <XmlUpdateStep Include="CoreClr">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>CoreClrExpectedPrerelease</ElementName>
-      <BuildInfoName>CoreClr</BuildInfoName>
-    </XmlUpdateStep>
-    <XmlUpdateStep Include="External">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>ExternalExpectedPrerelease</ElementName>
-      <BuildInfoName>External</BuildInfoName>
-    </XmlUpdateStep>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ValidationPattern Include="CoreFxVersions">
-      <IdentityRegex>$(CoreFxVersionsIdentityRegex)</IdentityRegex>
-      <ExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExpectedPrerelease>
-    </ValidationPattern>
-    <ValidationPattern Include="CoreClrVersions">
-      <IdentityRegex>^(?i)(Microsoft\.NETCore\.Runtime.*)|(Microsoft\.TargetingPack\.Private\.CoreCLR)$</IdentityRegex>
-      <ExpectedPrerelease>$(CoreClrExpectedPrerelease)</ExpectedPrerelease>
-    </ValidationPattern>
-    <ValidationPattern Include="CoreLibTargetingPackVersions">
-      <IdentityRegex>^(?i)Microsoft\.TargetingPack\.Private\.NETNative$</IdentityRegex>
-      <ExpectedPrerelease>$(ExternalExpectedPrerelease)</ExpectedPrerelease>
-    </ValidationPattern>
-    <ValidationPattern Include="TargetingPackVersions">
-      <IdentityRegex>^(?i)Microsoft\.TargetingPack\.(NetFramework.*|Private\.WinRT)$</IdentityRegex>
-      <ExpectedVersion>1.0.1</ExpectedVersion>
-    </ValidationPattern>
-    <ValidationPattern Include="xUnitStableVersions">
-      <IdentityRegex>^(?i)xunit$</IdentityRegex>
-      <ExpectedVersion>2.1.0</ExpectedVersion>
-    </ValidationPattern>
-    <ValidationPattern Include="xUnitExtensionsVersions">
-      <IdentityRegex>^(?i)Microsoft\.xunit\.netcore\.extensions$</IdentityRegex>
-      <ExpectedVersion>1.0.0-prerelease-00704-03</ExpectedVersion>
-    </ValidationPattern>
-    <ValidationPattern Include="buildToolsTestSuiteVersions">
-      <IdentityRegex>^(?i)Microsoft\.DotNet\.BuildTools\.TestSuite$</IdentityRegex>
-      <ExpectedVersion>1.0.0-prerelease-00704-03</ExpectedVersion>
-    </ValidationPattern>
-    <ValidationPattern Include="uwpRunnerVersion">
-      <IdentityRegex>^(?i)microsoft\.xunit\.runner\.uwp$</IdentityRegex>
-      <ExpectedVersion>$(AppXRunnerVersion)</ExpectedVersion>
-    </ValidationPattern>
-  </ItemGroup>
-
-  <!-- Runner versions -->
-  <PropertyGroup>
-    <AppXRunnerVersion>1.0.3-prerelease-00614-01</AppXRunnerVersion>
-  </PropertyGroup>
   <!-- Import packaging props -->
   <Import Project="$(MSBuildThisFileDirectory)Packaging.props"/>
 


### PR DESCRIPTION
CoreFX was already using full package versions to upgrade dependencies, so this brings in updated tools and configuration to do verification the same way. No more package id regexes.

I moved the verification step to be a dependency of `BatchRestorePackages`, so it runs during `sync -p`. This will make sure it isn't unintentionally skipped during dev, and it also means that if CI uses a two-step "sync then build" flow it will still verify before restore.

Here's an example PR that shows how it upgrades both the CurrentRef and ExpectedPrerelease for CoreCLR (as well as project.jsons as usual): https://github.com/dagood/corefx/pull/20

Here's some more reasoning behind this change: https://github.com/dotnet/buildtools/issues/732

Something potentially important to note is the new network dependency on github when `sync`ing. The download for each CurrentRef is cached in the `Tools` dir, and it can be disabled by setting `SkipVerifyPackageVersions` to `true`, so it shouldn't be an impact to corefx devs.

@weshaggard @ericstj
(FYI @eerhardt)