### PR TITLE
Fix lookup of non-public deserialization ctors

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
@@ -778,12 +778,19 @@ namespace System.Runtime.Serialization
 
         internal static ConstructorInfo GetDeserializationConstructor(Type t)
         {
-            ConstructorInfo ci = t.GetConstructor(new[] { typeof(SerializationInfo), typeof(StreamingContext) });
-            if (ci == null)
+            // TODO #10530: Use Type.GetConstructor that takes BindingFlags when it's available
+            foreach (ConstructorInfo ci in t.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
             {
-                throw new SerializationException(SR.Format(SR.Serialization_ConstructorNotFound, t.FullName));
+                ParameterInfo[] parameters = ci.GetParameters();
+                if (parameters.Length == 2 &&
+                    parameters[0].ParameterType == typeof(SerializationInfo) &&
+                    parameters[1].ParameterType == typeof(StreamingContext))
+                {
+                    return ci;
+                }
             }
-            return ci;
+
+            throw new SerializationException(SR.Format(SR.Serialization_ConstructorNotFound, t.FullName));
         }
 
         public virtual void DoFixups()

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -178,6 +178,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
 
             // ISerializable
             yield return new BasicISerializableObject(1, "2");
+            yield return new DerivedISerializableWithNonPublicDeserializationCtor(1, "2");
 
             // Various other special cases
             yield return new TypeWithoutNamespace();

--- a/src/System.Runtime.Serialization.Formatters/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/SerializationTypes.cs
@@ -271,7 +271,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
     }
 
     [Serializable]
-    public sealed class BasicISerializableObject : ISerializable
+    public class BasicISerializableObject : ISerializable
     {
         private NonSerializablePair<int, string> _data;
 
@@ -300,6 +300,13 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         public override int GetHashCode() => 1;
+    }
+
+    [Serializable]
+    public sealed class DerivedISerializableWithNonPublicDeserializationCtor : BasicISerializableObject
+    {
+        public DerivedISerializableWithNonPublicDeserializationCtor(int value1, string value2) : base(value1, value2) { }
+        private DerivedISerializableWithNonPublicDeserializationCtor(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     [Serializable]


### PR DESCRIPTION
We were using a GetConstructor overload that only finds public ctors (since that's the only one currently exposed), but we need to be able to find any deserialization ctor, regardless of visibility.  This was preventing the deserialization of a bunch of coreclr types.

cc: @danmosemsft, @weshaggard 