### PR TITLE
Compacting switch tables in expression compiler

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -355,7 +355,7 @@ namespace System.Linq.Expressions
             return visitor.VisitBinary(this);
         }
 
-        internal static Expression Create(ExpressionType nodeType, Expression left, Expression right, Type type, MethodInfo method, LambdaExpression conversion)
+        internal static BinaryExpression Create(ExpressionType nodeType, Expression left, Expression right, Type type, MethodInfo method, LambdaExpression conversion)
         {
             Debug.Assert(nodeType != ExpressionType.Assign);
             if (conversion != null)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Generated.cs
@@ -23,28 +23,68 @@ namespace System.Linq.Expressions.Compiler
             switch (node.NodeType)
             {
                 case ExpressionType.Add:
-                    EmitBinaryExpression(node, flags);
-                    break;
                 case ExpressionType.AddChecked:
-                    EmitBinaryExpression(node, flags);
-                    break;
                 case ExpressionType.And:
+                case ExpressionType.ArrayIndex:
+                case ExpressionType.Divide:
+                case ExpressionType.Equal:
+                case ExpressionType.ExclusiveOr:
+                case ExpressionType.GreaterThan:
+                case ExpressionType.GreaterThanOrEqual:
+                case ExpressionType.LeftShift:
+                case ExpressionType.LessThan:
+                case ExpressionType.LessThanOrEqual:
+                case ExpressionType.Modulo:
+                case ExpressionType.Multiply:
+                case ExpressionType.MultiplyChecked:
+                case ExpressionType.NotEqual:
+                case ExpressionType.Or:
+                case ExpressionType.Power:
+                case ExpressionType.RightShift:
+                case ExpressionType.Subtract:
+                case ExpressionType.SubtractChecked:
                     EmitBinaryExpression(node, flags);
                     break;
                 case ExpressionType.AndAlso:
                     EmitAndAlsoBinaryExpression(node, flags);
                     break;
-                case ExpressionType.ArrayLength:
-                    EmitUnaryExpression(node, flags);
-                    break;
-                case ExpressionType.ArrayIndex:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.Call:
-                    EmitMethodCallExpression(node, flags);
+                case ExpressionType.OrElse:
+                    EmitOrElseBinaryExpression(node, flags);
                     break;
                 case ExpressionType.Coalesce:
                     EmitCoalesceBinaryExpression(node);
+                    break;
+                case ExpressionType.Assign:
+                    EmitAssignBinaryExpression(node);
+                    break;
+                case ExpressionType.ArrayLength:
+                case ExpressionType.Decrement:
+                case ExpressionType.Increment:
+                case ExpressionType.IsFalse:
+                case ExpressionType.IsTrue:
+                case ExpressionType.Negate:
+                case ExpressionType.NegateChecked:
+                case ExpressionType.Not:
+                case ExpressionType.OnesComplement:
+                case ExpressionType.TypeAs:
+                case ExpressionType.UnaryPlus:
+                    EmitUnaryExpression(node, flags);
+                    break;
+                case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked:
+                    EmitConvertUnaryExpression(node, flags);
+                    break;
+                case ExpressionType.Quote:
+                    EmitQuoteUnaryExpression(node);
+                    break;
+                case ExpressionType.Throw:
+                    EmitThrowUnaryExpression(node);
+                    break;
+                case ExpressionType.Unbox:
+                    EmitUnboxUnaryExpression(node);
+                    break;
+                case ExpressionType.Call:
+                    EmitMethodCallExpression(node, flags);
                     break;
                 case ExpressionType.Conditional:
                     EmitConditionalExpression(node, flags);
@@ -52,41 +92,11 @@ namespace System.Linq.Expressions.Compiler
                 case ExpressionType.Constant:
                     EmitConstantExpression(node);
                     break;
-                case ExpressionType.Convert:
-                    EmitConvertUnaryExpression(node, flags);
-                    break;
-                case ExpressionType.ConvertChecked:
-                    EmitConvertUnaryExpression(node, flags);
-                    break;
-                case ExpressionType.Divide:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.Equal:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.ExclusiveOr:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.GreaterThan:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.GreaterThanOrEqual:
-                    EmitBinaryExpression(node, flags);
-                    break;
                 case ExpressionType.Invoke:
                     EmitInvocationExpression(node, flags);
                     break;
                 case ExpressionType.Lambda:
                     EmitLambdaExpression(node);
-                    break;
-                case ExpressionType.LeftShift:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.LessThan:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.LessThanOrEqual:
-                    EmitBinaryExpression(node, flags);
                     break;
                 case ExpressionType.ListInit:
                     EmitListInitExpression(node);
@@ -97,80 +107,25 @@ namespace System.Linq.Expressions.Compiler
                 case ExpressionType.MemberInit:
                     EmitMemberInitExpression(node);
                     break;
-                case ExpressionType.Modulo:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.Multiply:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.MultiplyChecked:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.Negate:
-                    EmitUnaryExpression(node, flags);
-                    break;
-                case ExpressionType.UnaryPlus:
-                    EmitUnaryExpression(node, flags);
-                    break;
-                case ExpressionType.NegateChecked:
-                    EmitUnaryExpression(node, flags);
-                    break;
                 case ExpressionType.New:
                     EmitNewExpression(node);
                     break;
                 case ExpressionType.NewArrayInit:
-                    EmitNewArrayExpression(node);
-                    break;
                 case ExpressionType.NewArrayBounds:
                     EmitNewArrayExpression(node);
-                    break;
-                case ExpressionType.Not:
-                    EmitUnaryExpression(node, flags);
-                    break;
-                case ExpressionType.NotEqual:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.Or:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.OrElse:
-                    EmitOrElseBinaryExpression(node, flags);
                     break;
                 case ExpressionType.Parameter:
                     EmitParameterExpression(node);
                     break;
-                case ExpressionType.Power:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.Quote:
-                    EmitQuoteUnaryExpression(node);
-                    break;
-                case ExpressionType.RightShift:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.Subtract:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.SubtractChecked:
-                    EmitBinaryExpression(node, flags);
-                    break;
-                case ExpressionType.TypeAs:
-                    EmitUnaryExpression(node, flags);
-                    break;
+                case ExpressionType.TypeEqual:
                 case ExpressionType.TypeIs:
                     EmitTypeBinaryExpression(node);
-                    break;
-                case ExpressionType.Assign:
-                    EmitAssignBinaryExpression(node);
                     break;
                 case ExpressionType.Block:
                     EmitBlockExpression(node, flags);
                     break;
                 case ExpressionType.DebugInfo:
                     EmitDebugInfoExpression(node);
-                    break;
-                case ExpressionType.Decrement:
-                    EmitUnaryExpression(node, flags);
                     break;
                 case ExpressionType.Dynamic:
                     EmitDynamicExpression(node);
@@ -183,9 +138,6 @@ namespace System.Linq.Expressions.Compiler
                     break;
                 case ExpressionType.Goto:
                     EmitGotoExpression(node, flags);
-                    break;
-                case ExpressionType.Increment:
-                    EmitUnaryExpression(node, flags);
                     break;
                 case ExpressionType.Index:
                     EmitIndexExpression(node);
@@ -202,26 +154,8 @@ namespace System.Linq.Expressions.Compiler
                 case ExpressionType.Switch:
                     EmitSwitchExpression(node, flags);
                     break;
-                case ExpressionType.Throw:
-                    EmitThrowUnaryExpression(node);
-                    break;
                 case ExpressionType.Try:
                     EmitTryExpression(node);
-                    break;
-                case ExpressionType.Unbox:
-                    EmitUnboxUnaryExpression(node);
-                    break;
-                case ExpressionType.TypeEqual:
-                    EmitTypeBinaryExpression(node);
-                    break;
-                case ExpressionType.OnesComplement:
-                    EmitUnaryExpression(node, flags);
-                    break;
-                case ExpressionType.IsTrue:
-                    EmitUnaryExpression(node, flags);
-                    break;
-                case ExpressionType.IsFalse:
-                    EmitUnaryExpression(node, flags);
                     break;
 
                 default:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -175,7 +175,7 @@ namespace System.Linq.Expressions.Compiler
                 {
                     // If there are no cases and no default then the type must be void.
                     // Assert that earlier validation caught any exceptions to that.
-                    Debug.Assert(expr.Type == typeof(void));
+                    Debug.Assert(node.Type == typeof(void));
                 }
 
                 return;
@@ -817,7 +817,7 @@ namespace System.Linq.Expressions.Compiler
 
             EmitExpression(node.Body);
 
-            Type tryType = expr.Type;
+            Type tryType = node.Type;
             LocalBuilder value = null;
             if (tryType != typeof(void))
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Generated.cs
@@ -28,67 +28,66 @@ namespace System.Linq.Expressions.Compiler
             switch (node.NodeType)
             {
                 case ExpressionType.Add:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
                 case ExpressionType.AddChecked:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
                 case ExpressionType.And:
+                case ExpressionType.ArrayIndex:
+                case ExpressionType.Divide:
+                case ExpressionType.Equal:
+                case ExpressionType.ExclusiveOr:
+                case ExpressionType.GreaterThan:
+                case ExpressionType.GreaterThanOrEqual:
+                case ExpressionType.LeftShift:
+                case ExpressionType.LessThan:
+                case ExpressionType.LessThanOrEqual:
+                case ExpressionType.Modulo:
+                case ExpressionType.Multiply:
+                case ExpressionType.MultiplyChecked:
+                case ExpressionType.NotEqual:
+                case ExpressionType.Or:
+                case ExpressionType.Power:
+                case ExpressionType.RightShift:
+                case ExpressionType.Subtract:
+                case ExpressionType.SubtractChecked:
                     result = RewriteBinaryExpression(node, stack);
                     break;
                 case ExpressionType.AndAlso:
+                case ExpressionType.Coalesce:
+                case ExpressionType.OrElse:
                     result = RewriteLogicalBinaryExpression(node, stack);
                     break;
+                case ExpressionType.Assign:
+                    result = RewriteAssignBinaryExpression(node, stack);
+                    break;
                 case ExpressionType.ArrayLength:
+                case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked:
+                case ExpressionType.Decrement:
+                case ExpressionType.Increment:
+                case ExpressionType.IsFalse:
+                case ExpressionType.IsTrue:
+                case ExpressionType.Negate:
+                case ExpressionType.NegateChecked:
+                case ExpressionType.Not:
+                case ExpressionType.OnesComplement:
+                case ExpressionType.TypeAs:
+                case ExpressionType.UnaryPlus:
+                case ExpressionType.Unbox:
                     result = RewriteUnaryExpression(node, stack);
                     break;
-                case ExpressionType.ArrayIndex:
-                    result = RewriteBinaryExpression(node, stack);
+                case ExpressionType.Throw:
+                    result = RewriteThrowUnaryExpression(node, stack);
                     break;
                 case ExpressionType.Call:
                     result = RewriteMethodCallExpression(node, stack);
                     break;
-                case ExpressionType.Coalesce:
-                    result = RewriteLogicalBinaryExpression(node, stack);
-                    break;
                 case ExpressionType.Conditional:
                     result = RewriteConditionalExpression(node, stack);
-                    break;
-                case ExpressionType.Convert:
-                    result = RewriteUnaryExpression(node, stack);
-                    break;
-                case ExpressionType.ConvertChecked:
-                    result = RewriteUnaryExpression(node, stack);
-                    break;
-                case ExpressionType.Divide:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.Equal:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.ExclusiveOr:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.GreaterThan:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.GreaterThanOrEqual:
-                    result = RewriteBinaryExpression(node, stack);
                     break;
                 case ExpressionType.Invoke:
                     result = RewriteInvocationExpression(node, stack);
                     break;
                 case ExpressionType.Lambda:
                     result = RewriteLambdaExpression(node, stack);
-                    break;
-                case ExpressionType.LeftShift:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.LessThan:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.LessThanOrEqual:
-                    result = RewriteBinaryExpression(node, stack);
                     break;
                 case ExpressionType.ListInit:
                     result = RewriteListInitExpression(node, stack);
@@ -99,71 +98,19 @@ namespace System.Linq.Expressions.Compiler
                 case ExpressionType.MemberInit:
                     result = RewriteMemberInitExpression(node, stack);
                     break;
-                case ExpressionType.Modulo:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.Multiply:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.MultiplyChecked:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.Negate:
-                    result = RewriteUnaryExpression(node, stack);
-                    break;
-                case ExpressionType.UnaryPlus:
-                    result = RewriteUnaryExpression(node, stack);
-                    break;
-                case ExpressionType.NegateChecked:
-                    result = RewriteUnaryExpression(node, stack);
-                    break;
                 case ExpressionType.New:
                     result = RewriteNewExpression(node, stack);
                     break;
                 case ExpressionType.NewArrayInit:
-                    result = RewriteNewArrayExpression(node, stack);
-                    break;
                 case ExpressionType.NewArrayBounds:
                     result = RewriteNewArrayExpression(node, stack);
                     break;
-                case ExpressionType.Not:
-                    result = RewriteUnaryExpression(node, stack);
-                    break;
-                case ExpressionType.NotEqual:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.Or:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.OrElse:
-                    result = RewriteLogicalBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.Power:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.RightShift:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.Subtract:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.SubtractChecked:
-                    result = RewriteBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.TypeAs:
-                    result = RewriteUnaryExpression(node, stack);
-                    break;
+                case ExpressionType.TypeEqual:
                 case ExpressionType.TypeIs:
                     result = RewriteTypeBinaryExpression(node, stack);
                     break;
-                case ExpressionType.Assign:
-                    result = RewriteAssignBinaryExpression(node, stack);
-                    break;
                 case ExpressionType.Block:
                     result = RewriteBlockExpression(node, stack);
-                    break;
-                case ExpressionType.Decrement:
-                    result = RewriteUnaryExpression(node, stack);
                     break;
                 case ExpressionType.Dynamic:
                     result = RewriteDynamicExpression(node, stack);
@@ -173,9 +120,6 @@ namespace System.Linq.Expressions.Compiler
                     break;
                 case ExpressionType.Goto:
                     result = RewriteGotoExpression(node, stack);
-                    break;
-                case ExpressionType.Increment:
-                    result = RewriteUnaryExpression(node, stack);
                     break;
                 case ExpressionType.Index:
                     result = RewriteIndexExpression(node, stack);
@@ -189,26 +133,8 @@ namespace System.Linq.Expressions.Compiler
                 case ExpressionType.Switch:
                     result = RewriteSwitchExpression(node, stack);
                     break;
-                case ExpressionType.Throw:
-                    result = RewriteThrowUnaryExpression(node, stack);
-                    break;
                 case ExpressionType.Try:
                     result = RewriteTryExpression(node, stack);
-                    break;
-                case ExpressionType.Unbox:
-                    result = RewriteUnaryExpression(node, stack);
-                    break;
-                case ExpressionType.TypeEqual:
-                    result = RewriteTypeBinaryExpression(node, stack);
-                    break;
-                case ExpressionType.OnesComplement:
-                    result = RewriteUnaryExpression(node, stack);
-                    break;
-                case ExpressionType.IsTrue:
-                    result = RewriteUnaryExpression(node, stack);
-                    break;
-                case ExpressionType.IsFalse:
-                    result = RewriteUnaryExpression(node, stack);
                     break;
                 case ExpressionType.AddAssign:
                 case ExpressionType.AndAssign:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1478,7 +1478,7 @@ namespace System.Linq.Expressions.Interpreter
             CompileAsVoid(node.Body);
 
             // emit loop branch:
-            _instructions.EmitBranch(continueLabel.GetLabel(this), expr.Type != typeof(void), false);
+            _instructions.EmitBranch(continueLabel.GetLabel(this), node.Type != typeof(void), false);
 
             _instructions.MarkLabel(breakLabel.GetLabel(this));
 
@@ -1508,7 +1508,7 @@ namespace System.Linq.Expressions.Interpreter
                     {
                         // If there are no cases and no default then the type must be void.
                         // Assert that earlier validation caught any exceptions to that.
-                        Debug.Assert(expr.Type == typeof(void));
+                        Debug.Assert(node.Type == typeof(void));
                     }
                     return;
                 }
@@ -2412,7 +2412,7 @@ namespace System.Linq.Expressions.Interpreter
             }
             else
             {
-                Debug.Assert(expr.Type.GetTypeInfo().IsValueType);
+                Debug.Assert(node.Type.GetTypeInfo().IsValueType);
                 _instructions.EmitDefaultValue(node.Type);
             }
         }
