### PR TITLE
Add missing license headers

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.IO;
 using System.IO.Pipes;
 using System.Net.Security;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 

--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 using System.Reflection;
 using System.Diagnostics;
 using System.Collections;

--- a/src/System.Data.SqlClient/tests/FunctionalTests/FakeDiagnosticListenerObserver.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/FakeDiagnosticListenerObserver.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/CheckConnStrSetupFactAttribute.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/CheckConnStrSetupFactAttribute.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SplitPacketTest/SplitPacketTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SplitPacketTest/SplitPacketTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Net;
 using System.Net.Sockets;

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using Xunit;
 using System.Threading.Tasks;

--- a/src/System.IO.Pipes/tests/NativeOverlapped.unix.cs
+++ b/src/System.IO.Pipes/tests/NativeOverlapped.unix.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // stub implementation of NativeOverlapped to compile windows only tests in Unix build
 internal struct NativeOverlapped {}

--- a/src/System.Net.Http/tests/FunctionalTests/FakeDiagnosticSourceListenerObserver.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/FakeDiagnosticSourceListenerObserver.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.Net.Http.Functional.Tests

--- a/src/System.Net.Http/tests/FunctionalTests/prerequisites/BasicAuthModule.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/prerequisites/BasicAuthModule.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Web;
 

--- a/src/System.Net.Security/tests/FunctionalTests/UnixGssFakeNegotiateStream.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/UnixGssFakeNegotiateStream.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/System.Net.Security/tests/FunctionalTests/UnixGssFakeStreamFramer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/UnixGssFakeStreamFramer.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/System.Reflection.Metadata/tests/Resources/Misc/Debug.cs
+++ b/src/System.Reflection.Metadata/tests/Resources/Misc/Debug.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 // csc /target:library /debug:full Debug.cs
 
 public class C 

--- a/src/System.Reflection.Metadata/tests/Resources/Misc/Deterministic.cs
+++ b/src/System.Reflection.Metadata/tests/Resources/Misc/Deterministic.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 // csc /target:library /debug:full /deterministic Deterministic.cs
 
 public class C 

--- a/src/System.Reflection.Metadata/tests/Resources/PortablePdbs/Documents.cs
+++ b/src/System.Reflection.Metadata/tests/Resources/PortablePdbs/Documents.cs
@@ -1,4 +1,8 @@
-﻿#line 1 "C:\Documents.cs"
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#line 1 "C:\Documents.cs"
 #pragma checksum "C:\Documents.cs" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "DBEB2A067B2F0E0D678A002C587A2806056C3DCE"
 using System;
 

--- a/src/System.Reflection/tests/ExceptionTests.cs
+++ b/src/System.Reflection/tests/ExceptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Xunit;
 using System;
 using System.Reflection;

--- a/src/System.Reflection/tests/MemberInfoTests.cs
+++ b/src/System.Reflection/tests/MemberInfoTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Xunit;
 using System;
 using System.Linq;

--- a/src/System.Text.RegularExpressions/tests/PrecompiledRegexScenarioTest.cs
+++ b/src/System.Text.RegularExpressions/tests/PrecompiledRegexScenarioTest.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Text.RegularExpressions;
 using RegexTestNamespace;
 using Xunit;

--- a/src/System.Text.RegularExpressions/tests/RegexGroupNameTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexGroupNameTests.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit;
 using System;


### PR DESCRIPTION
Some .cs files have snuck in without them.