### PR TITLE
Change the check range for BaseAddress and EntryPointAddress

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessModuleTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessModuleTests.cs
@@ -22,8 +22,8 @@ namespace System.Diagnostics.Tests
                 Assert.NotNull(module.FileName);
                 Assert.NotEmpty(module.FileName);
 
-                Assert.InRange(module.BaseAddress.ToInt64(), 0, long.MaxValue);
-                Assert.InRange(module.EntryPointAddress.ToInt64(), 0, long.MaxValue);
+                Assert.InRange(module.BaseAddress.ToInt64(), long.MinValue, long.MaxValue);
+                Assert.InRange(module.EntryPointAddress.ToInt64(), long.MinValue, long.MaxValue);
                 Assert.InRange(module.ModuleMemorySize, 0, long.MaxValue);
             }
         }


### PR DESCRIPTION
IntPtr::ToInt64() returns a signed value
so it should be checked btw long.MinValue and long.MaxValue.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

==================================================

BaseAddress in ProcessModule can be a negative value because it is IntPtr type.
So it should be checked the range btw long.MinValue and long.MaxValue.

Fix #11085 