### PR TITLE
Use -Werror in configure.cmake

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -31,7 +31,7 @@ OSName=$(uname -s)
                 __DOTNET_PKG=dotnet-dev-ubuntu.14.04-x64
             else
                 source /etc/os-release
-                if [[ "$ID" == "ubuntu" && "$VERSION_ID" != "14.04" && "$VERSION_ID" != "16.04" ]]; then
+                if [[ "$ID" == "ubuntu" && "$VERSION_ID" != "14.04" && "$VERSION_ID" != "16.04" && "$VERSION_ID" != "16.10" ]]; then
                     echo "Unsupported Ubuntu version, falling back to Ubuntu 14.04."
                     __DOTNET_PKG=dotnet-dev-ubuntu.14.04-x64
                 else

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -24,6 +24,9 @@ else ()
     message(FATAL_ERROR "Unknown platform.  Cannot define PAL_UNIX_NAME, used by RuntimeInformation.")
 endif ()
 
+# We compile with -Werror, so we need to make sure these code fragments compile without warnings.
+set(CMAKE_REQUIRED_FLAGS -Werror)
+
 # in_pktinfo: Find whether this struct exists
 check_include_files(
     linux/in.h
@@ -168,7 +171,11 @@ check_struct_has_member(
 check_cxx_source_compiles(
     "
     #include <string.h>
-    int main() { char* c = strerror_r(0, 0, 0); }
+    int main()
+    {
+        char buffer[1];
+        char* c = strerror_r(0, buffer, 0);
+    }
     "
     HAVE_GNU_STRERROR_R)
 


### PR DESCRIPTION
We recently made a fix to avoid the use of `readdir_r` in places where it is deprecated. However, our CMake configuration checks do not compile with `-Werror` enabled, so the code compiled successfully, even with the warning, and did not fail the test. I've added `-Werror` to the CMake compilation options used for these checks. As a result of that, another test was giving a false negative result because it was passing in null to a parameter which is not supposed to be null (`strerror_r`). To fix that, I've changed the code fragment to pass in a pointer to a 1-byte buffer instead.

I've verified that none of the other CMake checks are resulting in a different value on my machine by comparing the bin/obj/Linux.x64.Debug/CMakeCache.txt file before and after these changes.

Separately, I've added Ubuntu 16.10 (the distro I've encountered the above problems on) to the list of allowed versions in init-tools.sh.