### PR TITLE
RegistryKey.OpenSubKey should remove multiple/trailing slashes

### DIFF
--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -317,10 +317,8 @@ namespace Microsoft.Win32
         /// read-only access.
         /// </summary>
         /// <returns>the Subkey requested, or <b>null</b> if the operation failed.</returns>
-        public RegistryKey OpenSubKey(string name, bool writable)
-        {
-            return InternalOpenSubKey(name, writable);
-        }
+        public RegistryKey OpenSubKey(string name, bool writable) =>
+            OpenSubKey(name, GetRegistryKeyRights(writable));
 
         public RegistryKey OpenSubKey(string name, RegistryRights rights)
         {

--- a/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -52,6 +52,10 @@
     <Compile Include="RegistryKey\RegistryKey_OpenSubKey_str_rkpc.cs" />
     <Compile Include="RegistryKey\RegistryKey_SetValueKind_str_obj_valueKind.cs" />
     <Compile Include="RegistryKey\RegistryKey_SetValue_str_obj.cs" />
+    <Compile Include="RegistryKey\RegistryKeyCreateSubKeyTestsBase.cs" />
+    <Compile Include="RegistryKey\RegistryKeyDeleteSubKeyTestsBase.cs" />
+    <Compile Include="RegistryKey\RegistryKeyDeleteSubKeyTreeTestsBase.cs" />
+    <Compile Include="RegistryKey\RegistryKeyOpenSubKeyTestsBase.cs" />
     <Compile Include="RegistryKey\SafeRegistryHandle.cs" />
     <Compile Include="RegistryTestsBase.cs" />
     <Compile Include="TestData.cs" />

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyCreateSubKeyTestsBase.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyCreateSubKeyTestsBase.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Win32.RegistryTests
+{
+    public abstract class RegistryKeyCreateSubKeyTestsBase : RegistryTestsBase
+    {
+        protected void Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(Func<RegistryKey> createSubKey)
+        {
+            CreateTestRegistrySubKey();
+
+            using (RegistryKey key = createSubKey())
+            {
+                Assert.NotNull(key);
+                Assert.Equal(1, TestRegistryKey.SubKeyCount);
+                Assert.Equal(TestRegistrySubKeyFullName, key.Name);
+            }
+        }
+
+        protected void Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(Func<RegistryKey> createSubKey)
+        {
+            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Equal(0, TestRegistryKey.SubKeyCount);
+
+            using (RegistryKey key = createSubKey())
+            {
+                Assert.NotNull(key);
+                Assert.Equal(1, TestRegistryKey.SubKeyCount);
+                Assert.Equal(TestRegistrySubKeyFullName, key.Name);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyDeleteSubKeyTestsBase.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyDeleteSubKeyTestsBase.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Win32.RegistryTests
+{
+    public abstract class RegistryKeyDeleteSubKeyTestsBase : RegistryTestsBase
+    {
+        protected void Verify_DeleteSubKey_KeyExists_KeyDeleted(Action deleteSubKey)
+        {
+            CreateTestRegistrySubKey();
+
+            deleteSubKey();
+            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistryKeyName));
+        }
+
+        protected void Verify_DeleteSubKey_KeyDoesNotExists_Throws(Action deleteSubKey)
+        {
+            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Equal(0, TestRegistryKey.SubKeyCount);
+
+            Assert.Throws<ArgumentException>(() => deleteSubKey());
+        }
+
+        protected void Verify_DeleteSubKey_KeyDoesNotExists_DoesNotThrow(Action deleteSubKey)
+        {
+            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Equal(0, TestRegistryKey.SubKeyCount);
+
+            deleteSubKey();
+        }
+    }
+}

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyDeleteSubKeyTreeTestsBase.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyDeleteSubKeyTreeTestsBase.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Win32.RegistryTests
+{
+    public abstract class RegistryKeyDeleteSubKeyTreeTestsBase : RegistryTestsBase
+    {
+        protected void Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(Action deleteSubKeyTree)
+        {
+            CreateTestRegistrySubKey();
+
+            deleteSubKeyTree();
+            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistryKeyName));
+        }
+
+        protected void Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(Action deleteSubKeyTree)
+        {
+            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Equal(0, TestRegistryKey.SubKeyCount);
+
+            Assert.Throws<ArgumentException>(() => deleteSubKeyTree());
+        }
+
+        protected void Verify_DeleteSubKeyTree_KeyDoesNotExists_DoesNotThrow(Action deleteSubKeyTree)
+        {
+            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Equal(0, TestRegistryKey.SubKeyCount);
+
+            deleteSubKeyTree();
+        }
+    }
+}

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyOpenSubKeyTestsBase.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyOpenSubKeyTestsBase.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Win32.RegistryTests
+{
+    public abstract class RegistryKeyOpenSubKeyTestsBase : RegistryTestsBase
+    {
+        protected void Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(Func<RegistryKey> openSubKey)
+        {
+            CreateTestRegistrySubKey();
+
+            using (RegistryKey key = openSubKey())
+            {
+                Assert.NotNull(key);
+                Assert.Equal(1, TestRegistryKey.SubKeyCount);
+                Assert.Equal(TestRegistrySubKeyFullName, key.Name);
+            }
+        }
+
+        protected void Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(Func<RegistryKey> openSubKey)
+        {
+            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Equal(0, TestRegistryKey.SubKeyCount);
+
+            Assert.Null(openSubKey());
+        }
+    }
+}

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.Win32.RegistryTests
 {
-    public class RegistryKey_CreateSubKey_str : RegistryTestsBase
+    public class RegistryKey_CreateSubKey_str : RegistryKeyCreateSubKeyTestsBase
     {
         [Fact]
         public void NegativeTests()
@@ -114,5 +114,15 @@ namespace Microsoft.Win32.RegistryTests
                 rk.CreateSubKey(subkeyName);
             }
         }
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void CreateSubKey_KeyExists_OpensKeyWithFixedUpName(string subKeyName) =>
+            Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(string subKeyName) =>
+            Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str_rkpc.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str_rkpc.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.Win32.RegistryTests
 {
-    public class RegistryKey_CreateSubKey_str_rkpc : RegistryTestsBase
+    public class RegistryKey_CreateSubKey_str_rkpc : RegistryKeyCreateSubKeyTestsBase
     {
         [Fact]
         public void CreateWriteableSubkeyAndWrite()
@@ -100,5 +100,25 @@ namespace Microsoft.Win32.RegistryTests
 
             Assert.NotNull(TestRegistryKey.CreateSubKey(subkey));
         }
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void CreateSubKey_Writable_KeyExists_OpensKeyWithFixedUpName(string subKeyName) =>
+            Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName, writable: true));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void CreateSubKey_NonWritable_KeyExists_OpensKeyWithFixedUpName(string subKeyName) =>
+            Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName, writable: false));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void CreateSubKey_Writable_KeyDoesNotExist_CreatesKeyWithFixedUpName(string subKeyName) =>
+            Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName, writable: true));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void CreateSubKey_NonWritable_KeyDoesNotExist_CreatesKeyWithFixedUpName(string subKeyName) =>
+            Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName, writable: false));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKeyTree.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKeyTree.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.Win32.RegistryTests
 {
-    public class RegistryKey_DeleteSubKeyTree : RegistryTestsBase
+    public class RegistryKey_DeleteSubKeyTree : RegistryKeyDeleteSubKeyTreeTestsBase
     {
         [Fact]
         public void NegativeTests()
@@ -67,5 +67,25 @@ namespace Microsoft.Win32.RegistryTests
                 TestRegistryKey.DeleteSubKeyTree(subKeyExists2, true);
             }
         }
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void DeleteSubKeyTree_ThrowOnMissing_KeyExists_KeyDeleted(string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: true));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void DeleteSubKeyTree_DoNotThrow_KeyExists_KeyDeleted(string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: false));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void DeleteSubKeyTree_ThrowOnMissing_KeyDoesNotExists_Throws(string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(() => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: true));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void DeleteSubKeyTree_DoNotThrow_KeyDoesNotExists_DoesNotThrow(string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyDoesNotExists_DoesNotThrow(() => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: false));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKeyTree_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKeyTree_str.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.Win32.RegistryTests
 {
-    public class RegistryKey_DeleteSubKeyTree_str : RegistryTestsBase
+    public class RegistryKey_DeleteSubKeyTree_str : RegistryKeyDeleteSubKeyTreeTestsBase
     {
         [Fact]
         public void NegativeTests()
@@ -83,5 +83,16 @@ namespace Microsoft.Win32.RegistryTests
             TestRegistryKey.DeleteSubKeyTree(TestRegistryKeyName);
             Assert.Null(TestRegistryKey.OpenSubKey(TestRegistryKeyName));
         }
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void DeleteSubKeyTree_KeyExists_KeyDeleted(string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKeyTree(subKeyName));
+
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(() => TestRegistryKey.DeleteSubKeyTree(subKeyName));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKey_Str_Bln.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKey_Str_Bln.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.Win32.RegistryTests
 {
-    public class RegistryKey_DeleteSubKey_Str_Bln : RegistryTestsBase
+    public class RegistryKey_DeleteSubKey_Str_Bln : RegistryKeyDeleteSubKeyTestsBase
     {
         [Fact]
         public void NegativeTests()
@@ -71,5 +71,25 @@ namespace Microsoft.Win32.RegistryTests
                 Assert.Null(TestRegistryKey.OpenSubKey(subKeyName));
             }
         }
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void DeleteSubKey_KeyExists_ThrowOnMissing_KeyDeleted(string subkeyName) =>
+            Verify_DeleteSubKey_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: true));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void DeleteSubKey_KeyExists_DoNotThrow_KeyDeleted(string subkeyName) =>
+            Verify_DeleteSubKey_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: false));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void DeleteSubKey_KeyDoesNotExists_ThrowOnMissing_Throws(string subkeyName) =>
+            Verify_DeleteSubKey_KeyDoesNotExists_Throws(() => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: true));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void DeleteSubKey_KeyDoesNotExists_DoNotThrow_DoesNotThrow(string subkeyName) =>
+            Verify_DeleteSubKey_KeyDoesNotExists_DoesNotThrow(() => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: false));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKey_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKey_str.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Microsoft.Win32.RegistryTests
 {
-    public class RegistryKey_DeleteSubKey_str : RegistryTestsBase
+    public class RegistryKey_DeleteSubKey_str : RegistryKeyDeleteSubKeyTestsBase
     {
         [Fact]
         public void NegativeTests()
@@ -52,5 +52,15 @@ namespace Microsoft.Win32.RegistryTests
             Assert.Null(TestRegistryKey.OpenSubKey(TestRegistryKeyName));
             Assert.Equal(expected: 0, actual: TestRegistryKey.SubKeyCount);
         }
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void DeleteSubKey_KeyExists_KeyDeleted(string subkeyName) =>
+            Verify_DeleteSubKey_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKey(subkeyName));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void DeleteSubKey_KeyDoesNotExists_Throws(string subkeyName) =>
+            Verify_DeleteSubKey_KeyDoesNotExists_Throws(() => TestRegistryKey.DeleteSubKey(subkeyName));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.Win32.RegistryTests
 {
-    public class RegistryKey_OpenSubKey_str : RegistryTestsBase
+    public class RegistryKey_OpenSubKey_str : RegistryKeyOpenSubKeyTestsBase
     {
         [Fact]
         public void NegativeTests()
@@ -63,5 +63,15 @@ namespace Microsoft.Win32.RegistryTests
             Assert.Equal(subKeyNames.Length, TestRegistryKey.SubKeyCount);
             Assert.Equal(subKeyNames, TestRegistryKey.GetSubKeyNames());
         }
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void OpenSubKey_KeyExists_OpensWithFixedUpName(string subKeyName) =>
+            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(() => TestRegistryKey.OpenSubKey(subKeyName));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void OpenSubKey_KeyDoesNotExist_ReturnsNull(string subKeyName) =>
+            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(() => TestRegistryKey.OpenSubKey(subKeyName));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str_b.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str_b.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.Win32.RegistryTests
 {
-    public class RegistryKey_OpenSubKey_str_b : RegistryTestsBase
+    public class RegistryKey_OpenSubKey_str_b : RegistryKeyOpenSubKeyTestsBase
     {
         [Fact]
         public void NegativeTests()
@@ -53,5 +53,25 @@ namespace Microsoft.Win32.RegistryTests
                 Assert.Equal(testValue, (int)rk.GetValue(TestRegistryKeyName));
             }
         }
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void OpenSubKey_Writable_KeyExists_OpensWithFixedUpName(string subKeyName) =>
+            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(() => TestRegistryKey.OpenSubKey(subKeyName, writable: true));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void OpenSubKey_NonWritable_KeyExists_OpensWithFixedUpName(string subKeyName) =>
+            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(() => TestRegistryKey.OpenSubKey(subKeyName, writable: false));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void OpenSubKey_Writable_KeyDoesNotExist_ReturnsNull(string subKeyName) =>
+            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(() => TestRegistryKey.OpenSubKey(subKeyName, writable: true));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void OpenSubKey_NonWritable_KeyDoesNotExist_ReturnsNull(string subKeyName) =>
+            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(() => TestRegistryKey.OpenSubKey(subKeyName, writable: false));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str_rkpc.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str_rkpc.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.Win32.RegistryTests
 {
-    public class RegistryKey_OpenSubKey_str_rkpc : RegistryTestsBase
+    public class RegistryKey_OpenSubKey_str_rkpc : RegistryKeyOpenSubKeyTestsBase
     {
         [Fact]
         public void NegativeTests()
@@ -58,5 +58,28 @@ namespace Microsoft.Win32.RegistryTests
                 Assert.NotNull(rk.OpenSubKey(valueName));
             }
         }
+
+        private const RegistryRights Writable = RegistryRights.ReadKey | RegistryRights.WriteKey;
+        private const RegistryRights NonWritable = RegistryRights.ReadKey;
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void OpenSubKey_Writable_KeyExists_OpensWithFixedUpName(string subKeyName) =>
+            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(() => TestRegistryKey.OpenSubKey(subKeyName, Writable));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void OpenSubKey_NonWritable_KeyExists_OpensWithFixedUpName(string subKeyName) =>
+            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(() => TestRegistryKey.OpenSubKey(subKeyName, NonWritable));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void OpenSubKey_Writable_KeyDoesNotExist_ReturnsNull(string subKeyName) =>
+            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(() => TestRegistryKey.OpenSubKey(subKeyName, Writable));
+
+        [Theory]
+        [MemberData(nameof(TestRegistrySubKeyNames))]
+        public void OpenSubKey_NonWritable_KeyDoesNotExist_ReturnsNull(string subKeyName) =>
+            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(() => TestRegistryKey.OpenSubKey(subKeyName, NonWritable));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryTestsBase.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryTestsBase.cs
@@ -54,5 +54,34 @@ namespace Microsoft.Win32.RegistryTests
             //   classes running concurrently
             return "corefxtest_" + GetType().Name;
         }
