### PR TITLE
Include diagnostic info to debug failure in CI.

### DIFF
--- a/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -619,7 +619,7 @@ namespace System.Text.RegularExpressions.Tests
                 // In invariant culture, the unicode char matches differ from expected values provided.
                 if (originalCulture == CultureInfo.InvariantCulture)
                 {
-                    CultureInfo.CurrentCulture = new CultureInfo("en-US");
+                    CultureInfo.CurrentCulture = s_enUSCulture;
                 }
                 if (cultureInfo != null)
                 {
@@ -630,7 +630,7 @@ namespace System.Text.RegularExpressions.Tests
                 Assert.True(match.Success);
 
                 Assert.Equal(expectedGroups.Length, match.Groups.Count);
-                Assert.Equal(expectedGroups[0], match.Value);
+                Assert.True(expectedGroups[0] == match.Value, string.Format("Culture used: {0}", CultureInfo.CurrentCulture));
 
                 int[] groupNumbers = regex.GetGroupNumbers();
                 string[] groupNames = regex.GetGroupNames();


### PR DESCRIPTION
cc @tarekgh @karajas 

The earlier fix didn't give test pass on the 20160816 helix run.