### PR TITLE
Remove use of the modulo operator in Queue.Enumerator

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -416,7 +416,15 @@ namespace System.Collections.Generic
 
                         int arrayIndex = _q._head + _index; // this is the actual index into the queue's backing array
                         if (arrayIndex >= capacity)
-                            arrayIndex -= capacity; // wrap around
+                        {
+                            // NOTE: Originally we were using the modulo operator here, however
+                            // on Intel processors it has a very high instruction latency which
+                            // was slowing down the loop quite a bit.
+                            // Replacing it with simple comparison/subtraction operations sped up
+                            // the average foreach loop by 2x.
+
+                            arrayIndex -= capacity; // wrap around if needed
+                        }
                         
                         _currentElement = array[arrayIndex];
                     }

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -12,7 +12,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
@@ -387,7 +386,7 @@ namespace System.Collections.Generic
             public bool MoveNext()
             {
                 if (_version != _q._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
-                
+
                 if (_index == -2)
                     return false;
 
@@ -400,30 +399,28 @@ namespace System.Collections.Generic
                     _currentElement = default(T);
                     return false;
                 }
-                else
+
+                // Cache some fields in locals to decrease code size
+                T[] array = _q._array;
+                int capacity = array.Length;
+
+                // _index represents the 0-based index into the queue, however the queue
+                // doesn't have to start from 0 and it may not even be stored contiguously in memory.
+
+                int arrayIndex = _q._head + _index; // this is the actual index into the queue's backing array
+                if (arrayIndex >= capacity)
                 {
-                    // Cache some fields in locals to decrease code size
-                    T[] array = _q._array;
-                    int capacity = array.Length;
+                    // NOTE: Originally we were using the modulo operator here, however
+                    // on Intel processors it has a very high instruction latency which
+                    // was slowing down the loop quite a bit.
+                    // Replacing it with simple comparison/subtraction operations sped up
+                    // the average foreach loop by 2x.
 
-                    // _index represents the 0-based index into the queue, however the queue
-                    // doesn't have to start from 0 and it may not even be stored contiguously in memory.
-
-                    int arrayIndex = _q._head + _index; // this is the actual index into the queue's backing array
-                    if (arrayIndex >= capacity)
-                    {
-                        // NOTE: Originally we were using the modulo operator here, however
-                        // on Intel processors it has a very high instruction latency which
-                        // was slowing down the loop quite a bit.
-                        // Replacing it with simple comparison/subtraction operations sped up
-                        // the average foreach loop by 2x.
-
-                        arrayIndex -= capacity; // wrap around if needed
-                    }
-                    
-                    _currentElement = array[arrayIndex];
-                    return true;
+                    arrayIndex -= capacity; // wrap around if needed
                 }
+                
+                _currentElement = array[arrayIndex];
+                return true;
             }
 
             /// <include file='doc\Queue.uex' path='docs/doc[@for="QueueEnumerator.Current"]/*' />

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -386,15 +386,11 @@ namespace System.Collections.Generic
             /// <include file='doc\Queue.uex' path='docs/doc[@for="QueueEnumerator.MoveNext"]/*' />
             public bool MoveNext()
             {
-                // Typically both of these conditions will be true, so save ourselves
-                // a branch and use bitwise AND.
-                bool typicalIteration = (_version == _q._version) & (_index != -2);
-
                 // Instead of return true/false, we assign the result to a variable and
                 // return it at the end. This helps decrease code size, as currently the
                 // jit cannot do this for us and generates code for 3 returns.
                 bool result = true;
-                if (typicalIteration)
+                if (_version == _q._version && _index != -2)
                 {
                     _index++;
 

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -386,11 +386,14 @@ namespace System.Collections.Generic
             /// <include file='doc\Queue.uex' path='docs/doc[@for="QueueEnumerator.MoveNext"]/*' />
             public bool MoveNext()
             {
+                if (_version != _q._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+
                 // Instead of return true/false, we assign the result to a variable and
                 // return it at the end. This helps decrease code size, as currently the
                 // jit cannot do this for us and generates code for 3 returns.
-                bool result = true;
-                if (_version == _q._version && _index != -2)
+                bool result = false;
+
+                if (_index != -2)
                 {
                     _index++;
 
@@ -399,7 +402,6 @@ namespace System.Collections.Generic
                         // We've run past the last element
                         _index = -2;
                         _currentElement = default(T);
-                        result = false;
                     }
                     else
                     {
@@ -423,26 +425,11 @@ namespace System.Collections.Generic
                         }
                         
                         _currentElement = array[arrayIndex];
+                        result = true;
                     }
-                }
-                else
-                {
-                    result = MoveNextRare();
                 }
 
                 return result;
-            }
-
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            private bool MoveNextRare()
-            {
-                Debug.Assert(_version != _q._version || _index == -2);
-
-                // Note: If both conditions are true, then we have to throw the exception first.
-                if (_version != _q._version)
-                    throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
-                
-                return false;
             }
 
             /// <include file='doc\Queue.uex' path='docs/doc[@for="QueueEnumerator.Current"]/*' />


### PR DESCRIPTION
Currently Queue.Enumerator.MoveNext uses the modulo operator, which is very slow (`idiv` has lots of latency compared to other instructions). Additionally, the method it calls that uses it (`GetElement`) is not being inlined.

This PR removes such use of the % operator and replaces it with simple branch/subtraction operations. I also separated a part of the method that will not get called very often into a new `MoveNextRare` function, which decreases the code size for the main codepath significantly.

[Disassembly before and after](https://gist.github.com/jamesqo/bec83dbcd6f3c1af27051f92a53e8ddf)

I did some benchmarking and this change brings the average running time for a foreach loop from ~2.9s to ~1.7s. ([microbenchmark](https://gist.github.com/jamesqo/badae67ff75e48de0e1ac54b436d4c7e))

Fixes #10854

cc @ianhays, @GSPP

edit: forgot to cc @omariom who wrote #2515