+
+        protected const string TestRegistrySubKeyName = @"Foo\Bar";
+
+        protected string TestRegistrySubKeyFullName => TestRegistryKey.Name + @"\" + TestRegistrySubKeyName;
+
+        public static readonly object[][] TestRegistrySubKeyNames =
+        {
+            new object[] { @"Foo\Bar" },
+            new object[] { @"Foo\\Bar" },
+            new object[] { @"Foo\\\Bar" },
+            new object[] { @"Foo\Bar\" },
+            new object[] { @"Foo\Bar\\" },
+            new object[] { @"Foo\Bar\\\" },
+            new object[] { @"Foo\\Bar\" },
+            new object[] { @"Foo\\Bar\\" },
+            new object[] { @"Foo\\Bar\\\" },
+        };
+
+        protected void CreateTestRegistrySubKey()
+        {
+            Assert.Equal(0, TestRegistryKey.SubKeyCount);
+
+            using (RegistryKey key = TestRegistryKey.CreateSubKey(TestRegistrySubKeyName))
+            {
+                Assert.NotNull(key);
+                Assert.Equal(1, TestRegistryKey.SubKeyCount);
+                Assert.Equal(TestRegistrySubKeyFullName, key.Name);
+            }
+        }
     }
 }


### PR DESCRIPTION
After #9456, the `RegistryKey.OpenSubKey(string)` and `OpenSubKey(string, bool)` methods do not fix-up names that contain multiple/trailing slashes, which is a behavior change.

Notably, `OpenSubKey(string, RegistryRights)` did not change; it behaves as it should.

This commit fixes the issue, and adds more test coverage for the following methods:

- `OpenSubKey`
- `CreateSubKey`
- `DeleteSubKey`
- `DeleteSubKeyTree`

The relevant new `OpenSubKey` tests fail before this change and pass after. The new tests also pass when run on .NET Framework 4.6.2.