### PR TITLE
Initial prototyping of produces api for corefx repo

### DIFF
--- a/config.json
+++ b/config.json
@@ -275,78 +275,15 @@
       "valueType": "target",
       "values": [],
       "defaultValue": ""
-    }
+    },
+    "ProducesTarget": {
+      "description": "MsBuild target that displays all of the artifacts this repo produces.",
+      "valueType": "target",
+      "values": [],
+      "defaultValue": ""
+    }    
   },
   "commands": {
-    "sync":{
-      "alias":{
-        "p":{
-          "description": "Restores all NuGet packages for repository.",
-          "settings":{
-            "RestoreDuringBuild":  true,
-            "BatchRestorePackages": "default"
-          }
-        },
-        "ab":{
-          "description": "Downloads the latests product packages from Azure. The values for '-AzureAccount' and '-AzureToken' are required",
-          "settings":{
-            "Project": "src/syncAzure.proj",
-          }
-        },
-        "t":{
-          "description": "Generates project.jsons for test projects, restores packages, builds product and then builds tests against the generated project.json files.",
-          "settings":{
-            "RestoreDuringBuild":  true,
-            "BuildTestsAgainstPackages": true,
-            "BatchGenerateTestProjectJsons":  "default",
-            "BatchRestorePackages": "default"
-          }
-        },
-        "AzureAccount":{
-          "description": "Account name to connect to Azure Blob storage. Required for -ab to work.",
-          "settings":{
-            "CloudDropAccountName": "default"
-          }
-        },
-        "AzureToken":{
-          "description": "Account token to connect to Azure Blob storage. Required for -ab to work.",
-          "settings":{
-            "CloudDropAccessToken": "default"
-          }
-        },
-        "Container":{
-          "description": "Container name of the Azure Blob where the packages are going to be stored.",
-          "settings":{
-            "ContainerName": "default"
-          }
-        },
-        "BuildMajor": {
-          "description": "To download a specific group of product packages, specify build number. The value for -BuildMinor required.",
-          "settings": {
-            "BuildNumberMajor": "default"
-          }
-        },
-        "BuildMinor": {
-          "description": "To download a specific group of product packages, specify build number. The value for -BuildMajor required.",
-          "settings": {
-            "BuildNumberMinor": "default"
-          }
-        },
-        "verbose":{
-          "description": "Passes /flp:v=diag to the msbuild command or the value passed by the user.",
-          "settings":{
-            "MsBuildLogging": "/flp:v=diag;LogFile=sync.log"
-          }
-        }
-      },
-      "defaultValues":{
-        "toolName": "msbuild",
-        "settings": {
-          "MsBuildParameters":"default",
-          "MsBuildLogging":"/flp:v=normal;LogFile=sync.log"
-        }
-      }
-    },
     "build-managed":{
       "alias":{
         "binaries":{
@@ -497,6 +434,46 @@
          }
       }
     },
+    "clean":{
+      "alias":{
+        "b":{
+          "description": "Deletes the binary output directory.",
+          "settings":{
+            "CleanAllProjects": "default"
+          }
+        },
+        "p":{
+          "description": "Deletes the repo-local nuget package directory.",
+          "settings":{
+            "CleanPackages": "default"
+            }
+        },
+        "c":{
+          "description": "Deletes the user-local nuget package cache.",
+          "settings":{
+            "CleanPackagesCache": "default"
+          }
+        }
+      },
+      "defaultValues":{
+        "toolName": "msbuild",
+        "settings": {
+          "MsBuildParameters":"default",
+          "MsBuildLogging":"/flp:v=normal;LogFile=clean.log"
+        }
+      }
+    },
+    "produces":{
+      "alias":{},
+      "defaultValues":{
+        "toolName": "msbuild",
+        "settings": {
+          "Project": "src/packages.builds",
+          "MsBuildParameters": "default",
+          "ProducesTarget":"default"
+        }
+      }
+    },
     "publish-packages":{
       "alias":{
         "AzureAccount":{
@@ -533,24 +510,64 @@
         }
       }
     },
-    "clean":{
+    "sync":{
       "alias":{
-        "b":{
-          "description": "Deletes the binary output directory.",
+        "p":{
+          "description": "Restores all NuGet packages for repository.",
           "settings":{
-            "CleanAllProjects": "default"
+            "RestoreDuringBuild":  true,
+            "BatchRestorePackages": "default"
           }
         },
-        "p":{
-          "description": "Deletes the repo-local nuget package directory.",
+        "ab":{
+          "description": "Downloads the latests product packages from Azure. The values for '-AzureAccount' and '-AzureToken' are required",
           "settings":{
-            "CleanPackages": "default"
-            }
+            "Project": "src/syncAzure.proj"
+          }
         },
-        "c":{
-          "description": "Deletes the user-local nuget package cache.",
+        "t":{
+          "description": "Generates project.jsons for test projects, restores packages, builds product and then builds tests against the generated project.json files.",
           "settings":{
-            "CleanPackagesCache": "default"
+            "RestoreDuringBuild":  true,
+            "BuildTestsAgainstPackages": true,
+            "BatchGenerateTestProjectJsons":  "default",
+            "BatchRestorePackages": "default"
+          }
+        },
+        "AzureAccount":{
+          "description": "Account name to connect to Azure Blob storage. Required for -ab to work.",
+          "settings":{
+            "CloudDropAccountName": "default"
+          }
+        },
+        "AzureToken":{
+          "description": "Account token to connect to Azure Blob storage. Required for -ab to work.",
+          "settings":{
+            "CloudDropAccessToken": "default"
+          }
+        },
+        "Container":{
+          "description": "Container name of the Azure Blob where the packages are going to be stored.",
+          "settings":{
+            "ContainerName": "default"
+          }
+        },
+        "BuildMajor": {
+          "description": "To download a specific group of product packages, specify build number. The value for -BuildMinor required.",
+          "settings": {
+            "BuildNumberMajor": "default"
+          }
+        },
+        "BuildMinor": {
+          "description": "To download a specific group of product packages, specify build number. The value for -BuildMajor required.",
+          "settings": {
+            "BuildNumberMinor": "default"
+          }
+        },
+        "verbose":{
+          "description": "Passes /flp:v=diag to the msbuild command or the value passed by the user.",
+          "settings":{
+            "MsBuildLogging": "/flp:v=diag;LogFile=sync.log"
           }
         }
       },
@@ -558,7 +575,7 @@
         "toolName": "msbuild",
         "settings": {
           "MsBuildParameters":"default",
-          "MsBuildLogging":"/flp:v=normal;LogFile=clean.log"
+          "MsBuildLogging":"/flp:v=normal;LogFile=sync.log"
         }
       }
     }

--- a/dir.targets
+++ b/dir.targets
@@ -56,4 +56,11 @@
     </SupplementalTestData>
   </ItemGroup>
 
+  <Target Name="ProducesPackageId" 
+          Returns="@(PackageIds)">
+    <ItemGroup>
+      <PackageIds Include="$(Id)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -86,6 +86,32 @@
              ContinueOnError="ErrorAndContinue" />
   </Target>
 
+  <Target Name="ProducesPackageId"
+          Returns="@(PackageIds)" 
+          DependsOnTargets="FilterProjects">
+        <MSBuild Targets="ProducesPackageId"
+             Projects="@(Project)"
+             BuildInParallel="true"
+             ContinueOnError="ErrorAndContinue">
+          <Output TaskParameter="TargetOutputs"
+                  ItemName="PackageIds" />             
+        </MSBuild>
+    <ItemGroup>
+      <PackageIds Include="@(PackageIds)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ProducesTarget" DependsOnTargets="FilterProjects">
+    <MSBuild Targets="ProducesPackageId"
+             Projects="@(Project)"
+             BuildInParallel="true"
+             ContinueOnError="ErrorAndContinue">
+          <Output TaskParameter="TargetOutputs"
+                  ItemName="PackageIds" />      
+    </MSBuild>
+    <Message Text="%(PackageIds.Identity)" Importance="High" />
+  </Target>
+
   <Target Name="BuildAllProjects" DependsOnTargets="FilterProjects">
     <PropertyGroup>
       <DefaultBuildAllTarget Condition="'$(DefaultBuildAllTarget)'==''">$(MSBuildProjectDefaultTargets)</DefaultBuildAllTarget>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -89,13 +89,13 @@
   <Target Name="ProducesPackageId"
           Returns="@(PackageIds)" 
           DependsOnTargets="FilterProjects">
-        <MSBuild Targets="ProducesPackageId"
+    <MSBuild Targets="ProducesPackageId"
              Projects="@(Project)"
              BuildInParallel="true"
              ContinueOnError="ErrorAndContinue">
-          <Output TaskParameter="TargetOutputs"
-                  ItemName="PackageIds" />             
-        </MSBuild>
+      <Output TaskParameter="TargetOutputs"
+              ItemName="PackageIds" />             
+    </MSBuild>
     <ItemGroup>
       <PackageIds Include="@(PackageIds)" />
     </ItemGroup>
@@ -106,8 +106,8 @@
              Projects="@(Project)"
              BuildInParallel="true"
              ContinueOnError="ErrorAndContinue">
-          <Output TaskParameter="TargetOutputs"
-                  ItemName="PackageIds" />      
+      <Output TaskParameter="TargetOutputs"
+              ItemName="PackageIds" />      
     </MSBuild>
     <Message Text="%(PackageIds.Identity)" Importance="High" />
   </Target>


### PR DESCRIPTION
This is an initial implementation of the Produces API for the CoreFx repo.  It simply walks the packages projects and gathers package id's, then prints them to the console.  

This version brings us on par with Roslyn's current implementation of Produces (via RepoUtil), but it is not yet compliant with the full spec outlined at https://github.com/dotnet/buildtools/blob/master/Documentation/RepoCompose.md.  @jhendrixMSFT has plans to provide an API which repo's can consume to standardize the format for the produces output, and when that is available we will transition to using that work.

Note: The config.json change is noisy and largely ignorable.  There is the change there so that you can use "run produces", but also, I did some reordering so that commands are alphabetized. :/

/cc @weshaggard @dagood 