### PR TITLE
Add empty input tests for the SHA algorithms.

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/tests/Sha1Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/Sha1Tests.cs
@@ -13,6 +13,12 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             return SHA1.Create();
         }
 
+        [Fact]
+        public void Sha1_Empty()
+        {
+            Verify(Array.Empty<byte>(), "DA39A3EE5E6B4B0D3255BFEF95601890AFD80709");
+        }
+
         // SHA1 tests are defined somewhat obliquely within RFC 3174, section 7.3
         // The same tests appear in http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf Appendix A
         [Fact]

--- a/src/System.Security.Cryptography.Algorithms/tests/Sha256Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/Sha256Tests.cs
@@ -13,6 +13,14 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             return SHA256.Create();
         }
 
+        [Fact]
+        public void Sha256_Empty()
+        {
+            Verify(
+                Array.Empty<byte>(),
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        }
+
         // These test cases are from http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf Appendix B
         [Fact]
         public void Sha256_Fips180_1()

--- a/src/System.Security.Cryptography.Algorithms/tests/Sha384Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/Sha384Tests.cs
@@ -13,6 +13,14 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             return SHA384.Create();
         }
 
+        [Fact]
+        public void Sha384_Empty()
+        {
+            Verify(
+                Array.Empty<byte>(),
+                "38B060A751AC96384CD9327EB1B1E36A21FDB71114BE07434C0CC7BF63F6E1DA274EDEBFE76F65FBD51AD2F14898B95B");
+        }
+
         // These test cases are from http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA_All.pdf
         [Fact]
         public void Sha384_NistShaAll_1()

--- a/src/System.Security.Cryptography.Algorithms/tests/Sha512Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/Sha512Tests.cs
@@ -13,6 +13,14 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             return SHA512.Create();
         }
 
+        [Fact]
+        public void Sha512_Empty()
+        {
+            Verify(
+                Array.Empty<byte>(),
+                "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e");
+        }
+
         // These test cases are from http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf Appendix C
         [Fact]
         public void Sha512_Fips180_1()


### PR DESCRIPTION
MD5 already has one (MD5_Rfc1321_1), this just makes it clear no matter what
algorithm test suite you start with that the empty array is handled fine.

cc: @stephentoub 
