### PR TITLE
Further tests for String.Concat and String.Join

### DIFF
--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -338,7 +338,8 @@ namespace System.Tests
 
             yield return new object[] { new object[] { 1 }, "1" };
             yield return new object[] { new object[] { null }, "" };
-            yield return new object[] { new object[] { new ObjectWithNullToString() }, "" };
+            // dotnet/coreclr#6785, this will be null for the Concat(object) overload but "" for the object[]/IEnumerable<object> overload
+            // yield return new object[] { new object[] { new ObjectWithNullToString() }, "" };
 
             yield return new object[] { new object[] { 1, 2 }, "12" };
             yield return new object[] { new object[] { null, 1 }, "1" };

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -285,6 +285,7 @@ namespace System.Tests
 
             validate(string.Concat(values));
             validate(string.Concat((IEnumerable<string>)values));
+            validate(string.Concat<string>((IEnumerable<string>)values)); // Call the generic IEnumerable<T>-based overload
         }
 
         [Fact]
@@ -1412,9 +1413,11 @@ namespace System.Tests
 
                 var iEnumerableStringOptimized = new List<string>(values);
                 Assert.Equal(expected, string.Join(seperator, iEnumerableStringOptimized));
+                Assert.Equal(expected, string.Join<string>(seperator, iEnumerableStringOptimized)); // Call the generic IEnumerable<T>-based overload
 
                 var iEnumerableStringNotOptimized = new Queue<string>(values);
                 Assert.Equal(expected, string.Join(seperator, iEnumerableStringNotOptimized));
+                Assert.Equal(expected, string.Join<string>(seperator, iEnumerableStringNotOptimized));
 
                 var iEnumerableObject = new List<object>(values);
                 Assert.Equal(expected, string.Join(seperator, iEnumerableObject));

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -338,6 +338,7 @@ namespace System.Tests
 
             yield return new object[] { new object[] { 1 }, "1" };
             yield return new object[] { new object[] { null }, "" };
+            yield return new object[] { new object[] { new ObjectWithNullToString() }, "" };
 
             yield return new object[] { new object[] { 1, 2 }, "12" };
             yield return new object[] { new object[] { null, 1 }, "1" };
@@ -1453,6 +1454,7 @@ namespace System.Tests
         public static IEnumerable<object[]> Join_ObjectArray_TestData()
         {
             yield return new object[] { "$$", new object[] { }, "" };
+            yield return new object[] { "$$", new object[] { new ObjectWithNullToString() }, "" };
             yield return new object[] { "$$", new object[] { "Foo" }, "Foo" };
             yield return new object[] { "$$", new object[] { "Foo", "Bar", "Baz" }, "Foo$$Bar$$Baz" };
             yield return new object[] { null, new object[] { "Foo", "Bar", "Baz" }, "FooBarBaz" };

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1426,8 +1426,12 @@ namespace System.Tests
                 var iEnumerableObject = new List<object>(values);
                 Assert.Equal(expected, string.Join(separator, iEnumerableObject));
 
-                var arrayOfObjects = (object[])values;
-                Assert.Equal(expected, string.Join(separator, arrayOfObjects));
+                // Bug/Documented behavior: Join(string, object[]) returns "" when the first item in the array is null
+                if (values.Length == 0 || values[0] != null)
+                {
+                    var arrayOfObjects = (object[])values;
+                    Assert.Equal(expected, string.Join(separator, arrayOfObjects));
+                }
             }
             Assert.Equal(expected, string.Join(separator, values, startIndex, count));
         }

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -334,6 +334,8 @@ namespace System.Tests
 
         public static IEnumerable<object[]> Concat_Objects_TestData()
         {
+            yield return new object[] { new object[] { }, "" };
+
             yield return new object[] { new object[] { 1 }, "1" };
             yield return new object[] { new object[] { null }, "" };
 
@@ -1422,6 +1424,11 @@ namespace System.Tests
 
                 var iEnumerableObject = new List<object>(values);
                 Assert.Equal(expected, string.Join(seperator, iEnumerableObject));
+
+                // We're taking advantage of covariant arrays (which is bad) here,
+                // but this should not be a problem since Join shouldn't write to the array
+                var arrayOfObjects = (object[])values;
+                Assert.Equal(expected, string.Join(separator, arrayOfObjects));
             }
             Assert.Equal(expected, string.Join(seperator, values, startIndex, count));
         }

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1426,8 +1426,6 @@ namespace System.Tests
                 var iEnumerableObject = new List<object>(values);
                 Assert.Equal(expected, string.Join(seperator, iEnumerableObject));
 
