### PR TITLE
Delete MsBuildParameters caused by bad merge

### DIFF
--- a/config.json
+++ b/config.json
@@ -413,7 +413,6 @@
         "toolName": "msbuild",
         "settings": {
           "Project": "src/packages.builds",
-          "MsBuildParameters": "default",
           "ProducesTarget":"default"
         }
       }


### PR DESCRIPTION
The property `MsBuildParameters` doesn't exist in the Settings section anymore. When I updated my local config.json I didn't see that this property got introduced again and I pushed my change.

cc: @chcosta @weshaggard 