### PR TITLE
RegistryKey: Flesh out tests

### DIFF
--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyCreateSubKeyTestsBase.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyCreateSubKeyTestsBase.cs
@@ -9,28 +9,28 @@ namespace Microsoft.Win32.RegistryTests
 {
     public abstract class RegistryKeyCreateSubKeyTestsBase : RegistryTestsBase
     {
-        protected void Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(Func<RegistryKey> createSubKey)
+        protected void Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(string expected, Func<RegistryKey> createSubKey)
         {
-            CreateTestRegistrySubKey();
+            CreateTestRegistrySubKey(expected);
 
             using (RegistryKey key = createSubKey())
             {
                 Assert.NotNull(key);
                 Assert.Equal(1, TestRegistryKey.SubKeyCount);
-                Assert.Equal(TestRegistrySubKeyFullName, key.Name);
+                Assert.Equal(TestRegistryKey.Name + @"\" + expected, key.Name);
             }
         }
 
-        protected void Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(Func<RegistryKey> createSubKey)
+        protected void Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(string expected, Func<RegistryKey> createSubKey)
         {
-            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Null(TestRegistryKey.OpenSubKey(expected));
             Assert.Equal(0, TestRegistryKey.SubKeyCount);
 
             using (RegistryKey key = createSubKey())
             {
                 Assert.NotNull(key);
                 Assert.Equal(1, TestRegistryKey.SubKeyCount);
-                Assert.Equal(TestRegistrySubKeyFullName, key.Name);
+                Assert.Equal(TestRegistryKey.Name + @"\" + expected, key.Name);
             }
         }
     }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyDeleteSubKeyTestsBase.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyDeleteSubKeyTestsBase.cs
@@ -9,25 +9,25 @@ namespace Microsoft.Win32.RegistryTests
 {
     public abstract class RegistryKeyDeleteSubKeyTestsBase : RegistryTestsBase
     {
-        protected void Verify_DeleteSubKey_KeyExists_KeyDeleted(Action deleteSubKey)
+        protected void Verify_DeleteSubKey_KeyExists_KeyDeleted(string expected, Action deleteSubKey)
         {
-            CreateTestRegistrySubKey();
+            CreateTestRegistrySubKey(expected);
 
             deleteSubKey();
-            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistryKeyName));
+            Assert.Null(TestRegistryKey.OpenSubKey(expected));
         }
 
-        protected void Verify_DeleteSubKey_KeyDoesNotExists_Throws(Action deleteSubKey)
+        protected void Verify_DeleteSubKey_KeyDoesNotExists_Throws(string expected, Action deleteSubKey)
         {
-            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Null(TestRegistryKey.OpenSubKey(expected));
             Assert.Equal(0, TestRegistryKey.SubKeyCount);
 
             Assert.Throws<ArgumentException>(() => deleteSubKey());
         }
 
-        protected void Verify_DeleteSubKey_KeyDoesNotExists_DoesNotThrow(Action deleteSubKey)
+        protected void Verify_DeleteSubKey_KeyDoesNotExists_DoesNotThrow(string expected, Action deleteSubKey)
         {
-            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Null(TestRegistryKey.OpenSubKey(expected));
             Assert.Equal(0, TestRegistryKey.SubKeyCount);
 
             deleteSubKey();

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyDeleteSubKeyTreeTestsBase.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyDeleteSubKeyTreeTestsBase.cs
@@ -9,25 +9,25 @@ namespace Microsoft.Win32.RegistryTests
 {
     public abstract class RegistryKeyDeleteSubKeyTreeTestsBase : RegistryTestsBase
     {
-        protected void Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(Action deleteSubKeyTree)
+        protected void Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(string expected, Action deleteSubKeyTree)
         {
-            CreateTestRegistrySubKey();
+            CreateTestRegistrySubKey(expected);
 
             deleteSubKeyTree();
-            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistryKeyName));
+            Assert.Null(TestRegistryKey.OpenSubKey(expected));
         }
 
-        protected void Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(Action deleteSubKeyTree)
+        protected void Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(string expected, Action deleteSubKeyTree)
         {
-            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Null(TestRegistryKey.OpenSubKey(expected));
             Assert.Equal(0, TestRegistryKey.SubKeyCount);
 
             Assert.Throws<ArgumentException>(() => deleteSubKeyTree());
         }
 
-        protected void Verify_DeleteSubKeyTree_KeyDoesNotExists_DoesNotThrow(Action deleteSubKeyTree)
+        protected void Verify_DeleteSubKeyTree_KeyDoesNotExists_DoesNotThrow(string expected, Action deleteSubKeyTree)
         {
-            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Null(TestRegistryKey.OpenSubKey(expected));
             Assert.Equal(0, TestRegistryKey.SubKeyCount);
 
             deleteSubKeyTree();

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyOpenSubKeyTestsBase.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKeyOpenSubKeyTestsBase.cs
@@ -9,21 +9,21 @@ namespace Microsoft.Win32.RegistryTests
 {
     public abstract class RegistryKeyOpenSubKeyTestsBase : RegistryTestsBase
     {
-        protected void Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(Func<RegistryKey> openSubKey)
+        protected void Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(string expected, Func<RegistryKey> openSubKey)
         {
-            CreateTestRegistrySubKey();
+            CreateTestRegistrySubKey(expected);
 
             using (RegistryKey key = openSubKey())
             {
                 Assert.NotNull(key);
                 Assert.Equal(1, TestRegistryKey.SubKeyCount);
-                Assert.Equal(TestRegistrySubKeyFullName, key.Name);
+                Assert.Equal(TestRegistryKey.Name + @"\" + expected, key.Name);
             }
         }
 
-        protected void Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(Func<RegistryKey> openSubKey)
+        protected void Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(string expected, Func<RegistryKey> openSubKey)
         {
-            Assert.Null(TestRegistryKey.OpenSubKey(TestRegistrySubKeyName));
+            Assert.Null(TestRegistryKey.OpenSubKey(expected));
             Assert.Equal(0, TestRegistryKey.SubKeyCount);
 
             Assert.Null(openSubKey());

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str.cs
@@ -117,12 +117,12 @@ namespace Microsoft.Win32.RegistryTests
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void CreateSubKey_KeyExists_OpensKeyWithFixedUpName(string subKeyName) =>
-            Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName));
+        public void CreateSubKey_KeyExists_OpensKeyWithFixedUpName(string expected, string subKeyName) =>
+            Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(expected, () => TestRegistryKey.CreateSubKey(subKeyName));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(string subKeyName) =>
-            Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName));
+        public void CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(string expected, string subKeyName) =>
+            Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(expected, () => TestRegistryKey.CreateSubKey(subKeyName));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str_rkpc.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str_rkpc.cs
@@ -103,22 +103,22 @@ namespace Microsoft.Win32.RegistryTests
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void CreateSubKey_Writable_KeyExists_OpensKeyWithFixedUpName(string subKeyName) =>
-            Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName, writable: true));
+        public void CreateSubKey_Writable_KeyExists_OpensKeyWithFixedUpName(string expected, string subKeyName) =>
+            Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(expected, () => TestRegistryKey.CreateSubKey(subKeyName, writable: true));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void CreateSubKey_NonWritable_KeyExists_OpensKeyWithFixedUpName(string subKeyName) =>
-            Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName, writable: false));
+        public void CreateSubKey_NonWritable_KeyExists_OpensKeyWithFixedUpName(string expected, string subKeyName) =>
+            Verify_CreateSubKey_KeyExists_OpensKeyWithFixedUpName(expected, () => TestRegistryKey.CreateSubKey(subKeyName, writable: false));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void CreateSubKey_Writable_KeyDoesNotExist_CreatesKeyWithFixedUpName(string subKeyName) =>
-            Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName, writable: true));
+        public void CreateSubKey_Writable_KeyDoesNotExist_CreatesKeyWithFixedUpName(string expected, string subKeyName) =>
+            Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(expected, () => TestRegistryKey.CreateSubKey(subKeyName, writable: true));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void CreateSubKey_NonWritable_KeyDoesNotExist_CreatesKeyWithFixedUpName(string subKeyName) =>
-            Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(() => TestRegistryKey.CreateSubKey(subKeyName, writable: false));
+        public void CreateSubKey_NonWritable_KeyDoesNotExist_CreatesKeyWithFixedUpName(string expected, string subKeyName) =>
+            Verify_CreateSubKey_KeyDoesNotExist_CreatesKeyWithFixedUpName(expected, () => TestRegistryKey.CreateSubKey(subKeyName, writable: false));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKeyTree.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKeyTree.cs
@@ -70,22 +70,22 @@ namespace Microsoft.Win32.RegistryTests
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void DeleteSubKeyTree_ThrowOnMissing_KeyExists_KeyDeleted(string subKeyName) =>
-            Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: true));
+        public void DeleteSubKeyTree_ThrowOnMissing_KeyExists_KeyDeleted(string expected, string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(expected, () => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: true));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void DeleteSubKeyTree_DoNotThrow_KeyExists_KeyDeleted(string subKeyName) =>
-            Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: false));
+        public void DeleteSubKeyTree_DoNotThrow_KeyExists_KeyDeleted(string expected, string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(expected, () => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: false));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void DeleteSubKeyTree_ThrowOnMissing_KeyDoesNotExists_Throws(string subKeyName) =>
-            Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(() => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: true));
+        public void DeleteSubKeyTree_ThrowOnMissing_KeyDoesNotExists_Throws(string expected, string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(expected, () => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: true));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void DeleteSubKeyTree_DoNotThrow_KeyDoesNotExists_DoesNotThrow(string subKeyName) =>
-            Verify_DeleteSubKeyTree_KeyDoesNotExists_DoesNotThrow(() => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: false));
+        public void DeleteSubKeyTree_DoNotThrow_KeyDoesNotExists_DoesNotThrow(string expected, string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyDoesNotExists_DoesNotThrow(expected, () => TestRegistryKey.DeleteSubKeyTree(subKeyName, throwOnMissingSubKey: false));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKeyTree_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKeyTree_str.cs
@@ -86,13 +86,13 @@ namespace Microsoft.Win32.RegistryTests
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void DeleteSubKeyTree_KeyExists_KeyDeleted(string subKeyName) =>
-            Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKeyTree(subKeyName));
+        public void DeleteSubKeyTree_KeyExists_KeyDeleted(string expected, string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyExists_KeyDeleted(expected, () => TestRegistryKey.DeleteSubKeyTree(subKeyName));
 
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(string subKeyName) =>
-            Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(() => TestRegistryKey.DeleteSubKeyTree(subKeyName));
+        public void Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(string expected, string subKeyName) =>
+            Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(expected, () => TestRegistryKey.DeleteSubKeyTree(subKeyName));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKey_Str_Bln.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKey_Str_Bln.cs
@@ -74,22 +74,22 @@ namespace Microsoft.Win32.RegistryTests
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void DeleteSubKey_KeyExists_ThrowOnMissing_KeyDeleted(string subkeyName) =>
-            Verify_DeleteSubKey_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: true));
+        public void DeleteSubKey_KeyExists_ThrowOnMissing_KeyDeleted(string expected, string subkeyName) =>
+            Verify_DeleteSubKey_KeyExists_KeyDeleted(expected, () => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: true));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void DeleteSubKey_KeyExists_DoNotThrow_KeyDeleted(string subkeyName) =>
-            Verify_DeleteSubKey_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: false));
+        public void DeleteSubKey_KeyExists_DoNotThrow_KeyDeleted(string expected, string subkeyName) =>
+            Verify_DeleteSubKey_KeyExists_KeyDeleted(expected, () => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: false));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void DeleteSubKey_KeyDoesNotExists_ThrowOnMissing_Throws(string subkeyName) =>
-            Verify_DeleteSubKey_KeyDoesNotExists_Throws(() => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: true));
+        public void DeleteSubKey_KeyDoesNotExists_ThrowOnMissing_Throws(string expected, string subkeyName) =>
+            Verify_DeleteSubKey_KeyDoesNotExists_Throws(expected, () => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: true));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void DeleteSubKey_KeyDoesNotExists_DoNotThrow_DoesNotThrow(string subkeyName) =>
-            Verify_DeleteSubKey_KeyDoesNotExists_DoesNotThrow(() => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: false));
+        public void DeleteSubKey_KeyDoesNotExists_DoNotThrow_DoesNotThrow(string expected, string subkeyName) =>
+            Verify_DeleteSubKey_KeyDoesNotExists_DoesNotThrow(expected, () => TestRegistryKey.DeleteSubKey(subkeyName, throwOnMissingSubKey: false));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKey_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKey_str.cs
@@ -55,12 +55,12 @@ namespace Microsoft.Win32.RegistryTests
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void DeleteSubKey_KeyExists_KeyDeleted(string subkeyName) =>
-            Verify_DeleteSubKey_KeyExists_KeyDeleted(() => TestRegistryKey.DeleteSubKey(subkeyName));
+        public void DeleteSubKey_KeyExists_KeyDeleted(string expected, string subkeyName) =>
+            Verify_DeleteSubKey_KeyExists_KeyDeleted(expected, () => TestRegistryKey.DeleteSubKey(subkeyName));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void DeleteSubKey_KeyDoesNotExists_Throws(string subkeyName) =>
-            Verify_DeleteSubKey_KeyDoesNotExists_Throws(() => TestRegistryKey.DeleteSubKey(subkeyName));
+        public void DeleteSubKey_KeyDoesNotExists_Throws(string expected, string subkeyName) =>
+            Verify_DeleteSubKey_KeyDoesNotExists_Throws(expected, () => TestRegistryKey.DeleteSubKey(subkeyName));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str.cs
@@ -66,12 +66,12 @@ namespace Microsoft.Win32.RegistryTests
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void OpenSubKey_KeyExists_OpensWithFixedUpName(string subKeyName) =>
-            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(() => TestRegistryKey.OpenSubKey(subKeyName));
+        public void OpenSubKey_KeyExists_OpensWithFixedUpName(string expected, string subKeyName) =>
+            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(expected, () => TestRegistryKey.OpenSubKey(subKeyName));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void OpenSubKey_KeyDoesNotExist_ReturnsNull(string subKeyName) =>
-            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(() => TestRegistryKey.OpenSubKey(subKeyName));
+        public void OpenSubKey_KeyDoesNotExist_ReturnsNull(string expected, string subKeyName) =>
+            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(expected, () => TestRegistryKey.OpenSubKey(subKeyName));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str_b.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str_b.cs
@@ -56,22 +56,22 @@ namespace Microsoft.Win32.RegistryTests
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void OpenSubKey_Writable_KeyExists_OpensWithFixedUpName(string subKeyName) =>
-            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(() => TestRegistryKey.OpenSubKey(subKeyName, writable: true));
+        public void OpenSubKey_Writable_KeyExists_OpensWithFixedUpName(string expected, string subKeyName) =>
+            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(expected, () => TestRegistryKey.OpenSubKey(subKeyName, writable: true));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void OpenSubKey_NonWritable_KeyExists_OpensWithFixedUpName(string subKeyName) =>
-            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(() => TestRegistryKey.OpenSubKey(subKeyName, writable: false));
+        public void OpenSubKey_NonWritable_KeyExists_OpensWithFixedUpName(string expected, string subKeyName) =>
+            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(expected, () => TestRegistryKey.OpenSubKey(subKeyName, writable: false));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void OpenSubKey_Writable_KeyDoesNotExist_ReturnsNull(string subKeyName) =>
-            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(() => TestRegistryKey.OpenSubKey(subKeyName, writable: true));
+        public void OpenSubKey_Writable_KeyDoesNotExist_ReturnsNull(string expected, string subKeyName) =>
+            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(expected, () => TestRegistryKey.OpenSubKey(subKeyName, writable: true));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void OpenSubKey_NonWritable_KeyDoesNotExist_ReturnsNull(string subKeyName) =>
-            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(() => TestRegistryKey.OpenSubKey(subKeyName, writable: false));
+        public void OpenSubKey_NonWritable_KeyDoesNotExist_ReturnsNull(string expected, string subKeyName) =>
+            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(expected, () => TestRegistryKey.OpenSubKey(subKeyName, writable: false));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str_rkpc.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_OpenSubKey_str_rkpc.cs
@@ -64,22 +64,22 @@ namespace Microsoft.Win32.RegistryTests
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void OpenSubKey_Writable_KeyExists_OpensWithFixedUpName(string subKeyName) =>
-            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(() => TestRegistryKey.OpenSubKey(subKeyName, Writable));
+        public void OpenSubKey_Writable_KeyExists_OpensWithFixedUpName(string expected, string subKeyName) =>
+            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(expected, () => TestRegistryKey.OpenSubKey(subKeyName, Writable));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void OpenSubKey_NonWritable_KeyExists_OpensWithFixedUpName(string subKeyName) =>
-            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(() => TestRegistryKey.OpenSubKey(subKeyName, NonWritable));
+        public void OpenSubKey_NonWritable_KeyExists_OpensWithFixedUpName(string expected, string subKeyName) =>
+            Verify_OpenSubKey_KeyExists_OpensWithFixedUpName(expected, () => TestRegistryKey.OpenSubKey(subKeyName, NonWritable));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void OpenSubKey_Writable_KeyDoesNotExist_ReturnsNull(string subKeyName) =>
-            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(() => TestRegistryKey.OpenSubKey(subKeyName, Writable));
+        public void OpenSubKey_Writable_KeyDoesNotExist_ReturnsNull(string expected, string subKeyName) =>
+            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(expected, () => TestRegistryKey.OpenSubKey(subKeyName, Writable));
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void OpenSubKey_NonWritable_KeyDoesNotExist_ReturnsNull(string subKeyName) =>
-            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(() => TestRegistryKey.OpenSubKey(subKeyName, NonWritable));
+        public void OpenSubKey_NonWritable_KeyDoesNotExist_ReturnsNull(string expected, string subKeyName) =>
+            Verify_OpenSubKey_KeyDoesNotExist_ReturnsNull(expected, () => TestRegistryKey.OpenSubKey(subKeyName, NonWritable));
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/RegistryTestsBase.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryTestsBase.cs
@@ -55,32 +55,117 @@ namespace Microsoft.Win32.RegistryTests
             return "corefxtest_" + GetType().Name;
         }
 
