### PR TITLE
Allow to use clang 3.9 in build-native.sh

### DIFF
--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -187,6 +187,10 @@ while :; do
             __ClangMajorVersion=3
             __ClangMinorVersion=8
             ;;
+        clang3.9)
+            __ClangMajorVersion=3
+            __ClangMinorVersion=9
+            ;;
         cross)
             __CrossBuild=1
             ;;


### PR DESCRIPTION
Related with https://github.com/dotnet/coreclr/pull/6888