### PR TITLE
Fix WebSocketException.SetErrorCodeOnError to only set on error

### DIFF
--- a/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketException.cs
+++ b/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketException.cs
@@ -162,7 +162,10 @@ namespace System.Net.WebSockets
         // as the Exception..ctor() throws on setting HResult to 0. The default for HResult is -2147467259.
         private void SetErrorCodeOnError(int nativeError)
         {
-            HResult = nativeError;
+            if (!Succeeded(nativeError))
+            {
+                HResult = nativeError;
+            }
         }
 
         private static bool Succeeded(int hr)

--- a/src/System.Net.WebSockets/tests/WebSocketExceptionTests.cs
+++ b/src/System.Net.WebSockets/tests/WebSocketExceptionTests.cs
@@ -24,12 +24,12 @@ namespace System.Net.WebSockets.Tests
         };
 
         public static object[][] NativeErrorData = {
-            new object[] { 0, WebSocketError.Success },
-            new object[] { -2147467259, WebSocketError.NativeError },
+            new object[] { 0, WebSocketError.Success, unchecked((int)0x80004005) },
+            new object[] { -2147467259, WebSocketError.NativeError, -2147467259},
         };
 
         public static object[][] UnrelatedErrorData =
-            ErrorData.SelectMany(wse => NativeErrorData.Select(ne => new object[] { wse[0], ne[0] })).ToArray();
+            ErrorData.SelectMany(wse => NativeErrorData.Select(ne => new object[] { wse[0], ne[0], ne[2] })).ToArray();
 
         [Theory, MemberData(nameof(ErrorData))]
         public void ConstructorTests_WebSocketError_Success(WebSocketError error)
@@ -72,81 +72,82 @@ namespace System.Net.WebSockets.Tests
         }
 
         [Theory, MemberData(nameof(NativeErrorData))]
-        public void ConstructorTests_NativeError_Success(int nativeError, WebSocketError webSocketError)
+        public void ConstructorTests_NativeError_Success(int nativeError, WebSocketError webSocketError, int expectedHResult)
         {
             var wse = new WebSocketException(nativeError);
-            Assert.Equal(wse.HResult, nativeError);
+            Assert.Equal(expectedHResult, wse.HResult);
             Assert.Equal(wse.WebSocketErrorCode, webSocketError);
             Assert.NotEqual(wse.Message, "");
             Assert.Null(wse.InnerException);
         }
 
         [Theory, MemberData(nameof(NativeErrorData))]
-        public void ConstructorTests_NativeError_Message_Success(int nativeError, WebSocketError webSocketError)
+        public void ConstructorTests_NativeError_Message_Success(int nativeError, WebSocketError webSocketError, int expectedHResult)
         {
             const string Message = "Message";
             var wse = new WebSocketException(nativeError, Message);
-            Assert.Equal(wse.HResult, nativeError);
+            Assert.Equal(expectedHResult, wse.HResult);
             Assert.Equal(wse.WebSocketErrorCode, webSocketError);
             Assert.Equal(wse.Message, Message);
             Assert.Null(wse.InnerException);
         }
 
         [Theory, MemberData(nameof(NativeErrorData))]
-        public void ConstructorTests_NativeError_Exception_Success(int nativeError, WebSocketError webSocketError)
+        public void ConstructorTests_NativeError_Exception_Success(int nativeError, WebSocketError webSocketError, int expectedHResult)
         {
             var inner = new Exception();
             var wse = new WebSocketException(nativeError, inner);
-            Assert.Equal(wse.HResult, nativeError);
+            Assert.Equal(expectedHResult, wse.HResult);
             Assert.Equal(wse.WebSocketErrorCode, webSocketError);
             Assert.NotEqual(wse.Message, "");
             Assert.Equal(wse.InnerException, inner);
         }
 
         [Theory, MemberData(nameof(UnrelatedErrorData))]
-        public void ConstructorTests_WebSocketError_NativeError_Success(int nativeError, WebSocketError error)
+        public void ConstructorTests_WebSocketError_NativeError_Success(int nativeError, WebSocketError error, int expectedHResult)
         {
             var wse = new WebSocketException(error, nativeError);
-            Assert.Equal(wse.HResult, nativeError);
+            Assert.Equal(expectedHResult, wse.HResult);
             Assert.Equal(wse.WebSocketErrorCode, error);
             Assert.NotEqual(wse.Message, "");
             Assert.Null(wse.InnerException);
         }
 
         [Theory, MemberData(nameof(UnrelatedErrorData))]
-        public void ConstructorTests_WebSocketError_NativeError_Message_Success(int nativeError, WebSocketError error)
+        public void ConstructorTests_WebSocketError_NativeError_Message_Success(int nativeError, WebSocketError error, int expectedHResult)
         {
             const string Message = "Message";
             var wse = new WebSocketException(error, nativeError, Message);
-            Assert.Equal(wse.HResult, nativeError);
+            Assert.Equal(expectedHResult, wse.HResult);
             Assert.Equal(wse.WebSocketErrorCode, error);
             Assert.Equal(wse.Message, Message);
             Assert.Null(wse.InnerException);
         }
 
         [Theory, MemberData(nameof(UnrelatedErrorData))]
