### PR TITLE
Fix ProcessThread.StartAddress on Linux

### DIFF
--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -54,7 +54,7 @@ internal static partial class Interop
             internal ulong rsslim;
             //internal ulong startcode;
             //internal ulong endcode;
-            internal ulong startstack;
+            //internal ulong startstack;
             //internal ulong kstkesp;
             //internal ulong kstkeip;
             //internal ulong signal;
@@ -254,9 +254,6 @@ internal static partial class Interop
             results.vsize = parser.ParseNextUInt64();
             results.rss = parser.ParseNextInt64();
             results.rsslim = parser.ParseNextUInt64();
-            parser.MoveNextOrFail(); // startcode
-            parser.MoveNextOrFail(); // endcode
-            results.startstack = parser.ParseNextUInt64();
 
             // The following lines are commented out as there's no need to parse through
             // the rest of the entry (we've gotten all of the data we need).  Should any
@@ -264,6 +261,9 @@ internal static partial class Interop
             // through and including the one that's needed.  For now, these are being left 
             // commented to document what's available in the remainder of the entry.
 
+            //parser.MoveNextOrFail(); // startcode
+            //parser.MoveNextOrFail(); // endcode
+            //parser.MoveNextOrFail(); // startstack
             //parser.MoveNextOrFail(); // kstkesp
             //parser.MoveNextOrFail(); // kstkeip
             //parser.MoveNextOrFail(); // signal

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -147,7 +147,7 @@ namespace System.Diagnostics
                                 _threadId = (ulong)tid,
                                 _basePriority = pi.BasePriority,
                                 _currentPriority = (int)stat.nice,
-                                _startAddress = (IntPtr)(void *)stat.startstack,
+                                _startAddress = IntPtr.Zero,
                                 _threadState = ProcFsStateToThreadState(stat.state),
                                 _threadWaitReason = ThreadWaitReason.Unknown
                             });

--- a/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -117,25 +117,16 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void TestStartAddressProperty()
         {
-            Process p = Process.GetCurrentProcess();
-            try
+            using (Process p = Process.GetCurrentProcess())
             {
-                if (p.Threads.Count != 0)
-                {
-                    ProcessThread thread = p.Threads[0];
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    {
-                        Assert.True((long)thread.StartAddress >= 0);
-                    }
-                    else
-                    {
-                        Assert.Equal(RuntimeInformation.IsOSPlatform(OSPlatform.OSX), thread.StartAddress == IntPtr.Zero);
-                    }
-                }
-            }
-            finally
-            {
-                p.Dispose();
+                ProcessThreadCollection threads = p.Threads;
+                Assert.NotNull(threads);
+                Assert.NotEmpty(threads);
+
+                IntPtr startAddress = threads[0].StartAddress; 
+
+                // There's nothing we can really validate about StartAddress, other than that we can get its value
+                // without throwing.  All values (even zero) are valid on all platforms.
             }
         }
 


### PR DESCRIPTION
On Linux, we were reporting the starting *stack* address for a thread via `ProcessThread.StartAddress`.  This property is supposed to return the *code* address of the start of the thread.  We have no way of getting that info on Linux, so we'll just report it as `IntPtr.Zero`, as we already do on OSX (and apparently sometimes on Windows).

This change also reworks the test for this property to be more permissive of address values.  We already accepted `IntPtr.Zero` on Windows/OSX, and now on Linux.  We previously failed on "negative" address values, but this doesn't make sense, as addresses are really unsigned.  We really just need to allow any value here.

Fixes #11072 

@stephentoub