### PR TITLE
Add extra poll() call to work around libcurl issue

### DIFF
--- a/src/Native/Unix/System.Net.Http.Native/pal_multi.cpp
+++ b/src/Native/Unix/System.Net.Http.Native/pal_multi.cpp
@@ -7,6 +7,7 @@
 #include "pal_utilities.h"
 
 #include <assert.h>
+#include <poll.h>
 
 static_assert(PAL_CURLM_CALL_MULTI_PERFORM == CURLM_CALL_MULTI_PERFORM, "");
 static_assert(PAL_CURLM_OK == CURLM_OK, "");
@@ -69,8 +70,31 @@ extern "C" int32_t HttpNative_MultiWait(CURLM* multiHandle,
     int numFds;
     CURLMcode result = curl_multi_wait(multiHandle, &extraFds, 1, FailsafeTimeoutMilliseconds, &numFds);
 
-    *isExtraFileDescriptorActive = (extraFds.revents & CURL_WAIT_POLLIN) != 0;
-    *isTimeout = numFds == 0;
+    if (numFds == 0)
+    {
+        *isTimeout = true;
+        *isExtraFileDescriptorActive = false;
+    }
+    else
+    {
+        *isTimeout = false;
+
+        //
+        // Prior to libcurl version 7.32.0, the revents field was not returned properly for "extra" file descriptors
+        // passed to curl_multi_wait.  See https://github.com/dotnet/corefx/issues/9751.  So if we have a libcurl
+        // prior to that version, we need to do our own poll to get the status of the extra file descriptor.
+        //
+        if (curl_version_info(CURLVERSION_NOW)->version_num >= 0x073200)
+        {
+            *isExtraFileDescriptorActive = (extraFds.revents & CURL_WAIT_POLLIN) != 0;
+        }
+        else
+        {
+            pollfd pfd = { .fd = ToFileDescriptor(extraFileDescriptor),.events = POLLIN,.revents = 0 };
+            poll(&pfd, 1, 0);
+            *isExtraFileDescriptorActive = (pfd.revents & POLLIN) != 0;
+        }
+    }
 
     return result;
 }

--- a/src/Native/Unix/System.Net.Http.Native/pal_multi.cpp
+++ b/src/Native/Unix/System.Net.Http.Native/pal_multi.cpp
@@ -92,6 +92,11 @@ extern "C" int32_t HttpNative_MultiWait(CURLM* multiHandle,
         {
             pollfd pfd = { .fd = ToFileDescriptor(extraFileDescriptor),.events = POLLIN,.revents = 0 };
             poll(&pfd, 1, 0);
+
+            //
+            // We ignore any failure in poll(), to preserve the result from curl_multi_wait.  If poll() fails, it should
+            // leave revents cleared.
+            //
             *isExtraFileDescriptorActive = (pfd.revents & POLLIN) != 0;
         }
     }


### PR DESCRIPTION
libcurl versions prior to 7.32.0 have a bug in `curl_multi_wait`: the `revents` fields for the "extra" file descriptors are not populated with the relevant events that are signaled.  We rely on this info to know when to read data from a pipe, to reset those events, and so under some circumstances we can end up with a pipe that is always readable, leading to `curl_multi_wait` always returning immediately.  This results in 100% CPU usage for some scenarios.

This bug is fixed in libcurl 7.32.0 with [this commit](https://github.com/curl/curl/commit/6d30f8ebed34e7276c2a59ee20d466bff17fee56).  However, this version is not available on some supported Linux distros, so a workaround is also needed.  We simply add a manual `poll` call in the case where we're running on a libcurl version without the fix.

Fixes #9751.

cc: @stephentoub, @crozone, @CRCinAU, @ppanyukov, @TingluoHuang
