### PR TITLE
Fix incorrect AssemblyName in System.Net.Primitives/PerformanceTests

### DIFF
--- a/src/System.Net.Primitives/tests/PerformanceTests/System.Net.Primitives.Performance.Tests.csproj
+++ b/src/System.Net.Primitives/tests/PerformanceTests/System.Net.Primitives.Performance.Tests.csproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{86256B36-4C78-4A71-A80A-CCA35C4AE758}</ProjectGuid>
     <OutputType>Library</OutputType>
     <IncludePerformanceTests>true</IncludePerformanceTests>
-    <AssemblyName>System.Collections.NonGeneric.Performance.Tests</AssemblyName>
+    <AssemblyName>System.Net.Primitives.Performance.Tests</AssemblyName>
     <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->


### PR DESCRIPTION
Fixes what was presumably a typo/accident, introduced by #10192

cc @dsgouda, @stephentoub 