### PR TITLE
Close streams when exceptions thrown in Dispose

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -230,30 +230,25 @@ namespace System.IO.Compression
         {
             if (disposing && !_isDisposed)
             {
-                switch (_mode)
+                try
                 {
-                    case ZipArchiveMode.Read:
-                        break;
-                    case ZipArchiveMode.Create:
-                    case ZipArchiveMode.Update:
-                    default:
-                        Debug.Assert(_mode == ZipArchiveMode.Update || _mode == ZipArchiveMode.Create);
-                        try
-                        {
+                    switch (_mode)
+                    {
+                        case ZipArchiveMode.Read:
+                            break;
+                        case ZipArchiveMode.Create:
+                        case ZipArchiveMode.Update:
+                        default:
+                            Debug.Assert(_mode == ZipArchiveMode.Update || _mode == ZipArchiveMode.Create);
                             WriteFile();
-                        }
-                        catch (InvalidDataException)
-                        {
-                            CloseStreams();
-                            _isDisposed = true;
-                            throw;
-                        }
-                        break;
+                            break;
+                    }
                 }
-
-                CloseStreams();
-
-                _isDisposed = true;
+                finally
+                {
+                    CloseStreams();
+                    _isDisposed = true;
+                }
             }
         }
 
@@ -671,7 +666,6 @@ namespace System.IO.Compression
         }
 
 
-        //the only exceptions that this function will throw directly are InvalidDataExceptions
         private void WriteFile()
         {
             //if we are in create mode, we always set readEntries to true in Init
@@ -691,7 +685,6 @@ namespace System.IO.Compression
 
                 _archiveStream.Seek(0, SeekOrigin.Begin);
                 _archiveStream.SetLength(0);
-                //nothing after this should throw an exception
             }
 
             foreach (ZipArchiveEntry entry in _entries)


### PR DESCRIPTION
System.IO.Compression.ZipArchive should always close the underlying streams if exceptions are thrown while disposing (Ex. IOException).

It's best to change this code to expect the unexpected and always close the underlying streams. I also consolidated `CloseStreams(); _isDisposed = true;` so that it doesn't need to be written twice. Additionally I removed incorrect comments about WriteFile because IOExceptions (or any other exceptions the specific stream passed in throws) can be thrown in there.

Fix #10987