-        public void ConstructorTests_WebSocketError_NativeError_Exception_Success(int nativeError, WebSocketError error)
+        public void ConstructorTests_WebSocketError_NativeError_Exception_Success(int nativeError, WebSocketError error, int expectedHResult)
         {
             var inner = new Exception();
             var wse = new WebSocketException(error, nativeError, inner);
-            Assert.Equal(wse.HResult, nativeError);
+            Assert.Equal(expectedHResult, wse.HResult);
             Assert.Equal(wse.WebSocketErrorCode, error);
             Assert.NotEqual(wse.Message, "");
             Assert.Equal(wse.InnerException, inner);
         }
 
         [Theory, MemberData(nameof(UnrelatedErrorData))]
-        public void ConstructorTests_WebSocketError_NativeError_Message_Exception_Success(int nativeError, WebSocketError error)
+        public void ConstructorTests_WebSocketError_NativeError_Message_Exception_Success(int nativeError, WebSocketError error, int expectedHResult)
         {
             const string Message = "Message";
             var inner = new Exception();
             var wse = new WebSocketException(error, nativeError, Message, inner);
-            Assert.Equal(wse.HResult, nativeError);
+            Assert.Equal(expectedHResult, wse.HResult);
             Assert.Equal(wse.WebSocketErrorCode, error);
             Assert.Equal(wse.Message, Message);
             Assert.Equal(wse.InnerException, inner);
         }
 
+        [Fact]
         public void ConstructorTests_Message_Success()
         {
             const string Message = "Message";
@@ -156,6 +157,7 @@ namespace System.Net.WebSockets.Tests
             Assert.Null(wse.InnerException);
         }
 
+        [Fact]
         public void ConstructorTests_Message_Exception_Success()
         {
             const string Message = "Message";

--- a/src/System.Net.WebSockets/tests/WebSocketExceptionTests.cs
+++ b/src/System.Net.WebSockets/tests/WebSocketExceptionTests.cs
@@ -35,8 +35,8 @@ namespace System.Net.WebSockets.Tests
         public void ConstructorTests_WebSocketError_Success(WebSocketError error)
         {
             var wse = new WebSocketException(error);
-            Assert.Equal(wse.WebSocketErrorCode, error);
-            Assert.NotEqual(wse.Message, "");
+            Assert.Equal(error, wse.WebSocketErrorCode);
+            Assert.NotEqual("", wse.Message);
             Assert.Null(wse.InnerException);
         }
 
@@ -45,8 +45,8 @@ namespace System.Net.WebSockets.Tests
         {
             const string Message = "Message";
             var wse = new WebSocketException(error, Message);
-            Assert.Equal(wse.WebSocketErrorCode, error);
-            Assert.Equal(wse.Message, Message);
+            Assert.Equal(error, wse.WebSocketErrorCode);
+            Assert.Equal(Message, wse.Message);
             Assert.Null(wse.InnerException);
         }
 
@@ -55,9 +55,9 @@ namespace System.Net.WebSockets.Tests
         {
             var inner = new Exception();
             var wse = new WebSocketException(error, inner);
-            Assert.Equal(wse.WebSocketErrorCode, error);
-            Assert.NotEqual(wse.Message, "");
-            Assert.Equal(wse.InnerException, inner);
+            Assert.Equal(error, wse.WebSocketErrorCode);
+            Assert.NotEqual("", wse.Message);
+            Assert.Same(inner, wse.InnerException);
         }
 
         [Theory, MemberData(nameof(ErrorData))]
@@ -66,9 +66,9 @@ namespace System.Net.WebSockets.Tests
             const string Message = "Message";
             var inner = new Exception();
             var wse = new WebSocketException(error, Message, inner);
-            Assert.Equal(wse.WebSocketErrorCode, error);
-            Assert.Equal(wse.Message, Message);
-            Assert.Equal(wse.InnerException, inner);
+            Assert.Equal(error, wse.WebSocketErrorCode);
+            Assert.Equal(Message, wse.Message);
+            Assert.Same(inner, wse.InnerException);
         }
 
         [Theory, MemberData(nameof(NativeErrorData))]
@@ -76,8 +76,8 @@ namespace System.Net.WebSockets.Tests
         {
             var wse = new WebSocketException(nativeError);
             Assert.Equal(expectedHResult, wse.HResult);
-            Assert.Equal(wse.WebSocketErrorCode, webSocketError);
-            Assert.NotEqual(wse.Message, "");
+            Assert.Equal(webSocketError, wse.WebSocketErrorCode);
+            Assert.NotEqual("", wse.Message);
             Assert.Null(wse.InnerException);
         }
 
@@ -87,8 +87,8 @@ namespace System.Net.WebSockets.Tests
             const string Message = "Message";
             var wse = new WebSocketException(nativeError, Message);
             Assert.Equal(expectedHResult, wse.HResult);