-        protected const string TestRegistrySubKeyName = @"Foo\Bar";
-
-        protected string TestRegistrySubKeyFullName => TestRegistryKey.Name + @"\" + TestRegistrySubKeyName;
-
         public static readonly object[][] TestRegistrySubKeyNames =
         {
-            new object[] { @"Foo\Bar" },
-            new object[] { @"Foo\\Bar" },
-            new object[] { @"Foo\\\Bar" },
-            new object[] { @"Foo\Bar\" },
-            new object[] { @"Foo\Bar\\" },
-            new object[] { @"Foo\Bar\\\" },
-            new object[] { @"Foo\\Bar\" },
-            new object[] { @"Foo\\Bar\\" },
-            new object[] { @"Foo\\Bar\\\" },
+            new object[] { @"Foo", @"Foo" },
+            new object[] { @"Foo\Bar", @"Foo\Bar" },
+
+            // Multiple/trailing slashes should be removed.
+            new object[] { @"Foo", @"Foo\" },
+            new object[] { @"Foo", @"Foo\\" },
+            new object[] { @"Foo", @"Foo\\\" },
+            new object[] { @"Foo", @"Foo\\\\" },
+            new object[] { @"Foo\Bar", @"Foo\\Bar" },
+            new object[] { @"Foo\Bar", @"Foo\\\Bar" },
+            new object[] { @"Foo\Bar", @"Foo\\\\Bar" },
+            new object[] { @"Foo\Bar", @"Foo\Bar\" },
+            new object[] { @"Foo\Bar", @"Foo\Bar\\" },
+            new object[] { @"Foo\Bar", @"Foo\Bar\\\" },
+            new object[] { @"Foo\Bar", @"Foo\\Bar\" },
+            new object[] { @"Foo\Bar", @"Foo\\Bar\\" },
+            new object[] { @"Foo\Bar", @"Foo\\Bar\\\" },
+            new object[] { @"Foo\Bar", @"Foo\\\Bar\\\" },
+            new object[] { @"Foo\Bar", @"Foo\\\\Bar\\\\" },
+
+            // The name fix-up implementation uses a mark-and-sweep approach.
+            // If there are multiple slashes, any extra slash chars will be
+            // replaced with a marker char ('\uffff'), and then all '\uffff'
+            // chars will be removed, including any pre-existing '\uffff' chars.
+            InsertMarkerChar(@"Foo", @"{0}Foo\\"),
+            InsertMarkerChar(@"Foo", @"Foo{0}\\"),
+            InsertMarkerChar(@"Foo", @"Foo\\{0}"),
+            InsertMarkerChar(@"Foo", @"Fo{0}o\\"),
+            InsertMarkerChar(@"Foo", @"{0}Fo{0}o{0}\\{0}"),
+            InsertMarkerChar(@"Foo", @"{0}Foo\\\"),
+            InsertMarkerChar(@"Foo", @"Foo{0}\\\"),
+            InsertMarkerChar(@"Foo", @"Foo\\\{0}"),
+            InsertMarkerChar(@"Foo", @"Fo{0}o\\\"),
+            InsertMarkerChar(@"Foo", @"{0}Fo{0}o{0}\\\{0}"),
+            InsertMarkerChar(@"Foo\Bar", @"{0}Foo\\Bar"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo{0}\\Bar"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo\\{0}Bar"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo\\Bar{0}"),
+            InsertMarkerChar(@"Foo\Bar", @"Fo{0}o\\Bar"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo\\B{0}ar"),
+            InsertMarkerChar(@"Foo\Bar", @"Fo{0}o\\B{0}ar"),
+            InsertMarkerChar(@"Foo\Bar", @"{0}Fo{0}o{0}\\{0}B{0}ar{0}"),
+            InsertMarkerChar(@"Foo\Bar", @"{0}Foo\\\Bar"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo{0}\\\Bar"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo\\\{0}Bar"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo\\\Bar{0}"),
+            InsertMarkerChar(@"Foo\Bar", @"Fo{0}o\\\Bar"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo\\\B{0}ar"),
+            InsertMarkerChar(@"Foo\Bar", @"Fo{0}o\\\B{0}ar"),
+            InsertMarkerChar(@"Foo\Bar", @"{0}Fo{0}o{0}\\\{0}B{0}ar{0}"),
+            InsertMarkerChar(@"Foo\Bar", @"{0}Foo\Bar\\"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo{0}\Bar\\"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo\{0}Bar\\"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo\Bar{0}\\"),
+            InsertMarkerChar(@"Foo\Bar", @"Foo\Bar\\{0}"),
+            InsertMarkerChar(@"Foo\Bar", @"Fo{0}o\B{0}ar\\"),
+            InsertMarkerChar(@"Foo\Bar", @"{0}Fo{0}o{0}\{0}B{0}ar{0}\\{0}"),
+
+            // If there aren't multiple slashes, any '\uffff' chars should remain.
+            InsertMarkerChar(@"{0}Foo"),
+            InsertMarkerChar(@"Foo{0}"),
+            InsertMarkerChar(@"Fo{0}o"),
+            InsertMarkerChar(@"{0}Fo{0}o{0}"),
+            InsertMarkerChar(@"{0}Foo\"),
+            InsertMarkerChar(@"Foo{0}\"),
+            InsertMarkerChar(@"Fo{0}o\"),
+            InsertMarkerChar(@"{0}Fo{0}o{0}\"),
+            InsertMarkerChar(@"{0}Foo\Bar"),
+            InsertMarkerChar(@"Foo{0}\Bar"),
+            InsertMarkerChar(@"Foo\{0}Bar"),
+            InsertMarkerChar(@"Foo\Bar{0}"),
+            InsertMarkerChar(@"Fo{0}o\Bar"),
+            InsertMarkerChar(@"Foo\B{0}ar"),
+            InsertMarkerChar(@"Fo{0}o\B{0}ar"),
+            InsertMarkerChar(@"{0}Fo{0}o{0}\{0}B{0}ar{0}"),
+            InsertMarkerChar(@"{0}Foo\Bar\"),
+            InsertMarkerChar(@"Foo{0}\Bar\"),
+            InsertMarkerChar(@"Foo\{0}Bar\"),
+            InsertMarkerChar(@"Foo\Bar{0}\"),
+            InsertMarkerChar(@"Fo{0}o\Bar\"),
+            InsertMarkerChar(@"Foo\B{0}ar\"),
+            InsertMarkerChar(@"Fo{0}o\B{0}ar\"),
+            InsertMarkerChar(@"{0}Fo{0}o{0}\{0}B{0}ar{0}\"),
         };
 
-        protected void CreateTestRegistrySubKey()
+        private const char MarkerChar = '\uffff';
+
+        private static object[] InsertMarkerChar(string expected, string format)
+        {
+            string result = string.Format(format, MarkerChar);
+            return new object[] { expected, result };
+        }
+
+        private static object[] InsertMarkerChar(string format)
+        {
+            string result = string.Format(format, MarkerChar);
+            string expected = result.TrimEnd('\\');
+            return new object[] { expected, result };
+        }
+
+        protected void CreateTestRegistrySubKey(string expected)
         {
             Assert.Equal(0, TestRegistryKey.SubKeyCount);
 
-            using (RegistryKey key = TestRegistryKey.CreateSubKey(TestRegistrySubKeyName))
+            using (RegistryKey key = TestRegistryKey.CreateSubKey(expected))
             {
                 Assert.NotNull(key);
                 Assert.Equal(1, TestRegistryKey.SubKeyCount);
-                Assert.Equal(TestRegistrySubKeyFullName, key.Name);
+                Assert.Equal(TestRegistryKey.Name + @"\" + expected, key.Name);
             }
         }
     }


### PR DESCRIPTION
`RegistryKey`'s sub key name [fix-up implementation](https://github.com/dotnet/corefx/blob/b7e7969b076e674a11aa52779e0012ec4a4b337c/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs#L570-L630) uses a mark-and-sweep approach. If there are multiple slashes, any extra slash chars will be replaced with a marker char (`'\uffff'`), and then all `'\uffff'` chars will be removed, including any pre-existing `'\uffff'` chars.

If there aren't multiple slashes, any `'\uffff'` chars should remain.

This commit adds new tests to pin this behavior.

This behavior isn't documented AFAICT, but I assume we want to maintain it for compatibility sake. (I was looking into improving perf of the fix-up implementation for the common case of names that don't need to be fixed-up, which is why this extra coverage is useful).

cc: @stephentoub