### PR TITLE
Fix bug in property System.Console.ConsolePal.Windows.WIndowTop

### DIFF
--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -914,7 +914,7 @@ namespace System
             get
             {
                 Interop.mincore.CONSOLE_SCREEN_BUFFER_INFO csbi = GetBufferInfo();
-                return csbi.srWindow.Left;
+                return csbi.srWindow.Top;
             }
             set
             {


### PR DESCRIPTION
Property WindowTop returns csbi.srWindow.Left, which it should be srWindow.Top