### PR TITLE
Fix FindOidInfo to pass correct arg to PtrToStructure

### DIFF
--- a/src/Common/src/Interop/Windows/Crypt32/Interop.FindOidInfo.cs
+++ b/src/Common/src/Interop/Windows/Crypt32/Interop.FindOidInfo.cs
@@ -97,7 +97,7 @@ internal static partial class Interop
                     IntPtr allGroupOidInfo = CryptFindOIDInfo(keyType, rawKey, OidGroup.All);
                     if (allGroupOidInfo != IntPtr.Zero)
                     {
-                        return Marshal.PtrToStructure<CRYPT_OID_INFO>(fullOidInfo);
+                        return Marshal.PtrToStructure<CRYPT_OID_INFO>(allGroupOidInfo);
                     }
                 }
 


### PR DESCRIPTION
Found by a coverity scan. It doesn't look like any of our tests are hitting this code path, but I'm not sure how to trigger it.
cc: @bartonjs 