-                // We're taking advantage of covariant arrays (which is bad) here,
-                // but this should not be a problem since Join shouldn't write to the array
                 var arrayOfObjects = (object[])values;
                 Assert.Equal(expected, string.Join(separator, arrayOfObjects));
             }

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -392,6 +392,7 @@ namespace System.Tests
         public static void Concat_Invalid()
         {
             Assert.Throws<ArgumentNullException>("values", () => string.Concat((IEnumerable<string>)null)); // Values is null
+            Assert.Throws<ArgumentNullException>("values", () => string.Concat<string>((IEnumerable<string>)null)); // Generic overload
             Assert.Throws<ArgumentNullException>("values", () => string.Concat(null)); // Values is null
 
             Assert.Throws<ArgumentNullException>("args", () => string.Concat((object[])null)); // Values is null
@@ -1432,6 +1433,7 @@ namespace System.Tests
             Assert.Throws<ArgumentNullException>("value", () => string.Join("$$", null));
             Assert.Throws<ArgumentNullException>("value", () => string.Join("$$", null, 0, 0));
             Assert.Throws<ArgumentNullException>("values", () => string.Join("|", (IEnumerable<string>)null));
+            Assert.Throws<ArgumentNullException>("values", () => string.Join<string>("|", (IEnumerable<string>)null)); // Generic overload
 
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => string.Join("$$", new string[] { "Foo" }, -1, 0)); // Start index < 0
             Assert.Throws<ArgumentOutOfRangeException>("count", () => string.Join("$$", new string[] { "Foo" }, 0, -1)); // Count < 0

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1409,27 +1409,27 @@ namespace System.Tests
         [InlineData("$$", new string[] { "Foo", "Bar", "Baz" }, 0, 3, "Foo$$Bar$$Baz")]
         [InlineData("$$", new string[] { "Foo", "Bar", "Baz" }, 3, 0, "")]
         [InlineData("$$", new string[] { "Foo", "Bar", "Baz" }, 1, 1, "Bar")]
-        public static void Join_StringArray(string seperator, string[] values, int startIndex, int count, string expected)
+        public static void Join_StringArray(string separator, string[] values, int startIndex, int count, string expected)
         {
             if (startIndex + count == values.Length && count != 0)
             {
-                Assert.Equal(expected, string.Join(seperator, values));
+                Assert.Equal(expected, string.Join(separator, values));
 
                 var iEnumerableStringOptimized = new List<string>(values);
-                Assert.Equal(expected, string.Join(seperator, iEnumerableStringOptimized));
-                Assert.Equal(expected, string.Join<string>(seperator, iEnumerableStringOptimized)); // Call the generic IEnumerable<T>-based overload
+                Assert.Equal(expected, string.Join(separator, iEnumerableStringOptimized));
+                Assert.Equal(expected, string.Join<string>(separator, iEnumerableStringOptimized)); // Call the generic IEnumerable<T>-based overload
 
                 var iEnumerableStringNotOptimized = new Queue<string>(values);
-                Assert.Equal(expected, string.Join(seperator, iEnumerableStringNotOptimized));
-                Assert.Equal(expected, string.Join<string>(seperator, iEnumerableStringNotOptimized));
+                Assert.Equal(expected, string.Join(separator, iEnumerableStringNotOptimized));
+                Assert.Equal(expected, string.Join<string>(separator, iEnumerableStringNotOptimized));
 
                 var iEnumerableObject = new List<object>(values);
-                Assert.Equal(expected, string.Join(seperator, iEnumerableObject));
+                Assert.Equal(expected, string.Join(separator, iEnumerableObject));
 
                 var arrayOfObjects = (object[])values;
                 Assert.Equal(expected, string.Join(separator, arrayOfObjects));
             }
-            Assert.Equal(expected, string.Join(seperator, values, startIndex, count));
+            Assert.Equal(expected, string.Join(separator, values, startIndex, count));
         }
 
         [Fact]
@@ -1444,7 +1444,7 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => string.Join("$$", new string[] { "Foo" }, -1, 0)); // Start index < 0
             Assert.Throws<ArgumentOutOfRangeException>("count", () => string.Join("$$", new string[] { "Foo" }, 0, -1)); // Count < 0
 
-            // Start index > seperators.Length
+            // Start index > separators.Length
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => string.Join("$$", new string[] { "Foo" }, 2, 1));
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => string.Join("$$", new string[] { "Foo" }, 0, 2));
         }
@@ -1467,12 +1467,12 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Join_ObjectArray_TestData))]
-        public static void Join_ObjectArray(string seperator, object[] values, string expected)
+        public static void Join_ObjectArray(string separator, object[] values, string expected)
         {
-            Assert.Equal(expected, string.Join(seperator, values));
+            Assert.Equal(expected, string.Join(separator, values));
             if (!(values.Length > 0 && values[0] == null))
             {
-                Assert.Equal(expected, string.Join(seperator, (IEnumerable<object>)values));
+                Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
             }
         }
 


### PR DESCRIPTION
This increases the test coverage for string.Concat and string.Join by calling `Join<T>` and `Concat<T>` with a type parameter of string, as well as adding tests for a couple of other edge cases..

cc @hughbe @stephentoub 