### PR TITLE
Fix Stream.Read/WriteAsync calls to FromAsync

### DIFF
--- a/src/System.IO/src/System/IO/Stream.cs
+++ b/src/System.IO/src/System/IO/Stream.cs
@@ -249,7 +249,7 @@ namespace System.IO
                 Task.Factory.FromAsync(
                     (localBuffer, localOffset, localCount, callback, state) => ((Stream)state).BeginRead(localBuffer, localOffset, localCount, callback, state),
                     iar => ((Stream)iar.AsyncState).EndRead(iar),
-                    buffer, offset, count, this, TaskCreationOptions.DenyChildAttach | TaskCreationOptions.HideScheduler);
+                    buffer, offset, count, this);
         }
 
         public virtual IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
@@ -296,7 +296,7 @@ namespace System.IO
                 Task.Factory.FromAsync(
                     (localBuffer, localOffset, localCount, callback, state) => ((Stream)state).BeginWrite(localBuffer, localOffset, localCount, callback, state),
                     iar => ((Stream)iar.AsyncState).EndWrite(iar),
-                    buffer, offset, count, this, TaskCreationOptions.DenyChildAttach | TaskCreationOptions.HideScheduler);
+                    buffer, offset, count, this);
         }
 
         public virtual IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>


### PR DESCRIPTION
The task created from FromAsync is a promise, such that it doesn't actually run any code.  As a result, it's invalid to supply DenyChildAttach or HideScheduler, as these are only relevant to tasks that run code (since they affect ambient state around that running code).  We should just use the default options.

Fixes https://github.com/dotnet/corefx/issues/10944
cc: @SedarG, @joperezr 