### PR TITLE
Add some tests for Comparer<T>

### DIFF
--- a/src/Common/tests/System/Collections/TestingTypes.cs
+++ b/src/Common/tests/System/Collections/TestingTypes.cs
@@ -229,6 +229,85 @@ namespace System.Collections.Tests
             return StructuralComparisons.StructuralEqualityComparer.GetHashCode(obj);
         }
     }
+    
+    public enum SByteEnum : sbyte { }
+    public enum ByteEnum : byte { }
+    public enum ShortEnum : short { }
+    public enum UShortEnum : ushort { }
+    public enum IntEnum : int { }
+    public enum UIntEnum : uint { }
+    public enum LongEnum : long { }
+    public enum ULongEnum : ulong { }
+
+    public class GenericComparable : IComparable<GenericComparable>
+    {
+        private readonly int _value;
+
+        public GenericComparable(int value)
+        {
+            _value = value;
+        }
+
+        public int CompareTo(GenericComparable other) => _value.CompareTo(other._value);
+    }
+
+    public class NonGenericComparable : IComparable
+    {
+        private readonly GenericComparable _inner;
+
+        public NonGenericComparable(int value)
+        {
+            _inner = new GenericComparable(value);
+        }
+
+        public int CompareTo(object other) =>
+            _inner.CompareTo(((NonGenericComparable)other)._inner);
+    }
+
+    public class BadlyBehavingComparable : IComparable<BadlyBehavingComparable>, IComparable
+    {
+        public int CompareTo(BadlyBehavingComparable other) => 1;
+
+        public int CompareTo(object other) => -1;
+    }
+
+    public class MutatingComparable : IComparable<MutatingComparable>, IComparable
+    {
+        private int _state;
+
+        public MutatingComparable(int initialState)
+        {
+            _state = initialState;
+        }
+
+        public int State => _state;
+
+        public int CompareTo(object other) => _state++;
+
+        public int CompareTo(MutatingComparable other) => _state++;
+    }
+
+    public static class ValueComparable
+    {
+        // Convenience method so the compiler can work its type inference magic.
+        public static ValueComparable<T> Create<T>(T value) where T : IComparable<T>
+        {
+            return new ValueComparable<T>(value);
+        }
+    }
+
+    public struct ValueComparable<T> : IComparable<ValueComparable<T>> where T : IComparable<T>
+    {
+        public ValueComparable(T value)
+        {
+            Value = value;
+        }
+
+        public T Value { get; }
+
+        public int CompareTo(ValueComparable<T> other) =>
+            Value.CompareTo(other.Value);
+    }
 
     #endregion
 }

