### PR TITLE
Separate exception serialization test into helper

### DIFF
--- a/src/Common/tests/System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs
+++ b/src/Common/tests/System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Xunit;
+
+namespace System.Runtime.Serialization.Formatters.Tests
+{
+    internal static class BinaryFormatterHelpers
+    {
+        internal static T Clone<T>(T obj)
+        {
+            var f = new BinaryFormatter();
+            using (var s = new MemoryStream())
+            {
+                f.Serialize(s, obj);
+                s.Position = 0;
+                return (T)f.Deserialize(s);
+            }
+        }
+
+        internal static void AssertRoundtrips(Exception expected, params Func<Exception, object>[] additionalGetters)
+        {
+            for (int i = 0; i < 2; i++)
+            {
+                if (i > 0) // first time without stack trace, second time with
+                {
+                    try { throw expected; }
+                    catch { }
+                }
+
+                // Serialize/deserialize the exception
+                Exception actual = Clone(expected);
+
+                // Verify core state
+                Assert.Equal(expected.StackTrace, actual.StackTrace);
+                Assert.Equal(expected.Data, actual.Data);
+                Assert.Equal(expected.Message, actual.Message);
+                Assert.Equal(expected.Source, actual.Source);
+                Assert.Equal(expected.ToString(), actual.ToString());
+                Assert.Equal(expected.HResult, actual.HResult);
+
+                // Verify optional additional state
+                foreach (Func<Exception, object> getter in additionalGetters)
+                {
+                    Assert.Equal(getter(expected), getter(actual));
+                }
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -384,22 +384,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         [MemberData(nameof(SerializableExceptions))]
         public void Roundtrip_Exceptions(Exception expected)
         {
-            for (int i = 0; i < 2; i++)
-            {
-                Exception actual = FormatterClone(expected);
-
-                Assert.Equal(expected.StackTrace, actual.StackTrace);
-                Assert.Equal(expected.Data, actual.Data);
-                Assert.Equal(expected.Message, actual.Message);
-                Assert.Equal(expected.Source, actual.Source);
-                Assert.Equal(expected.ToString(), actual.ToString());
-                Assert.Equal(expected.HResult, actual.HResult);
-
-                if (i == 0)
-                {
-                    try { throw expected; } catch { }
-                }
-            }
+            BinaryFormatterHelpers.AssertRoundtrips(expected);
         }
 
         private static int Identity(int i) => i;

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -41,6 +41,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />


### PR DESCRIPTION
Many of the serializable types in corefx are exceptions.  To make it easier to test them, I'm separating out a helper that can be used in both the BinaryFormatter tests and in each individual project's tests.