### PR TITLE
Implement digest and HMAC on CommonCrypto

### DIFF
--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.Apple;
+
+internal static partial class Interop
+{
+    internal static partial class AppleCrypto
+    {
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestFree")]
+        internal static extern void DigestFree(IntPtr handle);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestCreate")]
+        internal static extern SafeDigestCtxHandle DigestCreate(PAL_HashAlgorithm algorithm, out int cbDigest);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestUpdate")]
+        internal static extern unsafe int DigestUpdate(SafeDigestCtxHandle ctx, byte* pbData, int cbData);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestFinal")]
+        internal static extern unsafe int DigestFinal(SafeDigestCtxHandle ctx, byte* pbOutput, int cbOutput);
+    }
+}
+
+namespace System.Security.Cryptography.Apple
+{
+    internal sealed class SafeDigestCtxHandle : SafeHandle
+    {
+        internal SafeDigestCtxHandle()
+            : base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.AppleCrypto.DigestFree(handle);
+            SetHandle(IntPtr.Zero);
+            return true;
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+    }
+}

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.Apple;
+
+internal static partial class Interop
+{
+    internal static partial class AppleCrypto
+    {
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacFree")]
+        internal static extern void HmacFree(IntPtr handle);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacCreate")]
+        internal static extern SafeHmacHandle HmacCreate(PAL_HashAlgorithm algorithm, ref int cbDigest);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacInit")]
+        internal static extern unsafe int HmacInit(SafeHmacHandle ctx, byte* pbKey, int cbKey);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacUpdate")]
+        internal static extern unsafe int HmacUpdate(SafeHmacHandle ctx, byte* pbData, int cbData);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacFinal")]
+        internal static extern unsafe int HmacFinal(SafeHmacHandle ctx, byte* pbOutput, int cbOutput);
+    }
+}
+
+namespace System.Security.Cryptography.Apple
+{
+    internal sealed class SafeHmacHandle : SafeHandle
+    {
+        internal SafeHmacHandle()
+            : base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.AppleCrypto.HmacFree(handle);
+            SetHandle(IntPtr.Zero);
+            return true;
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+    }
+}

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.PAL_HashAlgorithm.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.PAL_HashAlgorithm.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class AppleCrypto
+    {
+        internal enum PAL_HashAlgorithm
+        {
+            Unknown = 0,
+            Md5,
+            Sha1,
+            Sha256,
+            Sha384,
+            Sha512,
+        }
+    }
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_definitions(-DPIC=1)
 
 set(NATIVECRYPTO_SOURCES
+    pal_digest.cpp
+    pal_hmac.cpp
     pal_random.cpp
 )
 

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.cpp
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_digest.h"
+
+#include <CommonCrypto/CommonCrypto.h>
+#include <CommonCrypto/CommonDigest.h>
+#include <assert.h>
+
+struct digest_ctx_st
+{
+    PAL_HashAlgorithm algorithm;
+    // This 32-bit field is required for alignment,
+    // but it's also handy for remembering how big the final buffer is.
+    int32_t cbDigest;
+    union {
+        CC_MD5_CTX md5;
+        CC_SHA1_CTX sha1;
+        CC_SHA256_CTX sha256;
+        CC_SHA512_CTX sha384;
+        CC_SHA512_CTX sha512;
+    } d;
+};
+
+extern "C" void AppleCryptoNative_DigestFree(DigestCtx* pDigest)
+{
+    if (pDigest != nullptr)
+    {
+        free(pDigest);
+    }
+}
+
+extern "C" DigestCtx* AppleCryptoNative_DigestCreate(PAL_HashAlgorithm algorithm, int32_t* pcbDigest)
+{
+    if (pcbDigest == nullptr)
+        return nullptr;
+
+    DigestCtx* digestCtx = reinterpret_cast<DigestCtx*>(malloc(sizeof(DigestCtx)));
+    digestCtx->algorithm = algorithm;
+
+    switch (algorithm)
+    {
+        case PAL_MD5:
+            *pcbDigest = CC_MD5_DIGEST_LENGTH;
+            CC_MD5_Init(&digestCtx->d.md5);
+            break;
+        case PAL_SHA1:
+            *pcbDigest = CC_SHA1_DIGEST_LENGTH;
+            CC_SHA1_Init(&digestCtx->d.sha1);
+            break;
+        case PAL_SHA256:
+            *pcbDigest = CC_SHA256_DIGEST_LENGTH;
+            CC_SHA256_Init(&digestCtx->d.sha256);
+            break;
+        case PAL_SHA384:
+            *pcbDigest = CC_SHA384_DIGEST_LENGTH;
+            CC_SHA384_Init(&digestCtx->d.sha384);
+            break;
+        case PAL_SHA512:
+            *pcbDigest = CC_SHA512_DIGEST_LENGTH;
+            CC_SHA512_Init(&digestCtx->d.sha512);
+            break;
+        default:
+            *pcbDigest = -1;
+            free(digestCtx);
+            return nullptr;
+    }
+
+    digestCtx->cbDigest = *pcbDigest;
+    return digestCtx;
+}
+
+extern "C" int AppleCryptoNative_DigestUpdate(DigestCtx* ctx, uint8_t* pBuf, int32_t cbBuf)
+{
+    if (cbBuf == 0)
+        return 1;
+    if (ctx == nullptr || pBuf == nullptr)
+        return -1;
+
+    CC_LONG bufSize = static_cast<CC_LONG>(cbBuf);
+
+    switch (ctx->algorithm)
+    {
+        case PAL_MD5:
+            return CC_MD5_Update(&ctx->d.md5, pBuf, bufSize);
+        case PAL_SHA1:
+            return CC_SHA1_Update(&ctx->d.sha1, pBuf, bufSize);
+        case PAL_SHA256:
+            return CC_SHA256_Update(&ctx->d.sha256, pBuf, bufSize);
+        case PAL_SHA384:
+            return CC_SHA384_Update(&ctx->d.sha384, pBuf, bufSize);
+        case PAL_SHA512:
+            return CC_SHA512_Update(&ctx->d.sha512, pBuf, bufSize);
+        default:
+            return -1;
+    }
+}
+
+extern "C" int AppleCryptoNative_DigestFinal(DigestCtx* ctx, uint8_t* pOutput, int32_t cbOutput)
+{
+    if (ctx == nullptr || pOutput == nullptr || cbOutput < ctx->cbDigest)
+        return -1;
+
+    int ret = 0;
+
+    switch (ctx->algorithm)
+    {
+        case PAL_MD5:
+            ret = CC_MD5_Final(pOutput, &ctx->d.md5);
+            break;
+        case PAL_SHA1:
+            ret = CC_SHA1_Final(pOutput, &ctx->d.sha1);
+            break;
+        case PAL_SHA256:
+            ret = CC_SHA256_Final(pOutput, &ctx->d.sha256);
+            break;
+        case PAL_SHA384:
+            ret = CC_SHA384_Final(pOutput, &ctx->d.sha384);
+            break;
+        case PAL_SHA512:
+            ret = CC_SHA512_Final(pOutput, &ctx->d.sha512);
+            break;
+        default:
+            ret = -1;
+            break;
+    }
+
+    if (ret != 1)
+    {
+        return ret;
+    }
+
+    switch (ctx->algorithm)
+    {
+        case PAL_MD5:
+            return CC_MD5_Init(&ctx->d.md5);
+        case PAL_SHA1:
+            return CC_SHA1_Init(&ctx->d.sha1);
+        case PAL_SHA256:
+            return CC_SHA256_Init(&ctx->d.sha256);
+        case PAL_SHA384:
+            return CC_SHA384_Init(&ctx->d.sha384);
+        case PAL_SHA512:
+            return CC_SHA512_Init(&ctx->d.sha512);
+        default:
+            assert(false);
+            return -2;
+    }
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.h
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "pal_types.h"
+
+#include <CommonCrypto/CommonCrypto.h>
+#include <CommonCrypto/CommonHMAC.h>
+
+enum
+{
+    PAL_Unknown = 0,
+    PAL_MD5,
+    PAL_SHA1,
+    PAL_SHA256,
+    PAL_SHA384,
+    PAL_SHA512,
+};
+typedef uint32_t PAL_HashAlgorithm;
+
+typedef struct digest_ctx_st DigestCtx;
+
+/*
+Free the resources held by a DigestCtx
+*/
+extern "C" void AppleCryptoNative_DigestFree(DigestCtx* pDigest);
+
+/*
+Create a digest handle for the specified algorithm.
+
+Returns NULL when the algorithm is unknown, or pcbDigest is NULL; otherwise returns a pointer
+to a digest context suitable for calling DigestUpdate and DigestFinal on and sets pcbDigest to
+the size of the digest output.
+*/
+extern "C" DigestCtx* AppleCryptoNative_DigestCreate(PAL_HashAlgorithm algorithm, int32_t* pcbDigest);
+
+/*
+Apply cbBuf bytes of data from pBuf to the ongoing digest represented in ctx.
+
+Returns 1 on success, 0 on failure, any other value on invalid inputs/state.
+*/
+extern "C" int AppleCryptoNative_DigestUpdate(DigestCtx* ctx, uint8_t* pBuf, int32_t cbBuf);
+
+/*
+Complete the digest in ctx, copying the results to pOutput, and reset ctx for a new digest.
+
+Returns 1 on success, 0 on failure, any other value on invalid inputs/state.
+*/
+extern "C" int AppleCryptoNative_DigestFinal(DigestCtx* ctx, uint8_t* pOutput, int32_t cbOutput);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.cpp
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_hmac.h"
+
+struct hmac_ctx_st
+{
+    CCHmacAlgorithm appleAlgId;
+    CCHmacContext hmac;
+};
+
+extern "C" void AppleCryptoNative_HmacFree(HmacCtx* pHmac)
+{
+    if (pHmac != nullptr)
+    {
+        free(pHmac);
+    }
+}
+
+static CCHmacAlgorithm PalAlgorithmToAppleAlgorithm(PAL_HashAlgorithm algorithm)
+{
+    switch (algorithm)
+    {
+        case PAL_MD5:
+            return kCCHmacAlgMD5;
+        case PAL_SHA1:
+            return kCCHmacAlgSHA1;
+        case PAL_SHA256:
+            return kCCHmacAlgSHA256;
+        case PAL_SHA384:
+            return kCCHmacAlgSHA384;
+        case PAL_SHA512:
+            return kCCHmacAlgSHA512;
+        default:
+            // 0 is a defined value (SHA1) so "unknown" has to be something else
+            return UINT_MAX;
+    }
+}
+
+static int GetHmacOutputSize(PAL_HashAlgorithm algorithm)
+{
+    switch (algorithm)
+    {
+        case PAL_MD5:
+            return CC_MD5_DIGEST_LENGTH;
+        case PAL_SHA1:
+            return CC_SHA1_DIGEST_LENGTH;
+        case PAL_SHA256:
+            return CC_SHA256_DIGEST_LENGTH;
+        case PAL_SHA384:
+            return CC_SHA384_DIGEST_LENGTH;
+        case PAL_SHA512:
+            return CC_SHA512_DIGEST_LENGTH;
+        default:
+            return -1;
+    }
+}
+
+extern "C" HmacCtx* AppleCryptoNative_HmacCreate(PAL_HashAlgorithm algorithm, int32_t* pcbHmac)
+{
+    if (pcbHmac == nullptr)
+        return nullptr;
+
+    CCHmacAlgorithm appleAlgId = PalAlgorithmToAppleAlgorithm(algorithm);
+
+    if (appleAlgId == UINT_MAX)
+    {
+        *pcbHmac = -1;
+        return nullptr;
+    }
+
+    HmacCtx* hmacCtx = reinterpret_cast<HmacCtx*>(malloc(sizeof(HmacCtx)));
+    hmacCtx->appleAlgId = appleAlgId;
+    *pcbHmac = GetHmacOutputSize(algorithm);
+    return hmacCtx;
+}
+
+extern "C" int AppleCryptoNative_HmacInit(HmacCtx* ctx, uint8_t* pbKey, int32_t cbKey)
+{
+    if (ctx == nullptr || cbKey < 0)
+        return 0;
+    if (cbKey != 0 && pbKey == nullptr)
+        return 0;
+
+    // No return value
+    CCHmacInit(&ctx->hmac, ctx->appleAlgId, pbKey, static_cast<size_t>(cbKey));
+    return 1;
+}
+
+extern "C" int AppleCryptoNative_HmacUpdate(HmacCtx* ctx, uint8_t* pbData, int32_t cbData)
+{
+    if (cbData == 0)
+        return 1;
+    if (ctx == nullptr || pbData == nullptr)
+        return 0;
+
+    // No return value
+    CCHmacUpdate(&ctx->hmac, pbData, static_cast<size_t>(cbData));
+    return 1;
+}
+
+extern "C" int AppleCryptoNative_HmacFinal(HmacCtx* ctx, uint8_t* pbOutput)
+{
+    if (ctx == nullptr || pbOutput == nullptr)
+        return 0;
+
+    // No return value
+    CCHmacFinal(&ctx->hmac, pbOutput);
+    return 1;
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.h
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "pal_digest.h"
+#include "pal_types.h"
+
+typedef struct hmac_ctx_st HmacCtx;
+
+/*
+Free a HmacCtx created by AppleCryptoNative_HmacCreate
+*/
+extern "C" void AppleCryptoNative_HmacFree(HmacCtx* pHmac);
+
+/*
+Create an HmacCtx for the specified algorithm, receiving the hash output size in pcbHmac.
+
+If *pcbHmac is negative the algorithm is unknown or not supported. If a non-NULL value is returned
+it should be freed via AppleCryptoNative_HmacFree regardless of a negative pbHmac value.
+
+Returns NULL on error, an unkeyed HmacCtx otherwise.
+*/
+extern "C" HmacCtx* AppleCryptoNative_HmacCreate(PAL_HashAlgorithm algorithm, int32_t* pcbHmac);
+
+/*
+Initialize an HMAC to the correct key and start state.
+
+Returns 1 on success, 0 on error.
+*/
+extern "C" int AppleCryptoNative_HmacInit(HmacCtx* ctx, uint8_t* pbKey, int32_t cbKey);
+
+/*
+Add data into the HMAC
+
+Returns 1 on success, 0 on error.
+*/
+extern "C" int AppleCryptoNative_HmacUpdate(HmacCtx* ctx, uint8_t* pbData, int32_t cbData);
+
+/*
+Complete the HMAC and copy the result into pbOutput.
+
+Returns 1 on success, 0 on error.
+*/
+extern "C" int AppleCryptoNative_HmacFinal(HmacCtx* ctx, uint8_t* pbOutput);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_secimportexport.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_secimportexport.cpp
@@ -1,0 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_secimportexport.h"

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_secimportexport.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_secimportexport.h
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "pal_types.h"
+
+#include <Security/Security.h>

--- a/src/System.Security.Cryptography.Algorithms/System.Security.Cryptography.Algorithms.sln
+++ b/src/System.Security.Cryptography.Algorithms/System.Security.Cryptography.Algorithms.sln
@@ -9,12 +9,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Cryptograph
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		OSX_Debug|Any CPU = OSX_Debug|Any CPU
+		OSX_Release|Any CPU = OSX_Release|Any CPU
 		Unix_Debug|Any CPU = Unix_Debug|Any CPU
 		Unix_Release|Any CPU = Unix_Release|Any CPU
 		Windows_Debug|Any CPU = Windows_Debug|Any CPU
 		Windows_Release|Any CPU = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}.OSX_Debug|Any CPU.ActiveCfg = OSX_Debug|Any CPU
+		{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}.OSX_Debug|Any CPU.Build.0 = OSX_Debug|Any CPU
+		{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}.OSX_Release|Any CPU.ActiveCfg = OSX_Release|Any CPU
+		{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}.OSX_Release|Any CPU.Build.0 = OSX_Release|Any CPU
 		{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
 		{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
 		{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
@@ -23,6 +29,10 @@ Global
 		{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{508A7D81-6462-459C-9F8F-B58FCCCFC8E7}.OSX_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{508A7D81-6462-459C-9F8F-B58FCCCFC8E7}.OSX_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{508A7D81-6462-459C-9F8F-B58FCCCFC8E7}.OSX_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{508A7D81-6462-459C-9F8F-B58FCCCFC8E7}.OSX_Release|Any CPU.Build.0 = Debug|Any CPU
 		{508A7D81-6462-459C-9F8F-B58FCCCFC8E7}.Unix_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{508A7D81-6462-459C-9F8F-B58FCCCFC8E7}.Unix_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{508A7D81-6462-459C-9F8F-B58FCCCFC8E7}.Unix_Release|Any CPU.ActiveCfg = Debug|Any CPU

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.OSX.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.OSX.cs
@@ -1,0 +1,247 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Apple;
+
+namespace Internal.Cryptography
+{
+    internal static partial class HashProviderDispenser
+    {
+        public static HashProvider CreateHashProvider(string hashAlgorithmId)
+        {
+            switch (hashAlgorithmId)
+            {
+                case HashAlgorithmNames.MD5:
+                    return new AppleDigestProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Md5);
+                case HashAlgorithmNames.SHA1:
+                    return new AppleDigestProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Sha1);
+                case HashAlgorithmNames.SHA256:
+                    return new AppleDigestProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Sha256);
+                case HashAlgorithmNames.SHA384:
+                    return new AppleDigestProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Sha384);
+                case HashAlgorithmNames.SHA512:
+                    return new AppleDigestProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Sha512);
+            }
+
+            throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
+        }
+
+        public static HashProvider CreateMacProvider(string hashAlgorithmId, byte[] key)
+        {
+            switch (hashAlgorithmId)
+            {
+                case HashAlgorithmNames.MD5:
+                    return new AppleHmacProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Md5, key);
+                case HashAlgorithmNames.SHA1:
+                    return new AppleHmacProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Sha1, key);
+                case HashAlgorithmNames.SHA256:
+                    return new AppleHmacProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Sha256, key);
+                case HashAlgorithmNames.SHA384:
+                    return new AppleHmacProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Sha384, key);
+                case HashAlgorithmNames.SHA512:
+                    return new AppleHmacProvider(Interop.AppleCrypto.PAL_HashAlgorithm.Sha512, key);
+            }
+
+            throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
+        }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+
+        private sealed class AppleHmacProvider : HashProvider
+        {
+            private readonly byte[] _key;
+            private readonly SafeHmacHandle _ctx;
+
+            private bool _running;
+
+            public override int HashSizeInBytes { get; }
+
+            internal AppleHmacProvider(Interop.AppleCrypto.PAL_HashAlgorithm algorithm, byte[] key)
+            {
+                _key = key.CloneByteArray();
+                int hashSizeInBytes = 0;
+                _ctx = Interop.AppleCrypto.HmacCreate(algorithm, ref hashSizeInBytes);
+
+                if (hashSizeInBytes < 0)
+                {
+                    _ctx.Dispose();
+                    throw new PlatformNotSupportedException(
+                        SR.Format(
+                            SR.Cryptography_UnknownHashAlgorithm,
+                            Enum.GetName(typeof(Interop.AppleCrypto.PAL_HashAlgorithm), algorithm)));
+                }
+
+                if (_ctx.IsInvalid)
+                {
+                    _ctx.Dispose();
+                    throw new CryptographicException();
+                }
+
+                HashSizeInBytes = hashSizeInBytes;
+            }
+
+            public override unsafe void AppendHashDataCore(byte[] data, int offset, int count)
+            {
+                Debug.Assert(data != null);
+                Debug.Assert(offset >= 0);
+                Debug.Assert(offset < data.Length);
+                Debug.Assert(count >= 0);
+                Debug.Assert(data.Length - offset > count);
+
+                if (!_running)
+                {
+                    SetKey();
+                }
+
+                int ret;
+
+                fixed (byte* pData = data)
+                {
+                    byte* pbData = pData + offset;
+                    ret = Interop.AppleCrypto.HmacUpdate(_ctx, pbData, count);
+                }
+
+                if (ret != 1)
+                {
+                    throw new CryptographicException();
+                }
+            }
+
+            private unsafe void SetKey()
+            {
+                int ret;
+
+                fixed (byte* pbKey = _key)
+                {
+                    ret = Interop.AppleCrypto.HmacInit(_ctx, pbKey, _key.Length);
+                }
+
+                if (ret != 1)
+                {
+                    throw new CryptographicException();
+                }
+
+                _running = true;
+            }
+
+            public override unsafe byte[] FinalizeHashAndReset()
+            {
+                if (!_running)
+                {
+                    SetKey();
+                }
+
+                byte[] output = new byte[HashSizeInBytes];
+                int ret;
+
+                fixed (byte* pbOutput = output)
+                {
+                    ret = Interop.AppleCrypto.HmacFinal(_ctx, pbOutput, output.Length);
+                }
+
+                if (ret != 1)
+                {
+                    throw new CryptographicException();
+                }
+
+                _running = false;
+                return output;
+            }
+
+            public override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _ctx?.Dispose();
+                    Array.Clear(_key, 0, _key.Length);
+                }
+            }
+        }
+
+        private sealed class AppleDigestProvider : HashProvider
+        {
+            private readonly SafeDigestCtxHandle _ctx;
+
+            public override int HashSizeInBytes { get; }
+
+            internal AppleDigestProvider(Interop.AppleCrypto.PAL_HashAlgorithm algorithm)
+            {
+                int hashSizeInBytes;
+                _ctx = Interop.AppleCrypto.DigestCreate(algorithm, out hashSizeInBytes);
+
+                if (hashSizeInBytes < 0)
+                {
+                    _ctx.Dispose();
+                    throw new PlatformNotSupportedException(
+                        SR.Format(
+                            SR.Cryptography_UnknownHashAlgorithm,
+                            Enum.GetName(typeof(Interop.AppleCrypto.PAL_HashAlgorithm), algorithm)));
+                }
+
+                if (_ctx.IsInvalid)
+                {
+                    _ctx.Dispose();
+                    throw new CryptographicException();
+                }
+
+                HashSizeInBytes = hashSizeInBytes;
+            }
+
+            public override unsafe void AppendHashDataCore(byte[] data, int offset, int count)
+            {
+                Debug.Assert(data != null);
+                Debug.Assert(offset >= 0);
+                Debug.Assert(offset < data.Length);
+                Debug.Assert(count >= 0);
+                Debug.Assert(data.Length - offset > count);
+
+                int ret;
+
+                fixed (byte* pData = data)
+                {
+                    byte* pbData = pData + offset;
+                    ret = Interop.AppleCrypto.DigestUpdate(_ctx, pbData, count);
+                }
+
+                if (ret != 1)
+                {
+                    Debug.Assert(ret == 0, $"DigestUpdate return value {ret} was not 0 or 1");
+                    throw new CryptographicException();
+                }
+            }
+
+            public override unsafe byte[] FinalizeHashAndReset()
+            {
+                byte[] hash = new byte[HashSizeInBytes];
+                int ret;
+
+                fixed (byte* pHash = hash)
+                {
+                    ret = Interop.AppleCrypto.DigestFinal(_ctx, pHash, hash.Length);
+                }
+
+                if (ret != 1)
+                {
+                    Debug.Assert(ret == 0, $"DigestFinal return value {ret} was not 0 or 1");
+                    throw new CryptographicException();
+                }
+
+                return hash;
+            }
+
+            public override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _ctx?.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -22,6 +22,8 @@
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.6</NuGetTargetMoniker>
     <GenFacadesArgs Condition="'$(TargetGroup)'=='net463'">$(GenFacadesArgs) -ignoreMissingTypes</GenFacadesArgs>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
@@ -237,24 +239,46 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' AND '$(TargetsOSX)' != 'true' ">
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs</Link>
+    </Compile>
+    <Compile Include="Internal\Cryptography\HashProviderDispenser.Unix.cs" />
     <Compile Include="System\Security\Cryptography\RNGCryptoServiceProvider.Unix.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
     <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Digest.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Digest.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Hmac.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Hmac.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs</Link>
     </Compile>
+    <Compile Include="Internal\Cryptography\HashProviderDispenser.OSX.cs" />
     <Compile Include="System\Security\Cryptography\RNGCryptoServiceProvider.OSX.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Security\Cryptography\ECDsaOpenSsl.cs" />
     <Compile Include="Internal\Cryptography\AesImplementation.Unix.cs" />
-    <Compile Include="Internal\Cryptography\HashProviderDispenser.Unix.cs" />
     <Compile Include="Internal\Cryptography\OpenSslCipher.cs" />
     <Compile Include="Internal\Cryptography\TripleDesImplementation.Unix.cs" />
     <Compile Include="$(CommonPath)\Internal\Cryptography\OpenSslAsymmetricAlgorithmCore.cs">
@@ -284,9 +308,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs">
-      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.Cipher.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.Cipher.cs</Link>
     </Compile>
@@ -295,9 +316,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.RAND.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.RAND.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs">
-      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs</Link>
@@ -316,12 +334,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs">
-      <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs">
-      <Link>Common\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs</Link>


### PR DESCRIPTION
Digest algorithms: MD5, SHA1, SHA-2-256, SHA-2-384, SHA-2-512
HMAC algorithms: MD5, SHA1, SHA-2-256, SHA-2-384, SHA-2-512

The rough design:
* Use a single PAL identifier for the algorithm across digest and HMAC.
* The same identifier will be used in RSA
* Apple's hashing primitives require 3 exports per algorithm.
Instead of exposing them directly, make a shim-internal struct.
* Apple's HMAC primitives require re-asserting the algorithm ID on reset,
instead of persisting it in a managed field, just carry it in a shim-internal struct.

Regarding the identifiers.  While HMAC has an enum for algorithm ID,
and we could use the HMAC algorithm ID as our hash algorithm ID, the
identifiers for RSA signatures are different (for one, they're strings instead
of numbers).  The algorithm identifiers for RSA are further different in that
they use a single "SHA2" value for algorithm, then disambiguate
256/384/512 based on a second value (hash input size). That, combined
with many identifiers across their cryptography libraries being documented
as "may change in a future version" (to get people to use the constant
expression instead of just writing the literal value) resulted in identifiers
matching our (and Windows' and OpenSSL's) notion of an algorithm and
not trying to maintain semantic alignment for pass-through benefits.

Another incremental piece of #9394.
Next: 3DES and AES
cc: @AtsushiKan @stephentoub 