@@ -2844,7 +2844,7 @@ namespace System.Linq.Expressions.Interpreter
 
             Compile(node.Operand);
 
-            if (expr.Type.GetTypeInfo().IsValueType && !TypeUtils.IsNullableType(expr.Type))
+            if (node.Type.GetTypeInfo().IsValueType && !TypeUtils.IsNullableType(node.Type))
             {
                 _instructions.Emit(NullCheckInstruction.Instance);
             }
@@ -2972,71 +2972,71 @@ namespace System.Linq.Expressions.Interpreter
             int startingStackDepth = _instructions.CurrentStackDepth;
             switch (expr.NodeType)
             {
-                case ExpressionType.Add: CompileBinaryExpression(expr); break;
-                case ExpressionType.AddChecked: CompileBinaryExpression(expr); break;
-                case ExpressionType.And: CompileBinaryExpression(expr); break;
+                case ExpressionType.Add:
+                case ExpressionType.AddChecked:
+                case ExpressionType.And:
+                case ExpressionType.ArrayIndex:
+                case ExpressionType.Divide:
+                case ExpressionType.Equal:
+                case ExpressionType.ExclusiveOr:
+                case ExpressionType.GreaterThan:
+                case ExpressionType.GreaterThanOrEqual:
+                case ExpressionType.LeftShift:
+                case ExpressionType.LessThan:
+                case ExpressionType.LessThanOrEqual:
+                case ExpressionType.Modulo:
+                case ExpressionType.Multiply:
+                case ExpressionType.MultiplyChecked:
+                case ExpressionType.NotEqual:
+                case ExpressionType.Or:
+                case ExpressionType.Power:
+                case ExpressionType.RightShift:
+                case ExpressionType.Subtract:
+                case ExpressionType.SubtractChecked: CompileBinaryExpression(expr); break;
                 case ExpressionType.AndAlso: CompileAndAlsoBinaryExpression(expr); break;
-                case ExpressionType.ArrayLength: CompileUnaryExpression(expr); break;
-                case ExpressionType.ArrayIndex: CompileBinaryExpression(expr); break;
-                case ExpressionType.Call: CompileMethodCallExpression(expr); break;
+                case ExpressionType.OrElse: CompileOrElseBinaryExpression(expr); break;
                 case ExpressionType.Coalesce: CompileCoalesceBinaryExpression(expr); break;
+                case ExpressionType.ArrayLength:
+                case ExpressionType.Decrement:
+                case ExpressionType.Increment:
+                case ExpressionType.IsTrue:
+                case ExpressionType.IsFalse:
+                case ExpressionType.Negate:
+                case ExpressionType.NegateChecked:
+                case ExpressionType.Not:
+                case ExpressionType.OnesComplement:
+                case ExpressionType.TypeAs:
+                case ExpressionType.UnaryPlus: CompileUnaryExpression(expr); break;
+                case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked: CompileConvertUnaryExpression(expr); break;
+                case ExpressionType.Quote: CompileQuoteUnaryExpression(expr); break;
+                case ExpressionType.Throw: CompileThrowUnaryExpression(expr, expr.Type == typeof(void)); break;
+                case ExpressionType.Unbox: CompileUnboxUnaryExpression(expr); break;
+                case ExpressionType.Call: CompileMethodCallExpression(expr); break;
                 case ExpressionType.Conditional: CompileConditionalExpression(expr, expr.Type == typeof(void)); break;
                 case ExpressionType.Constant: CompileConstantExpression(expr); break;
-                case ExpressionType.Convert: CompileConvertUnaryExpression(expr); break;
-                case ExpressionType.ConvertChecked: CompileConvertUnaryExpression(expr); break;
-                case ExpressionType.Divide: CompileBinaryExpression(expr); break;
-                case ExpressionType.Equal: CompileBinaryExpression(expr); break;
-                case ExpressionType.ExclusiveOr: CompileBinaryExpression(expr); break;
-                case ExpressionType.GreaterThan: CompileBinaryExpression(expr); break;
-                case ExpressionType.GreaterThanOrEqual: CompileBinaryExpression(expr); break;
                 case ExpressionType.Invoke: CompileInvocationExpression(expr); break;
                 case ExpressionType.Lambda: CompileLambdaExpression(expr); break;
-                case ExpressionType.LeftShift: CompileBinaryExpression(expr); break;
-                case ExpressionType.LessThan: CompileBinaryExpression(expr); break;
-                case ExpressionType.LessThanOrEqual: CompileBinaryExpression(expr); break;
                 case ExpressionType.ListInit: CompileListInitExpression(expr); break;
                 case ExpressionType.MemberAccess: CompileMemberExpression(expr); break;
                 case ExpressionType.MemberInit: CompileMemberInitExpression(expr); break;
-                case ExpressionType.Modulo: CompileBinaryExpression(expr); break;
-                case ExpressionType.Multiply: CompileBinaryExpression(expr); break;
-                case ExpressionType.MultiplyChecked: CompileBinaryExpression(expr); break;
-                case ExpressionType.Negate: CompileUnaryExpression(expr); break;
-                case ExpressionType.UnaryPlus: CompileUnaryExpression(expr); break;
-                case ExpressionType.NegateChecked: CompileUnaryExpression(expr); break;
                 case ExpressionType.New: CompileNewExpression(expr); break;
-                case ExpressionType.NewArrayInit: CompileNewArrayExpression(expr); break;
+                case ExpressionType.NewArrayInit:
                 case ExpressionType.NewArrayBounds: CompileNewArrayExpression(expr); break;
-                case ExpressionType.Not: CompileUnaryExpression(expr); break;
-                case ExpressionType.NotEqual: CompileBinaryExpression(expr); break;
-                case ExpressionType.Or: CompileBinaryExpression(expr); break;
-                case ExpressionType.OrElse: CompileOrElseBinaryExpression(expr); break;
                 case ExpressionType.Parameter: CompileParameterExpression(expr); break;
-                case ExpressionType.Power: CompileBinaryExpression(expr); break;
-                case ExpressionType.Quote: CompileQuoteUnaryExpression(expr); break;
-                case ExpressionType.RightShift: CompileBinaryExpression(expr); break;
-                case ExpressionType.Subtract: CompileBinaryExpression(expr); break;
-                case ExpressionType.SubtractChecked: CompileBinaryExpression(expr); break;
-                case ExpressionType.TypeAs: CompileUnaryExpression(expr); break;
                 case ExpressionType.TypeIs: CompileTypeIsExpression(expr); break;
+                case ExpressionType.TypeEqual: CompileTypeEqualExpression(expr); break;
                 case ExpressionType.Assign: CompileAssignBinaryExpression(expr, expr.Type == typeof(void)); break;
                 case ExpressionType.Block: CompileBlockExpression(expr, expr.Type == typeof(void)); break;
                 case ExpressionType.DebugInfo: CompileDebugInfoExpression(expr); break;
-                case ExpressionType.Decrement: CompileUnaryExpression(expr); break;
                 case ExpressionType.Default: CompileDefaultExpression(expr); break;
                 case ExpressionType.Goto: CompileGotoExpression(expr); break;
-                case ExpressionType.Increment: CompileUnaryExpression(expr); break;
                 case ExpressionType.Index: CompileIndexExpression(expr); break;
                 case ExpressionType.Label: CompileLabelExpression(expr); break;
                 case ExpressionType.RuntimeVariables: CompileRuntimeVariablesExpression(expr); break;
                 case ExpressionType.Loop: CompileLoopExpression(expr); break;
                 case ExpressionType.Switch: CompileSwitchExpression(expr); break;
-                case ExpressionType.Throw: CompileThrowUnaryExpression(expr, expr.Type == typeof(void)); break;
                 case ExpressionType.Try: CompileTryExpression(expr); break;
-                case ExpressionType.Unbox: CompileUnboxUnaryExpression(expr); break;
-                case ExpressionType.TypeEqual: CompileTypeEqualExpression(expr); break;
-                case ExpressionType.OnesComplement: CompileUnaryExpression(expr); break;
-                case ExpressionType.IsTrue: CompileUnaryExpression(expr); break;
-                case ExpressionType.IsFalse: CompileUnaryExpression(expr); break;
                 default:
                     Compile(expr.ReduceAndCheck());
                     break;


### PR DESCRIPTION
This fixes #11105 by changing dispatch methods in `LambdaCompiler`, `LightCompiler`, and `StackSpiller` to perform the necessary cast prior to calling the specialized `Emit`, `Compile`, or `Rewrite` method. By doing so, we eliminate the need for these methods to have a weakly typed parameter and a strongly typed local, thus reducing the stack usage. A nice side-effect of this change is that the dispatch methods got a bit more compact because the different `ExpressionType` cases that correspond to a particular subtype of `Expression` have been put together.