--- a/src/Common/tests/System/ObjectCloner.cs
+++ b/src/Common/tests/System/ObjectCloner.cs
@@ -9,10 +9,6 @@ namespace System
 {
     // Provides methods for making shallow/deep clones of objects.
 
-    // NOTE TO CONSUMERS: This class will only compile with netstandard1.5
-    // and above, since it appears BindingFlags and TypeInfo.GetMethod are
-    // not available in lower versions.
-
     public static class ObjectCloner
     {
         // This should only be used for reference types.
@@ -22,10 +18,9 @@ namespace System
             Debug.Assert(obj != null);
 
             // Invoke MemberwiseClone() via reflection to create a shallow copy of the object
-            var bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
             MethodInfo memberwiseClone = typeof(object)
                 .GetTypeInfo()
-                .GetMethod("MemberwiseClone", bindingFlags);
+                .GetDeclaredMethod("MemberwiseClone");
             object cloned = memberwiseClone.Invoke(obj, parameters: Array.Empty<object>());
 
             Debug.Assert(cloned != null && !object.ReferenceEquals(obj, cloned));

--- a/src/Common/tests/System/ObjectCloner.cs
+++ b/src/Common/tests/System/ObjectCloner.cs
@@ -17,8 +17,7 @@ namespace System
     {
         // This should only be used for reference types.
         // Simply doing T copied = value will give you the same effect with a value type.
-        public static T MemberwiseClone<T>(T obj)
-            where T : class
+        public static T MemberwiseClone<T>(T obj) where T : class
         {
             Debug.Assert(obj != null);
 

--- a/src/Common/tests/System/ObjectCloner.cs
+++ b/src/Common/tests/System/ObjectCloner.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Reflection;
+
+namespace System
+{
+    // Provides methods for making shallow/deep clones of objects.
+
+    // NOTE TO CONSUMERS: This class will only compile with netstandard1.5
+    // and above, since it appears BindingFlags and TypeInfo.GetMethod are
+    // not available in lower versions.
+
+    public static class ObjectCloner
+    {
+        // This should only be used for reference types.
+        // Simply doing T copied = value will give you the same effect with a value type.
+        public static T MemberwiseClone<T>(T obj)
+            where T : class
+        {
+            Debug.Assert(obj != null);
+
+            // Invoke MemberwiseClone() via reflection to create a shallow copy of the object
+            var bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+            MethodInfo memberwiseClone = typeof(object)
+                .GetTypeInfo()
+                .GetMethod("MemberwiseClone", bindingFlags);
+            object cloned = memberwiseClone.Invoke(obj, parameters: Array.Empty<object>());
+
+            Debug.Assert(cloned != null && !object.ReferenceEquals(obj, cloned));
+            Debug.Assert(obj.GetType() == cloned.GetType());
+            return (T)cloned;
+        }
+    }
+}

--- a/src/Common/tests/System/RuntimeDetection.cs
+++ b/src/Common/tests/System/RuntimeDetection.cs
@@ -11,9 +11,9 @@ namespace System
     {
         private static readonly string s_frameworkDescription = RuntimeInformation.FrameworkDescription;
 
-        public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
-        public static bool IsNetFramework { get; } = s_frameworkDescription.StartsWith(".NET Framework");
-        public static bool IsCoreclr { get; } = s_frameworkDescription.StartsWith(".NET Core");
+        // public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
+        // public static bool IsNetFramework { get; } = s_frameworkDescription.StartsWith(".NET Framework");
+        // public static bool IsCoreclr { get; } = s_frameworkDescription.StartsWith(".NET Core");
         public static bool IsNetNative { get; } = s_frameworkDescription.StartsWith(".NET Native");
     }
 }

--- a/src/Common/tests/System/RuntimeDetection.cs
+++ b/src/Common/tests/System/RuntimeDetection.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    public static class RuntimeDetection
+    {
+        private static readonly string s_frameworkDescription = RuntimeInformation.FrameworkDescription;
+
+        public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
+        public static bool IsNetFramework { get; } = s_frameworkDescription.StartsWith(".NET Framework");
+        public static bool IsCoreclr { get; } = s_frameworkDescription.StartsWith(".NET Core");
+        public static bool IsNetNative { get; } = s_frameworkDescription.StartsWith(".NET Native");
+    }
+}

--- a/src/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Collections.Generic.Tests
+{
+    public abstract partial class ComparerGenericTests<T>
+    {
+        [Fact]
+        public void ComparerDefault()
+        {
+            var firstResult = Comparer<T>.Default;
+            Assert.NotNull(firstResult);
+            Assert.Same(firstResult, Comparer<T>.Default);
+        }
+
+        [Fact]
+        public void EqualsShouldBeOverriddenAndWorkForDifferentInstances()
+        {
+            var comparer = Comparer<T>.Default;
+
+            // Whether the comparer has overridden Object.Equals or not, all of these
+            // comparisons should be false
+            Assert.False(comparer.Equals(null));
+            Assert.False(comparer.Equals(3));
+            Assert.False(comparer.Equals("foo"));
+            Assert.False(comparer.Equals(Comparer<Task<T>>.Default));
+
+            // If we are running on full framework/CoreCLR, Comparer<T> additionally
+            // overrides the Equals(object) and GetHashCode() methods for itself,
+            // presumably to support serialization, so test that behavior as well.
+            // This is not done in .NET Native.
+            if (!RuntimeDetection.IsNetNative)
+            {
+                var cloned = ObjectCloner.MemberwiseClone(comparer); // calls MemberwiseClone() on the comparer via reflection, which returns a different instance
+
+                // Whatever the type of the comparer, it should have overridden Equals(object) so
+                // it can return true as long as the other object is the same type (not nec. the same instance)
+                Assert.True(cloned.Equals(comparer));
+                Assert.True(comparer.Equals(cloned));
+
+                // Equals() should not return true for null
+                // Prevent a faulty implementation like Equals(obj) => obj is FooComparer<T>, which will be true for null
+                Assert.False(cloned.Equals(null));
+            }
+        }
+
+        [Fact]
+        public void GetHashCodeShouldBeOverriddenAndBeTheSameAsLongAsTheTypeIsTheSame()
+        {
+            var comparer = Comparer<T>.Default;
+
+            // Multiple invocations should return the same result,
+            // whether GetHashCode() was overridden or not
+            Assert.Equal(comparer.GetHashCode(), comparer.GetHashCode());
+
+            // If we are running on full framework/CoreCLR, Comparer<T> additionally
+            // overrides the Equals(object) and GetHashCode() methods for itself,
+            // presumably to support serialization, so test that behavior as well.
+            // This is not done in .NET Native.
+            if (!RuntimeDetection.IsNetNative)
+            {
+                var cloned = ObjectCloner.MemberwiseClone(comparer);
+                Assert.Equal(cloned.GetHashCode(), cloned.GetHashCode());
+
+                // Since comparer and cloned should have the same type, they should have the same hash
+                Assert.Equal(comparer.GetHashCode(), cloned.GetHashCode());
+            }
+        }
+
+        [Fact]
+        public void IComparerCompareWithObjectsNotOfMatchingTypeShouldThrow()
+        {
+            // Comparer<T> implements IComparer for back-compat reasons.
+            // The explicit implementation of IComparer.Compare(object, object) should
+            // throw if both inputs are non-null and one of them is not of type T
+            IComparer comparer = Comparer<T>.Default;
+            Task<T> notOfTypeT = Task.FromResult(default(T));
+            if (default(T) != null) // if default(T) is null these asserts will fail as IComparer.Compare returns early if either side is null
+            {
+                Assert.Throws<ArgumentException>(() => comparer.Compare(notOfTypeT, default(T))); // lhs is the problem
+                Assert.Throws<ArgumentException>(() => comparer.Compare(default(T), notOfTypeT)); // rhs is the problem
+            }
+            else if (!typeof(T).GetTypeInfo().IsAssignableFrom(typeof(Task<T>))) // catch cases where Task<T> actually is a T, like object or non-generic Task
+            {
+                Assert.Throws<ArgumentException>(() => comparer.Compare(notOfTypeT, notOfTypeT)); // The implementation should not attempt to short-circuit if both sides have reference equality
+            }
+            Assert.Throws<ArgumentException>(() => comparer.Compare(notOfTypeT, Task.FromResult(default(T)))); // And it should also work when they don't
+        }
+
+        [Fact]
+        public void ComparerCreate()
+        {
+            const int ExpectedValue = 0x77777777;
+
+            bool comparisonCalled = false;
+            Comparison<T> comparison = (left, right) =>
+            {
+                comparisonCalled = true;
+                return ExpectedValue;
+            };
+
+            var comparer = Comparer<T>.Create(comparison);
+            var comparer2 = Comparer<T>.Create(comparison);
+
+            Assert.NotNull(comparer);
+            Assert.NotNull(comparer2);
+            Assert.NotSame(comparer, comparer2);
+
+            // Test the functionality of the Comparer's Compare()
+            int result = comparer.Compare(default(T), default(T));
+            Assert.True(comparisonCalled);
+            Assert.Equal(ExpectedValue, result);
+
+            // Unlike the Default comparers, comparers created with Create
+            // should not override Equals() or GetHashCode()
+            Assert.False(comparer.Equals(comparer2));
+            Assert.False(comparer2.Equals(comparer));
+            // The default GetHashCode implementation is just a call to RuntimeHelpers.GetHashCode
+            Assert.Equal(RuntimeHelpers.GetHashCode(comparer), comparer.GetHashCode());
+            Assert.Equal(RuntimeHelpers.GetHashCode(comparer2), comparer2.GetHashCode());
+        }
+
+        [Fact]
+        public void ComparerCreateWithNullComparisonThrows()
+        {
+            Assert.Throws<ArgumentNullException>("comparison", () => Comparer<T>.Create(comparison: null));
+        }
+    }
+}

--- a/src/System.Collections/tests/Generic/Comparers/Comparer.Tests.cs
+++ b/src/System.Collections/tests/Generic/Comparers/Comparer.Tests.cs
@@ -1,0 +1,321 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Tests;
+using System.Diagnostics;
+using Xunit;
+
+namespace System.Collections.Generic.Tests
+{
+    public class ComparerTests
+    {
+        [Theory]
+        [MemberData(nameof(IComparableComparisonsData))]
+        [MemberData(nameof(ULongEnumComparisonsData))]
+        [MemberData(nameof(IntEnumComparisonsData))]
+        [MemberData(nameof(UIntEnumComparisonsData))]
+        [MemberData(nameof(LongEnumComparisonsData))]
+        [MemberData(nameof(PlainObjectComparisonsData))]
+        public void MostComparisons<T>(T left, T right, int expected) // xUnit is awesome and supports generic theories :-)
+        {
+            var comparer = Comparer<T>.Default;
+            Assert.Equal(expected, Math.Sign(comparer.Compare(left, right)));
+            Assert.Equal(0, comparer.Compare(left, left));
+            Assert.Equal(0, comparer.Compare(right, right));
+
+            IComparer nonGenericComparer = comparer;
+            // If both sides are Ts then the explicit implementation of IComparer.Compare
+            // should also succeed, with the same results
+            Assert.Equal(expected, Math.Sign(nonGenericComparer.Compare(left, right)));
+            Assert.Equal(0, nonGenericComparer.Compare(left, left));
+            Assert.Equal(0, nonGenericComparer.Compare(right, right));
+
+            // All comparers returned by Comparer<T>.Default should be able
+            // to handle nulls before dispatching to IComparable<T>.CompareTo()
+            if (default(T) == null) // This will be true if T is a reference type or nullable
+            {
+                T nil = default(T);
+                Assert.Equal(0, comparer.Compare(nil, nil));
+
+                // null should be ordered before/equal to everything (never after)
+                // We assert that it's -1 or 0 in case left/right is null, as well
+                // We assert that it's -1 rather than any negative number since these
+                // values are hardcoded in the comparer logic, rather than being left
+                // to the object being compared
+                Assert.InRange(comparer.Compare(nil, left), -1, 0);
+                Assert.InRange(comparer.Compare(nil, right), -1, 0);
+
+                Assert.InRange(comparer.Compare(left, nil), 0, 1);
+                Assert.InRange(comparer.Compare(right, nil), 0, 1);
+
+                // Validate behavior for the IComparer.Compare implementation, as well
+                Assert.Equal(0, nonGenericComparer.Compare(nil, nil));
+
+                Assert.InRange(nonGenericComparer.Compare(nil, left), -1, 0);
+                Assert.InRange(nonGenericComparer.Compare(nil, right), -1, 0);
+
+                Assert.InRange(nonGenericComparer.Compare(left, nil), 0, 1);
+                Assert.InRange(nonGenericComparer.Compare(right, nil), 0, 1);
+            }
+        }
+
+        public static IEnumerable<object[]> IComparableComparisonsData()
+        {
+            var testCases = new[]
+            {
+                Tuple.Create(new GenericComparable(3), new GenericComparable(4), -1),
+                Tuple.Create(new GenericComparable(5), new GenericComparable(2), 1),
+                Tuple.Create(new GenericComparable(int.MinValue), new GenericComparable(int.MinValue), 0),
+                Tuple.Create(default(GenericComparable), default(GenericComparable), 0), // default(T) is used to help the compiler infer types here
+                // GenericComparable's CompareTo does not handle nulls intentionally, the Comparer should check both
+                // inputs for null before dispatching to CompareTo
+                Tuple.Create(new GenericComparable(int.MinValue), default(GenericComparable), 1)
+            };
+
+            foreach (var testCase in testCases)
+            {
+                yield return new object[] { testCase.Item1, testCase.Item2, testCase.Item3 };
+                yield return new object[] { testCase.Item2, testCase.Item1, -testCase.Item3 }; // Do the comparison in reverse as well
+            }
+        }
+
+        public static IEnumerable<object[]> ULongEnumComparisonsData()
+        {
+            var testCases = new[]
+            {
+                Tuple.Create(3UL, 5UL, -1),
+                Tuple.Create(0x55555UL, 0x55555UL, 0),
+                // Catch any attempt to cast the enum value to a signed type,
+                // which may result in overflow and an incorrect comparison
+                Tuple.Create(ulong.MaxValue, (ulong)long.MaxValue, 1),
+                Tuple.Create(ulong.MaxValue - 3, ulong.MaxValue, -1)
+            };
+            
+            foreach (var testCase in testCases)
+            {
+                yield return new object[] { (ULongEnum)testCase.Item1, (ULongEnum)testCase.Item2, testCase.Item3 };
+                yield return new object[] { (ULongEnum)testCase.Item2, (ULongEnum)testCase.Item1, -testCase.Item3 };
+            }
+        }
+
+        public static IEnumerable<object[]> IntEnumComparisonsData()
+        {
+            var testCases = new[]
+            {
+                Tuple.Create(-1, 4, -1),
+                Tuple.Create(-222, -375, 1),
+                Tuple.Create(int.MinValue, int.MinValue, 0),
+                // The same principle applies for overflow in signed types as above,
+                // the implementation should not cast to an unsigned type
+                Tuple.Create(int.MaxValue, int.MinValue, 1),
+                Tuple.Create(int.MinValue + 1, int.MinValue, 1)
+            };
+
+            foreach (var testCase in testCases)
+            {
+                yield return new object[] { (IntEnum)testCase.Item1, (IntEnum)testCase.Item2, testCase.Item3 };
+                yield return new object[] { (IntEnum)testCase.Item2, (IntEnum)testCase.Item1, -testCase.Item3 };
+            }
+        }
+
+        public static IEnumerable<object[]> UIntEnumComparisonsData()
+        {
+            var testCases = new[]
+            {
+                Tuple.Create(5u, 5u, 0),
+                Tuple.Create(445u, 123u, 1),
+                Tuple.Create(uint.MaxValue, 111u, 1),
+                Tuple.Create(uint.MaxValue - 333, uint.MaxValue, -1)
+            };
+
+            foreach (var testCase in testCases)
+            {
+                yield return new object[] { (UIntEnum)testCase.Item1, (UIntEnum)testCase.Item2, testCase.Item3 };
+                yield return new object[] { (UIntEnum)testCase.Item2, (UIntEnum)testCase.Item1, -testCase.Item3 };
+            }
+        }
+
+        public static IEnumerable<object[]> LongEnumComparisonsData()
+        {
+            var testCases = new[]
+            {
+                Tuple.Create(555L, 555L, 0),
+                Tuple.Create(182912398L, 33L, 1),
+                Tuple.Create(long.MinValue, long.MaxValue, -1),
+                Tuple.Create(long.MinValue + 9, long.MinValue, 1),
+                Tuple.Create(-1L, -1L, 0)
+            };
+            
+            foreach (var testCase in testCases)
+            {
+                yield return new object[] { (LongEnum)testCase.Item1, (LongEnum)testCase.Item2, testCase.Item3 };
+                yield return new object[] { (LongEnum)testCase.Item2, (LongEnum)testCase.Item1, -testCase.Item3 };
+            }
+        }
+
+        public static IEnumerable<object[]> PlainObjectComparisonsData()
+        {
+            var obj = new object(); // this needs to be cached into a local so we can pass the same ref in twice
+
+            var testCases = new[]
+            {
+                Tuple.Create(default(object), default(object), 0),
+                Tuple.Create(obj, obj, 0), // even if it doesn't implement IComparable, if 2 refs are the same then the result should be 0
+                Tuple.Create(default(object), obj, -1) // even if it doesn't implement IComparable, if one side is null -1 or 1 should be returned
+            };
+
+            foreach (var testCase in testCases)
+            {
+                yield return new object[] { testCase.Item1, testCase.Item2, testCase.Item3 };
+                yield return new object[] { testCase.Item2, testCase.Item1, -testCase.Item3 };
+            }
+        }
+
+        [Fact]
+        public void IComparableComparisonsShouldTryToCallLeftHandCompareToFirst()
+        {
+            var left = new MutatingComparable(0);
+            var right = new MutatingComparable(0);
+
+            var comparer = Comparer<MutatingComparable>.Default;
+
+            // Every CompareTo() call yields the comparable's current
+            // state and then increments it
+            Assert.Equal(0, comparer.Compare(left, right));
+            Assert.Equal(1, comparer.Compare(left, right));
+            Assert.Equal(0, comparer.Compare(right, left));
+        }
+
+        [Fact]
+        public void NonGenericIComparableComparisonsShouldTryToCallLeftHandCompareToFirst()
+        {
+            var left = new MutatingComparable(0);
+            var right = new object();
+
+            var comparer = Comparer<object>.Default;
+
+            Assert.Equal(0, comparer.Compare(left, right));
+            Assert.Equal(1, comparer.Compare(left, right));
+            // If the lhs does not implement IComparable, the rhs should be checked
+            // Additionally the result from rhs.CompareTo should be negated
+            Assert.Equal(-2, comparer.Compare(right, left));
+        }
+
+        [Fact]
+        public void DifferentNonNullObjectsThatDoNotImplementIComparableShouldThrowWhenCompared()
+        {
+            var left = new object();
+            var right = new object();
+
+            var comparer = Comparer<object>.Default;
+            Assert.Throws<ArgumentException>(() => comparer.Compare(left, right));
+        }
+
+        [Fact]
+        public void ComparerDefaultShouldAttemptToUseTheGenericIComparableInterfaceFirst()
+        {
+            // IComparable<>.CompareTo returns 1 for this type,
+            // non-generic overload returns -1
+            var left = new BadlyBehavingComparable();
+            var right = new BadlyBehavingComparable();
+
+            var comparer = Comparer<BadlyBehavingComparable>.Default;
+            // The comparer should pick up on the generic implementation first
+            Assert.Equal(1, comparer.Compare(left, right));
+            Assert.Equal(1, comparer.Compare(right, left));
+        }
+        
+        // The runtime treats nullables specially when they're boxed,
+        // for example `object o = new int?(3); o is int` is true.
+        // This messes with the xUnit type inference for generic theories,
+        // so we need to write another theory (accepting non-nullable parameters)
+        // just for nullables.
+
+        [Theory]
+        [MemberData(nameof(NullableOfIntComparisonsData))]
+        [MemberData(nameof(NullableOfIntEnumComparisonsData))]
+        public void NullableComparisons<T>(T leftValue, bool leftHasValue, T rightValue, bool rightHasValue, int expected) where T : struct
+        {
+            // Comparer<T> is specialized (for perf reasons) when T : U? where U : IComparable<U>
+            T? left = leftHasValue ? new T?(leftValue) : null;
+            T? right = rightHasValue ? new T?(rightValue) : null;
+
+            var comparer = Comparer<T?>.Default;
+            Assert.Equal(expected, Math.Sign(comparer.Compare(left, right)));
+            Assert.Equal(0, comparer.Compare(left, left));
+            Assert.Equal(0, comparer.Compare(right, right));
+
+            // As above, the comparer should handle null inputs itself and only
+            // return -1, 0, or 1 in such circumstances
+            Assert.Equal(0, comparer.Compare(null, null));
+            Assert.InRange(comparer.Compare(null, left), -1, 0);
+            Assert.InRange(comparer.Compare(null, right), -1, 0);
+            Assert.InRange(comparer.Compare(left, null), 0, 1);
+            Assert.InRange(comparer.Compare(right, null), 0, 1);
+        }
+
+        public static IEnumerable<object[]> NullableOfIntComparisonsData()
+        {
+            var testCases = new[]
+            {
+                Tuple.Create(default(int), false, default(int), false, 0), // null and null should have the same sorting order
+                Tuple.Create(int.MinValue, true, int.MinValue, true, 0),
+                Tuple.Create(default(int), false, int.MinValue, true, -1), // "null" values should come before anything else
+                Tuple.Create(int.MaxValue, true, int.MinValue, true, 1) // Comparisons between two non-null nullables should work as normal
+            };
+
+            foreach (var testCase in testCases)
+            {
+                yield return new object[] { testCase.Item1, testCase.Item2, testCase.Item3, testCase.Item4, testCase.Item5 };
+                yield return new object[] { testCase.Item3, testCase.Item4, testCase.Item1, testCase.Item2, -testCase.Item5 };
+            }
+        }
+
+        public static IEnumerable<object[]> NullableOfIntEnumComparisonsData()
+        {
+            // Currently the default Comparer/EqualityComparer is optimized for when
+            // T : U? where U : IComparable<U> or T : enum, but not T : U? where
+            // U : enum (aka T is a nullable enum).
+            // So, let's cover that codepath in case that changes/regresses in the future.
+
+            var testCases = new[]
+            {
+                Tuple.Create(default(int), false, default(int), false, 0),
+                Tuple.Create(int.MinValue, true, default(int), false, 1), // "null" values should come first
+                Tuple.Create(-1, true, 4, true, -1),
+                Tuple.Create(999, true, 999, true, 0)
+            };
+
+            foreach (var testCase in testCases)
+            {
+                yield return new object[] { testCase.Item1, testCase.Item2, testCase.Item3, testCase.Item4, testCase.Item5 };
+                yield return new object[] { testCase.Item3, testCase.Item4, testCase.Item1, testCase.Item2, -testCase.Item5 };
+            }
+        }
+
+        [Fact]
+        public void NullableOfIComparableComparisonsShouldTryToCallLeftHandCompareToFirst()
+        {
+            // If two non-null nullables are passed in, Default<T?>.Compare
+            // should try to call the left-hand side's CompareTo() first
+
+            // Would have liked to reuse MutatingComparable here, but it is
+            // a class and can't be nullable, so it's necessary to wrap it
+            // in a struct
+
+            var leftValue = new MutatingComparable(0);
+            var rightValue = new MutatingComparable(0);
+
+            var left = new ValueComparable<MutatingComparable>?(ValueComparable.Create(leftValue));
+            var right = new ValueComparable<MutatingComparable>?(ValueComparable.Create(rightValue));
+
+            var comparer = Comparer<ValueComparable<MutatingComparable>?>.Default;
+            Assert.Equal(0, comparer.Compare(left, right));
+            Assert.Equal(1, comparer.Compare(left, right));
+            Assert.Equal(0, comparer.Compare(right, left));
+        }
+    }
+}

--- a/src/System.Collections/tests/Generic/Comparers/Comparers.Generic.cs
+++ b/src/System.Collections/tests/Generic/Comparers/Comparers.Generic.cs
@@ -11,54 +11,54 @@ namespace System.Collections.Generic.Tests
     // On .NET Native EqualityComparer is specialized for all of the primitive
     // types and a few more
     // Cover all of those cases
-    public class SByteComparerTests : ComparerGenericTests<sbyte> { }
-    public class ByteComparerTests : ComparerGenericTests<byte> { }
-    public class ShortComparerTests : ComparerGenericTests<short> { }
-    public class UShortComparerTests : ComparerGenericTests<ushort> { }
-    public class IntComparerTests : ComparerGenericTests<int> { }
-    public class UIntComparerTests : ComparerGenericTests<uint> { }
-    public class LongComparerTests : ComparerGenericTests<long> { }
-    public class ULongComparerTests : ComparerGenericTests<ulong> { }
-    public class IntPtrComparerTests : ComparerGenericTests<IntPtr> { }
-    public class UIntPtrComparerTests : ComparerGenericTests<UIntPtr> { }
-    public class FloatComparerTests : ComparerGenericTests<float> { }
-    public class DoubleComparerTests : ComparerGenericTests<double> { }
-    public class DecimalComparerTests : ComparerGenericTests<decimal> { }
-    public class StringComparerTests : ComparerGenericTests<string> { }
+    public class SByteComparerTests : ComparersGenericTests<sbyte> { }
+    public class ByteComparerTests : ComparersGenericTests<byte> { }
+    public class ShortComparerTests : ComparersGenericTests<short> { }
+    public class UShortComparerTests : ComparersGenericTests<ushort> { }
+    public class IntComparerTests : ComparersGenericTests<int> { }
+    public class UIntComparerTests : ComparersGenericTests<uint> { }
+    public class LongComparerTests : ComparersGenericTests<long> { }
+    public class ULongComparerTests : ComparersGenericTests<ulong> { }
+    public class IntPtrComparerTests : ComparersGenericTests<IntPtr> { }
+    public class UIntPtrComparerTests : ComparersGenericTests<UIntPtr> { }
+    public class FloatComparerTests : ComparersGenericTests<float> { }
+    public class DoubleComparerTests : ComparersGenericTests<double> { }
+    public class DecimalComparerTests : ComparersGenericTests<decimal> { }
+    public class StringComparerTests : ComparersGenericTests<string> { }
 
     // Nullables are handled specially
-    public class NullableIntComparerTests : ComparerGenericTests<int?> { }
-    public class NullableUIntComparerTests : ComparerGenericTests<uint?> { }
+    public class NullableIntComparerTests : ComparersGenericTests<int?> { }
+    public class NullableUIntComparerTests : ComparersGenericTests<uint?> { }
 
     // Currently the Default properties are special-cased for enums depending
     // on their underlying type (byte, short, ulong, etc.)
     // We should cover all of those.
-    public class SByteEnumComparerTests : ComparerGenericTests<SByteEnum> { }
-    public class ByteEnumComparerTests : ComparerGenericTests<ByteEnum> { }
-    public class ShortEnumComparerTests : ComparerGenericTests<ShortEnum> { }
-    public class UShortEnumComparerTests : ComparerGenericTests<UShortEnum> { }
-    public class IntEnumComparerTests : ComparerGenericTests<IntEnum> { }
-    public class UIntEnumComparerTests : ComparerGenericTests<UIntEnum> { }
-    public class LongEnumComparerTests : ComparerGenericTests<LongEnum> { }
-    public class ULongEnumComparerTests : ComparerGenericTests<ULongEnum> { }
+    public class SByteEnumComparerTests : ComparersGenericTests<SByteEnum> { }
+    public class ByteEnumComparerTests : ComparersGenericTests<ByteEnum> { }
+    public class ShortEnumComparerTests : ComparersGenericTests<ShortEnum> { }
+    public class UShortEnumComparerTests : ComparersGenericTests<UShortEnum> { }
+    public class IntEnumComparerTests : ComparersGenericTests<IntEnum> { }
+    public class UIntEnumComparerTests : ComparersGenericTests<UIntEnum> { }
+    public class LongEnumComparerTests : ComparersGenericTests<LongEnum> { }
+    public class ULongEnumComparerTests : ComparersGenericTests<ULongEnum> { }
 
     // Default properties currently will be special-cased for T : enum and
     // T : U? where U : {IComparable,IEquatable}<U>, but not if T : U? where U : enum
     // So let's cover those cases as well
-    public class NullableSByteEnumComparerTests : ComparerGenericTests<SByteEnum?> { }
-    public class NullableByteEnumComparerTests : ComparerGenericTests<ByteEnum?> { }
-    public class NullableShortEnumComparerTests : ComparerGenericTests<ShortEnum?> { }
-    public class NullableUShortEnumComparerTests : ComparerGenericTests<UShortEnum?> { }
-    public class NullableIntEnumComparerTests : ComparerGenericTests<IntEnum?> { }
-    public class NullableUIntEnumComparerTests : ComparerGenericTests<UIntEnum?> { }
-    public class NullableLongEnumComparerTests : ComparerGenericTests<LongEnum?> { }
-    public class NullableULongEnumComparerTests : ComparerGenericTests<ULongEnum?> { }
+    public class NullableSByteEnumComparerTests : ComparersGenericTests<SByteEnum?> { }
+    public class NullableByteEnumComparerTests : ComparersGenericTests<ByteEnum?> { }
+    public class NullableShortEnumComparerTests : ComparersGenericTests<ShortEnum?> { }
+    public class NullableUShortEnumComparerTests : ComparersGenericTests<UShortEnum?> { }
+    public class NullableIntEnumComparerTests : ComparersGenericTests<IntEnum?> { }
+    public class NullableUIntEnumComparerTests : ComparersGenericTests<UIntEnum?> { }
+    public class NullableLongEnumComparerTests : ComparersGenericTests<LongEnum?> { }
+    public class NullableULongEnumComparerTests : ComparersGenericTests<ULongEnum?> { }
 
     // Comparer<T>.Default should still work OK with non-IComparables
-    public class ObjectComparerTests : ComparerGenericTests<object> { }
+    public class ObjectComparerTests : ComparersGenericTests<object> { }
 
     // Other cases: IComparable<T>, IComparable, and both
-    public class GenericComparableComparerTests : ComparerGenericTests<GenericComparable> { }
-    public class NonGenericComparableComparerTests : ComparerGenericTests<NonGenericComparable> { }
-    public class BadlyBehavingComparableComparerTests : ComparerGenericTests<BadlyBehavingComparable> { }
+    public class GenericComparableComparerTests : ComparersGenericTests<GenericComparable> { }
+    public class NonGenericComparableComparerTests : ComparersGenericTests<NonGenericComparable> { }
+    public class BadlyBehavingComparableComparerTests : ComparersGenericTests<BadlyBehavingComparable> { }
 }

--- a/src/System.Collections/tests/Generic/Comparers/Comparers.Generic.cs
+++ b/src/System.Collections/tests/Generic/Comparers/Comparers.Generic.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Tests;
+
+namespace System.Collections.Generic.Tests
+{
+    // On .NET Native EqualityComparer is specialized for all of the primitive
+    // types and a few more
+    // Cover all of those cases
+    public class SByteComparerTests : ComparerGenericTests<sbyte> { }
+    public class ByteComparerTests : ComparerGenericTests<byte> { }
+    public class ShortComparerTests : ComparerGenericTests<short> { }
+    public class UShortComparerTests : ComparerGenericTests<ushort> { }
+    public class IntComparerTests : ComparerGenericTests<int> { }
+    public class UIntComparerTests : ComparerGenericTests<uint> { }
+    public class LongComparerTests : ComparerGenericTests<long> { }
+    public class ULongComparerTests : ComparerGenericTests<ulong> { }
+    public class IntPtrComparerTests : ComparerGenericTests<IntPtr> { }
+    public class UIntPtrComparerTests : ComparerGenericTests<UIntPtr> { }
+    public class FloatComparerTests : ComparerGenericTests<float> { }
+    public class DoubleComparerTests : ComparerGenericTests<double> { }
+    public class DecimalComparerTests : ComparerGenericTests<decimal> { }
+    public class StringComparerTests : ComparerGenericTests<string> { }
+
+    // Nullables are handled specially
+    public class NullableIntComparerTests : ComparerGenericTests<int?> { }
+    public class NullableUIntComparerTests : ComparerGenericTests<uint?> { }
+
+    // Currently the Default properties are special-cased for enums depending
+    // on their underlying type (byte, short, ulong, etc.)
+    // We should cover all of those.
+    public class SByteEnumComparerTests : ComparerGenericTests<SByteEnum> { }
+    public class ByteEnumComparerTests : ComparerGenericTests<ByteEnum> { }
+    public class ShortEnumComparerTests : ComparerGenericTests<ShortEnum> { }
+    public class UShortEnumComparerTests : ComparerGenericTests<UShortEnum> { }
+    public class IntEnumComparerTests : ComparerGenericTests<IntEnum> { }
+    public class UIntEnumComparerTests : ComparerGenericTests<UIntEnum> { }
+    public class LongEnumComparerTests : ComparerGenericTests<LongEnum> { }
+    public class ULongEnumComparerTests : ComparerGenericTests<ULongEnum> { }
+
+    // Default properties currently will be special-cased for T : enum and
+    // T : U? where U : {IComparable,IEquatable}<U>, but not if T : U? where U : enum
+    // So let's cover those cases as well
+    public class NullableSByteEnumComparerTests : ComparerGenericTests<SByteEnum?> { }
+    public class NullableByteEnumComparerTests : ComparerGenericTests<ByteEnum?> { }
+    public class NullableShortEnumComparerTests : ComparerGenericTests<ShortEnum?> { }
+    public class NullableUShortEnumComparerTests : ComparerGenericTests<UShortEnum?> { }
+    public class NullableIntEnumComparerTests : ComparerGenericTests<IntEnum?> { }
+    public class NullableUIntEnumComparerTests : ComparerGenericTests<UIntEnum?> { }
+    public class NullableLongEnumComparerTests : ComparerGenericTests<LongEnum?> { }
+    public class NullableULongEnumComparerTests : ComparerGenericTests<ULongEnum?> { }
+
+    // Comparer<T>.Default should still work OK with non-IComparables
+    public class ObjectComparerTests : ComparerGenericTests<object> { }
+
+    // Other cases: IComparable<T>, IComparable, and both
+    public class GenericComparableComparerTests : ComparerGenericTests<GenericComparable> { }
+    public class NonGenericComparableComparerTests : ComparerGenericTests<NonGenericComparable> { }
+    public class BadlyBehavingComparableComparerTests : ComparerGenericTests<BadlyBehavingComparable> { }
+}

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Tests</AssemblyName>
     <RootNamespace>System.Collections.Tests</RootNamespace>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker>.NETStandard,Version=v1.5</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -85,11 +85,20 @@
     <Compile Include="$(CommonTestPath)\System\Collections\TestingTypes.cs" >
       <Link>Common\System\Collections\TestingTypes.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\ObjectCloner.cs" >
+      <Link>Common\System\ObjectCloner.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\RuntimeDetection.cs" >
+      <Link>Common\System\RuntimeDetection.cs</Link>
+    </Compile>
     <!-- Generic tests -->
     <Compile Include="StructuralComparisonsTests.cs" />
     <Compile Include="BitArray\BitArray_CtorTests.cs" />
     <Compile Include="BitArray\BitArray_GetSetTests.cs" />
     <Compile Include="BitArray\BitArray_OperatorsTests.cs" />
+    <Compile Include="Generic\Comparers\Comparer.Generic.Tests.cs" />
+    <Compile Include="Generic\Comparers\Comparer.Tests.cs" />
+    <Compile Include="Generic\Comparers\Comparers.Generic.cs" />
     <Compile Include="Generic\Dictionary\Dictionary.Tests.cs" />
     <Compile Include="Generic\Dictionary\HashCollisionScenarios\InputData.cs" />
     <Compile Include="Generic\Dictionary\HashCollisionScenarios\OutOfBoundsRegression.cs" />

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Tests</AssemblyName>
     <RootNamespace>System.Collections.Tests</RootNamespace>
-    <NugetTargetMoniker>.NETStandard,Version=v1.5</NugetTargetMoniker>
+    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -7,6 +7,7 @@
     "System.Linq": "4.3.0-beta-24431-01",
     "System.Linq.Expressions": "4.3.0-beta-24431-01",
     "System.ObjectModel": "4.3.0-beta-24431-01",
+    "System.Reflection": "4.3.0-beta-24431-01",
     "System.Runtime": "4.3.0-beta-24431-01",
     "System.Runtime.Extensions": "4.3.0-beta-24431-01",
     "System.Text.RegularExpressions": "4.3.0-beta-24431-01",


### PR DESCRIPTION
`Comparer<T>` currently lacks any sort of test coverage in CoreFX to my knowledge, so here are a couple of tests that account for that.

`EqualityComparer<T>` tests are going to be submitted soon after this is merged, since they depend on some changes in this PR. I did not submit them here since the changes were taking longer than anticipated.

Partially addresses #9379

cc @stephentoub, @ianhays, @GSPP, @jkotas, @hughbe 