### PR TITLE
Add tests for DebugInfoExpression and SymbolDocumentInfo in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -825,7 +825,7 @@ namespace System.Linq.Expressions
         /// </summary>
         internal static Exception OutOfRange(string paramName, object p1)
         {
-            return new ArgumentOutOfRangeException(Strings.OutOfRange(paramName, p1), paramName);
+            return new ArgumentOutOfRangeException(paramName, Strings.OutOfRange(paramName, p1));
         }
         /// <summary>
         /// InvalidOperationException with message like "Cannot redefine label '{0}' in an inner block."

--- a/src/System.Linq.Expressions/tests/DebugInfo/DebugInfoExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/DebugInfo/DebugInfoExpressionTests.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public static class DebugInfoExpressionTests
+    {
+        [Theory]
+        [InlineData(1, 1, 1, 1, false)]
+        [InlineData(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, false)]
+        [InlineData(1, 1, int.MaxValue, int.MaxValue, false)]
+        [InlineData(5, 10, 15, 20, false)]
+        [InlineData(5, 25, 15, 20, false)]
+        [InlineData(0xfeefee, 0, 0xfeefee, 0, true)]
+        public static void DebugInfo(int startLine, int startColumn, int endLine, int endColumn, bool isClear)
+        {
+            SymbolDocumentInfo document = Expression.SymbolDocument("AFile");
+            DebugInfoExpression ex = Expression.DebugInfo(document, startLine, startColumn, endLine, endColumn);
+            VerifyDebugInfoExpression(ex, document, startLine, startColumn, endLine, endColumn, isClear);
+        }
+
+        [Fact]
+        public static void DebugInfo_Invalid()
+        {
+            Assert.Throws<ArgumentNullException>("document", () => Expression.DebugInfo(null, 1, 1, 1, 1));
+
+            SymbolDocumentInfo document = Expression.SymbolDocument("AFile");
+            Assert.Throws<ArgumentOutOfRangeException>("startLine", () => Expression.DebugInfo(document, 0, 1, 1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("startColumn", () => Expression.DebugInfo(document, 1, 0, 1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("endLine", () => Expression.DebugInfo(document, 1, 1, 0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("endColumn", () => Expression.DebugInfo(document, 1, 1, 1, 0));
+
+            Assert.Throws<ArgumentException>(null, () => Expression.DebugInfo(document, 10, 1, 1, 1));
+            Assert.Throws<ArgumentException>(null, () => Expression.DebugInfo(document, 1, 10, 1, 1));
+        }
+
+        [Fact]
+        public static void ClearDebugInfo()
+        {
+            SymbolDocumentInfo document = Expression.SymbolDocument("AFile");
+            DebugInfoExpression ex = Expression.ClearDebugInfo(document);
+            VerifyDebugInfoExpression(ex, document, 0xfeefee, 0, 0xfeefee, 0, true);
+        }
+
+        private static void VerifyDebugInfoExpression(DebugInfoExpression ex, SymbolDocumentInfo document, int startLine, int startColumn, int endLine, int endColumn, bool isClear)
+        {
+            Assert.Same(document, ex.Document);
+            Assert.Equal(startLine, ex.StartLine);
+            Assert.Equal(startColumn, ex.StartColumn);
+            Assert.Equal(endLine, ex.EndLine);
+            Assert.Equal(endColumn, ex.EndColumn);
+
+            Assert.Equal(ExpressionType.DebugInfo, ex.NodeType);
+            Assert.Equal(typeof(void), ex.Type);
+            Assert.Equal(isClear, ex.IsClear);
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/DebugInfo/SymbolDocumentInfoTests.cs
+++ b/src/System.Linq.Expressions/tests/DebugInfo/SymbolDocumentInfoTests.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public static class SymbolDocumentInfoTests
+    {
+        public static IEnumerable<object[]> TestData()
+        {
+            Guid documentType = new Guid(0x5a869d0b, 0x6611, 0x11d3, 0xbd, 0x2a, 0, 0, 0xf8, 8, 0x49, 0xbd);
+            yield return new object[] { "", Guid.Empty, Guid.Empty, documentType };
+            yield return new object[] { " \t \r ", Guid.Empty, Guid.NewGuid(), documentType };
+            yield return new object[] { "abc", Guid.NewGuid(), Guid.NewGuid(), documentType };
+            yield return new object[] { "\uD800\uDC00", Guid.NewGuid(), Guid.NewGuid(), Guid.Empty };
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public static void SymbolDocument(string fileName, Guid language, Guid languageVendor, Guid documentType)
+        {
+            if (documentType == new Guid(0x5a869d0b, 0x6611, 0x11d3, 0xbd, 0x2a, 0, 0, 0xf8, 8, 0x49, 0xbd))
+            {
+                if (languageVendor == Guid.Empty)
+                {
+                    if (language == Guid.Empty)
+                    {
+                        // SymbolDocument(string)
+                        SymbolDocumentInfo symbolDocument1 = Expression.SymbolDocument(fileName);
+                        VerifySymbolDocumentInfo(symbolDocument1, fileName, language, languageVendor, documentType);
+                    }
+                    // SymbolDocument(string, Guid)
+                    SymbolDocumentInfo symbolDocument2 = Expression.SymbolDocument(fileName, language);
+                    VerifySymbolDocumentInfo(symbolDocument2, fileName, language, languageVendor, documentType);
+                }
+                // SymbolDocument(string, Guid)
+                SymbolDocumentInfo symbolDocument3 = Expression.SymbolDocument(fileName, language, languageVendor);
+                VerifySymbolDocumentInfo(symbolDocument3, fileName, language, languageVendor, documentType);
+            }
+            // SymbolDocument(string, Guid, Guid)
+            SymbolDocumentInfo symbolDocument4 = Expression.SymbolDocument(fileName, language, languageVendor, documentType);
+            VerifySymbolDocumentInfo(symbolDocument4, fileName, language, languageVendor, documentType);
+        }
+
+        [Fact]
+        public static void SymbolDocument_NullFileName_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("fileName", () => Expression.SymbolDocument(null));
+            Assert.Throws<ArgumentNullException>("fileName", () => Expression.SymbolDocument(null, Guid.Empty));
+            Assert.Throws<ArgumentNullException>("fileName", () => Expression.SymbolDocument(null, Guid.Empty, Guid.Empty));
+            Assert.Throws<ArgumentNullException>("fileName", () => Expression.SymbolDocument(null, Guid.Empty, Guid.Empty, Guid.Empty));
+        }
+
+        private static void VerifySymbolDocumentInfo(SymbolDocumentInfo document, string fileName, Guid language, Guid languageVendor, Guid documentType)
+        {
+            Assert.Equal(fileName, document.FileName);
+            Assert.Equal(language, document.Language);
+            Assert.Equal(languageVendor, document.LanguageVendor);
+            Assert.Equal(documentType, document.DocumentType);
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -97,6 +97,8 @@
     <Compile Include="Constant\ConstantTests.cs" />
     <Compile Include="Convert\ConvertCheckedTests.cs" />
     <Compile Include="Convert\ConvertTests.cs" />
+    <Compile Include="DebugInfo\DebugInfoExpressionTests.cs" />
+    <Compile Include="DebugInfo\SymbolDocumentInfoTests.cs" />
     <Compile Include="Default\DefaultTests.cs" />
     <Compile Include="DelegateType\ActionTypeTests.cs" />
     <Compile Include="DelegateType\DelegateCreationTests.cs" />

--- a/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
+++ b/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
@@ -197,7 +197,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void VisitCollectionReturnSameIfChildrenUnchanged()
         {
-            var collection = new List<Expression> { Expression.Constant(0), Expression.Constant(2) }.AsReadOnly();
+            var collection = new List<Expression> { Expression.Constant(0), Expression.Constant(2), Expression.DebugInfo(Expression.SymbolDocument("fileName"), 1, 1, 1, 1) }.AsReadOnly();
             Assert.Same(collection, new DefaultVisitor().Visit(collection));
         }
 
@@ -338,6 +338,13 @@ namespace System.Linq.Expressions.Tests
             var call = (MethodCallExpression)innerBlock.Expressions.Last();
             var instance = (ConstantExpression)call.Object;
             Assert.Same(list, instance.Value);
+        }
+
+        [Fact]
+        public void Visit_DebugInfoExpression_DoesNothing()
+        {
+            DebugInfoExpression expression = Expression.DebugInfo(Expression.SymbolDocument("fileName"), 1, 1, 1, 1);
+            Assert.Same(expression, new DefaultVisitor().Visit(expression));
         }
     }
 }


### PR DESCRIPTION
And fix an incorrect param name in an exception message

Also contributes to #1198 (increases total coverage by around 2%)

/cc @stephentoub @VSadov