### PR TITLE
Skip failing process test on Windows Nano.

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -727,7 +727,7 @@ namespace System.Diagnostics.Tests
         }
 
         [PlatformSpecific(PlatformID.Windows)]
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TestStartOnWindowsWithBadFileFormat()
         {
             string path = GetTestFilePath();

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -727,6 +727,7 @@ namespace System.Diagnostics.Tests
         }
 
         [PlatformSpecific(PlatformID.Windows)]
+        // NativeErrorCode not 193 on Windows Nano for ERROR_BAD_EXE_FORMAT, issue #10290
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TestStartOnWindowsWithBadFileFormat()
         {


### PR DESCRIPTION
This bug is redirected to Nano team, in the meantime, skipping this to unblock CI.
In reference to #10290 
cc @stephentoub 