### PR TITLE
Tests using a cleared environment for RemoteInvoke now copy over LD_LIBRARY_PATH

### DIFF
--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -112,7 +112,8 @@ namespace System.Globalization.Tests
             var psi = new ProcessStartInfo();
             psi.Environment.Clear();
 
-            CopyHomeIfPresent(psi.Environment);
+            CopyEssentialTestEnvironment(psi.Environment);
+
             psi.Environment["LANG"] = langEnvVar;
 
             RemoteInvoke(expected =>
@@ -136,7 +137,8 @@ namespace System.Globalization.Tests
             var psi = new ProcessStartInfo();
             psi.Environment.Clear();
 
-            CopyHomeIfPresent(psi.Environment);
+            CopyEssentialTestEnvironment(psi.Environment);
+
             if (langEnvVar != null)
             {
                psi.Environment["LANG"] = langEnvVar;
@@ -154,13 +156,17 @@ namespace System.Globalization.Tests
             }, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
 
-        private static void CopyHomeIfPresent(IDictionary<string, string> environment)
+        private static void CopyEssentialTestEnvironment(IDictionary<string, string> environment)
         {
-            string currentHome = Environment.GetEnvironmentVariable("HOME");
-
-            if (currentHome != null)
+            string[] essentialVariables = { "HOME", "LD_LIBRARY_PATH" };
+            foreach(string essentialVariable in essentialVariables)
             {
-                environment["HOME"] = currentHome;
+                string varValue = Environment.GetEnvironmentVariable(essentialVariable);
+
+                if (varValue != null)
+                {
+                    environment[essentialVariable] = varValue;
+                }
             }
         }
     }


### PR DESCRIPTION

Fix #11103