-            Assert.Equal(wse.WebSocketErrorCode, webSocketError);
-            Assert.Equal(wse.Message, Message);
+            Assert.Equal(webSocketError, wse.WebSocketErrorCode);
+            Assert.Equal(Message, wse.Message);
             Assert.Null(wse.InnerException);
         }
 
@@ -98,9 +98,9 @@ namespace System.Net.WebSockets.Tests
             var inner = new Exception();
             var wse = new WebSocketException(nativeError, inner);
             Assert.Equal(expectedHResult, wse.HResult);
-            Assert.Equal(wse.WebSocketErrorCode, webSocketError);
-            Assert.NotEqual(wse.Message, "");
-            Assert.Equal(wse.InnerException, inner);
+            Assert.Equal(webSocketError, wse.WebSocketErrorCode);
+            Assert.NotEqual("", wse.Message);
+            Assert.Same(inner, wse.InnerException);
         }
 
         [Theory, MemberData(nameof(UnrelatedErrorData))]
@@ -108,8 +108,8 @@ namespace System.Net.WebSockets.Tests
         {
             var wse = new WebSocketException(error, nativeError);
             Assert.Equal(expectedHResult, wse.HResult);
-            Assert.Equal(wse.WebSocketErrorCode, error);
-            Assert.NotEqual(wse.Message, "");
+            Assert.Equal(error, wse.WebSocketErrorCode);
+            Assert.NotEqual("", wse.Message);
             Assert.Null(wse.InnerException);
         }
 
@@ -119,8 +119,8 @@ namespace System.Net.WebSockets.Tests
             const string Message = "Message";
             var wse = new WebSocketException(error, nativeError, Message);
             Assert.Equal(expectedHResult, wse.HResult);
-            Assert.Equal(wse.WebSocketErrorCode, error);
-            Assert.Equal(wse.Message, Message);
+            Assert.Equal(error, wse.WebSocketErrorCode);
+            Assert.Equal(Message, wse.Message);
             Assert.Null(wse.InnerException);
         }
 
@@ -130,9 +130,9 @@ namespace System.Net.WebSockets.Tests
             var inner = new Exception();
             var wse = new WebSocketException(error, nativeError, inner);
             Assert.Equal(expectedHResult, wse.HResult);
-            Assert.Equal(wse.WebSocketErrorCode, error);
-            Assert.NotEqual(wse.Message, "");
-            Assert.Equal(wse.InnerException, inner);
+            Assert.Equal(error, wse.WebSocketErrorCode);
+            Assert.NotEqual("", wse.Message);
+            Assert.Same(inner, wse.InnerException);
         }
 
         [Theory, MemberData(nameof(UnrelatedErrorData))]
@@ -142,9 +142,9 @@ namespace System.Net.WebSockets.Tests
             var inner = new Exception();
             var wse = new WebSocketException(error, nativeError, Message, inner);
             Assert.Equal(expectedHResult, wse.HResult);
-            Assert.Equal(wse.WebSocketErrorCode, error);
-            Assert.Equal(wse.Message, Message);
-            Assert.Equal(wse.InnerException, inner);
+            Assert.Equal(error, wse.WebSocketErrorCode);
+            Assert.Equal(Message, wse.Message);
+            Assert.Same(inner, wse.InnerException);
         }
 
         [Fact]
@@ -152,8 +152,8 @@ namespace System.Net.WebSockets.Tests
         {
             const string Message = "Message";
             var wse = new WebSocketException(Message);
-            Assert.Equal(wse.WebSocketErrorCode, WebSocketError.Success);
-            Assert.Equal(wse.Message, Message);
+            Assert.Equal(WebSocketError.Success, wse.WebSocketErrorCode);
+            Assert.Equal(Message, wse.Message);
             Assert.Null(wse.InnerException);
         }
 
@@ -163,9 +163,9 @@ namespace System.Net.WebSockets.Tests
             const string Message = "Message";
             var inner = new Exception();
             var wse = new WebSocketException(Message, inner);
-            Assert.Equal(wse.WebSocketErrorCode, WebSocketError.Success);
-            Assert.Equal(wse.Message, Message);
-            Assert.Equal(wse.InnerException, inner);
+            Assert.Equal(WebSocketError.Success, wse.WebSocketErrorCode);
+            Assert.Equal(Message, wse.Message);
+            Assert.Same(inner, wse.InnerException);
         }
     }
 }


### PR DESCRIPTION
- Fix WebSocketException.SetErrorCodeOnError... it was setting it always rather than only on error, resulting in different behavior from desktop (http://referencesource.microsoft.com/#System/net/System/Net/WebSockets/WebSocketException.cs,197)
- As long as I was fixing that, I fixed the order of the arguments to Assert.Equal in the tests, as well as changing a few Equal calls to Same calls, and marking a few tests as [Fact]s so that they actually ran.

Fixes https://github.com/dotnet/corefx/issues/10913
cc: @cipop, @davidsh, @ericeil, @anurse 