### PR TITLE
WinHttpHandler: Avoid repeated Version allocations

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -48,8 +48,8 @@ namespace System.Net.Http
 #endif
     {
 #if NET46
-        internal static Version HttpVersion20 => new Version(2,0);
-        internal static Version HttpVersionUnknown => new Version(0,0);
+        internal static readonly Version HttpVersion20 = new Version(2, 0);
+        internal static readonly Version HttpVersionUnknown = new Version(0, 0);
 #else
         internal static Version HttpVersion20 => HttpVersion.Version20;
         internal static Version HttpVersionUnknown => HttpVersion.Unknown;


### PR DESCRIPTION
For NET46, use static readonly fields that always return the same cached instances, instead of properties that always allocate and return new `Version` instances.

Fixes #10974.

cc: @davidsh @benaadams