### PR TITLE
Add HTTP/2 support to WinHttpHandler

### DIFF
--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
@@ -165,6 +165,14 @@ internal partial class Interop
 
         [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool WinHttpQueryOption(
+            SafeWinHttpHandle handle,
+            uint option,
+            ref uint buffer,
+            ref uint bufferSize);
+
+        [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool WinHttpWriteData(
             SafeWinHttpHandle requestHandle,
             IntPtr buffer,

--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
@@ -149,6 +149,10 @@ internal partial class Interop
 
         public const uint WINHTTP_OPTION_ASSURED_NON_BLOCKING_CALLBACKS = 111;
 
+        public const uint WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL = 133;
+        public const uint WINHTTP_OPTION_HTTP_PROTOCOL_USED = 134;
+        public const uint WINHTTP_PROTOCOL_FLAG_HTTP2 = 0x1;
+
         public const uint WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET = 114;
         public const uint WINHTTP_OPTION_WEB_SOCKET_CLOSE_TIMEOUT = 115;
         public const uint WINHTTP_OPTION_WEB_SOCKET_KEEPALIVE_INTERVAL = 116;

--- a/src/Common/tests/System/Net/Configuration.Http.cs
+++ b/src/Common/tests/System/Net/Configuration.Http.cs
@@ -15,6 +15,10 @@ namespace System.Net.Test.Common
             public static string SecureHost => GetValue("COREFX_SECUREHTTPHOST", DefaultAzureServer);
 
             public static string Http2Host => GetValue("COREFX_HTTP2HOST", "http2.akamai.com");
+            
+            // This server doesn't use HTTP/2 server push (push promise) feature. Some HttpClient implementations
+            // don't support servers that use push right now.
+            public static string Http2NoPushHost => GetValue("COREFX_HTTP2NOPUSHHOST", "www.microsoft.com");
 
             public static string DomainJoinedHttpHost => GetValue("COREFX_DOMAINJOINED_HTTPHOST");
 
@@ -60,6 +64,7 @@ namespace System.Net.Test.Common
             public readonly static object[][] VerifyUploadServers = { new object[] { RemoteVerifyUploadServer }, new object[] { SecureRemoteVerifyUploadServer } };
             public readonly static object[][] CompressedServers = { new object[] { RemoteDeflateServer }, new object[] { RemoteGZipServer } };
             public readonly static object[][] Http2Servers = { new object[] { new Uri("https://" + Http2Host) } };
+            public readonly static object[][] Http2NoPushServers = { new object[] { new Uri("https://" + Http2NoPushHost) } };
 
             public static Uri NegotiateAuthUriForDefaultCreds(bool secure)
             {

--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -17,7 +17,9 @@ namespace System
         public static bool IsOSX { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         public static bool IsNetBSD { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
         public static bool IsNotWindowsNanoServer { get; } = (IsWindows &&
-                File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "regedit.exe")));
+            File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "regedit.exe")));
+        public static bool IsWindows10Version1607OrGreater { get; } = IsWindows &&
+            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
 
         public static int WindowsVersion { get; } = GetWindowsVersion();
 
@@ -102,6 +104,19 @@ namespace System
                 osvi.dwOSVersionInfoSize = (uint)Marshal.SizeOf(osvi);
                 Assert.Equal(0, RtlGetVersion(out osvi));
                 return (int)osvi.dwMinorVersion;
+            }
+
+            return -1;
+        }
+
+        private static int GetWindowsBuildNumber()
+        {
+            if (IsWindows)
+            {
+                RTL_OSVERSIONINFOEX osvi = new RTL_OSVERSIONINFOEX();
+                osvi.dwOSVersionInfoSize = (uint)Marshal.SizeOf(osvi);
+                Assert.Equal(0, RtlGetVersion(out osvi));
+                return (int)osvi.dwBuildNumber;
             }
 
             return -1;

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -22,7 +22,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
     {
         // TODO: This is a placeholder until GitHub Issue #2383 gets resolved.
         private const string SlowServer = "http://httpbin.org/drip?numbytes=1&duration=1&delay=40&code=200";
-        
+
         private readonly ITestOutputHelper _output;
 
         public WinHttpHandlerTest(ITestOutputHelper output)

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
@@ -388,6 +388,15 @@ internal static partial class Interop
             return true;
         }
 
+        public static bool WinHttpQueryOption(
+            SafeWinHttpHandle handle,
+            uint option,
+            ref uint buffer,
+            ref uint bufferSize)
+        {
+            return true;
+        }
+
         public static bool WinHttpWriteData(
             SafeWinHttpHandle requestHandle,
             IntPtr buffer,

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -50,6 +50,7 @@ namespace System.Net.Http.Functional.Tests
                 hops:1) },
         };
         public readonly static object[][] Http2Servers = Configuration.Http.Http2Servers;
+        public readonly static object[][] Http2NoPushServers = Configuration.Http.Http2NoPushServers;
 
         public readonly static object[][] RedirectStatusCodes = {
             new object[] { 300 },
@@ -67,7 +68,9 @@ namespace System.Net.Http.Functional.Tests
             GetMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "CUSTOM1");
         public readonly static IEnumerable<object[]> HttpMethodsThatDontAllowContent =
             GetMethods("HEAD", "TRACE");
-        
+
+        private static bool IsWindows10Version1607OrGreater => PlatformDetection.IsWindows10Version1607OrGreater;
+
         private static IEnumerable<object[]> GetMethods(params string[] methods)
         {
             foreach (string method in methods)
@@ -1489,6 +1492,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory, MemberData(nameof(Http2Servers))]
+        [ActiveIssue(10958, PlatformID.Windows)]
         public async Task SendAsync_RequestVersion20_ResponseVersion20IfHttp2Supported(Uri server)
         {
             // We don't currently have a good way to test whether HTTP/2 is supported without
@@ -1528,6 +1532,24 @@ namespace System.Net.Http.Functional.Tests
                         response.Version == new Version(2, 0) ||
                         response.Version == new Version(1, 1),
                         "Response version " + response.Version);
+                }
+            }
+        }
+
+        [ConditionalTheory(nameof(IsWindows10Version1607OrGreater)), MemberData(nameof(Http2NoPushServers))]
+        public async Task SendAsync_RequestVersion20_ResponseVersion20(Uri server)
+        {
+            _output.WriteLine(server.AbsoluteUri.ToString());
+            var request = new HttpRequestMessage(HttpMethod.Get, server);
+            request.Version = new Version(2, 0);
+
+            var handler = new HttpClientHandler();
+            using (var client = new HttpClient(handler))
+            {
+                using (HttpResponseMessage response = await client.SendAsync(request))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    Assert.Equal(new Version(2, 0), response.Version);
                 }
             }
         }


### PR DESCRIPTION
Windows 10 Anniversary release a.k.a Windows 10 Version 1607 added support to native WinHTTP for HTTP/2 protocol support. Added code to use this when sending request messages  with HTTP/2. This change affects both the System.Net.Http and System.Net.Http.WinHttpHandler library packages.

Added new tests that validate the functionality and verify the test client is running on the proper version of Windows 10.

Switched the HTTP/2 test server endpoint to www.microsoft.com since it supports HTTP/2.

Fixes #4870