### PR TITLE
Enable init-tools option to suppress non-error output from the console output

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -1,7 +1,6 @@
 @if "%_echo%" neq "on" echo off
 setlocal
 
-if /I [%1] equ [-quiet] set VERBOSITY=quiet
 set INIT_TOOLS_LOG=%~dp0init-tools.log
 if [%PACKAGES_DIR%]==[] set PACKAGES_DIR=%~dp0packages\
 if [%TOOLRUNTIME_DIR%]==[] set TOOLRUNTIME_DIR=%~dp0Tools
@@ -23,7 +22,7 @@ if [%1]==[force] (
 
 :: If sempahore exists do nothing
 if exist "%BUILD_TOOLS_SEMAPHORE%" (
-  if [%VERBOSITY%]==[] echo Tools are already initialized.
+  echo Tools are already initialized. >> "%INIT_TOOLS_LOG%"
   goto :EOF
 )
 
@@ -35,7 +34,7 @@ echo Running %0 > "%INIT_TOOLS_LOG%"
 
 if exist "%DOTNET_CMD%" goto :afterdotnetrestore
 
-if [%VERBOSITY%]==[] echo Installing dotnet cli...
+echo Installing dotnet cli... >> "%INIT_TOOLS_LOG%"
 if NOT exist "%DOTNET_PATH%" mkdir "%DOTNET_PATH%"
 set /p DOTNET_VERSION=< "%~dp0DotnetCLIVersion.txt"
 set DOTNET_ZIP_NAME=dotnet-dev-win-x86.%DOTNET_VERSION%.zip
@@ -51,7 +50,7 @@ if NOT exist "%DOTNET_LOCAL_PATH%" (
 :afterdotnetrestore
 
 if exist "%BUILD_TOOLS_PATH%" goto :afterbuildtoolsrestore
-if [%VERBOSITY%]==[] echo Restoring BuildTools version %BUILDTOOLS_VERSION%...
+echo Restoring BuildTools version %BUILDTOOLS_VERSION%... >> "%INIT_TOOLS_LOG%"
 echo Running: "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --no-cache --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> "%INIT_TOOLS_LOG%"
 call "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --no-cache --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> "%INIT_TOOLS_LOG%"
 if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
@@ -61,7 +60,7 @@ if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
 
 :afterbuildtoolsrestore
 
-if [%VERBOSITY%]==[] echo Initializing BuildTools ...
+echo Initializing BuildTools ... >> "%INIT_TOOLS_LOG%"
 echo Running: "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
 call "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
 set INIT_TOOLS_ERRORLEVEL=%ERRORLEVEL%
@@ -71,5 +70,5 @@ if not [%INIT_TOOLS_ERRORLEVEL%]==[0] (
 )
 
 :: Create sempahore file
-if [%VERBOSITY%]==[] echo Done initializing tools.
+echo Done initializing tools. >> "%INIT_TOOLS_LOG%"
 echo Init-Tools.cmd completed for BuildTools Version: %BUILDTOOLS_VERSION% > "%BUILD_TOOLS_SEMAPHORE%"

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -37,7 +37,7 @@ if exist "%DOTNET_CMD%" goto :afterdotnetrestore
 echo Installing dotnet cli... >> "%INIT_TOOLS_LOG%"
 if NOT exist "%DOTNET_PATH%" mkdir "%DOTNET_PATH%"
 set /p DOTNET_VERSION=< "%~dp0DotnetCLIVersion.txt"
-set DOTNET_ZIP_NAME=dotnet-dev-win-x86.%DOTNET_VERSION%.zip
+set DOTNET_ZIP_NAME=dotnet-dev-win-x64.%DOTNET_VERSION%.zip
 set DOTNET_REMOTE_PATH=https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/%DOTNET_VERSION%/%DOTNET_ZIP_NAME%
 set DOTNET_LOCAL_PATH=%DOTNET_PATH%%DOTNET_ZIP_NAME%
 echo Installing '%DOTNET_REMOTE_PATH%' to '%DOTNET_LOCAL_PATH%' >> "%INIT_TOOLS_LOG%"

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -1,6 +1,7 @@
 @if "%_echo%" neq "on" echo off
 setlocal
 
+if /I [%1] equ [-quiet] set VERBOSITY=quiet
 set INIT_TOOLS_LOG=%~dp0init-tools.log
 if [%PACKAGES_DIR%]==[] set PACKAGES_DIR=%~dp0packages\
 if [%TOOLRUNTIME_DIR%]==[] set TOOLRUNTIME_DIR=%~dp0Tools
@@ -22,7 +23,7 @@ if [%1]==[force] (
 
 :: If sempahore exists do nothing
 if exist "%BUILD_TOOLS_SEMAPHORE%" (
-  echo Tools are already initialized.
+  if [%VERBOSITY%]==[] echo Tools are already initialized.
   goto :EOF
 )
 
@@ -34,10 +35,10 @@ echo Running %0 > "%INIT_TOOLS_LOG%"
 
 if exist "%DOTNET_CMD%" goto :afterdotnetrestore
 
-echo Installing dotnet cli...
+if [%VERBOSITY%]==[] echo Installing dotnet cli...
 if NOT exist "%DOTNET_PATH%" mkdir "%DOTNET_PATH%"
 set /p DOTNET_VERSION=< "%~dp0DotnetCLIVersion.txt"
-set DOTNET_ZIP_NAME=dotnet-dev-win-x64.%DOTNET_VERSION%.zip
+set DOTNET_ZIP_NAME=dotnet-dev-win-x86.%DOTNET_VERSION%.zip
 set DOTNET_REMOTE_PATH=https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/%DOTNET_VERSION%/%DOTNET_ZIP_NAME%
 set DOTNET_LOCAL_PATH=%DOTNET_PATH%%DOTNET_ZIP_NAME%
 echo Installing '%DOTNET_REMOTE_PATH%' to '%DOTNET_LOCAL_PATH%' >> "%INIT_TOOLS_LOG%"
@@ -50,7 +51,7 @@ if NOT exist "%DOTNET_LOCAL_PATH%" (
 :afterdotnetrestore
 
 if exist "%BUILD_TOOLS_PATH%" goto :afterbuildtoolsrestore
-echo Restoring BuildTools version %BUILDTOOLS_VERSION%...
+if [%VERBOSITY%]==[] echo Restoring BuildTools version %BUILDTOOLS_VERSION%...
 echo Running: "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --no-cache --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> "%INIT_TOOLS_LOG%"
 call "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --no-cache --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> "%INIT_TOOLS_LOG%"
 if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
@@ -60,7 +61,7 @@ if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
 
 :afterbuildtoolsrestore
 
-echo Initializing BuildTools ...
+if [%VERBOSITY%]==[] echo Initializing BuildTools ...
 echo Running: "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
 call "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
 set INIT_TOOLS_ERRORLEVEL=%ERRORLEVEL%
@@ -70,5 +71,5 @@ if not [%INIT_TOOLS_ERRORLEVEL%]==[0] (
 )
 
 :: Create sempahore file
-echo Done initializing tools.
+if [%VERBOSITY%]==[] echo Done initializing tools.
 echo Init-Tools.cmd completed for BuildTools Version: %BUILDTOOLS_VERSION% > "%BUILD_TOOLS_SEMAPHORE%"

--- a/run.cmd
+++ b/run.cmd
@@ -17,12 +17,11 @@ if not defined VisualStudioVersion (
 set Platform=
 
 :: Restore the Tools directory
-call %~dp0init-tools.cmd
+call %~dp0init-tools.cmd -quiet
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
 
 set _toolRuntime=%~dp0Tools
 set _dotnet=%_toolRuntime%\dotnetcli\dotnet.exe
 
-echo Running: %_dotnet% %_toolRuntime%\run.exe %*
 call %_dotnet% %_toolRuntime%\run.exe %*
 exit /b %ERRORLEVEL%

--- a/run.cmd
+++ b/run.cmd
@@ -17,7 +17,7 @@ if not defined VisualStudioVersion (
 set Platform=
 
 :: Restore the Tools directory
-call %~dp0init-tools.cmd -quiet
+call %~dp0init-tools.cmd
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
 
 set _toolRuntime=%~dp0Tools

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,5 @@ fi
 __toolRuntime=$__scriptpath/Tools
 __dotnet=$__toolRuntime/dotnetcli/dotnet
 
-echo Running: $__dotnet $__toolRuntime/run.exe $*
 $__dotnet $__toolRuntime/run.exe $*
 exit $?


### PR DESCRIPTION
Add an argument option to init-tools so we can suppress displaying non-error output to the console.  Allows us to run quietly unless an error is encountered.

/cc @weshaggard @maririos 