### PR TITLE
Throw specific error messages for unsupported zip

### DIFF
--- a/src/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/System.IO.Compression/src/Resources/Strings.resx
@@ -306,6 +306,9 @@
   <data name="UnsupportedCompression" xml:space="preserve">
     <value>The archive entry was compressed using an unsupported compression method.</value>
   </data>
+  <data name="UnsupportedCompressionMethod" xml:space="preserve">
+    <value>The archive entry was compressed using {0} and is not supported.</value>
+  </data>
   <data name="UpdateModeCapabilities" xml:space="preserve">
     <value>Update mode requires a stream with read, write, and seek capabilities.</value>
   </data>

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -749,7 +749,17 @@ namespace System.IO.Compression
                     if (CompressionMethod != CompressionMethodValues.Stored &&
                         CompressionMethod != CompressionMethodValues.Deflate)
                     {
-                        message = SR.UnsupportedCompression;
+                        switch (CompressionMethod)
+                        {
+                            case CompressionMethodValues.Deflate64:
+                            case CompressionMethodValues.BZip2:
+                            case CompressionMethodValues.LZMA:
+                                message = SR.Format(SR.UnsupportedCompressionMethod, CompressionMethod.ToString());
+                                break;
+                            default:
+                                message = SR.UnsupportedCompression;
+                                break;
+                        }
                         return false;
                     }
                 }
@@ -1277,7 +1287,7 @@ namespace System.IO.Compression
         [Flags]
         private enum BitFlagValues : ushort { DataDescriptor = 0x8, UnicodeFileName = 0x800 }
 
-        private enum CompressionMethodValues : ushort { Stored = 0x0, Deflate = 0x8 }
+        private enum CompressionMethodValues : ushort { Stored = 0x0, Deflate = 0x8, Deflate64 = 0x9, BZip2 = 0xC, LZMA = 0xE }
 
         private enum OpenableValues { Openable, FileNonExistent, FileTooLarge }
         #endregion Nested Types


### PR DESCRIPTION
Appends the common unsupported compression type to the end of the exception message for an unsupported compression type. This should make it easier to diagnose the issues that arise from https://github.com/dotnet/corefx/issues/9925.

resolves https://github.com/dotnet/corefx/issues/9924