### PR TITLE
Make corefx collections serializable

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -58,4 +58,12 @@
     </SupplementalTestData>
   </ItemGroup>
 
+  
+  <!-- ToDo: Remove this target once the infrastructure for testing in netcoreapp1.1 is ready -->
+  <Target Name="RemoveUnwantedTestMonikers" Condition="'$(TargetGroup)'=='netstandard1.7'" BeforeTargets="CopyTestToTestDirectory">
+    <ItemGroup>
+        <TestNugetTargetMoniker Remove=".NETCoreApp,Version=v1.1" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/dir.targets
+++ b/dir.targets
@@ -58,12 +58,4 @@
     </SupplementalTestData>
   </ItemGroup>
 
-  
-  <!-- ToDo: Remove this target once the infrastructure for testing in netcoreapp1.1 is ready -->
-  <Target Name="RemoveUnwantedTestMonikers" Condition="'$(TargetGroup)'=='netstandard1.7'" BeforeTargets="CopyTestToTestDirectory">
-    <ItemGroup>
-        <TestNugetTargetMoniker Remove=".NETCoreApp,Version=v1.1" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/src/Common/src/System/Collections/CompatibleComparer.cs
+++ b/src/Common/src/System/Collections/CompatibleComparer.cs
@@ -6,6 +6,9 @@
 
 namespace System.Collections
 {
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class CompatibleComparer : IEqualityComparer
     {
         private readonly IHashCodeProvider _hcp;

--- a/src/Common/src/System/Collections/CompatibleComparer.cs
+++ b/src/Common/src/System/Collections/CompatibleComparer.cs
@@ -6,9 +6,7 @@
 
 namespace System.Collections
 {
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class CompatibleComparer : IEqualityComparer
     {
         private readonly IHashCodeProvider _hcp;

--- a/src/Common/src/System/Collections/HashHelpers.cs
+++ b/src/Common/src/System/Collections/HashHelpers.cs
@@ -17,9 +17,7 @@ using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime;
 using System.Runtime.CompilerServices;
-#if netstandard17
 using System.Runtime.Serialization;
-#endif
 using System.Threading;
 
 namespace System.Collections
@@ -83,12 +81,10 @@ namespace System.Collections
         // This is the maximum prime smaller than Array.MaxArrayLength
         public const int MaxPrimeArrayLength = 0x7FEFFFFD;
 
-#if netstandard17
         private static ConditionalWeakTable<object, SerializationInfo> s_serializationInfoTable;
 
         internal static ConditionalWeakTable<object, SerializationInfo> SerializationInfoTable => LazyInitializer.EnsureInitialized(ref s_serializationInfoTable);
 
         internal static object GetEqualityComparerForSerialization(object comparer) => comparer;
-#endif
     }
 }

--- a/src/Common/src/System/Collections/HashHelpers.cs
+++ b/src/Common/src/System/Collections/HashHelpers.cs
@@ -17,6 +17,9 @@ using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime;
 using System.Runtime.CompilerServices;
+#if netstandard17
+using System.Runtime.Serialization;
+#endif
 using System.Threading;
 
 namespace System.Collections
@@ -79,5 +82,13 @@ namespace System.Collections
 
         // This is the maximum prime smaller than Array.MaxArrayLength
         public const int MaxPrimeArrayLength = 0x7FEFFFFD;
+
+#if netstandard17
+        private static ConditionalWeakTable<object, SerializationInfo> s_serializationInfoTable;
+
+        internal static ConditionalWeakTable<object, SerializationInfo> SerializationInfoTable => LazyInitializer.EnsureInitialized(ref s_serializationInfoTable);
+
+        internal static object GetEqualityComparerForSerialization(object comparer) => comparer;
+#endif
     }
 }

--- a/src/Common/tests/System/Collections/IEnumerable.Generic.Serialization.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.Generic.Serialization.Tests.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization.Formatters.Binary;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public abstract partial class IEnumerable_Generic_Tests<T> : TestBase<T>
+    {
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void IGenericSharedAPI_SerializeDeserialize(int count)
+        {
+            IEnumerable<T> expected = GenericIEnumerableFactory(count);
+
+            var bf = new BinaryFormatter();
+            using (var ms = new MemoryStream())
+            {
+                bf.Serialize(ms, expected);
+                ms.Position = 0;
+                IEnumerable<T> actual = (IEnumerable<T>)bf.Deserialize(ms);
+
+                if (Order == EnumerableOrder.Sequential)
+                {
+                    Assert.Equal(expected, actual);
+                }
+                else
+                {
+                    var expectedSet = new HashSet<T>(expected);
+                    var actualSet = new HashSet<T>(actual);
+                    Assert.Subset(expectedSet, actualSet);
+                    Assert.Subset(actualSet, expectedSet);
+                }
+            }
+        }
+    }
+}

--- a/src/Common/tests/System/Collections/IEnumerable.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.Generic.Tests.cs
@@ -14,7 +14,7 @@ namespace System.Collections.Tests
     /// Contains tests that ensure the correctness of any class that implements the generic
     /// IEnumerable interface.
     /// </summary>
-    public abstract class IEnumerable_Generic_Tests<T> : TestBase<T>
+    public abstract partial class IEnumerable_Generic_Tests<T> : TestBase<T>
     {
         #region IEnumerable<T> Helper Methods
 
@@ -731,39 +731,6 @@ namespace System.Collections.Tests
             }
         }
 
-        #endregion
-
-        #region Serialization
-        #if netstandard17
-        
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IGenericSharedAPI_SerializeDeserialize(int count)
-        {
-            IEnumerable<T> expected = GenericIEnumerableFactory(count);
-
-            var bf = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
-            using (var ms = new MemoryStream())
-            {
-                bf.Serialize(ms, expected);
-                ms.Position = 0;
-                IEnumerable<T> actual = (IEnumerable<T>)bf.Deserialize(ms);
-
-                if (Order == EnumerableOrder.Sequential)
-                {
-                    Assert.Equal(expected, actual);
-                }
-                else
-                {
-                    var expectedSet = new HashSet<T>(expected);
-                    var actualSet = new HashSet<T>(actual);
-                    Assert.Subset(expectedSet, actualSet);
-                    Assert.Subset(actualSet, expectedSet);
-                }
-            }
-        }
-        
-        #endif
         #endregion
     }
 }

--- a/src/Common/tests/System/Collections/IEnumerable.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.Generic.Tests.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace System.Collections.Tests
@@ -729,6 +731,39 @@ namespace System.Collections.Tests
             }
         }
 
+        #endregion
+
+        #region Serialization
+        #if netstandard17
+        
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void IGenericSharedAPI_SerializeDeserialize(int count)
+        {
+            IEnumerable<T> expected = GenericIEnumerableFactory(count);
+
+            var bf = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+            using (var ms = new MemoryStream())
+            {
+                bf.Serialize(ms, expected);
+                ms.Position = 0;
+                IEnumerable<T> actual = (IEnumerable<T>)bf.Deserialize(ms);
+
+                if (Order == EnumerableOrder.Sequential)
+                {
+                    Assert.Equal(expected, actual);
+                }
+                else
+                {
+                    var expectedSet = new HashSet<T>(expected);
+                    var actualSet = new HashSet<T>(actual);
+                    Assert.Subset(expectedSet, actualSet);
+                    Assert.Subset(actualSet, expectedSet);
+                }
+            }
+        }
+        
+        #endif
         #endregion
     }
 }

--- a/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Serialization.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Serialization.Tests.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization.Formatters.Binary;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public abstract partial class IEnumerable_NonGeneric_Tests : TestBase
+    {
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void IGenericSharedAPI_SerializeDeserialize(int count)
+        {
+            IEnumerable expected = NonGenericIEnumerableFactory(count);
+
+            var bf = new BinaryFormatter();
+            using (var ms = new MemoryStream())
+            {
+                bf.Serialize(ms, expected);
+                ms.Position = 0;
+                IEnumerable actual = (IEnumerable)bf.Deserialize(ms);
+
+                if (Order == EnumerableOrder.Sequential)
+                {
+                    Assert.Equal(expected, actual);
+                }
+                else
+                {
+                    var expectedSet = new HashSet<object>(expected.Cast<object>());
+                    var actualSet = new HashSet<object>(actual.Cast<object>());
+                    Assert.Subset(expectedSet, actualSet);
+                    Assert.Subset(actualSet, expectedSet);
+                }
+            }
+        }
+    }
+}

--- a/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Tests.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace System.Collections.Tests
@@ -55,6 +58,20 @@ namespace System.Collections.Tests
         /// false.
         /// </summary>
         protected virtual bool Enumerator_Current_UndefinedOperation_Throws => false;
+
+        /// <summary>
+        /// Specifies whether this IEnumerable follows some sort of ordering pattern.
+        /// </summary>
+        protected virtual EnumerableOrder Order => EnumerableOrder.Sequential;
+
+        /// <summary>
+        /// An enum to allow specification of the order of the Enumerable. Used in validation for enumerables.
+        /// </summary>
+        protected enum EnumerableOrder
+        {
+            Unspecified,
+            Sequential
+        }
 
         #endregion
 
@@ -300,6 +317,39 @@ namespace System.Collections.Tests
             });
         }
 
+        #endregion
+
+        #region Serialization
+        #if netstandard17
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void IGenericSharedAPI_SerializeDeserialize(int count)
+        {
+            IEnumerable expected = NonGenericIEnumerableFactory(count);
+
+            var bf = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+            using (var ms = new MemoryStream())
+            {
+                bf.Serialize(ms, expected);
+                ms.Position = 0;
+                IEnumerable actual = (IEnumerable)bf.Deserialize(ms);
+
+                if (Order == EnumerableOrder.Sequential)
+                {
+                    Assert.Equal(expected, actual);
+                }
+                else
+                {
+                    var expectedSet = new HashSet<object>(expected.Cast<object>());
+                    var actualSet = new HashSet<object>(actual.Cast<object>());
+                    Assert.Subset(expectedSet, actualSet);
+                    Assert.Subset(actualSet, expectedSet);
+                }
+            }
+        }
+        
+        #endif
         #endregion
     }
 }

--- a/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Tests.cs
@@ -14,7 +14,7 @@ namespace System.Collections.Tests
     /// Contains tests that ensure the correctness of any class that implements the nongeneric
     /// IEnumerable interface
     /// </summary>
-    public abstract class IEnumerable_NonGeneric_Tests : TestBase
+    public abstract partial class IEnumerable_NonGeneric_Tests : TestBase
     {
         #region IEnumerable Helper Methods
 
@@ -317,39 +317,6 @@ namespace System.Collections.Tests
             });
         }
 
-        #endregion
-
-        #region Serialization
-        #if netstandard17
-
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IGenericSharedAPI_SerializeDeserialize(int count)
-        {
-            IEnumerable expected = NonGenericIEnumerableFactory(count);
-
-            var bf = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
-            using (var ms = new MemoryStream())
-            {
-                bf.Serialize(ms, expected);
-                ms.Position = 0;
-                IEnumerable actual = (IEnumerable)bf.Deserialize(ms);
-
-                if (Order == EnumerableOrder.Sequential)
-                {
-                    Assert.Equal(expected, actual);
-                }
-                else
-                {
-                    var expectedSet = new HashSet<object>(expected.Cast<object>());
-                    var actualSet = new HashSet<object>(actual.Cast<object>());
-                    Assert.Subset(expectedSet, actualSet);
-                    Assert.Subset(actualSet, expectedSet);
-                }
-            }
-        }
-        
-        #endif
         #endregion
     }
 }

--- a/src/Common/tests/System/Collections/TestingTypes.cs
+++ b/src/Common/tests/System/Collections/TestingTypes.cs
@@ -147,9 +147,7 @@ namespace System.Collections.Tests
 
     #region TestClasses
 
-#if netstandard17
     [Serializable]
-#endif
     public struct SimpleInt : IStructuralComparable, IStructuralEquatable, IComparable, IComparable<SimpleInt>
     {
         private int _val;
@@ -197,9 +195,7 @@ namespace System.Collections.Tests
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     public class WrapStructural_Int : IEqualityComparer<int>, IComparer<int>
     {
         public int Compare(int x, int y)
@@ -218,9 +214,7 @@ namespace System.Collections.Tests
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     public class WrapStructural_SimpleInt : IEqualityComparer<SimpleInt>, IComparer<SimpleInt>
     {
         public int Compare(SimpleInt x, SimpleInt y)

--- a/src/Common/tests/System/Collections/TestingTypes.cs
+++ b/src/Common/tests/System/Collections/TestingTypes.cs
@@ -147,6 +147,9 @@ namespace System.Collections.Tests
 
     #region TestClasses
 
+#if netstandard17
+    [Serializable]
+#endif
     public struct SimpleInt : IStructuralComparable, IStructuralEquatable, IComparable, IComparable<SimpleInt>
     {
         private int _val;
@@ -194,6 +197,9 @@ namespace System.Collections.Tests
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     public class WrapStructural_Int : IEqualityComparer<int>, IComparer<int>
     {
         public int Compare(int x, int y)
@@ -212,6 +218,9 @@ namespace System.Collections.Tests
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     public class WrapStructural_SimpleInt : IEqualityComparer<SimpleInt>, IComparer<SimpleInt>
     {
         public int Compare(SimpleInt x, SimpleInt y)

--- a/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
+++ b/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>System.Collections.Concurrent</RootNamespace>
     <DefineConstants>FEATURE_TRACING</DefineConstants>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.3</PackageTargetFramework>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 using System.Threading;
 
 namespace System.Collections.Concurrent
@@ -37,17 +38,24 @@ namespace System.Collections.Concurrent
     /// </remarks>
     [DebuggerTypeProxy(typeof(IProducerConsumerCollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
+    [Serializable]
     public class ConcurrentBag<T> : IProducerConsumerCollection<T>, IReadOnlyCollection<T>
     {
         // ThreadLocalList object that contains the data per thread
+        [NonSerialized]
         private ThreadLocal<ThreadLocalList> _locals;
 
         // This head and tail pointers points to the first and last local lists, to allow enumeration on the thread locals objects
+        [NonSerialized]
         private volatile ThreadLocalList _headList, _tailList;
 
         // A flag used to tell the operations thread that it must synchronize the operation, this flag is set/unset within
         // GlobalListsLock lock
+        [NonSerialized]
         private bool _needSync;
+
+        // Used for custom serialization.
+        private T[] _serializationArray;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentBag{T}"/>
@@ -93,6 +101,38 @@ namespace System.Collections.Concurrent
                     list.Add(item, false);
                 }
             }
+        }
+
+        /// <summary>Get the data array to be serialized.</summary>
+        [OnSerializing]
+        private void OnSerializing(StreamingContext context)
+        {
+            // save the data into the serialization array to be saved
+            _serializationArray = ToArray();
+        }
+
+        /// <summary>Clear the serialized array.</summary>
+        [OnSerialized]
+        private void OnSerialized(StreamingContext context)
+        {
+            _serializationArray = null;
+        }
+
+        /// <summary>Construct the stack from a previously seiralized one.</summary>
+        [OnDeserialized]
+        private void OnDeserialized(StreamingContext context)
+        {
+            _locals = new ThreadLocal<ThreadLocalList>();
+
+            ThreadLocalList list = GetThreadList(true);
+            foreach (T item in _serializationArray)
+            {
+                list.Add(item, false);
+            }
+            _headList = list;
+            _tailList = list;
+
+            _serializationArray = null;
         }
 
         /// <summary>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -17,6 +17,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using System.Threading;
 
 namespace System.Collections.Concurrent
@@ -32,6 +33,7 @@ namespace System.Collections.Concurrent
     /// </remarks>
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
+    [Serializable]
     public class ConcurrentDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
     {
         /// <summary>
@@ -54,10 +56,17 @@ namespace System.Collections.Concurrent
             }
         }
 
+        [NonSerialized]
         private volatile Tables _tables; // Internal tables of the dictionary
-        private readonly IEqualityComparer<TKey> _comparer; // Key equality comparer
+        private IEqualityComparer<TKey> _comparer; // Key equality comparer
+        [NonSerialized]
         private readonly bool _growLockArray; // Whether to dynamically increase the size of the striped lock
+        [NonSerialized]
         private int _budget; // The maximum number of elements per lock before a resize operation is triggered
+
+        private KeyValuePair<TKey, TValue>[] _serializationArray; // Used for custom serialization
+        private int _serializationConcurrencyLevel; // used to save the concurrency level in serialization
+        private int _serializationCapacity; // used to save the capacity in serialization
 
         // The default capacity, i.e. the initial # of buckets. When choosing this value, we are making
         // a trade-off between the size of a very small dictionary, and the number of resizes when
@@ -291,6 +300,43 @@ namespace System.Collections.Concurrent
             _budget = buckets.Length / locks.Length;
         }
 
+        /// <summary>Get the data array to be serialized.</summary>
+        [OnSerializing]
+        private void OnSerializing(StreamingContext context)
+        {
+            Tables tables = _tables;
+
+            // save the data into the serialization array to be saved
+            _serializationArray = ToArray();
+            _serializationConcurrencyLevel = tables._locks.Length;
+            _serializationCapacity = tables._buckets.Length;
+        }
+
+        /// <summary>Clear the serialized state.</summary>
+        [OnSerialized]
+        private void OnSerialized(StreamingContext context)
+        {
+            _serializationArray = null;
+        }
+
+        /// <summary>Construct the dictionary from a previously serialized one</summary>
+        [OnDeserialized]
+        private void OnDeserialized(StreamingContext context)
+        {
+            KeyValuePair<TKey, TValue>[] array = _serializationArray;
+
+            var buckets = new Node[_serializationCapacity];
+            var countPerLock = new int[_serializationConcurrencyLevel];
+            var locks = new object[_serializationConcurrencyLevel];
+            for (int i = 0; i < locks.Length; i++)
+            {
+                locks[i] = new object();
+            }
+            _tables = new Tables(buckets, locks, countPerLock);
+
+            InitializeFromCollection(array);
+            _serializationArray = null;
+        }
 
         /// <summary>
         /// Attempts to add the specified key and value to the <see cref="ConcurrentDictionary{TKey,
@@ -1889,6 +1935,7 @@ namespace System.Collections.Concurrent
         /// <summary>
         /// A node in a singly-linked list representing a particular hash table bucket.
         /// </summary>
+        [Serializable]
         private sealed class Node
         {
             internal readonly TKey _key;
@@ -1909,6 +1956,7 @@ namespace System.Collections.Concurrent
         /// A private class to represent enumeration over the dictionary that implements the 
         /// IDictionaryEnumerator interface.
         /// </summary>
+        [Serializable]
         private sealed class DictionaryEnumerator : IDictionaryEnumerator
         {
             IEnumerator<KeyValuePair<TKey, TValue>> _enumerator; // Enumerator over the dictionary.

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -12,6 +12,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.Serialization;
 using System.Threading;
 
 namespace System.Collections.Concurrent
@@ -36,11 +37,13 @@ namespace System.Collections.Concurrent
     /// </remarks>
     [DebuggerDisplay("Count = {Count}")]
     [DebuggerTypeProxy(typeof(IProducerConsumerCollectionDebugView<>))]
+    [Serializable]
     public class ConcurrentStack<T> : IProducerConsumerCollection<T>, IReadOnlyCollection<T>
     {
         /// <summary>
         /// A simple (internal) node type used to store elements of concurrent stacks and queues.
         /// </summary>
+        [Serializable]
         private class Node
         {
             internal readonly T _value; // Value of the node.
@@ -57,9 +60,12 @@ namespace System.Collections.Concurrent
             }
         }
 
+        [NonSerialized]
         private volatile Node _head; // The stack is a singly linked list, and only remembers the head.
 
         private const int BACKOFF_MAX_YIELDS = 8; // Arbitrary number to cap backoff.
+
+        private T[] _serializationArray; // Used for custom serialization
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentStack{T}"/>
@@ -84,6 +90,45 @@ namespace System.Collections.Concurrent
                 throw new ArgumentNullException(nameof(collection));
             }
             InitializeFromCollection(collection);
+        }
+
+        /// <summary>Get the data array to be serialized.</summary>
+        [OnSerializing]
+        private void OnSerializing(StreamingContext context)
+        {
+            // save the data into the serialization array to be saved
+            _serializationArray = ToArray();
+        }
+
+        /// <summary>
+        /// Construct the stack from a previously seiralized one
+        /// </summary>
+        [OnDeserialized]
+        private void OnDeserialized(StreamingContext context)
+        {
+            Debug.Assert(_serializationArray != null);
+
+            // Add the elements to our stack.  We need to add them from head-to-tail, to
+            // preserve the original ordering of the stack before serialization.
+            Node prevNode = null, head = null;
+            for (int i = 0; i < _serializationArray.Length; i++)
+            {
+                Node currNode = new Node(_serializationArray[i]);
+
+                if (prevNode == null)
+                {
+                    head = currNode;
+                }
+                else
+                {
+                    prevNode._next = currNode;
+                }
+
+                prevNode = currNode;
+            }
+
+            _head = head;
+            _serializationArray = null;
         }
 
         /// <summary>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
@@ -23,6 +23,7 @@ namespace System.Collections.Concurrent
     /// non-blocking.  These behaviors can be overridden via this enumeration.
     /// </summary>
     [Flags]
+    [Serializable]
     public enum EnumerablePartitionerOptions
     {
         /// <summary>

--- a/src/System.Collections.Concurrent/src/project.json
+++ b/src/System.Collections.Concurrent/src/project.json
@@ -1,6 +1,6 @@
 {
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
         "System.Collections": "4.0.10",
@@ -8,16 +8,16 @@
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
         "System.Diagnostics.Tracing": "4.0.20",
-        "System.Globalization": "4.0.10",
+        "System.Globalization": "4.0.12-beta-devapi-24422-01",
         "System.Reflection": "4.0.10",
         "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.0.20",
+        "System.Runtime": "4.2.0-beta-devapi-24422-01",
         "System.Runtime.Extensions": "4.0.10",
         "System.Threading": "4.0.10",
         "System.Threading.Tasks": "4.0.10"
       },
       "imports": [
-        "dotnet5.4"
+        "dotnet5.8"
       ]
     },
     "net46": {

--- a/src/System.Collections.Concurrent/src/project.json
+++ b/src/System.Collections.Concurrent/src/project.json
@@ -8,10 +8,10 @@
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
         "System.Diagnostics.Tracing": "4.0.20",
-        "System.Globalization": "4.0.12-beta-devapi-24422-01",
+        "System.Globalization": "4.0.12-beta-devapi-24424-01",
         "System.Reflection": "4.0.10",
         "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.2.0-beta-devapi-24422-01",
+        "System.Runtime": "4.2.0-beta-devapi-24424-01",
         "System.Runtime.Extensions": "4.0.10",
         "System.Threading": "4.0.10",
         "System.Threading.Tasks": "4.0.10"

--- a/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Collections.Tests;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -10,8 +13,14 @@ using Xunit;
 namespace System.Collections.Concurrent.Tests
 {
     /// <summary>The class that contains the unit tests of the LazyInit.</summary>
-    public class ConcurrentBagTests
+    public class ConcurrentBagTests : IEnumerable_Generic_Tests<int>
     {
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
+        protected override IEnumerable<int> GenericIEnumerableFactory(int count) => new ConcurrentBag<int>(Enumerable.Range(0, count));
+        protected override int CreateT(int seed) => new Random(seed).Next();
+        protected override EnumerableOrder Order => EnumerableOrder.Unspecified;
+        protected override bool ResetImplemented => true;
+
         [Fact]
         public static void TestBasicScenarios()
         {

--- a/src/System.Collections.Concurrent/tests/ConcurrentQueueTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentQueueTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Tests;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -11,8 +12,15 @@ using Xunit;
 
 namespace System.Collections.Concurrent.Tests
 {
-    public class ConcurrentQueueTests
+    public class ConcurrentQueueTests : IEnumerable_Generic_Tests<int>
     {
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
+        protected override IEnumerable<int> GenericIEnumerableFactory(int count) => new ConcurrentQueue<int>(Enumerable.Range(0, count));
+        protected override int CreateT(int seed) => new Random(seed).Next();
+        protected override EnumerableOrder Order => EnumerableOrder.Unspecified;
+        protected override bool ResetImplemented => false;
+        protected override bool IEnumerable_Generic_Enumerator_Current_EnumerationNotStarted_ThrowsInvalidOperationException => false;
+
         [Fact]
         public void Ctor_NoArg_ItemsAndCountMatch()
         {

--- a/src/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
@@ -3,15 +3,24 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Tests;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Collections.Concurrent.Tests
 {
-    public class ConcurrentStackTests
+    public class ConcurrentStackTests : IEnumerable_Generic_Tests<int>
     {
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
+        protected override IEnumerable<int> GenericIEnumerableFactory(int count) => new ConcurrentStack<int>(Enumerable.Range(0, count));
+        protected override int CreateT(int seed) => new Random(seed).Next();
+        protected override EnumerableOrder Order => EnumerableOrder.Unspecified;
+        protected override bool ResetImplemented => false;
+        protected override bool IEnumerable_Generic_Enumerator_Current_EnumerationNotStarted_ThrowsInvalidOperationException => false;
+
         [Fact]
         public static void Test0_Empty()
         {

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.builds
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.builds
@@ -4,6 +4,10 @@
   <ItemGroup>
     <Project Include="System.Collections.Concurrent.Tests.csproj"/>
     <Project Include="System.Collections.Concurrent.Tests.csproj">
+      <TargetGroup>netstandard1.7</TargetGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+    </Project>
+    <Project Include="System.Collections.Concurrent.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -8,8 +8,20 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Concurrent.Tests</AssemblyName>
     <RootNamespace>System.Collections.Concurrent.Tests</RootNamespace>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
+    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <!-- 
+        Until we get first class support for NS1.7 and Netcoreapp1.1 
+        we need to hard code $(TestTFM) and $(TestNugetTargetMoniker) 
+        in the project file. 
+      --> 
+    <TestTFM Condition="'$(TargetGroup)'=='netstandard1.7'">netcoreapp1.1</TestTFM> 
   </PropertyGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
+      <Folder>netcoreapp1.1</Folder>
+    </TestNugetTargetMoniker>
+  </ItemGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -105,5 +105,11 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <!-- ToDo: Remove this target once the infrastructure for testing in netcoreapp1.1 is ready -->
+  <Target Name="RemoveUnwantedTestMonikers" Condition="'$(TargetGroup)'=='netstandard1.7'" BeforeTargets="CopyTestToTestDirectory">
+    <ItemGroup>
+      <TestNugetTargetMoniker Remove=".NETCoreApp,Version=v1.1" />
+    </ItemGroup>
+  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -96,6 +96,19 @@
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'!='netstandard1.7'">
+    <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
+      <Link>Common\System\SerializableAttribute.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs" >
+      <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Serialization.Tests.cs" >
+      <Link>Common\System\Collections\IEnumerable.Generic.Serialization.Tests.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Collections.Concurrent.pkgproj">
       <Project>{96AA2060-C846-4E56-9509-E8CB9C114C8F}</Project>

--- a/src/System.Collections.Concurrent/tests/project.json
+++ b/src/System.Collections.Concurrent/tests/project.json
@@ -26,7 +26,7 @@
     "netstandard1.3": {},
     "netstandard1.7": {
 		"dependencies": {
-	        "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24422-01",
+	        "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24424-01",
 		}
 	}
   },

--- a/src/System.Collections.Concurrent/tests/project.json
+++ b/src/System.Collections.Concurrent/tests/project.json
@@ -23,7 +23,12 @@
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-03"
   },
   "frameworks": {
-    "netstandard1.3": {}
+    "netstandard1.3": {},
+    "netstandard1.7": {
+		"dependencies": {
+	        "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24422-01",
+		}
+	}
   },
   "supports": {
     "coreFx.Test.netcore50": {},
@@ -31,6 +36,22 @@
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},
-    "coreFx.Test.net463": {}
+    "coreFx.Test.net463": {}, 
+    "coreFx.Test.netcoreapp1.1-ns17": { 
+      "netstandard1.7": [ 
+        "win7-x86", 
+        "win7-x64", 
+        "win10-arm64", 
+        "osx.10.10-x64", 
+        "centos.7-x64", 
+        "debian.8-x64", 
+        "rhel.7-x64", 
+        "ubuntu.14.04-x64", 
+        "ubuntu.16.04-x64", 
+        "fedora.23-x64", 
+        "linux-x64", 
+        "opensuse.13.2-x64" 
+      ] 
+    } 
   }
 }

--- a/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
+++ b/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
@@ -101,6 +101,9 @@
     <Compile Include="$(CommonTestPath)\System\Collections\TestingTypes.cs">
       <Link>Common\System\Collections\TestingTypes.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
+      <Link>Common\System\SerializableAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="ClassDiagram1.cd" />

--- a/src/System.Collections.NonGeneric/ref/System.Collections.NonGeneric.cs
+++ b/src/System.Collections.NonGeneric/ref/System.Collections.NonGeneric.cs
@@ -112,12 +112,14 @@ namespace System.Collections
         void System.Collections.IList.Insert(int index, object value) { }
         void System.Collections.IList.Remove(object value) { }
     }
-    public sealed partial class Comparer : System.Collections.IComparer
+    public sealed partial class Comparer : System.Collections.IComparer, System.Runtime.Serialization.ISerializable
     {
         public static readonly System.Collections.Comparer Default;
         public static readonly System.Collections.Comparer DefaultInvariant;
         public Comparer(System.Globalization.CultureInfo culture) { }
+        private Comparer(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public int Compare(object a, object b) { return default(int); }
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public abstract partial class DictionaryBase : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
     {
@@ -150,7 +152,7 @@ namespace System.Collections
         void System.Collections.IDictionary.Remove(object key) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
     }
-    public partial class Hashtable : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+    public partial class Hashtable : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Runtime.Serialization.ISerializable, System.Runtime.Serialization.IDeserializationCallback
     {
         public Hashtable() { }
         public Hashtable(System.Collections.IDictionary d) { }
@@ -172,6 +174,7 @@ namespace System.Collections
         public Hashtable(int capacity, float loadFactor, System.Collections.IEqualityComparer equalityComparer) { }
         [System.ObsoleteAttribute("Please use Hashtable(int, float, IEqualityComparer) instead.")]
         public Hashtable(int capacity, float loadFactor, System.Collections.IHashCodeProvider hcp, System.Collections.IComparer comparer) { }
+        protected Hashtable(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         [System.ObsoleteAttribute("Please use KeyComparer properties.")]
         protected System.Collections.IComparer comparer { get { return default(System.Collections.IComparer); } set { } }
         public virtual int Count { get { return default(int); } }
@@ -194,7 +197,9 @@ namespace System.Collections
         public virtual void CopyTo(System.Array array, int arrayIndex) { }
         public virtual System.Collections.IDictionaryEnumerator GetEnumerator() { return default(System.Collections.IDictionaryEnumerator); }
         protected virtual int GetHash(object key) { return default(int); }
+        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         protected virtual bool KeyEquals(object item, object key) { return default(bool); }
+        public virtual void OnDeserialization(object sender) { }
         public virtual void Remove(object key) { }
         public static System.Collections.Hashtable Synchronized(System.Collections.Hashtable table) { return default(System.Collections.Hashtable); }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }

--- a/src/System.Collections.NonGeneric/ref/project.json
+++ b/src/System.Collections.NonGeneric/ref/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.0",
-    "System.Globalization": "4.0.0"
+    "System.Runtime": "4.2.0-beta-devapi-24422-01",
+    "System.Globalization": "4.0.12-beta-devapi-24422-01"
   },
   "frameworks": {
     "netstandard1.7": {

--- a/src/System.Collections.NonGeneric/ref/project.json
+++ b/src/System.Collections.NonGeneric/ref/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "System.Runtime": "4.2.0-beta-devapi-24422-01",
-    "System.Globalization": "4.0.12-beta-devapi-24422-01"
+    "System.Runtime": "4.2.0-beta-devapi-24424-01",
+    "System.Globalization": "4.0.12-beta-devapi-24424-01"
   },
   "frameworks": {
     "netstandard1.7": {

--- a/src/System.Collections.NonGeneric/src/Resources/Strings.resx
+++ b/src/System.Collections.NonGeneric/src/Resources/Strings.resx
@@ -219,4 +219,22 @@
   <data name="Arg_CannotMixComparisonInfrastructure" xml:space="preserve">
     <value>The usage of IKeyComparer and IHashCodeProvider/IComparer interfaces cannot be mixed; use one or the other.</value>
   </data>
+  <data name="Serialization_InsufficientState" xml:space="preserve">
+    <value>Insufficient state to return the real object.</value>
+  </data>
+  <data name="Serialization_InvalidOnDeser" xml:space="preserve">
+    <value>OnDeserialization method was called while the object was not being deserialized.</value>
+  </data>
+  <data name="Serialization_KeyValueDifferentSizes" xml:space="preserve">
+    <value>The keys and values arrays have different sizes.</value>
+  </data>
+  <data name="Serialization_MissingKeys" xml:space="preserve">
+    <value>The Keys for this Hashtable are missing.</value>
+  </data>
+  <data name="Serialization_MissingValues" xml:space="preserve">
+    <value>The Values for this Hashtable are missing.</value>
+  </data>
+  <data name="Serialization_NullKey" xml:space="preserve">
+    <value>One of the serialized keys is null.</value>
+  </data>
 </root>

--- a/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.builds
+++ b/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.builds
@@ -4,12 +4,6 @@
   <ItemGroup>
     <Project Include="System.Collections.NonGeneric.csproj" />
     <Project Include="System.Collections.NonGeneric.csproj">
-      <TargetGroup>netstandard1.3</TargetGroup>
-    </Project>
-    <Project Include="System.Collections.NonGeneric.csproj">
-      <TargetGroup>net46</TargetGroup>
-    </Project>
-    <Project Include="System.Collections.NonGeneric.csproj">
       <TargetGroup>net463</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
+++ b/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
@@ -9,7 +9,7 @@
     <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">4.0.2.0</AssemblyVersion>
     <ContractProject Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">../ref/4.0.1/System.Collections.NonGeneric.depproj</ContractProject>
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46' OR '$(TargetGroup)'=='net463'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
     <DefineConstants Condition="'$(AssemblyVersion)'=='4.1.0.0'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>

--- a/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
+++ b/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
@@ -6,23 +6,18 @@
     <RootNamespace>System.Collections.NonGeneric</RootNamespace>
     <AssemblyName>System.Collections.NonGeneric</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">4.0.2.0</AssemblyVersion>
-    <ContractProject Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">../ref/4.0.1/System.Collections.NonGeneric.depproj</ContractProject>
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46' OR '$(TargetGroup)'=='net463'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net463'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
-    <DefineConstants Condition="'$(AssemblyVersion)'=='4.1.0.0'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetGroup)' != 'net463'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
     <Compile Include="System\Collections\ArrayList.cs" />
     <Compile Include="System\Collections\CaseInsensitiveComparer.cs" />
     <Compile Include="System\Collections\CaseInsensitiveHashCodeProvider.cs" />
@@ -41,7 +36,7 @@
       <Link>Common\System\Collections\CompatibleComparer.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="mscorlib" />
   </ItemGroup>

--- a/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
+++ b/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
@@ -11,6 +11,7 @@
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <DefineConstants Condition="'$(AssemblyVersion)'=='4.1.0.0'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -27,7 +28,6 @@
     <Compile Include="System\Collections\CaseInsensitiveHashCodeProvider.cs" />
     <Compile Include="System\Collections\CollectionBase.cs" />
     <Compile Include="System\Collections\Comparer.cs" />
-    <Compile Include="System\Collections\CompatibleComparer.cs" />
     <Compile Include="System\Collections\DictionaryBase.cs" />
     <Compile Include="System\Collections\Hashtable.cs" />
     <Compile Include="System\Collections\IHashCodeProvider.cs" />
@@ -37,6 +37,9 @@
     <Compile Include="System\Collections\SortedList.cs" />
     <Compile Include="System\Collections\Stack.cs" />
     <Compile Include="System\Collections\Specialized\CollectionsUtil.cs" />
+    <Compile Include="$(CommonPath)\System\Collections\CompatibleComparer.cs">
+      <Link>Common\System\Collections\CompatibleComparer.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="System" />

--- a/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
@@ -33,12 +33,18 @@ namespace System.Collections
 #endif
     [DebuggerTypeProxy(typeof(System.Collections.ArrayList.ArrayListDebugView))]
     [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+    [Serializable]
+#endif
     public class ArrayList : IList
     {
         private Object[] _items;
         [ContractPublicPropertyName("Count")]
         private int _size;
         private int _version;
+#if netstandard17
+        [NonSerialized]
+#endif
         private Object _syncRoot;
 
         private const int _defaultCapacity = 4;
@@ -857,6 +863,9 @@ namespace System.Collections
 
         // This class wraps an IList, exposing it as a ArrayList
         // Note this requires reimplementing half of ArrayList...
+#if netstandard17
+        [Serializable]
+#endif
         private class IListWrapper : ArrayList
         {
             private IList _list;
@@ -1261,6 +1270,9 @@ namespace System.Collections
 
             // This is the enumerator for an IList that's been wrapped in another
             // class that implements all of ArrayList's methods.
+#if netstandard17
+            [Serializable]
+#endif
             private sealed class IListWrapperEnumWrapper : IEnumerator
             {
                 private IEnumerator _en;
@@ -1315,7 +1327,9 @@ namespace System.Collections
             }
         }
 
-
+#if netstandard17
+        [Serializable]
+#endif
         private class SyncArrayList : ArrayList
         {
             private ArrayList _list;
@@ -1671,6 +1685,9 @@ namespace System.Collections
         }
 
 
+#if netstandard17
+        [Serializable]
+#endif
         private class SyncIList : IList
         {
             private IList _list;
@@ -1800,6 +1817,9 @@ namespace System.Collections
             }
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private class FixedSizeList : IList
         {
             private IList _list;
@@ -1892,6 +1912,9 @@ namespace System.Collections
             }
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private class FixedSizeArrayList : ArrayList
         {
             private ArrayList _list;
@@ -2113,6 +2136,9 @@ namespace System.Collections
             }
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private class ReadOnlyList : IList
         {
             private IList _list;
@@ -2205,6 +2231,9 @@ namespace System.Collections
             }
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private class ReadOnlyArrayList : ArrayList
         {
             private ArrayList _list;
@@ -2426,6 +2455,9 @@ namespace System.Collections
         // Implements an enumerator for a ArrayList. The enumerator uses the
         // internal version number of the list to ensure that no modifications are
         // made to the list while an enumeration is in progress.
+#if netstandard17
+        [Serializable]
+#endif
         private sealed class ArrayListEnumerator : IEnumerator
         {
             private ArrayList _list;
@@ -2484,6 +2516,9 @@ namespace System.Collections
 
         // Implementation of a generic list subrange. An instance of this class
         // is returned by the default implementation of List.GetRange.
+#if netstandard17
+        [Serializable]
+#endif
         private class Range : ArrayList
         {
             private ArrayList _baseList;
@@ -2917,6 +2952,9 @@ namespace System.Collections
             }
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private sealed class ArrayListEnumeratorSimple : IEnumerator
         {
             private ArrayList _list;

--- a/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
@@ -33,18 +33,14 @@ namespace System.Collections
 #endif
     [DebuggerTypeProxy(typeof(System.Collections.ArrayList.ArrayListDebugView))]
     [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
     [Serializable]
-#endif
     public class ArrayList : IList
     {
         private Object[] _items;
         [ContractPublicPropertyName("Count")]
         private int _size;
         private int _version;
-#if netstandard17
         [NonSerialized]
-#endif
         private Object _syncRoot;
 
         private const int _defaultCapacity = 4;
@@ -863,9 +859,7 @@ namespace System.Collections
 
         // This class wraps an IList, exposing it as a ArrayList
         // Note this requires reimplementing half of ArrayList...
-#if netstandard17
         [Serializable]
-#endif
         private class IListWrapper : ArrayList
         {
             private IList _list;
@@ -1270,9 +1264,7 @@ namespace System.Collections
 
             // This is the enumerator for an IList that's been wrapped in another
             // class that implements all of ArrayList's methods.
-#if netstandard17
             [Serializable]
-#endif
             private sealed class IListWrapperEnumWrapper : IEnumerator
             {
                 private IEnumerator _en;
@@ -1327,9 +1319,7 @@ namespace System.Collections
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class SyncArrayList : ArrayList
         {
             private ArrayList _list;
@@ -1685,9 +1675,7 @@ namespace System.Collections
         }
 
 
-#if netstandard17
         [Serializable]
-#endif
         private class SyncIList : IList
         {
             private IList _list;
@@ -1817,9 +1805,7 @@ namespace System.Collections
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class FixedSizeList : IList
         {
             private IList _list;
@@ -1912,9 +1898,7 @@ namespace System.Collections
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class FixedSizeArrayList : ArrayList
         {
             private ArrayList _list;
@@ -2136,9 +2120,7 @@ namespace System.Collections
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class ReadOnlyList : IList
         {
             private IList _list;
@@ -2231,9 +2213,7 @@ namespace System.Collections
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class ReadOnlyArrayList : ArrayList
         {
             private ArrayList _list;
@@ -2455,9 +2435,7 @@ namespace System.Collections
         // Implements an enumerator for a ArrayList. The enumerator uses the
         // internal version number of the list to ensure that no modifications are
         // made to the list while an enumeration is in progress.
-#if netstandard17
         [Serializable]
-#endif
         private sealed class ArrayListEnumerator : IEnumerator
         {
             private ArrayList _list;
@@ -2516,9 +2494,7 @@ namespace System.Collections
 
         // Implementation of a generic list subrange. An instance of this class
         // is returned by the default implementation of List.GetRange.
-#if netstandard17
         [Serializable]
-#endif
         private class Range : ArrayList
         {
             private ArrayList _baseList;
@@ -2952,9 +2928,7 @@ namespace System.Collections
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private sealed class ArrayListEnumeratorSimple : IEnumerator
         {
             private ArrayList _list;

--- a/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveComparer.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveComparer.cs
@@ -16,9 +16,7 @@ using System.Diagnostics.Contracts;
 
 namespace System.Collections
 {
-#if netstandard17
     [Serializable]
-#endif
     public class CaseInsensitiveComparer : IComparer
     {
         private CompareInfo _compareInfo;

--- a/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveComparer.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveComparer.cs
@@ -16,6 +16,9 @@ using System.Diagnostics.Contracts;
 
 namespace System.Collections
 {
+#if netstandard17
+    [Serializable]
+#endif
     public class CaseInsensitiveComparer : IComparer
     {
         private CompareInfo _compareInfo;

--- a/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveHashCodeProvider.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveHashCodeProvider.cs
@@ -11,9 +11,7 @@ namespace System.Collections
     /// this provides an efficient mechanism for getting the hashcode of the string ignoring case.
     /// </summary>
     [Obsolete("Please use StringComparer instead.")]
-#if netstandard17
     [Serializable]
-#endif
     public class CaseInsensitiveHashCodeProvider : IHashCodeProvider
     {
         private static volatile CaseInsensitiveHashCodeProvider s_invariantCaseInsensitiveHashCodeProvider = null;

--- a/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveHashCodeProvider.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveHashCodeProvider.cs
@@ -11,6 +11,9 @@ namespace System.Collections
     /// this provides an efficient mechanism for getting the hashcode of the string ignoring case.
     /// </summary>
     [Obsolete("Please use StringComparer instead.")]
+#if netstandard17
+    [Serializable]
+#endif
     public class CaseInsensitiveHashCodeProvider : IHashCodeProvider
     {
         private static volatile CaseInsensitiveHashCodeProvider s_invariantCaseInsensitiveHashCodeProvider = null;

--- a/src/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
@@ -15,6 +15,9 @@ using System.Diagnostics.Contracts;
 namespace System.Collections
 {
     // Useful base class for typed read/write collections where items derive from object
+#if netstandard17
+    [Serializable]
+#endif
     public abstract class CollectionBase : IList
     {
         private ArrayList _list;

--- a/src/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
@@ -15,9 +15,7 @@ using System.Diagnostics.Contracts;
 namespace System.Collections
 {
     // Useful base class for typed read/write collections where items derive from object
-#if netstandard17
     [Serializable]
-#endif
     public abstract class CollectionBase : IList
     {
         private ArrayList _list;

--- a/src/System.Collections.NonGeneric/src/System/Collections/Comparer.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Comparer.cs
@@ -13,10 +13,19 @@
 
 using System.Globalization;
 using System.Diagnostics.Contracts;
+#if netstandard17
+using System.Runtime.Serialization;
+#endif
 
 namespace System.Collections
 {
+#if netstandard17
+    [Serializable]
+#endif
     public sealed class Comparer : IComparer
+#if netstandard17
+        , ISerializable
+#endif
     {
         private CompareInfo _compareInfo;
         public static readonly Comparer Default = new Comparer(CultureInfo.CurrentCulture);
@@ -33,6 +42,36 @@ namespace System.Collections
             Contract.EndContractBlock();
             _compareInfo = culture.CompareInfo;
         }
+
+#if netstandard17
+        private Comparer(SerializationInfo info, StreamingContext context)
+        {
+            _compareInfo = null;
+            SerializationInfoEnumerator enumerator = info.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                switch (enumerator.Name)
+                {
+                    case CompareInfoName:
+                        _compareInfo = (CompareInfo)info.GetValue(CompareInfoName, typeof(CompareInfo));
+                        break;
+                }
+            }
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            if (_compareInfo != null)
+            {
+                info.AddValue(CompareInfoName, _compareInfo);
+            }
+        }
+#endif
 
         // Compares two Objects by calling CompareTo.
         // If a == b, 0 is returned.

--- a/src/System.Collections.NonGeneric/src/System/Collections/Comparer.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Comparer.cs
@@ -13,19 +13,12 @@
 
 using System.Globalization;
 using System.Diagnostics.Contracts;
-#if netstandard17
 using System.Runtime.Serialization;
-#endif
 
 namespace System.Collections
 {
-#if netstandard17
     [Serializable]
-#endif
-    public sealed class Comparer : IComparer
-#if netstandard17
-        , ISerializable
-#endif
+    public sealed class Comparer : IComparer, ISerializable
     {
         private CompareInfo _compareInfo;
         public static readonly Comparer Default = new Comparer(CultureInfo.CurrentCulture);
@@ -43,7 +36,6 @@ namespace System.Collections
             _compareInfo = culture.CompareInfo;
         }
 
-#if netstandard17
         private Comparer(SerializationInfo info, StreamingContext context)
         {
             _compareInfo = null;
@@ -71,7 +63,6 @@ namespace System.Collections
                 info.AddValue(CompareInfoName, _compareInfo);
             }
         }
-#endif
 
         // Compares two Objects by calling CompareTo.
         // If a == b, 0 is returned.

--- a/src/System.Collections.NonGeneric/src/System/Collections/DictionaryBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/DictionaryBase.cs
@@ -15,9 +15,7 @@
 namespace System.Collections
 {
     // Useful base class for typed read/write collections where items derive from object
-#if netstandard17
     [Serializable]
-#endif
     public abstract class DictionaryBase : IDictionary
     {
         private Hashtable _hashtable;

--- a/src/System.Collections.NonGeneric/src/System/Collections/DictionaryBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/DictionaryBase.cs
@@ -15,6 +15,9 @@
 namespace System.Collections
 {
     // Useful base class for typed read/write collections where items derive from object
+#if netstandard17
+    [Serializable]
+#endif
     public abstract class DictionaryBase : IDictionary
     {
         private Hashtable _hashtable;

--- a/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
@@ -15,9 +15,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-#if netstandard17
 using System.Runtime.Serialization;
-#endif
 using System.Threading;
 
 namespace System.Collections
@@ -58,13 +56,8 @@ namespace System.Collections
     //
     [DebuggerTypeProxy(typeof(System.Collections.Hashtable.HashtableDebugView))]
     [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
     [Serializable]
-#endif
-    public class Hashtable : IDictionary
-#if netstandard17
-        , ISerializable, IDeserializationCallback
-#endif
+    public class Hashtable : IDictionary, ISerializable, IDeserializationCallback
     {
         /*
           This Hashtable uses double hashing.  There are hashsize buckets in the 
@@ -120,7 +113,6 @@ namespace System.Collections
         internal const Int32 HashPrime = 101;
         private const Int32 InitialSize = 3;
 
-#if netstandard17
         private const String LoadFactorName = "LoadFactor";
         private const String VersionName = "Version";
         private const String ComparerName = "Comparer";
@@ -129,7 +121,6 @@ namespace System.Collections
         private const String KeysName = "Keys";
         private const String ValuesName = "Values";
         private const String KeyComparerName = "KeyComparer";
-#endif
 
         // Deleted entries have their key set to buckets
 
@@ -387,7 +378,6 @@ namespace System.Collections
             while (e.MoveNext()) Add(e.Key, e.Value);
         }
 
-#if netstandard17
         protected Hashtable(SerializationInfo info, StreamingContext context)
         {
             //We can't do anything with the keys and values until the entire graph has been deserialized
@@ -395,7 +385,6 @@ namespace System.Collections
             //we'll just cache this.  The graph is not valid until OnDeserialization has been called.
             HashHelpers.SerializationInfoTable.Add(this, info);
         }
-#endif
 
         // ?InitHash? is basically an implementation of classic DoubleHashing (see http://en.wikipedia.org/wiki/Double_hashing)  
         //
@@ -1150,7 +1139,6 @@ namespace System.Collections
             return new SyncHashtable(table);
         }
 
-#if netstandard17
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)
@@ -1307,13 +1295,10 @@ namespace System.Collections
 
             HashHelpers.SerializationInfoTable.Remove(this);
         }
-#endif
 
         // Implements a Collection for the keys of a hashtable. An instance of this
         // class is created by the GetKeys method of a hashtable.
-#if netstandard17
         [Serializable]
-#endif
         private class KeyCollection : ICollection
         {
             private Hashtable _hashtable;
@@ -1360,9 +1345,7 @@ namespace System.Collections
 
         // Implements a Collection for the values of a hashtable. An instance of
         // this class is created by the GetValues method of a hashtable.
-#if netstandard17
         [Serializable]
-#endif
         private class ValueCollection : ICollection
         {
             private Hashtable _hashtable;
@@ -1408,9 +1391,7 @@ namespace System.Collections
         }
 
         // Synchronized wrapper for hashtable
-#if netstandard17
         [Serializable]
-#endif
         private class SyncHashtable : Hashtable, IEnumerable
         {
             protected Hashtable _table;
@@ -1420,7 +1401,6 @@ namespace System.Collections
                 _table = table;
             }
 
-#if netstandard17
             internal SyncHashtable(SerializationInfo info, StreamingContext context) : base(info, context)
             {
                 _table = (Hashtable)info.GetValue("ParentTable", typeof(Hashtable));
@@ -1445,7 +1425,6 @@ namespace System.Collections
                     info.AddValue("ParentTable", _table, typeof(Hashtable));
                 }
             }
-#endif
 
             public override int Count
             {
@@ -1582,14 +1561,12 @@ namespace System.Collections
                 }
             }
 
-#if netstandard17
             public override void OnDeserialization(Object sender)
             {
                 // Does nothing.  We have to implement this because our parent HT implements it,
                 // but it doesn't do anything meaningful.  The real work will be done when we
                 // call OnDeserialization on our parent table.
             }
-#endif
 
             internal override KeyValuePairs[] ToKeyValuePairsArray()
             {
@@ -1601,9 +1578,7 @@ namespace System.Collections
         // Implements an enumerator for a hashtable. The enumerator uses the
         // internal version number of the hashtable to ensure that no modifications
         // are made to the hashtable while an enumeration is in progress.
-#if netstandard17
         [Serializable]
-#endif
         private class HashtableEnumerator : IDictionaryEnumerator
         {
             private Hashtable _hashtable;
@@ -1807,10 +1782,8 @@ namespace System.Collections
         // This is the maximum prime smaller than Array.MaxArrayLength
         public const int MaxPrimeArrayLength = 0x7FEFFFFD;
 
-#if netstandard17
         private static ConditionalWeakTable<object, SerializationInfo> s_serializationInfoTable;
         public static ConditionalWeakTable<object, SerializationInfo> SerializationInfoTable => LazyInitializer.EnsureInitialized(ref s_serializationInfoTable);
-#endif
 
 #if FEATURE_RANDOMIZED_STRING_HASHING
         public static bool IsWellKnownEqualityComparer(object comparer)

--- a/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
@@ -20,6 +20,9 @@ namespace System.Collections
     // buffer, so Enqueue can be O(n).  Dequeue is O(1).
     [DebuggerTypeProxy(typeof(System.Collections.Queue.QueueDebugView))]
     [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+    [Serializable]
+#endif
     public class Queue : ICollection
     {
         private Object[] _array;
@@ -28,6 +31,9 @@ namespace System.Collections
         private int _size;       // Number of elements.
         private int _growFactor; // 100 == 1.0, 130 == 1.3, 200 == 2.0
         private int _version;
+#if netstandard17
+        [NonSerialized]
+#endif
         private Object _syncRoot;
 
         private const int _MinimumGrow = 4;
@@ -319,6 +325,9 @@ namespace System.Collections
 
 
         // Implements a synchronization wrapper around a queue.
+#if netstandard17
+        [Serializable]
+#endif
         private class SynchronizedQueue : Queue
         {
             private Queue _q;
@@ -441,6 +450,9 @@ namespace System.Collections
         // Implements an enumerator for a Queue.  The enumerator uses the
         // internal version number of the list to ensure that no modifications are
         // made to the list while an enumeration is in progress.
+#if netstandard17
+        [Serializable]
+#endif
         private class QueueEnumerator : IEnumerator
         {
             private Queue _q;

--- a/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
@@ -20,9 +20,7 @@ namespace System.Collections
     // buffer, so Enqueue can be O(n).  Dequeue is O(1).
     [DebuggerTypeProxy(typeof(System.Collections.Queue.QueueDebugView))]
     [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
     [Serializable]
-#endif
     public class Queue : ICollection
     {
         private Object[] _array;
@@ -31,9 +29,7 @@ namespace System.Collections
         private int _size;       // Number of elements.
         private int _growFactor; // 100 == 1.0, 130 == 1.3, 200 == 2.0
         private int _version;
-#if netstandard17
         [NonSerialized]
-#endif
         private Object _syncRoot;
 
         private const int _MinimumGrow = 4;
@@ -325,9 +321,7 @@ namespace System.Collections
 
 
         // Implements a synchronization wrapper around a queue.
-#if netstandard17
         [Serializable]
-#endif
         private class SynchronizedQueue : Queue
         {
             private Queue _q;
@@ -450,9 +444,7 @@ namespace System.Collections
         // Implements an enumerator for a Queue.  The enumerator uses the
         // internal version number of the list to ensure that no modifications are
         // made to the list while an enumeration is in progress.
-#if netstandard17
         [Serializable]
-#endif
         private class QueueEnumerator : IEnumerator
         {
             private Queue _q;

--- a/src/System.Collections.NonGeneric/src/System/Collections/ReadOnlyCollectionBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ReadOnlyCollectionBase.cs
@@ -15,6 +15,9 @@
 namespace System.Collections
 {
     // Useful base class for typed readonly collections where items derive from object
+#if netstandard17
+    [Serializable]
+#endif
     public abstract class ReadOnlyCollectionBase : ICollection
     {
         private ArrayList _list;

--- a/src/System.Collections.NonGeneric/src/System/Collections/ReadOnlyCollectionBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ReadOnlyCollectionBase.cs
@@ -15,9 +15,7 @@
 namespace System.Collections
 {
     // Useful base class for typed readonly collections where items derive from object
-#if netstandard17
     [Serializable]
-#endif
     public abstract class ReadOnlyCollectionBase : ICollection
     {
         private ArrayList _list;

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -63,6 +63,9 @@ namespace System.Collections
 #if FEATURE_CORECLR
     [Obsolete("Non-generic collections have been deprecated. Please use collections in System.Collections.Generic.")]
 #endif
+#if netstandard17
+    [Serializable]
+#endif
     public class SortedList : IDictionary
     {
         private Object[] _keys;
@@ -72,6 +75,9 @@ namespace System.Collections
         private IComparer _comparer;
         private KeyList _keyList;
         private ValueList _valueList;
+#if netstandard17
+        [NonSerialized]
+#endif
         private Object _syncRoot;
 
         private const int _defaultCapacity = 16;
@@ -608,6 +614,9 @@ namespace System.Collections
             Capacity = _size;
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private class SyncSortedList : SortedList
         {
             private SortedList _list;
@@ -828,7 +837,9 @@ namespace System.Collections
             }
         }
 
-
+#if netstandard17
+        [Serializable]
+#endif
         private class SortedListEnumerator : IDictionaryEnumerator
         {
             private SortedList _sortedList;
@@ -929,6 +940,9 @@ namespace System.Collections
             }
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private class KeyList : IList
         {
             private SortedList _sortedList;
@@ -1034,6 +1048,9 @@ namespace System.Collections
             }
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private class ValueList : IList
         {
             private SortedList _sortedList;

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -63,9 +63,7 @@ namespace System.Collections
 #if FEATURE_CORECLR
     [Obsolete("Non-generic collections have been deprecated. Please use collections in System.Collections.Generic.")]
 #endif
-#if netstandard17
     [Serializable]
-#endif
     public class SortedList : IDictionary
     {
         private Object[] _keys;
@@ -75,9 +73,7 @@ namespace System.Collections
         private IComparer _comparer;
         private KeyList _keyList;
         private ValueList _valueList;
-#if netstandard17
         [NonSerialized]
-#endif
         private Object _syncRoot;
 
         private const int _defaultCapacity = 16;
@@ -614,9 +610,7 @@ namespace System.Collections
             Capacity = _size;
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class SyncSortedList : SortedList
         {
             private SortedList _list;
@@ -837,9 +831,7 @@ namespace System.Collections
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class SortedListEnumerator : IDictionaryEnumerator
         {
             private SortedList _sortedList;
@@ -940,9 +932,7 @@ namespace System.Collections
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class KeyList : IList
         {
             private SortedList _sortedList;
@@ -1048,9 +1038,7 @@ namespace System.Collections
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class ValueList : IList
         {
             private SortedList _sortedList;

--- a/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
@@ -22,18 +22,14 @@ namespace System.Collections
     // so Push can be O(n).  Pop is O(1).
     [DebuggerTypeProxy(typeof(System.Collections.Stack.StackDebugView))]
     [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
     [Serializable]
-#endif
     public class Stack : ICollection
     {
         private Object[] _array;     // Storage for stack elements
         [ContractPublicPropertyName("Count")]
         private int _size;           // Number of items in the stack.
         private int _version;        // Used to keep enumerator in sync w/ collection.
-#if netstandard17
         [NonSerialized]
-#endif
         private Object _syncRoot;
 
         private const int _defaultCapacity = 10;
@@ -245,9 +241,7 @@ namespace System.Collections
             return objArray;
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class SyncStack : Stack
         {
             private Stack _s;
@@ -358,9 +352,7 @@ namespace System.Collections
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class StackEnumerator : IEnumerator
         {
             private Stack _stack;

--- a/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
@@ -22,12 +22,18 @@ namespace System.Collections
     // so Push can be O(n).  Pop is O(1).
     [DebuggerTypeProxy(typeof(System.Collections.Stack.StackDebugView))]
     [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+    [Serializable]
+#endif
     public class Stack : ICollection
     {
         private Object[] _array;     // Storage for stack elements
         [ContractPublicPropertyName("Count")]
         private int _size;           // Number of items in the stack.
         private int _version;        // Used to keep enumerator in sync w/ collection.
+#if netstandard17
+        [NonSerialized]
+#endif
         private Object _syncRoot;
 
         private const int _defaultCapacity = 10;
@@ -239,6 +245,9 @@ namespace System.Collections
             return objArray;
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private class SyncStack : Stack
         {
             private Stack _s;
@@ -349,7 +358,9 @@ namespace System.Collections
             }
         }
 
-
+#if netstandard17
+        [Serializable]
+#endif
         private class StackEnumerator : IEnumerator
         {
             private Stack _stack;

--- a/src/System.Collections.NonGeneric/src/project.json
+++ b/src/System.Collections.NonGeneric/src/project.json
@@ -22,9 +22,9 @@
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
-        "System.Globalization": "4.0.12-beta-devapi-24422-01",
+        "System.Globalization": "4.0.12-beta-devapi-24424-01",
         "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.2.0-beta-devapi-24422-01",
+        "System.Runtime": "4.2.0-beta-devapi-24424-01",
         "System.Runtime.Extensions": "4.0.10",
         "System.Threading": "4.0.10"
       },

--- a/src/System.Collections.NonGeneric/src/project.json
+++ b/src/System.Collections.NonGeneric/src/project.json
@@ -22,9 +22,9 @@
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
-        "System.Globalization": "4.0.10",
+        "System.Globalization": "4.0.12-beta-devapi-24422-01",
         "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.0.20",
+        "System.Runtime": "4.2.0-beta-devapi-24422-01",
         "System.Runtime.Extensions": "4.0.10",
         "System.Threading": "4.0.10"
       },

--- a/src/System.Collections.NonGeneric/src/project.json
+++ b/src/System.Collections.NonGeneric/src/project.json
@@ -1,21 +1,5 @@
 {
   "frameworks": {
-    "netstandard1.3": {
-      "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1",
-        "System.Diagnostics.Contracts": "4.0.0",
-        "System.Diagnostics.Debug": "4.0.10",
-        "System.Diagnostics.Tools": "4.0.0",
-        "System.Globalization": "4.0.10",
-        "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.0.20",
-        "System.Runtime.Extensions": "4.0.10",
-        "System.Threading": "4.0.10"
-      },
-      "imports": [
-        "dotnet5.4"
-      ]
-    },
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
@@ -31,11 +15,6 @@
       "imports": [
         "dotnet5.8"
       ]
-    },
-    "net46": {
-      "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
-      }
     },
     "net463": {
       "dependencies": {

--- a/src/System.Collections.NonGeneric/tests/Hashtable/Hashtable.Keys.Tests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/Hashtable.Keys.Tests.cs
@@ -13,8 +13,8 @@ namespace System.Collections.Tests
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(InvalidCastException);
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType => typeof(InvalidCastException);
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType => typeof(InvalidCastException);
-
         protected override bool IsReadOnly => true;
+        protected override EnumerableOrder Order => EnumerableOrder.Unspecified;
 
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();

--- a/src/System.Collections.NonGeneric/tests/Hashtable/Hashtable.Values.Tests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/Hashtable.Values.Tests.cs
@@ -15,6 +15,7 @@ namespace System.Collections.Tests
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType => typeof(InvalidCastException);
 
         protected override bool IsReadOnly => true;
+        protected override EnumerableOrder Order => EnumerableOrder.Unspecified;
 
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -68,6 +68,16 @@
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'!='netstandard1.7'">
+    <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
+      <Link>Common\System\SerializableAttribute.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs" >
+      <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Collections.NonGeneric.pkgproj">
       <Name>System.Collections.NonGeneric</Name>

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -10,7 +10,18 @@
     <ProjectGuid>{EE95AE39-845A-42D3-86D0-8065DBE56612}</ProjectGuid>
     <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
     <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <!-- 
+        Until we get first class support for NS1.7 and Netcoreapp1.1 
+        we need to hard code $(TestTFM) and $(TestNugetTargetMoniker) 
+        in the project file. 
+      -->
+    <TestTFM Condition="'$(TargetGroup)'=='netstandard1.7'">netcoreapp1.1</TestTFM>
   </PropertyGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
+      <Folder>netcoreapp1.1</Folder>
+    </TestNugetTargetMoniker>
+  </ItemGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -76,5 +76,11 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <!-- ToDo: Remove this target once the infrastructure for testing in netcoreapp1.1 is ready -->
+  <Target Name="RemoveUnwantedTestMonikers" Condition="'$(TargetGroup)'=='netstandard1.7'" BeforeTargets="CopyTestToTestDirectory">
+    <ItemGroup>
+      <TestNugetTargetMoniker Remove=".NETCoreApp,Version=v1.1" />
+    </ItemGroup>
+  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -26,7 +26,7 @@
     "netstandard1.3": {},
     "netstandard1.7": {
 		"dependencies": {
-	        "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24422-01",
+	        "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24424-01",
 		}
 	}
   },

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -24,7 +24,11 @@
   },
   "frameworks": {
     "netstandard1.3": {},
-    "netstandard1.7": {}
+    "netstandard1.7": {
+		"dependencies": {
+	        "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24422-01",
+		}
+	}
   },
   "supports": {
     "coreFx.Test.netcore50": {},
@@ -32,6 +36,22 @@
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},
-    "coreFx.Test.net463": {}
+    "coreFx.Test.net463": {},
+    "coreFx.Test.netcoreapp1.1-ns17": {
+      "netstandard1.7": [
+        "win7-x86",
+        "win7-x64",
+        "win10-arm64",
+        "osx.10.10-x64",
+        "centos.7-x64",
+        "debian.8-x64",
+        "rhel.7-x64",
+        "ubuntu.14.04-x64",
+        "ubuntu.16.04-x64",
+        "fedora.23-x64",
+        "linux-x64",
+        "opensuse.13.2-x64"
+      ]
+    }
   }
 }

--- a/src/System.Collections.Specialized/pkg/System.Collections.Specialized.pkgproj
+++ b/src/System.Collections.Specialized/pkg/System.Collections.Specialized.pkgproj
@@ -2,8 +2,11 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.1\System.Collections.Specialized.depproj">
+      <SupportedFramework>net46;netcore50;netcoreapp1.0</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.Collections.Specialized.csproj">
-      <SupportedFramework>net46;netcore50;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Collections.Specialized.builds" />
   </ItemGroup>

--- a/src/System.Collections.Specialized/pkg/ValidationSuppression.txt
+++ b/src/System.Collections.Specialized/pkg/ValidationSuppression.txt
@@ -1,0 +1,1 @@
+PermitHigherCompatibleImplementationVersion

--- a/src/System.Collections.Specialized/ref/4.0.1/System.Collections.Specialized.depproj
+++ b/src/System.Collections.Specialized/ref/4.0.1/System.Collections.Specialized.depproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections.Specialized/ref/4.0.1/project.json
+++ b/src/System.Collections.Specialized/ref/4.0.1/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Collections.Specialized": "4.0.1"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4"
+      ]
+    }
+  }
+}

--- a/src/System.Collections.Specialized/ref/System.Collections.Specialized.cs
+++ b/src/System.Collections.Specialized/ref/System.Collections.Specialized.cs
@@ -87,12 +87,13 @@ namespace System.Collections.Specialized
         public void Remove(object key) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
     }
-    public abstract partial class NameObjectCollectionBase : System.Collections.ICollection, System.Collections.IEnumerable
+    public abstract partial class NameObjectCollectionBase : System.Collections.ICollection, System.Collections.IEnumerable, System.Runtime.Serialization.ISerializable, System.Runtime.Serialization.IDeserializationCallback
     {
         protected NameObjectCollectionBase() { }
         protected NameObjectCollectionBase(System.Collections.IEqualityComparer equalityComparer) { }
         protected NameObjectCollectionBase(int capacity) { }
         protected NameObjectCollectionBase(int capacity, System.Collections.IEqualityComparer equalityComparer) { }
+        protected NameObjectCollectionBase(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual int Count { get { return default(int); } }
         protected bool IsReadOnly { get { return default(bool); } set { } }
         public virtual System.Collections.Specialized.NameObjectCollectionBase.KeysCollection Keys { get { return default(System.Collections.Specialized.NameObjectCollectionBase.KeysCollection); } }
@@ -112,6 +113,8 @@ namespace System.Collections.Specialized
         protected void BaseSet(int index, object value) { }
         protected void BaseSet(string name, object value) { }
         public virtual System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
+        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public virtual void OnDeserialization(object sender) { }
         void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
         public partial class KeysCollection : System.Collections.ICollection, System.Collections.IEnumerable
         {
@@ -150,12 +153,13 @@ namespace System.Collections.Specialized
         public virtual void Remove(string name) { }
         public virtual void Set(string name, string value) { }
     }
-    public partial class OrderedDictionary : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Specialized.IOrderedDictionary
+    public partial class OrderedDictionary : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Specialized.IOrderedDictionary, System.Runtime.Serialization.ISerializable, System.Runtime.Serialization.IDeserializationCallback
     {
         public OrderedDictionary() { }
         public OrderedDictionary(System.Collections.IEqualityComparer comparer) { }
         public OrderedDictionary(int capacity) { }
         public OrderedDictionary(int capacity, System.Collections.IEqualityComparer comparer) { }
+        protected OrderedDictionary(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public int Count { get { return default(int); } }
         public bool IsReadOnly { get { return default(bool); } }
         public object this[int index] { get { return default(object); } set { } }
@@ -171,7 +175,9 @@ namespace System.Collections.Specialized
         public bool Contains(object key) { return default(bool); }
         public void CopyTo(System.Array array, int index) { }
         public virtual System.Collections.IDictionaryEnumerator GetEnumerator() { return default(System.Collections.IDictionaryEnumerator); }
+        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public void Insert(int index, object key, object value) { }
+        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
         public void Remove(object key) { }
         public void RemoveAt(int index) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }

--- a/src/System.Collections.Specialized/ref/System.Collections.Specialized.csproj
+++ b/src/System.Collections.Specialized/ref/System.Collections.Specialized.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>

--- a/src/System.Collections.Specialized/ref/System.Collections.Specialized.csproj
+++ b/src/System.Collections.Specialized/ref/System.Collections.Specialized.csproj
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Collections.Specialized.cs" />

--- a/src/System.Collections.Specialized/ref/project.json
+++ b/src/System.Collections.Specialized/ref/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Runtime": "4.2.0-beta-devapi-24422-01"
+    "System.Runtime": "4.2.0-beta-devapi-24424-01"
   },
   "frameworks": {
     "netstandard1.7": {

--- a/src/System.Collections.Specialized/ref/project.json
+++ b/src/System.Collections.Specialized/ref/project.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.0"
+    "System.Runtime": "4.2.0-beta-devapi-24422-01"
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "imports": [
-        "dotnet5.4"
+        "dotnet5.8"
       ]
     }
   }

--- a/src/System.Collections.Specialized/src/Resources/Strings.resx
+++ b/src/System.Collections.Specialized/src/Resources/Strings.resx
@@ -150,4 +150,13 @@
   <data name="OrderedDictionary_ReadOnly" xml:space="preserve">
     <value>The OrderedDictionary is read-only and cannot be modified.</value>
   </data>
+  <data name="Argument_ImplementIComparable" xml:space="preserve">
+    <value>At least one object must implement IComparable.</value>
+  </data>
+  <data name="OrderedDictionary_SerializationMismatch" xml:space="preserve">
+    <value>There was an error deserializing the OrderedDictionary.  The ArrayList does not contain DictionaryEntries.</value>
+  </data>
+  <data name="Serialization_InvalidOnDeser" xml:space="preserve">
+    <value>OnDeserialization method was called while the object was not being deserialized.</value>
+  </data>
 </root>

--- a/src/System.Collections.Specialized/src/System.Collections.Specialized.builds
+++ b/src/System.Collections.Specialized/src/System.Collections.Specialized.builds
@@ -4,7 +4,13 @@
   <ItemGroup>
     <Project Include="System.Collections.Specialized.csproj" />
     <Project Include="System.Collections.Specialized.csproj">
+      <TargetGroup>netstandard1.3</TargetGroup>
+    </Project>
+    <Project Include="System.Collections.Specialized.csproj">
       <TargetGroup>net46</TargetGroup>
+    </Project>
+    <Project Include="System.Collections.Specialized.csproj">
+      <TargetGroup>net463</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Collections.Specialized/src/System.Collections.Specialized.builds
+++ b/src/System.Collections.Specialized/src/System.Collections.Specialized.builds
@@ -4,12 +4,6 @@
   <ItemGroup>
     <Project Include="System.Collections.Specialized.csproj" />
     <Project Include="System.Collections.Specialized.csproj">
-      <TargetGroup>netstandard1.3</TargetGroup>
-    </Project>
-    <Project Include="System.Collections.Specialized.csproj">
-      <TargetGroup>net46</TargetGroup>
-    </Project>
-    <Project Include="System.Collections.Specialized.csproj">
       <TargetGroup>net463</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Collections.Specialized/src/System.Collections.Specialized.csproj
+++ b/src/System.Collections.Specialized/src/System.Collections.Specialized.csproj
@@ -5,17 +5,24 @@
     <ProjectGuid>{63634289-90D7-4947-8BF3-DBBE98D76C85}</ProjectGuid>
     <RootNamespace>System.Collections.Specialized</RootNamespace>
     <AssemblyName>System.Collections.Specialized</AssemblyName>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">4.0.2.0</AssemblyVersion>
+    <ContractProject Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">../ref/4.0.1/System.Collections.Specialized.depproj</ContractProject>
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46' OR '$(TargetGroup)'=='net463'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <DefineConstants Condition="'$(AssemblyVersion)'=='4.1.0.0'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetGroup)' != 'net463'">
     <Compile Include="System\Collections\Specialized\BitVector32.cs" />
     <Compile Include="System\Collections\Specialized\HybridDictionary.cs" />
     <Compile Include="System\Collections\Specialized\IOrderedDictionary.cs" />
@@ -25,11 +32,13 @@
     <Compile Include="System\Collections\Specialized\OrderedDictionary.cs" />
     <Compile Include="System\Collections\Specialized\StringCollection.cs" />
     <Compile Include="System\Collections\Specialized\StringDictionary.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(AssemblyVersion)'=='4.1.0.0'">
     <Compile Include="$(CommonPath)\System\Collections\CompatibleComparer.cs">
       <Link>Common\System\Collections\CompatibleComparer.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />
   </ItemGroup>

--- a/src/System.Collections.Specialized/src/System.Collections.Specialized.csproj
+++ b/src/System.Collections.Specialized/src/System.Collections.Specialized.csproj
@@ -7,8 +7,8 @@
     <AssemblyName>System.Collections.Specialized</AssemblyName>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.3</PackageTargetFramework>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -25,6 +25,9 @@
     <Compile Include="System\Collections\Specialized\OrderedDictionary.cs" />
     <Compile Include="System\Collections\Specialized\StringCollection.cs" />
     <Compile Include="System\Collections\Specialized\StringDictionary.cs" />
+    <Compile Include="$(CommonPath)\System\Collections\CompatibleComparer.cs">
+      <Link>Common\System\Collections\CompatibleComparer.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
     <TargetingPackReference Include="mscorlib" />

--- a/src/System.Collections.Specialized/src/System.Collections.Specialized.csproj
+++ b/src/System.Collections.Specialized/src/System.Collections.Specialized.csproj
@@ -6,23 +6,18 @@
     <RootNamespace>System.Collections.Specialized</RootNamespace>
     <AssemblyName>System.Collections.Specialized</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">4.0.2.0</AssemblyVersion>
-    <ContractProject Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46'">../ref/4.0.1/System.Collections.Specialized.depproj</ContractProject>
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46' OR '$(TargetGroup)'=='net463'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net463'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
-    <DefineConstants Condition="'$(AssemblyVersion)'=='4.1.0.0'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetGroup)' != 'net463'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
     <Compile Include="System\Collections\Specialized\BitVector32.cs" />
     <Compile Include="System\Collections\Specialized\HybridDictionary.cs" />
     <Compile Include="System\Collections\Specialized\IOrderedDictionary.cs" />
@@ -32,13 +27,11 @@
     <Compile Include="System\Collections\Specialized\OrderedDictionary.cs" />
     <Compile Include="System\Collections\Specialized\StringCollection.cs" />
     <Compile Include="System\Collections\Specialized\StringDictionary.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(AssemblyVersion)'=='4.1.0.0'">
     <Compile Include="$(CommonPath)\System\Collections\CompatibleComparer.cs">
       <Link>Common\System\Collections\CompatibleComparer.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />
   </ItemGroup>

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/HybridDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/HybridDictionary.cs
@@ -14,6 +14,7 @@ namespace System.Collections.Specialized
     ///    ambient culture and has been optimized for looking up case-insensitive symbols
     ///  </para>
     /// </devdoc>
+    [Serializable]
     public class HybridDictionary : IDictionary
     {
         // These numbers have been carefully tested to be optimal. Please don't change them

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/HybridDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/HybridDictionary.cs
@@ -14,7 +14,9 @@ namespace System.Collections.Specialized
     ///    ambient culture and has been optimized for looking up case-insensitive symbols
     ///  </para>
     /// </devdoc>
+#if netstandard17
     [Serializable]
+#endif
     public class HybridDictionary : IDictionary
     {
         // These numbers have been carefully tested to be optimal. Please don't change them

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/HybridDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/HybridDictionary.cs
@@ -14,9 +14,7 @@ namespace System.Collections.Specialized
     ///    ambient culture and has been optimized for looking up case-insensitive symbols
     ///  </para>
     /// </devdoc>
-#if netstandard17
     [Serializable]
-#endif
     public class HybridDictionary : IDictionary
     {
         // These numbers have been carefully tested to be optimal. Please don't change them

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
@@ -11,14 +11,18 @@ namespace System.Collections.Specialized
     ///    This should not be used if performance is important for large numbers of elements.
     ///  </para>
     /// </devdoc>
+#if netstandard17
     [Serializable]
+#endif
     public class ListDictionary : IDictionary
     {
         private DictionaryNode _head;
         private int _version;
         private int _count;
         private readonly IComparer _comparer;
+#if netstandard17
         [NonSerialized]
+#endif
         private Object _syncRoot;
 
         public ListDictionary()
@@ -502,7 +506,9 @@ namespace System.Collections.Specialized
             }
         }
 
+#if netstandard17
         [Serializable]
+#endif
         private class DictionaryNode
         {
             public object key;

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
@@ -11,18 +11,14 @@ namespace System.Collections.Specialized
     ///    This should not be used if performance is important for large numbers of elements.
     ///  </para>
     /// </devdoc>
-#if netstandard17
     [Serializable]
-#endif
     public class ListDictionary : IDictionary
     {
         private DictionaryNode _head;
         private int _version;
         private int _count;
         private readonly IComparer _comparer;
-#if netstandard17
         [NonSerialized]
-#endif
         private Object _syncRoot;
 
         public ListDictionary()
@@ -506,9 +502,7 @@ namespace System.Collections.Specialized
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class DictionaryNode
         {
             public object key;

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
@@ -11,12 +11,14 @@ namespace System.Collections.Specialized
     ///    This should not be used if performance is important for large numbers of elements.
     ///  </para>
     /// </devdoc>
+    [Serializable]
     public class ListDictionary : IDictionary
     {
         private DictionaryNode _head;
         private int _version;
         private int _count;
         private readonly IComparer _comparer;
+        [NonSerialized]
         private Object _syncRoot;
 
         public ListDictionary()
@@ -500,6 +502,7 @@ namespace System.Collections.Specialized
             }
         }
 
+        [Serializable]
         private class DictionaryNode
         {
             public object key;

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
@@ -12,7 +12,9 @@
 #pragma warning disable 618 // obsolete types, namely IHashCodeProvider
 
 using System.Globalization;
+#if netstandard17
 using System.Runtime.Serialization;
+#endif
 
 namespace System.Collections.Specialized
 {
@@ -21,9 +23,15 @@ namespace System.Collections.Specialized
     ///    and <see cref='System.Object' qualify='true'/> values that can be accessed either with the hash code of
     ///    the key or with the index.</para>
     /// </devdoc>
+#if netstandard17
     [Serializable]
-    public abstract class NameObjectCollectionBase : ICollection, ISerializable, IDeserializationCallback
+#endif
+    public abstract class NameObjectCollectionBase : ICollection
+#if netstandard17
+        , ISerializable, IDeserializationCallback
+#endif
     {
+#if netstandard17
         // const names used for serialization
         private const String ReadOnlyName = "ReadOnly";
         private const String CountName = "Count";
@@ -33,6 +41,7 @@ namespace System.Collections.Specialized
         private const String ValuesName = "Values";
         private const String KeyComparerName = "KeyComparer";
         private const String VersionName = "Version";
+#endif
 
         private bool _readOnly = false;
         private ArrayList _entriesArray;
@@ -40,9 +49,11 @@ namespace System.Collections.Specialized
         private volatile Hashtable _entriesTable;
         private volatile NameObjectEntry _nullKeyEntry;
         private KeysCollection _keys;
-        private SerializationInfo _serializationInfo;
         private int _version;
+#if netstandard17
+        private SerializationInfo _serializationInfo;
         [NonSerialized]
+#endif
         private Object _syncRoot;
 
         private static readonly StringComparer s_defaultComparer = CultureInfo.InvariantCulture.CompareInfo.GetStringComparer(CompareOptions.IgnoreCase);
@@ -77,6 +88,7 @@ namespace System.Collections.Specialized
             Reset(capacity);
         }
 
+#if netstandard17
         protected NameObjectCollectionBase(SerializationInfo info, StreamingContext context)
         {
             _serializationInfo = info;
@@ -220,6 +232,7 @@ namespace System.Collections.Specialized
                 _version = serializedVersion;
             }
         }
+#endif
 
         //
         // Private helpers
@@ -624,7 +637,9 @@ namespace System.Collections.Specialized
         // Enumerator over keys of NameObjectCollection
         //
 
+#if netstandard17
         [Serializable]
+#endif
         internal class NameObjectKeysEnumerator : IEnumerator
         {
             private int _pos;
@@ -685,7 +700,9 @@ namespace System.Collections.Specialized
         /// <devdoc>
         /// <para>Represents a collection of the <see cref='System.String' qualify='true'/> keys of a collection.</para>
         /// </devdoc>
+#if netstandard17
         [Serializable]
+#endif
         public class KeysCollection : ICollection
         {
             private NameObjectCollectionBase _coll;

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
@@ -9,7 +9,10 @@
  *
  */
 
+#pragma warning disable 618 // obsolete types, namely IHashCodeProvider
+
 using System.Globalization;
+using System.Runtime.Serialization;
 
 namespace System.Collections.Specialized
 {
@@ -18,15 +21,28 @@ namespace System.Collections.Specialized
     ///    and <see cref='System.Object' qualify='true'/> values that can be accessed either with the hash code of
     ///    the key or with the index.</para>
     /// </devdoc>
-    public abstract class NameObjectCollectionBase : ICollection
+    [Serializable]
+    public abstract class NameObjectCollectionBase : ICollection, ISerializable, IDeserializationCallback
     {
+        // const names used for serialization
+        private const String ReadOnlyName = "ReadOnly";
+        private const String CountName = "Count";
+        private const String ComparerName = "Comparer";
+        private const String HashCodeProviderName = "HashProvider";
+        private const String KeysName = "Keys";
+        private const String ValuesName = "Values";
+        private const String KeyComparerName = "KeyComparer";
+        private const String VersionName = "Version";
+
         private bool _readOnly = false;
         private ArrayList _entriesArray;
         private IEqualityComparer _keyComparer;
         private volatile Hashtable _entriesTable;
         private volatile NameObjectEntry _nullKeyEntry;
         private KeysCollection _keys;
+        private SerializationInfo _serializationInfo;
         private int _version;
+        [NonSerialized]
         private Object _syncRoot;
 
         private static readonly StringComparer s_defaultComparer = CultureInfo.InvariantCulture.CompareInfo.GetStringComparer(CompareOptions.IgnoreCase);
@@ -59,6 +75,150 @@ namespace System.Collections.Specialized
         {
             _keyComparer = s_defaultComparer;
             Reset(capacity);
+        }
+
+        protected NameObjectCollectionBase(SerializationInfo info, StreamingContext context)
+        {
+            _serializationInfo = info;
+        }
+
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            info.AddValue(ReadOnlyName, _readOnly);
+
+            // Maintain backward serialization compatibility if new APIs are not used.
+            if (_keyComparer == s_defaultComparer)
+            {
+                info.AddValue(HashCodeProviderName, CaseInsensitiveHashCodeProvider.DefaultInvariant, typeof(IHashCodeProvider));
+                info.AddValue(ComparerName, CaseInsensitiveComparer.DefaultInvariant, typeof(IComparer));
+            }
+            else if (_keyComparer == null)
+            {
+                info.AddValue(HashCodeProviderName, null, typeof(IHashCodeProvider));
+                info.AddValue(ComparerName, null, typeof(IComparer));
+            }
+            else if (_keyComparer is CompatibleComparer)
+            {
+                CompatibleComparer c = (CompatibleComparer)_keyComparer;
+                info.AddValue(HashCodeProviderName, c.HashCodeProvider, typeof(IHashCodeProvider));
+                info.AddValue(ComparerName, c.Comparer, typeof(IComparer));
+            }
+            else
+            {
+                info.AddValue(KeyComparerName, _keyComparer, typeof(IEqualityComparer));
+            }
+
+            int count = _entriesArray.Count;
+            info.AddValue(CountName, count);
+
+            string[] keys = new string[count];
+            object[] values = new object[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                NameObjectEntry entry = (NameObjectEntry)_entriesArray[i];
+                keys[i] = entry.Key;
+                values[i] = entry.Value;
+            }
+
+            info.AddValue(KeysName, keys, typeof(String[]));
+            info.AddValue(ValuesName, values, typeof(Object[]));
+            info.AddValue(VersionName, _version);
+        }
+
+        public virtual void OnDeserialization(object sender)
+        {
+            if (_keyComparer != null)
+            {
+                //Somebody had a dependency on this and fixed us up before the ObjectManager got to it.
+                return;
+            }
+
+            if (_serializationInfo == null)
+            {
+                throw new SerializationException();
+            }
+
+            SerializationInfo info = _serializationInfo;
+            _serializationInfo = null;
+
+            bool readOnly = false;
+            int count = 0;
+            string[] keys = null;
+            object[] values = null;
+            IHashCodeProvider hashProvider = null;
+            IComparer comparer = null;
+            bool hasVersion = false;
+            int serializedVersion = 0;
+
+            SerializationInfoEnumerator enumerator = info.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                switch (enumerator.Name)
+                {
+                    case ReadOnlyName:
+                        readOnly = info.GetBoolean(ReadOnlyName); ;
+                        break;
+                    case HashCodeProviderName:
+                        hashProvider = (IHashCodeProvider)info.GetValue(HashCodeProviderName, typeof(IHashCodeProvider)); ;
+                        break;
+                    case ComparerName:
+                        comparer = (IComparer)info.GetValue(ComparerName, typeof(IComparer));
+                        break;
+                    case KeyComparerName:
+                        _keyComparer = (IEqualityComparer)info.GetValue(KeyComparerName, typeof(IEqualityComparer));
+                        break;
+                    case CountName:
+                        count = info.GetInt32(CountName);
+                        break;
+                    case KeysName:
+                        keys = (String[])info.GetValue(KeysName, typeof(String[]));
+                        break;
+                    case ValuesName:
+                        values = (Object[])info.GetValue(ValuesName, typeof(Object[]));
+                        break;
+                    case VersionName:
+                        hasVersion = true;
+                        serializedVersion = info.GetInt32(VersionName);
+                        break;
+                }
+            }
+
+            if (_keyComparer == null)
+            {
+                if (comparer == null || hashProvider == null)
+                {
+                    throw new SerializationException();
+                }
+                else
+                {
+                    // create a new key comparer for V1 Object    
+                    _keyComparer = new CompatibleComparer(hashProvider, comparer);
+                }
+            }
+
+            if (keys == null || values == null)
+            {
+                throw new SerializationException();
+            }
+
+            Reset(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                BaseAdd(keys[i], values[i]);
+            }
+
+            _readOnly = readOnly;  // after collection populated
+            if (hasVersion)
+            {
+                _version = serializedVersion;
+            }
         }
 
         //
@@ -464,6 +624,7 @@ namespace System.Collections.Specialized
         // Enumerator over keys of NameObjectCollection
         //
 
+        [Serializable]
         internal class NameObjectKeysEnumerator : IEnumerator
         {
             private int _pos;
@@ -524,6 +685,7 @@ namespace System.Collections.Specialized
         /// <devdoc>
         /// <para>Represents a collection of the <see cref='System.String' qualify='true'/> keys of a collection.</para>
         /// </devdoc>
+        [Serializable]
         public class KeysCollection : ICollection
         {
             private NameObjectCollectionBase _coll;

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
@@ -12,9 +12,7 @@
 #pragma warning disable 618 // obsolete types, namely IHashCodeProvider
 
 using System.Globalization;
-#if netstandard17
 using System.Runtime.Serialization;
-#endif
 
 namespace System.Collections.Specialized
 {
@@ -23,15 +21,9 @@ namespace System.Collections.Specialized
     ///    and <see cref='System.Object' qualify='true'/> values that can be accessed either with the hash code of
     ///    the key or with the index.</para>
     /// </devdoc>
-#if netstandard17
     [Serializable]
-#endif
-    public abstract class NameObjectCollectionBase : ICollection
-#if netstandard17
-        , ISerializable, IDeserializationCallback
-#endif
+    public abstract class NameObjectCollectionBase : ICollection, ISerializable, IDeserializationCallback
     {
-#if netstandard17
         // const names used for serialization
         private const String ReadOnlyName = "ReadOnly";
         private const String CountName = "Count";
@@ -41,7 +33,6 @@ namespace System.Collections.Specialized
         private const String ValuesName = "Values";
         private const String KeyComparerName = "KeyComparer";
         private const String VersionName = "Version";
-#endif
 
         private bool _readOnly = false;
         private ArrayList _entriesArray;
@@ -50,10 +41,8 @@ namespace System.Collections.Specialized
         private volatile NameObjectEntry _nullKeyEntry;
         private KeysCollection _keys;
         private int _version;
-#if netstandard17
         private SerializationInfo _serializationInfo;
         [NonSerialized]
-#endif
         private Object _syncRoot;
 
         private static readonly StringComparer s_defaultComparer = CultureInfo.InvariantCulture.CompareInfo.GetStringComparer(CompareOptions.IgnoreCase);
@@ -88,7 +77,6 @@ namespace System.Collections.Specialized
             Reset(capacity);
         }
 
-#if netstandard17
         protected NameObjectCollectionBase(SerializationInfo info, StreamingContext context)
         {
             _serializationInfo = info;
@@ -232,7 +220,6 @@ namespace System.Collections.Specialized
                 _version = serializedVersion;
             }
         }
-#endif
 
         //
         // Private helpers
@@ -637,9 +624,7 @@ namespace System.Collections.Specialized
         // Enumerator over keys of NameObjectCollection
         //
 
-#if netstandard17
         [Serializable]
-#endif
         internal class NameObjectKeysEnumerator : IEnumerator
         {
             private int _pos;
@@ -700,9 +685,7 @@ namespace System.Collections.Specialized
         /// <devdoc>
         /// <para>Represents a collection of the <see cref='System.String' qualify='true'/> keys of a collection.</para>
         /// </devdoc>
-#if netstandard17
         [Serializable]
-#endif
         public class KeysCollection : ICollection
         {
             private NameObjectCollectionBase _coll;

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
@@ -8,6 +8,7 @@
  *
  */
 
+using System.Runtime.Serialization;
 using System.Text;
 
 namespace System.Collections.Specialized
@@ -16,6 +17,7 @@ namespace System.Collections.Specialized
     /// <para>Represents a sorted collection of associated <see cref='System.String' qualify='true'/> keys and <see cref='System.String' qualify='true'/> values that
     ///    can be accessed either with the hash code of the key or with the index.</para>
     /// </devdoc>
+    [Serializable]
     public class NameValueCollection : NameObjectCollectionBase
     {
         private String[] _all;
@@ -79,6 +81,10 @@ namespace System.Collections.Specialized
 
             this.Comparer = col.Comparer;
             Add(col);
+        }
+
+        protected NameValueCollection(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
         }
 
         //

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
@@ -8,7 +8,9 @@
  *
  */
 
+#if netstandard17
 using System.Runtime.Serialization;
+ #endif
 using System.Text;
 
 namespace System.Collections.Specialized
@@ -17,7 +19,9 @@ namespace System.Collections.Specialized
     /// <para>Represents a sorted collection of associated <see cref='System.String' qualify='true'/> keys and <see cref='System.String' qualify='true'/> values that
     ///    can be accessed either with the hash code of the key or with the index.</para>
     /// </devdoc>
+#if netstandard17
     [Serializable]
+#endif
     public class NameValueCollection : NameObjectCollectionBase
     {
         private String[] _all;
@@ -83,9 +87,11 @@ namespace System.Collections.Specialized
             Add(col);
         }
 
+#if netstandard17
         protected NameValueCollection(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
+#endif
 
         //
         //  Helper methods

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
@@ -8,9 +8,7 @@
  *
  */
 
-#if netstandard17
 using System.Runtime.Serialization;
- #endif
 using System.Text;
 
 namespace System.Collections.Specialized
@@ -19,9 +17,7 @@ namespace System.Collections.Specialized
     /// <para>Represents a sorted collection of associated <see cref='System.String' qualify='true'/> keys and <see cref='System.String' qualify='true'/> values that
     ///    can be accessed either with the hash code of the key or with the index.</para>
     /// </devdoc>
-#if netstandard17
     [Serializable]
-#endif
     public class NameValueCollection : NameObjectCollectionBase
     {
         private String[] _all;
@@ -87,11 +83,9 @@ namespace System.Collections.Specialized
             Add(col);
         }
 
-#if netstandard17
         protected NameValueCollection(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
 
         //
         //  Helper methods

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-#if netstandard17
 using System.Runtime.Serialization;
-#endif
 
 namespace System.Collections.Specialized
 {
@@ -22,13 +20,8 @@ namespace System.Collections.Specialized
     /// contained ArrayList and Hashtable deserialized before it tries to get its count and objects.
     /// </para>
     /// </devdoc>
-#if netstandard17
     [Serializable]
-#endif
-    public class OrderedDictionary : IOrderedDictionary
-#if netstandard17
-        , ISerializable, IDeserializationCallback
-#endif
+    public class OrderedDictionary : IOrderedDictionary, ISerializable, IDeserializationCallback
     {
         private ArrayList _objectsArray;
         private Hashtable _objectsTable;
@@ -36,9 +29,7 @@ namespace System.Collections.Specialized
         private IEqualityComparer _comparer;
         private bool _readOnly;
         private Object _syncRoot;
-#if netstandard17
         private SerializationInfo _siInfo; //A temporary variable which we need during deserialization.
-#endif
 
         private const string KeyComparerName = "KeyComparer";
         private const string ArrayListName = "ArrayList";
@@ -74,7 +65,6 @@ namespace System.Collections.Specialized
             _initialCapacity = dictionary._initialCapacity;
         }
 
-#if netstandard17
         protected OrderedDictionary(SerializationInfo info, StreamingContext context)
         {
             // We can't do anything with the keys and values until the entire graph has been deserialized
@@ -82,7 +72,6 @@ namespace System.Collections.Specialized
             // The graph is not valid until OnDeserialization has been called.
             _siInfo = info;
         }
-#endif
 
         /// <devdoc>
         /// Gets the size of the table.
@@ -387,7 +376,6 @@ namespace System.Collections.Specialized
         }
 #endregion
 
-#if netstandard17
 #region ISerializable implementation 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -439,7 +427,7 @@ namespace System.Collections.Specialized
             }
         }
 #endregion
-#endif
+
         /// <devdoc>
         /// OrderedDictionaryEnumerator works just like any other IDictionaryEnumerator, but it retrieves DictionaryEntries
         /// in the order by index.

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+#if netstandard17
 using System.Runtime.Serialization;
+#endif
 
 namespace System.Collections.Specialized
 {
@@ -20,8 +22,13 @@ namespace System.Collections.Specialized
     /// contained ArrayList and Hashtable deserialized before it tries to get its count and objects.
     /// </para>
     /// </devdoc>
+#if netstandard17
     [Serializable]
-    public class OrderedDictionary : IOrderedDictionary, ISerializable, IDeserializationCallback
+#endif
+    public class OrderedDictionary : IOrderedDictionary
+#if netstandard17
+        , ISerializable, IDeserializationCallback
+#endif
     {
         private ArrayList _objectsArray;
         private Hashtable _objectsTable;
@@ -29,7 +36,9 @@ namespace System.Collections.Specialized
         private IEqualityComparer _comparer;
         private bool _readOnly;
         private Object _syncRoot;
+#if netstandard17
         private SerializationInfo _siInfo; //A temporary variable which we need during deserialization.
+#endif
 
         private const string KeyComparerName = "KeyComparer";
         private const string ArrayListName = "ArrayList";
@@ -65,6 +74,7 @@ namespace System.Collections.Specialized
             _initialCapacity = dictionary._initialCapacity;
         }
 
+#if netstandard17
         protected OrderedDictionary(SerializationInfo info, StreamingContext context)
         {
             // We can't do anything with the keys and values until the entire graph has been deserialized
@@ -72,6 +82,7 @@ namespace System.Collections.Specialized
             // The graph is not valid until OnDeserialization has been called.
             _siInfo = info;
         }
+#endif
 
         /// <devdoc>
         /// Gets the size of the table.
@@ -362,21 +373,22 @@ namespace System.Collections.Specialized
             objectsArray.RemoveAt(index);
         }
 
-        #region IDictionary implementation
+#region IDictionary implementation
         public virtual IDictionaryEnumerator GetEnumerator()
         {
             return new OrderedDictionaryEnumerator(objectsArray, OrderedDictionaryEnumerator.DictionaryEntry);
         }
-        #endregion
+#endregion
 
-        #region IEnumerable implementation
+#region IEnumerable implementation
         IEnumerator IEnumerable.GetEnumerator()
         {
             return new OrderedDictionaryEnumerator(objectsArray, OrderedDictionaryEnumerator.DictionaryEntry);
         }
-        #endregion
+#endregion
 
-        #region ISerializable implementation 
+#if netstandard17
+#region ISerializable implementation 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)
@@ -392,9 +404,9 @@ namespace System.Collections.Specialized
             _objectsArray.CopyTo(serArray);
             info.AddValue(ArrayListName, serArray);
         }
-        #endregion
+#endregion
 
-        #region IDeserializationCallback implementation
+#region IDeserializationCallback implementation
         void IDeserializationCallback.OnDeserialization(object sender)
         {
             if (_siInfo == null)
@@ -426,8 +438,8 @@ namespace System.Collections.Specialized
                 }
             }
         }
-        #endregion
-
+#endregion
+#endif
         /// <devdoc>
         /// OrderedDictionaryEnumerator works just like any other IDictionaryEnumerator, but it retrieves DictionaryEntries
         /// in the order by index.

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.Serialization;
 
 namespace System.Collections.Specialized
 {
@@ -14,16 +15,26 @@ namespace System.Collections.Specialized
     /// OrderedDictionary is used by the ParameterCollection because MSAccess relies on ordering of
     /// parameters, while almost all other DBs do not.  DataKeyArray also uses it so
     /// DataKeys can be retrieved by either their name or their index.
+    /// 
+    /// OrderedDictionary implements IDeserializationCallback because it needs to have the
+    /// contained ArrayList and Hashtable deserialized before it tries to get its count and objects.
     /// </para>
     /// </devdoc>
-    public class OrderedDictionary : IOrderedDictionary
+    [Serializable]
+    public class OrderedDictionary : IOrderedDictionary, ISerializable, IDeserializationCallback
     {
         private ArrayList _objectsArray;
         private Hashtable _objectsTable;
-        private readonly int _initialCapacity;
-        private readonly IEqualityComparer _comparer;
-        private readonly bool _readOnly;
+        private int _initialCapacity;
+        private IEqualityComparer _comparer;
+        private bool _readOnly;
         private Object _syncRoot;
+        private SerializationInfo _siInfo; //A temporary variable which we need during deserialization.
+
+        private const string KeyComparerName = "KeyComparer";
+        private const string ArrayListName = "ArrayList";
+        private const string ReadOnlyName = "ReadOnly";
+        private const string InitCapacityName = "InitialCapacity";
 
         public OrderedDictionary() : this(0)
         {
@@ -52,6 +63,14 @@ namespace System.Collections.Specialized
             _objectsTable = dictionary._objectsTable;
             _comparer = dictionary._comparer;
             _initialCapacity = dictionary._initialCapacity;
+        }
+
+        protected OrderedDictionary(SerializationInfo info, StreamingContext context)
+        {
+            // We can't do anything with the keys and values until the entire graph has been deserialized
+            // and getting Counts and objects won't fail.  For the time being, we'll just cache this.  
+            // The graph is not valid until OnDeserialization has been called.
+            _siInfo = info;
         }
 
         /// <devdoc>
@@ -354,6 +373,58 @@ namespace System.Collections.Specialized
         IEnumerator IEnumerable.GetEnumerator()
         {
             return new OrderedDictionaryEnumerator(objectsArray, OrderedDictionaryEnumerator.DictionaryEntry);
+        }
+        #endregion
+
+        #region ISerializable implementation 
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            info.AddValue(KeyComparerName, _comparer, typeof(IEqualityComparer));
+            info.AddValue(ReadOnlyName, _readOnly);
+            info.AddValue(InitCapacityName, _initialCapacity);
+
+            object[] serArray = new object[Count];
+            _objectsArray.CopyTo(serArray);
+            info.AddValue(ArrayListName, serArray);
+        }
+        #endregion
+
+        #region IDeserializationCallback implementation
+        void IDeserializationCallback.OnDeserialization(object sender)
+        {
+            if (_siInfo == null)
+            {
+                throw new SerializationException(SR.Serialization_InvalidOnDeser);
+            }
+            _comparer = (IEqualityComparer)_siInfo.GetValue(KeyComparerName, typeof(IEqualityComparer));
+            _readOnly = _siInfo.GetBoolean(ReadOnlyName);
+            _initialCapacity = _siInfo.GetInt32(InitCapacityName);
+
+            object[] serArray = (object[])_siInfo.GetValue(ArrayListName, typeof(object[]));
+
+            if (serArray != null)
+            {
+                foreach (object o in serArray)
+                {
+                    DictionaryEntry entry;
+                    try
+                    {
+                        // DictionaryEntry is a value type, so it can only be casted.
+                        entry = (DictionaryEntry)o;
+                    }
+                    catch
+                    {
+                        throw new SerializationException(SR.OrderedDictionary_SerializationMismatch);
+                    }
+                    objectsArray.Add(entry);
+                    objectsTable.Add(entry.Key, entry.Value);
+                }
+            }
         }
         #endregion
 

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/StringCollection.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/StringCollection.cs
@@ -8,6 +8,7 @@ namespace System.Collections.Specialized
     /// <devdoc>
     ///    <para>Represents a collection of strings.</para>
     /// </devdoc>
+    [Serializable]
     public class StringCollection : IList
     {
         private readonly ArrayList _data = new ArrayList();

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/StringCollection.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/StringCollection.cs
@@ -8,9 +8,7 @@ namespace System.Collections.Specialized
     /// <devdoc>
     ///    <para>Represents a collection of strings.</para>
     /// </devdoc>
-#if netstandard17
     [Serializable]
-#endif
     public class StringCollection : IList
     {
         private readonly ArrayList _data = new ArrayList();

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/StringCollection.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/StringCollection.cs
@@ -8,7 +8,9 @@ namespace System.Collections.Specialized
     /// <devdoc>
     ///    <para>Represents a collection of strings.</para>
     /// </devdoc>
+#if netstandard17
     [Serializable]
+#endif
     public class StringCollection : IList
     {
         private readonly ArrayList _data = new ArrayList();

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/StringDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/StringDictionary.cs
@@ -11,6 +11,7 @@ namespace System.Collections.Specialized
     ///    <para>Consider this class obsolete - use Dictionary&lt;String, String&gt; instead
     ///       with a proper StringComparer instance.</para>
     /// </devdoc>
+    [Serializable]
     public class StringDictionary : IEnumerable
     {
         // For compatibility, we want the Keys property to return values in lower-case.

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/StringDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/StringDictionary.cs
@@ -11,7 +11,9 @@ namespace System.Collections.Specialized
     ///    <para>Consider this class obsolete - use Dictionary&lt;String, String&gt; instead
     ///       with a proper StringComparer instance.</para>
     /// </devdoc>
+#if netstandard17
     [Serializable]
+#endif
     public class StringDictionary : IEnumerable
     {
         // For compatibility, we want the Keys property to return values in lower-case.

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/StringDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/StringDictionary.cs
@@ -11,9 +11,7 @@ namespace System.Collections.Specialized
     ///    <para>Consider this class obsolete - use Dictionary&lt;String, String&gt; instead
     ///       with a proper StringComparer instance.</para>
     /// </devdoc>
-#if netstandard17
     [Serializable]
-#endif
     public class StringDictionary : IEnumerable
     {
         // For compatibility, we want the Keys property to return values in lower-case.

--- a/src/System.Collections.Specialized/src/project.json
+++ b/src/System.Collections.Specialized/src/project.json
@@ -7,6 +7,7 @@
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
         "System.Globalization": "4.0.10",
+        "System.Globalization.Extensions": "4.0.1",
         "System.Resources.ResourceManager": "4.0.0",
         "System.Runtime": "4.0.20",
         "System.Runtime.Extensions": "4.0.10",
@@ -20,12 +21,13 @@
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "System.Collections.NonGeneric": "4.1.0-beta-devapi-24422-01 ",
+        "System.Collections.NonGeneric": "4.1.0-beta-devapi-24424-01 ",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
-        "System.Globalization": "4.0.12-beta-devapi-24422-01",
+        "System.Globalization": "4.0.12-beta-devapi-24424-01",
+        "System.Globalization.Extensions": "4.0.2-beta-devapi-24424-01",
         "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.2.0-beta-devapi-24422-01",
+        "System.Runtime": "4.2.0-beta-devapi-24424-01",
         "System.Runtime.Extensions": "4.0.10",
         "System.Threading": "4.0.10",
         "System.Threading.Tasks": "4.0.10"

--- a/src/System.Collections.Specialized/src/project.json
+++ b/src/System.Collections.Specialized/src/project.json
@@ -1,21 +1,21 @@
 {
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "System.Collections.NonGeneric": "4.0.0",
+        "System.Collections.NonGeneric": "4.1.0-beta-devapi-24422-01 ",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
-        "System.Globalization": "4.0.10",
+        "System.Globalization": "4.0.12-beta-devapi-24422-01",
         "System.Globalization.Extensions": "4.0.0",
         "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.0.20",
+        "System.Runtime": "4.2.0-beta-devapi-24422-01",
         "System.Runtime.Extensions": "4.0.10",
         "System.Threading": "4.0.10",
         "System.Threading.Tasks": "4.0.10"
       },
       "imports": [
-        "dotnet5.4"
+        "dotnet5.8"
       ]
     },
     "net46": {

--- a/src/System.Collections.Specialized/src/project.json
+++ b/src/System.Collections.Specialized/src/project.json
@@ -1,23 +1,5 @@
 {
   "frameworks": {
-    "netstandard1.3": {
-      "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1",
-        "System.Collections.NonGeneric": "4.0.0",
-        "System.Diagnostics.Debug": "4.0.10",
-        "System.Diagnostics.Tools": "4.0.0",
-        "System.Globalization": "4.0.10",
-        "System.Globalization.Extensions": "4.0.1",
-        "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.0.20",
-        "System.Runtime.Extensions": "4.0.10",
-        "System.Threading": "4.0.10",
-        "System.Threading.Tasks": "4.0.10",
-      },
-      "imports": [
-        "dotnet5.4"
-      ]
-    },
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
@@ -35,11 +17,6 @@
       "imports": [
         "dotnet5.8"
       ]
-    },
-    "net46": {
-      "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
-      }
     },
     "net463": {
       "dependencies": {

--- a/src/System.Collections.Specialized/src/project.json
+++ b/src/System.Collections.Specialized/src/project.json
@@ -1,5 +1,22 @@
 {
   "frameworks": {
+    "netstandard1.3": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Collections.NonGeneric": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.Globalization": "4.0.10",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Threading": "4.0.10",
+        "System.Threading.Tasks": "4.0.10",
+      },
+      "imports": [
+        "dotnet5.4"
+      ]
+    },
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
@@ -7,7 +24,6 @@
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
         "System.Globalization": "4.0.12-beta-devapi-24422-01",
-        "System.Globalization.Extensions": "4.0.0",
         "System.Resources.ResourceManager": "4.0.0",
         "System.Runtime": "4.2.0-beta-devapi-24422-01",
         "System.Runtime.Extensions": "4.0.10",
@@ -19,6 +35,11 @@
       ]
     },
     "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    },
+    "net463": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.builds
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.builds
@@ -4,6 +4,10 @@
   <ItemGroup>
     <Project Include="System.Collections.Specialized.Tests.csproj"/>
     <Project Include="System.Collections.Specialized.Tests.csproj">
+      <TargetGroup>netstandard1.7</TargetGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+    </Project>
+    <Project Include="System.Collections.Specialized.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -4,12 +4,28 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{7F5F5134-00FE-4DE8-B20C-3DA8BA2EBA68}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>System.Collections.Specialized.Tests</RootNamespace>
     <AssemblyName>System.Collections.Specialized.Tests</AssemblyName>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <ProjectGuid>{7F5F5134-00FE-4DE8-B20C-3DA8BA2EBA68}</ProjectGuid>
+    <!--
+    TODO: Uncomment once a System.Collection.NonGeneric is published containing the serialization changes.
+          System.Collections.Specialized collections depend on those types being serializable.
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
+    -->
+    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <!-- 
+        Until we get first class support for NS1.7 and Netcoreapp1.1 
+        we need to hard code $(TestTFM) and $(TestNugetTargetMoniker) 
+        in the project file. 
+      -->
+    <TestTFM Condition="'$(TargetGroup)'=='netstandard1.7'">netcoreapp1.1</TestTFM>
   </PropertyGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
+      <Folder>netcoreapp1.1</Folder>
+    </TestNugetTargetMoniker>
+  </ItemGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -117,5 +117,11 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <!-- ToDo: Remove this target once the infrastructure for testing in netcoreapp1.1 is ready -->
+  <Target Name="RemoveUnwantedTestMonikers" Condition="'$(TargetGroup)'=='netstandard1.7'" BeforeTargets="CopyTestToTestDirectory">
+    <ItemGroup>
+      <TestNugetTargetMoniker Remove=".NETCoreApp,Version=v1.1" />
+    </ItemGroup>
+  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -108,6 +108,16 @@
     <Compile Include="StringDictionary\StringDictionary.ValuesTests.cs" />
     <Compile Include="StringDictionary\StringDictionaryClearTests.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'!='netstandard1.7'">
+    <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
+      <Link>Common\System\SerializableAttribute.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs" >
+      <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Collections.Specialized.pkgproj">
       <Project>{63634289-90d7-4947-8bf3-dbbe98d76c85}</Project>

--- a/src/System.Collections.Specialized/tests/project.json
+++ b/src/System.Collections.Specialized/tests/project.json
@@ -24,8 +24,8 @@
     "netstandard1.3": {},
     "netstandard1.7": {
         "dependencies": {
-		    "System.Globalization.Extensions": "4.0.2-beta-devapi-24422-01",
-            "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24422-01",
+		    "System.Globalization.Extensions": "4.0.2-beta-devapi-24424-01",
+            "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24424-01",
         }
     }
   },

--- a/src/System.Collections.Specialized/tests/project.json
+++ b/src/System.Collections.Specialized/tests/project.json
@@ -21,7 +21,13 @@
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-03"
   },
   "frameworks": {
-    "netstandard1.3": {}
+    "netstandard1.3": {},
+    "netstandard1.7": {
+        "dependencies": {
+		    "System.Globalization.Extensions": "4.0.2-beta-devapi-24422-01",
+            "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24422-01",
+        }
+    }
   },
   "supports": {
     "coreFx.Test.netcore50": {},
@@ -29,6 +35,22 @@
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},
-    "coreFx.Test.net463": {}
+    "coreFx.Test.net463": {},
+    "coreFx.Test.netcoreapp1.1-ns17": {
+      "netstandard1.7": [
+        "win7-x86",
+        "win7-x64",
+        "win10-arm64",
+        "osx.10.10-x64",
+        "centos.7-x64",
+        "debian.8-x64",
+        "rhel.7-x64",
+        "ubuntu.14.04-x64",
+        "ubuntu.16.04-x64",
+        "fedora.23-x64",
+        "linux-x64",
+        "opensuse.13.2-x64"
+      ]
+    }
   }
 }

--- a/src/System.Collections/pkg/any/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/any/System.Collections.pkgproj
@@ -9,12 +9,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Collections.csproj" />
-    <ProjectReference Include="..\..\src\System.Collections.csproj">
-      <TargetGroup>netstandard1.3</TargetGroup>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\redist\System.Collections.depproj">
-      <TargetGroup>netcore50</TargetGroup>
-    </ProjectReference>
 
     <!-- AOT implementation comes from AOT package -->
     <File Include="$(PlaceholderFile)">

--- a/src/System.Collections/pkg/aot/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/aot/System.Collections.pkgproj
@@ -7,11 +7,5 @@
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\redist\System.Collections.depproj">
-      <TargetGroup>netcore50aot</TargetGroup>
-    </ProjectReference>
-  </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -48,12 +48,13 @@ namespace System.Collections.Generic
         public static System.Collections.Generic.Comparer<T> Create(System.Comparison<T> comparison) { return default(System.Collections.Generic.Comparer<T>); }
         int System.Collections.IComparer.Compare(object x, object y) { return default(int); }
     }
-    public partial class Dictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+    public partial class Dictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         public Dictionary() { }
         public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
         public Dictionary(System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+        protected Dictionary(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public Dictionary(int capacity) { }
         public Dictionary(int capacity, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
         public System.Collections.Generic.IEqualityComparer<TKey> Comparer { get { return default(System.Collections.Generic.IEqualityComparer<TKey>); } }
@@ -78,6 +79,8 @@ namespace System.Collections.Generic
         public bool ContainsKey(TKey key) { return default(bool); }
         public bool ContainsValue(TValue value) { return default(bool); }
         public System.Collections.Generic.Dictionary<TKey, TValue>.Enumerator GetEnumerator() { return default(System.Collections.Generic.Dictionary<TKey, TValue>.Enumerator); }
+        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public virtual void OnDeserialization(object sender) { }
         public bool Remove(TKey key) { return default(bool); }
         void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
         bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { return default(bool); }
@@ -165,12 +168,13 @@ namespace System.Collections.Generic
         bool System.Collections.IEqualityComparer.Equals(object x, object y) { return default(bool); }
         int System.Collections.IEqualityComparer.GetHashCode(object obj) { return default(int); }
     }
-    public partial class HashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+    public partial class HashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         public HashSet() { }
         public HashSet(System.Collections.Generic.IEnumerable<T> collection) { }
         public HashSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public HashSet(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        protected HashSet(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public System.Collections.Generic.IEqualityComparer<T> Comparer { get { return default(System.Collections.Generic.IEqualityComparer<T>); } }
         public int Count { get { return default(int); } }
         bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { return default(bool); } }
@@ -183,11 +187,13 @@ namespace System.Collections.Generic
         public static IEqualityComparer<HashSet<T>> CreateSetComparer() { return default(IEqualityComparer<HashSet<T>>); }
         public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
         public System.Collections.Generic.HashSet<T>.Enumerator GetEnumerator() { return default(System.Collections.Generic.HashSet<T>.Enumerator); }
+        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
         public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { return default(bool); }
         public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { return default(bool); }
         public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { return default(bool); }
         public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { return default(bool); }
+        public virtual void OnDeserialization(object sender) { }
         public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { return default(bool); }
         public bool Remove(T item) { return default(bool); }
         public int RemoveWhere(System.Predicate<T> match) { return default(int); }
@@ -208,10 +214,11 @@ namespace System.Collections.Generic
             void System.Collections.IEnumerator.Reset() { }
         }
     }
-    public partial class LinkedList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+    public partial class LinkedList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         public LinkedList() { }
         public LinkedList(System.Collections.Generic.IEnumerable<T> collection) { }
+        protected LinkedList(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public int Count { get { return default(int); } }
         public System.Collections.Generic.LinkedListNode<T> First { get { return default(System.Collections.Generic.LinkedListNode<T>); } }
         public System.Collections.Generic.LinkedListNode<T> Last { get { return default(System.Collections.Generic.LinkedListNode<T>); } }
@@ -232,6 +239,8 @@ namespace System.Collections.Generic
         public System.Collections.Generic.LinkedListNode<T> Find(T value) { return default(System.Collections.Generic.LinkedListNode<T>); }
         public System.Collections.Generic.LinkedListNode<T> FindLast(T value) { return default(System.Collections.Generic.LinkedListNode<T>); }
         public System.Collections.Generic.LinkedList<T>.Enumerator GetEnumerator() { return default(System.Collections.Generic.LinkedList<T>.Enumerator); }
+        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public virtual void OnDeserialization(object sender) { }
         public bool Remove(T value) { return default(bool); }
         public void Remove(System.Collections.Generic.LinkedListNode<T> node) { }
         public void RemoveFirst() { }
@@ -241,12 +250,14 @@ namespace System.Collections.Generic
         void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
         {
             public T Current { get { return default(T); } }
             object System.Collections.IEnumerator.Current { get { return default(object); } }
             public void Dispose() { }
+            void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
             public bool MoveNext() { return default(bool); }
+            void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(Object sender) { }
             void System.Collections.IEnumerator.Reset() { }
         }
     }
@@ -521,12 +532,13 @@ namespace System.Collections.Generic
         public void TrimExcess() { }
         public bool TryGetValue(TKey key, out TValue value) { value = default(TValue); return default(bool); }
     }
-    public partial class SortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+    public partial class SortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         public SortedSet() { }
         public SortedSet(System.Collections.Generic.IComparer<T> comparer) { }
         public SortedSet(System.Collections.Generic.IEnumerable<T> collection) { }
         public SortedSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IComparer<T> comparer) { }
+        protected SortedSet(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public System.Collections.Generic.IComparer<T> Comparer { get { return default(System.Collections.Generic.IComparer<T>); } }
         public int Count { get { return default(int); } }
         public T Max { get { return default(T); } }
@@ -544,12 +556,16 @@ namespace System.Collections.Generic
         public static IEqualityComparer<SortedSet<T>> CreateSetComparer(IEqualityComparer<T> memberEqualityComparer) { return default(IEqualityComparer<SortedSet<T>>); }
         public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
         public System.Collections.Generic.SortedSet<T>.Enumerator GetEnumerator() { return default(System.Collections.Generic.SortedSet<T>.Enumerator); }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual System.Collections.Generic.SortedSet<T> GetViewBetween(T lowerValue, T upperValue) { return default(System.Collections.Generic.SortedSet<T>); }
         public virtual void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
         public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { return default(bool); }
         public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { return default(bool); }
         public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { return default(bool); }
         public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { return default(bool); }
+        protected virtual void OnDeserialization(object sender) { }
+        void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
         public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { return default(bool); }
         public bool Remove(T item) { return default(bool); }
         public int RemoveWhere(System.Predicate<T> match) { return default(int); }
@@ -562,12 +578,14 @@ namespace System.Collections.Generic
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
         public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
         {
             public T Current { get { return default(T); } }
             object System.Collections.IEnumerator.Current { get { return default(object); } }
             public void Dispose() { }
+            void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
             public bool MoveNext() { return default(bool); }
+            void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
             void System.Collections.IEnumerator.Reset() { }
         }
     }

--- a/src/System.Collections/src/Resources/Strings.resx
+++ b/src/System.Collections/src/Resources/Strings.resx
@@ -216,4 +216,16 @@
   <data name="SortedSet_LowerValueGreaterThanUpperValue" xml:space="preserve">
     <value>Must be less than or equal to upperValue.</value>
   </data>
+  <data name="Serialization_InvalidOnDeser" xml:space="preserve">
+    <value>OnDeserialization method was called while the object was not being deserialized.</value>
+  </data>
+  <data name="Serialization_MismatchedCount" xml:space="preserve">
+    <value>The serialized Count information doesn't match the number of items.</value>
+  </data>
+  <data name="Serialization_MissingKeys" xml:space="preserve">
+    <value>The keys for this dictionary are missing.</value>
+  </data>
+  <data name="Serialization_MissingValues" xml:space="preserve">
+    <value>The values for this dictionary are missing.</value>
+  </data>
 </root>

--- a/src/System.Collections/src/System.Collections.builds
+++ b/src/System.Collections/src/System.Collections.builds
@@ -4,20 +4,7 @@
   <ItemGroup>
     <Project Include="System.Collections.csproj" />
     <Project Include="System.Collections.csproj">
-      <TargetGroup>netstandard1.3</TargetGroup>
-    </Project>
-    <Project Include="System.Collections.csproj">
       <TargetGroup>net463</TargetGroup>
-    </Project>
-    <!-- NETCore50 must redistribute binaries due to shared library
-    <Project Include="System.Collections.csproj">
-      <TargetGroup>netcore50aot</TargetGroup>
-    </Project> -->
-    <Project Include="redist/System.Collections.depproj">
-      <TargetGroup>netcore50</TargetGroup>
-    </Project>
-    <Project Include="redist/System.Collections.depproj">
-      <TargetGroup>netcore50aot</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -3,28 +3,23 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{D5FF747F-7A0B-9003-885A-FE9A63E755E5}</ProjectGuid>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netcore50aot' OR '$(TargetGroup)' != 'net463'">true</IsPartialFacadeAssembly>
     <AssemblyName>System.Collections</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3'">4.0.12.0</AssemblyVersion>
-    <ContractProject Condition="'$(TargetGroup)'=='netstandard1.3'">../ref/4.0.10/System.Collections.depproj</ContractProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
-    <DefineConstants Condition="'$(AssemblyVersion)'=='4.1.0.0'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.346_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aotao_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' == '' OR '$(TargetGroup)'=='netstandard1.3'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' == '' OR '$(TargetGroup)'=='netstandard1.7'">
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj">
-      <TargetGroup>netstandard1.5</TargetGroup>
+      <TargetGroup>netstandard1.7</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
       <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
@@ -53,14 +48,6 @@
     <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
       <Link>Common\System\Collections\Generic\EnumerableHelpers.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
-    <Compile Include="System\Converter.cs" />
-    <Compile Include="System\Collections\BitArray.cs" />
-    <Compile Include="System\Collections\Generic\Comparer.cs" />
-    <Compile Include="System\Collections\Generic\Dictionary.cs" />
-    <Compile Include="System\Collections\Generic\EqualityComparer.cs" />
-    <Compile Include="System\Collections\Generic\List.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />

--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -11,6 +11,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <DefineConstants Condition="'$(AssemblyVersion)'=='4.1.0.0'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -10,9 +10,7 @@ namespace System.Collections
     // A vector of bits.  Use this to store bits efficiently, without having to do bit 
     // shifting yourself.
     [System.Runtime.InteropServices.ComVisible(true)]
-#if netstandard17
     [Serializable]
-#endif
     public sealed class BitArray : ICollection
     {
         private BitArray()
@@ -498,9 +496,7 @@ namespace System.Collections
             return n > 0 ? (((n - 1) / div) + 1) : 0;
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private class BitArrayEnumeratorSimple : IEnumerator
         {
             private BitArray bitarray;

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -10,6 +10,9 @@ namespace System.Collections
     // A vector of bits.  Use this to store bits efficiently, without having to do bit 
     // shifting yourself.
     [System.Runtime.InteropServices.ComVisible(true)]
+#if netstandard17
+    [Serializable]
+#endif
     public sealed class BitArray : ICollection
     {
         private BitArray()
@@ -495,6 +498,9 @@ namespace System.Collections
             return n > 0 ? (((n - 1) / div) + 1) : 0;
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private class BitArrayEnumeratorSimple : IEnumerator
         {
             private BitArray bitarray;
@@ -552,6 +558,7 @@ namespace System.Collections
         private int[] m_array;
         private int m_length;
         private int _version;
+        [NonSerialized]
         private object _syncRoot;
 
         private const int _ShrinkThreshold = 256;

--- a/src/System.Collections/src/System/Collections/Generic/Comparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Comparer.cs
@@ -8,9 +8,7 @@ using System.Diagnostics.Contracts;
 
 namespace System.Collections.Generic
 {
-#if netstandard17
     [Serializable]
-#endif
     public abstract class Comparer<T> : IComparer, IComparer<T>
     {
         protected Comparer()
@@ -72,9 +70,7 @@ namespace System.Collections.Generic
         private static Comparer<T> _default;
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal class DefaultComparer<T> : Comparer<T>
     {
         public override int Compare(T x, T y)
@@ -119,9 +115,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal class ComparisonComparer<T> : Comparer<T>
     {
         private readonly Comparison<T> _comparison;
@@ -137,9 +131,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal class Int32Comparer : Comparer<Int32>
     {
         public override int Compare(int x, int y)

--- a/src/System.Collections/src/System/Collections/Generic/Comparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Comparer.cs
@@ -8,6 +8,9 @@ using System.Diagnostics.Contracts;
 
 namespace System.Collections.Generic
 {
+#if netstandard17
+    [Serializable]
+#endif
     public abstract class Comparer<T> : IComparer, IComparer<T>
     {
         protected Comparer()
@@ -69,7 +72,9 @@ namespace System.Collections.Generic
         private static Comparer<T> _default;
     }
 
-
+#if netstandard17
+    [Serializable]
+#endif
     internal class DefaultComparer<T> : Comparer<T>
     {
         public override int Compare(T x, T y)
@@ -114,6 +119,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal class ComparisonComparer<T> : Comparer<T>
     {
         private readonly Comparison<T> _comparison;
@@ -129,6 +137,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal class Int32Comparer : Comparer<Int32>
     {
         public override int Compare(int x, int y)

--- a/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
@@ -7,22 +7,15 @@ using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-#if netstandard17
 using System.Runtime.Serialization;
-#endif
 
 namespace System.Collections.Generic
 {
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
     [System.Runtime.InteropServices.ComVisible(false)]
-#if netstandard17
     [Serializable]
-#endif
-    public class Dictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
-#if netstandard17
-        , ISerializable, IDeserializationCallback
-#endif
+    public class Dictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>, ISerializable, IDeserializationCallback
     {
         private struct Entry
         {
@@ -44,13 +37,11 @@ namespace System.Collections.Generic
         private ValueCollection values;
         private object _syncRoot;
 
-#if netstandard17
         // constants for serialization
-        private const String VersionName = "Version";
-        private const String HashSizeName = "HashSize"; // Must save buckets.Length
-        private const String KeyValuePairsName = "KeyValuePairs";
-        private const String ComparerName = "Comparer";
-#endif
+        private const string VersionName = "Version";
+        private const string HashSizeName = "HashSize"; // Must save buckets.Length
+        private const string KeyValuePairsName = "KeyValuePairs";
+        private const string ComparerName = "Comparer";
 
         public Dictionary() : this(0, null) { }
 
@@ -100,7 +91,6 @@ namespace System.Collections.Generic
             }
         }
 
-#if netstandard17
         protected Dictionary(SerializationInfo info, StreamingContext context)
         {
             // We can't do anything with the keys and values until the entire graph has been deserialized
@@ -108,7 +98,6 @@ namespace System.Collections.Generic
             // we'll just cache this.  The graph is not valid until OnDeserialization has been called.
             HashHelpers.SerializationInfoTable.Add(this, info);
         }
-#endif
 
         public IEqualityComparer<TKey> Comparer
         {
@@ -300,7 +289,6 @@ namespace System.Collections.Generic
             return new Enumerator(this, Enumerator.KeyValuePair);
         }
 
-#if netstandard17
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)
@@ -319,7 +307,6 @@ namespace System.Collections.Generic
                 info.AddValue(KeyValuePairsName, array, typeof(KeyValuePair<TKey, TValue>[]));
             }
         }
-#endif
 
         private int FindEntry(TKey key)
         {
@@ -414,7 +401,6 @@ namespace System.Collections.Generic
 #endif
         }
 
-#if netstandard17
         public virtual void OnDeserialization(object sender)
         {
             SerializationInfo siInfo;
@@ -462,7 +448,6 @@ namespace System.Collections.Generic
             version = realVersion;
             HashHelpers.SerializationInfoTable.Remove(this);
         }
-#endif
 
         private void Resize()
         {
@@ -794,9 +779,7 @@ namespace System.Collections.Generic
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>,
             IDictionaryEnumerator
         {
@@ -925,9 +908,7 @@ namespace System.Collections.Generic
 
         [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
         [Serializable]
-#endif
         public sealed class KeyCollection : ICollection<TKey>, ICollection, IReadOnlyCollection<TKey>
         {
             private Dictionary<TKey, TValue> dictionary;
@@ -1079,9 +1060,7 @@ namespace System.Collections.Generic
                 get { return ((ICollection)dictionary).SyncRoot; }
             }
 
-#if netstandard17
             [Serializable]
-#endif
             public struct Enumerator : IEnumerator<TKey>, System.Collections.IEnumerator
             {
                 private Dictionary<TKey, TValue> dictionary;
@@ -1160,9 +1139,7 @@ namespace System.Collections.Generic
 
         [DebuggerTypeProxy(typeof(DictionaryValueCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
         [Serializable]
-#endif
         public sealed class ValueCollection : ICollection<TValue>, ICollection, IReadOnlyCollection<TValue>
         {
             private Dictionary<TKey, TValue> dictionary;
@@ -1312,9 +1289,7 @@ namespace System.Collections.Generic
                 get { return ((ICollection)dictionary).SyncRoot; }
             }
 
-#if netstandard17
             [Serializable]
-#endif
             public struct Enumerator : IEnumerator<TValue>, System.Collections.IEnumerator
             {
                 private Dictionary<TKey, TValue> dictionary;

--- a/src/System.Collections/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/EqualityComparer.cs
@@ -13,9 +13,7 @@ using System.Collections;
 
 namespace System.Collections.Generic
 {
-#if netstandard17
     [Serializable]
-#endif
     public abstract class EqualityComparer<T> : IEqualityComparer, IEqualityComparer<T>
     {
         protected EqualityComparer()
@@ -129,9 +127,7 @@ namespace System.Collections.Generic
     //    incompatible with Object.Equals(). That goes specifically against the documented guidelines (and would in any case,
     //    break any hashcode-dependent collection.) 
     //
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class LastResortEqualityComparer<T> : EqualityComparer<T>
     {
         public LastResortEqualityComparer()
@@ -156,9 +152,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForSByte : EqualityComparer<sbyte>
     {
         public override bool Equals(sbyte x, sbyte y)
@@ -172,9 +166,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForByte : EqualityComparer<byte>
     {
         public override bool Equals(byte x, byte y)
@@ -188,9 +180,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForInt16 : EqualityComparer<short>
     {
         public override bool Equals(short x, short y)
@@ -204,9 +194,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForUInt16 : EqualityComparer<ushort>
     {
         public override bool Equals(ushort x, ushort y)
@@ -220,9 +208,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForInt32 : EqualityComparer<int>
     {
         public override bool Equals(int x, int y)
@@ -236,9 +222,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForUInt32 : EqualityComparer<uint>
     {
         public override bool Equals(uint x, uint y)
@@ -252,9 +236,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForInt64 : EqualityComparer<long>
     {
         public override bool Equals(long x, long y)
@@ -268,9 +250,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForUInt64 : EqualityComparer<ulong>
     {
         public override bool Equals(ulong x, ulong y)
@@ -284,9 +264,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForIntPtr : EqualityComparer<IntPtr>
     {
         public override bool Equals(IntPtr x, IntPtr y)
@@ -300,9 +278,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForUIntPtr : EqualityComparer<UIntPtr>
     {
         public override bool Equals(UIntPtr x, UIntPtr y)
@@ -316,9 +292,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForSingle : EqualityComparer<float>
     {
         public override bool Equals(float x, float y)
@@ -333,9 +307,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForDouble : EqualityComparer<double>
     {
         public override bool Equals(double x, double y)
@@ -350,9 +322,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForDecimal : EqualityComparer<decimal>
     {
         public override bool Equals(decimal x, decimal y)
@@ -366,9 +336,7 @@ namespace System.Collections.Generic
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class EqualityComparerForString : EqualityComparer<string>
     {
         public override bool Equals(string x, string y)

--- a/src/System.Collections/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/EqualityComparer.cs
@@ -13,6 +13,9 @@ using System.Collections;
 
 namespace System.Collections.Generic
 {
+#if netstandard17
+    [Serializable]
+#endif
     public abstract class EqualityComparer<T> : IEqualityComparer, IEqualityComparer<T>
     {
         protected EqualityComparer()
@@ -126,6 +129,9 @@ namespace System.Collections.Generic
     //    incompatible with Object.Equals(). That goes specifically against the documented guidelines (and would in any case,
     //    break any hashcode-dependent collection.) 
     //
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class LastResortEqualityComparer<T> : EqualityComparer<T>
     {
         public LastResortEqualityComparer()
@@ -150,6 +156,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForSByte : EqualityComparer<sbyte>
     {
         public override bool Equals(sbyte x, sbyte y)
@@ -163,6 +172,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForByte : EqualityComparer<byte>
     {
         public override bool Equals(byte x, byte y)
@@ -176,6 +188,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForInt16 : EqualityComparer<short>
     {
         public override bool Equals(short x, short y)
@@ -189,6 +204,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForUInt16 : EqualityComparer<ushort>
     {
         public override bool Equals(ushort x, ushort y)
@@ -202,6 +220,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForInt32 : EqualityComparer<int>
     {
         public override bool Equals(int x, int y)
@@ -215,6 +236,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForUInt32 : EqualityComparer<uint>
     {
         public override bool Equals(uint x, uint y)
@@ -228,6 +252,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForInt64 : EqualityComparer<long>
     {
         public override bool Equals(long x, long y)
@@ -241,6 +268,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForUInt64 : EqualityComparer<ulong>
     {
         public override bool Equals(ulong x, ulong y)
@@ -254,6 +284,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForIntPtr : EqualityComparer<IntPtr>
     {
         public override bool Equals(IntPtr x, IntPtr y)
@@ -267,6 +300,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForUIntPtr : EqualityComparer<UIntPtr>
     {
         public override bool Equals(UIntPtr x, UIntPtr y)
@@ -280,6 +316,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForSingle : EqualityComparer<float>
     {
         public override bool Equals(float x, float y)
@@ -294,6 +333,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForDouble : EqualityComparer<double>
     {
         public override bool Equals(double x, double y)
@@ -308,6 +350,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForDecimal : EqualityComparer<decimal>
     {
         public override bool Equals(decimal x, decimal y)
@@ -321,6 +366,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class EqualityComparerForString : EqualityComparer<string>
     {
         public override bool Equals(string x, string y)

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -5,9 +5,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-#if netstandard17
 using System.Runtime.Serialization;
-#endif
 
 namespace System.Collections.Generic
 {
@@ -50,13 +48,8 @@ namespace System.Collections.Generic
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "By design")]
-#if netstandard17
     [Serializable]
-#endif
-    public class HashSet<T> : ICollection<T>, ISet<T>, IReadOnlyCollection<T>
-#if netstandard17
-        , ISerializable, IDeserializationCallback
-#endif
+    public class HashSet<T> : ICollection<T>, ISet<T>, IReadOnlyCollection<T>, ISerializable, IDeserializationCallback
     {
         // store lower 31 bits of hash code
         private const int Lower31BitMask = 0x7FFFFFFF;
@@ -69,13 +62,11 @@ namespace System.Collections.Generic
         // This is set to 3 because capacity is acceptable as 2x rounded up to nearest prime.
         private const int ShrinkThreshold = 3;
 
-#if netstandard17
         // constants for serialization
-        private const String CapacityName = "Capacity";
-        private const String ElementsName = "Elements";
-        private const String ComparerName = "Comparer";
-        private const String VersionName = "Version";
-#endif
+        private const string CapacityName = "Capacity";
+        private const string ElementsName = "Elements";
+        private const string ComparerName = "Comparer";
+        private const string VersionName = "Version";
 
         private int[] _buckets;
         private Slot[] _slots;
@@ -85,9 +76,7 @@ namespace System.Collections.Generic
         private IEqualityComparer<T> _comparer;
         private int _version;
 
-#if netstandard17
         private SerializationInfo _siInfo; // temporary variable needed during deserialization
-#endif
 
         #region Constructors
 
@@ -152,7 +141,6 @@ namespace System.Collections.Generic
             }
         }
 
-#if netstandard17
         protected HashSet(SerializationInfo info, StreamingContext context)
         {
             // We can't do anything with the keys and values until the entire graph has been 
@@ -161,7 +149,6 @@ namespace System.Collections.Generic
             // OnDeserialization has been called.
             _siInfo = info;
         }
-#endif
 
         // Initializes the HashSet from another HashSet with the same element type and
         // equality comparer.
@@ -362,7 +349,6 @@ namespace System.Collections.Generic
 
         #endregion
 
-#if netstandard17
         #region ISerializable methods
 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -430,7 +416,6 @@ namespace System.Collections.Generic
         }
 
         #endregion
-#endif
 
         #region HashSet methods
 
@@ -1722,9 +1707,7 @@ namespace System.Collections.Generic
             internal T value;
         }
 
-#if netstandard17
         [Serializable]
-#endif
         public struct Enumerator : IEnumerator<T>, IEnumerator
         {
             private HashSet<T> _set;

--- a/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
@@ -4,18 +4,36 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+#if netstandard17
+using System.Runtime.Serialization;
+#endif
 
 namespace System.Collections.Generic
 {
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+    [Serializable]
+#endif
     public class LinkedList<T> : ICollection<T>, ICollection, IReadOnlyCollection<T>
+#if netstandard17
+        , ISerializable, IDeserializationCallback
+#endif
     {
         // This LinkedList is a doubly-Linked circular list.
         internal LinkedListNode<T> head;
         internal int count;
         internal int version;
         private object _syncRoot;
+
+#if netstandard17
+        private SerializationInfo _siInfo; //A temporary variable which we need during deserialization.  
+
+        // names for serialization
+        const String VersionName = "Version";
+        const String CountName = "Count";  
+        const String ValuesName = "Data";
+#endif
 
         public LinkedList()
         {
@@ -33,6 +51,13 @@ namespace System.Collections.Generic
                 AddLast(item);
             }
         }
+
+#if netstandard17
+        protected LinkedList(SerializationInfo info, StreamingContext context)
+        {
+            _siInfo = info;
+        }
+#endif
 
         public int Count
         {
@@ -319,6 +344,61 @@ namespace System.Collections.Generic
             InternalRemoveNode(head.prev);
         }
 
+#if netstandard17
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            // Customized serialization for LinkedList.
+            // We need to do this because it will be too expensive to Serialize each node.
+            // This will give us the flexiblility to change internal implementation freely in future.
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            info.AddValue(VersionName, version);
+            info.AddValue(CountName, count); // this is the length of the bucket array.
+
+            if (count != 0)
+            {
+                T[] array = new T[count];
+                CopyTo(array, 0);
+                info.AddValue(ValuesName, array, typeof(T[]));
+            }
+        }
+
+        public virtual void OnDeserialization(Object sender)
+        {
+            if (_siInfo == null)
+            {
+                return; //Somebody had a dependency on this Dictionary and fixed us up before the ObjectManager got to it.
+            }
+
+            int realVersion = _siInfo.GetInt32(VersionName);
+            int count = _siInfo.GetInt32(CountName);
+
+            if (count != 0)
+            {
+                T[] array = (T[])_siInfo.GetValue(ValuesName, typeof(T[]));
+
+                if (array == null)
+                {
+                    throw new SerializationException(SR.Serialization_MissingValues);
+                }
+                for (int i = 0; i < array.Length; i++)
+                {
+                    AddLast(array[i]);
+                }
+            }
+            else
+            {
+                head = null;
+            }
+
+            version = realVersion;
+            _siInfo = null;
+        }
+#endif
+
         private void InternalInsertNodeBefore(LinkedListNode<T> node, LinkedListNode<T> newNode)
         {
             newNode.next = node;
@@ -471,13 +551,27 @@ namespace System.Collections.Generic
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "not an expected scenario")]
+#if netstandard17
+        [Serializable]
+#endif
         public struct Enumerator : IEnumerator<T>, IEnumerator
+#if netstandard17
+            , ISerializable, IDeserializationCallback
+#endif
         {
             private LinkedList<T> _list;
             private LinkedListNode<T> _node;
             private int _version;
             private T _current;
             private int _index;
+#if netstandard17
+            private SerializationInfo _siInfo; //A temporary variable which we need during deserialization.
+
+            const string LinkedListName = "LinkedList";
+            const string CurrentValueName = "Current";
+            const string VersionName = "Version";
+            const string IndexName = "Index";
+#endif
 
             internal Enumerator(LinkedList<T> list)
             {
@@ -486,7 +580,22 @@ namespace System.Collections.Generic
                 _node = list.head;
                 _current = default(T);
                 _index = 0;
+#if netstandard17
+                _siInfo = null;
+#endif
             }
+
+#if netstandard17
+            internal Enumerator(SerializationInfo info, StreamingContext context)
+            {
+                _siInfo = info;
+                _list = null;
+                _version = 0;
+                _node = null;
+                _current = default(T);
+                _index = 0;
+            }
+#endif
 
             public T Current
             {
@@ -544,6 +653,70 @@ namespace System.Collections.Generic
             public void Dispose()
             {
             }
+
+#if netstandard17
+            void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                if (info == null)
+                {
+                    throw new ArgumentNullException(nameof(info));
+                }
+
+                info.AddValue(LinkedListName, _list);
+                info.AddValue(VersionName, _version);
+                info.AddValue(CurrentValueName, _current);
+                info.AddValue(IndexName, _index);
+            }
+
+            void IDeserializationCallback.OnDeserialization(Object sender)
+            {
+                if (_list != null)
+                {
+                    return; // Somebody had a dependency on this Dictionary and fixed us up before the ObjectManager got to it.
+                }
+
+                if (_siInfo == null)
+                {
+                    throw new SerializationException(SR.Serialization_InvalidOnDeser);
+                }
+
+                _list = (LinkedList<T>)_siInfo.GetValue(LinkedListName, typeof(LinkedList<T>));
+                _version = _siInfo.GetInt32(VersionName);
+                _current = (T)_siInfo.GetValue(CurrentValueName, typeof(T));
+                _index = _siInfo.GetInt32(IndexName);
+
+                if (_list._siInfo != null)
+                {
+                    _list.OnDeserialization(sender);
+                }
+
+                if (_index == _list.Count + 1)
+                {
+                    // end of enumeration
+                    _node = null;
+                }
+                else
+                {
+                    _node = _list.First;
+
+                    // We don't care if we can point to the correct node if the LinkedList was changed   
+                    // MoveNext will throw upon next call and Current has the correct value. 
+                    if (_node != null && _index != 0)
+                    {
+                        for (int i = 0; i < _index; i++)
+                        {
+                            _node = _node.next;
+                        }
+                        if (_node == _list.First)
+                        {
+                            _node = null;
+                        }
+                    }
+                }
+
+                _siInfo = null;
+            }
+#endif
         }
     }
 

--- a/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
@@ -4,36 +4,26 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-#if netstandard17
 using System.Runtime.Serialization;
-#endif
 
 namespace System.Collections.Generic
 {
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
     [Serializable]
-#endif
-    public class LinkedList<T> : ICollection<T>, ICollection, IReadOnlyCollection<T>
-#if netstandard17
-        , ISerializable, IDeserializationCallback
-#endif
+    public class LinkedList<T> : ICollection<T>, ICollection, IReadOnlyCollection<T>, ISerializable, IDeserializationCallback
     {
         // This LinkedList is a doubly-Linked circular list.
         internal LinkedListNode<T> head;
         internal int count;
         internal int version;
         private object _syncRoot;
-
-#if netstandard17
         private SerializationInfo _siInfo; //A temporary variable which we need during deserialization.  
 
         // names for serialization
-        const String VersionName = "Version";
-        const String CountName = "Count";  
-        const String ValuesName = "Data";
-#endif
+        private const string VersionName = "Version";
+        private const string CountName = "Count";  
+        private const string ValuesName = "Data";
 
         public LinkedList()
         {
@@ -52,12 +42,10 @@ namespace System.Collections.Generic
             }
         }
 
-#if netstandard17
         protected LinkedList(SerializationInfo info, StreamingContext context)
         {
             _siInfo = info;
         }
-#endif
 
         public int Count
         {
@@ -344,7 +332,6 @@ namespace System.Collections.Generic
             InternalRemoveNode(head.prev);
         }
 
-#if netstandard17
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             // Customized serialization for LinkedList.
@@ -397,7 +384,6 @@ namespace System.Collections.Generic
             version = realVersion;
             _siInfo = null;
         }
-#endif
 
         private void InternalInsertNodeBefore(LinkedListNode<T> node, LinkedListNode<T> newNode)
         {
@@ -551,27 +537,20 @@ namespace System.Collections.Generic
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "not an expected scenario")]
-#if netstandard17
         [Serializable]
-#endif
-        public struct Enumerator : IEnumerator<T>, IEnumerator
-#if netstandard17
-            , ISerializable, IDeserializationCallback
-#endif
+        public struct Enumerator : IEnumerator<T>, IEnumerator, ISerializable, IDeserializationCallback
         {
             private LinkedList<T> _list;
             private LinkedListNode<T> _node;
             private int _version;
             private T _current;
             private int _index;
-#if netstandard17
             private SerializationInfo _siInfo; //A temporary variable which we need during deserialization.
 
             const string LinkedListName = "LinkedList";
             const string CurrentValueName = "Current";
             const string VersionName = "Version";
             const string IndexName = "Index";
-#endif
 
             internal Enumerator(LinkedList<T> list)
             {
@@ -580,12 +559,9 @@ namespace System.Collections.Generic
                 _node = list.head;
                 _current = default(T);
                 _index = 0;
-#if netstandard17
                 _siInfo = null;
-#endif
             }
 
-#if netstandard17
             internal Enumerator(SerializationInfo info, StreamingContext context)
             {
                 _siInfo = info;
@@ -595,7 +571,6 @@ namespace System.Collections.Generic
                 _current = default(T);
                 _index = 0;
             }
-#endif
 
             public T Current
             {
@@ -654,7 +629,6 @@ namespace System.Collections.Generic
             {
             }
 
-#if netstandard17
             void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
             {
                 if (info == null)
@@ -716,7 +690,6 @@ namespace System.Collections.Generic
 
                 _siInfo = null;
             }
-#endif
         }
     }
 

--- a/src/System.Collections/src/System/Collections/Generic/List.cs
+++ b/src/System.Collections/src/System/Collections/Generic/List.cs
@@ -19,9 +19,7 @@ namespace System.Collections.Generic
     // 
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
     [Serializable]
-#endif
     public class List<T> : IList<T>, System.Collections.IList, IReadOnlyList<T>
     {
         private const int _defaultCapacity = 4;
@@ -30,9 +28,7 @@ namespace System.Collections.Generic
         [ContractPublicPropertyName("Count")]
         private int _size;
         private int _version;
-#if netstandard17
         [NonSerialized]
-#endif
         private object _syncRoot;
 
         static readonly T[] _emptyArray = new T[0];
@@ -1166,9 +1162,7 @@ namespace System.Collections.Generic
             return true;
         }
 
-#if netstandard17
         [Serializable]
-#endif
         public struct Enumerator : IEnumerator<T>, System.Collections.IEnumerator
         {
             private List<T> list;

--- a/src/System.Collections/src/System/Collections/Generic/List.cs
+++ b/src/System.Collections/src/System/Collections/Generic/List.cs
@@ -19,6 +19,9 @@ namespace System.Collections.Generic
     // 
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+    [Serializable]
+#endif
     public class List<T> : IList<T>, System.Collections.IList, IReadOnlyList<T>
     {
         private const int _defaultCapacity = 4;
@@ -27,6 +30,9 @@ namespace System.Collections.Generic
         [ContractPublicPropertyName("Count")]
         private int _size;
         private int _version;
+#if netstandard17
+        [NonSerialized]
+#endif
         private object _syncRoot;
 
         static readonly T[] _emptyArray = new T[0];
@@ -1160,6 +1166,9 @@ namespace System.Collections.Generic
             return true;
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         public struct Enumerator : IEnumerator<T>, System.Collections.IEnumerator
         {
             private List<T> list;

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -19,6 +19,9 @@ namespace System.Collections.Generic
     // circular buffer, so Enqueue can be O(n).  Dequeue is O(1).
     [DebuggerTypeProxy(typeof(QueueDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+    [Serializable]
+#endif
     public class Queue<T> : IEnumerable<T>,
         System.Collections.ICollection,
         IReadOnlyCollection<T>
@@ -28,6 +31,9 @@ namespace System.Collections.Generic
         private int _tail;       // The index at which to enqueue if the queue isn't full.
         private int _size;       // Number of elements.
         private int _version;
+#if netstandard17
+        [NonSerialized]
+#endif
         private object _syncRoot;
 
         private const int MinimumGrow = 4;
@@ -364,6 +370,9 @@ namespace System.Collections.Generic
         // made to the list while an enumeration is in progress.
         /// <include file='doc\Queue.uex' path='docs/doc[@for="QueueEnumerator"]/*' />
         [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "not an expected scenario")]
+#if netstandard17
+        [Serializable]
+#endif
         public struct Enumerator : IEnumerator<T>,
             System.Collections.IEnumerator
         {

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -19,9 +19,7 @@ namespace System.Collections.Generic
     // circular buffer, so Enqueue can be O(n).  Dequeue is O(1).
     [DebuggerTypeProxy(typeof(QueueDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
     [Serializable]
-#endif
     public class Queue<T> : IEnumerable<T>,
         System.Collections.ICollection,
         IReadOnlyCollection<T>
@@ -31,9 +29,7 @@ namespace System.Collections.Generic
         private int _tail;       // The index at which to enqueue if the queue isn't full.
         private int _size;       // Number of elements.
         private int _version;
-#if netstandard17
         [NonSerialized]
-#endif
         private object _syncRoot;
 
         private const int MinimumGrow = 4;
@@ -370,9 +366,7 @@ namespace System.Collections.Generic
         // made to the list while an enumeration is in progress.
         /// <include file='doc\Queue.uex' path='docs/doc[@for="QueueEnumerator"]/*' />
         [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "not an expected scenario")]
-#if netstandard17
         [Serializable]
-#endif
         public struct Enumerator : IEnumerator<T>,
             System.Collections.IEnumerator
         {

--- a/src/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -4,27 +4,18 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-#if netstandard17
 using System.Runtime.Serialization;
-#endif
 
 namespace System.Collections.Generic
 {
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
     [Serializable]
-#endif
     public class SortedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
     {
-#if netstandard17
         [NonSerialized]
-#endif
         private KeyCollection _keys;
-
-#if netstandard17
         [NonSerialized]
-#endif
         private ValueCollection _values;
 
         private TreeSet<KeyValuePair<TKey, TValue>> _set;
@@ -563,9 +554,7 @@ namespace System.Collections.Generic
 
         [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
         [Serializable]
-#endif
         public sealed class KeyCollection : ICollection<TKey>, ICollection, IReadOnlyCollection<TKey>
         {
             private SortedDictionary<TKey, TValue> _dictionary;
@@ -750,9 +739,7 @@ namespace System.Collections.Generic
 
         [DebuggerTypeProxy(typeof(DictionaryValueCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
         [Serializable]
-#endif
         public sealed class ValueCollection : ICollection<TValue>, ICollection, IReadOnlyCollection<TValue>
         {
             private SortedDictionary<TKey, TValue> _dictionary;
@@ -935,9 +922,7 @@ namespace System.Collections.Generic
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         internal sealed class KeyValuePairComparer : Comparer<KeyValuePair<TKey, TValue>>
         {
             internal IComparer<TKey> keyComparer;
@@ -971,9 +956,7 @@ namespace System.Collections.Generic
     /// The only thing that makes it different from SortedSet is that it throws on duplicates
     /// </summary>
     /// <typeparam name="T"></typeparam>
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class TreeSet<T> : SortedSet<T>
     {
         public TreeSet()
@@ -986,9 +969,7 @@ namespace System.Collections.Generic
 
         public TreeSet(ICollection<T> collection, IComparer<T> comparer) : base(collection, comparer) { }
 
-#if netstandard17
         public TreeSet(SerializationInfo siInfo, StreamingContext context) : base(siInfo, context) { }
-#endif
 
         internal override bool AddIfNotPresent(T item)
         {

--- a/src/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -4,6 +4,9 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+#if netstandard17
+using System.Runtime.Serialization;
+#endif
 
 namespace System.Collections.Generic
 {
@@ -982,6 +985,10 @@ namespace System.Collections.Generic
         public TreeSet(ICollection<T> collection) : base(collection) { }
 
         public TreeSet(ICollection<T> collection, IComparer<T> comparer) : base(collection, comparer) { }
+
+#if netstandard17
+        public TreeSet(SerializationInfo siInfo, StreamingContext context) : base(siInfo, context) { }
+#endif
 
         internal override bool AddIfNotPresent(T item)
         {

--- a/src/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -9,10 +9,19 @@ namespace System.Collections.Generic
 {
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+    [Serializable]
+#endif
     public class SortedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
     {
+#if netstandard17
+        [NonSerialized]
+#endif
         private KeyCollection _keys;
 
+#if netstandard17
+        [NonSerialized]
+#endif
         private ValueCollection _values;
 
         private TreeSet<KeyValuePair<TKey, TValue>> _set;
@@ -551,6 +560,9 @@ namespace System.Collections.Generic
 
         [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+        [Serializable]
+#endif
         public sealed class KeyCollection : ICollection<TKey>, ICollection, IReadOnlyCollection<TKey>
         {
             private SortedDictionary<TKey, TValue> _dictionary;
@@ -735,6 +747,9 @@ namespace System.Collections.Generic
 
         [DebuggerTypeProxy(typeof(DictionaryValueCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+        [Serializable]
+#endif
         public sealed class ValueCollection : ICollection<TValue>, ICollection, IReadOnlyCollection<TValue>
         {
             private SortedDictionary<TKey, TValue> _dictionary;
@@ -917,6 +932,9 @@ namespace System.Collections.Generic
             }
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         internal sealed class KeyValuePairComparer : Comparer<KeyValuePair<TKey, TValue>>
         {
             internal IComparer<TKey> keyComparer;
@@ -950,6 +968,9 @@ namespace System.Collections.Generic
     /// The only thing that makes it different from SortedSet is that it throws on duplicates
     /// </summary>
     /// <typeparam name="T"></typeparam>
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class TreeSet<T> : SortedSet<T>
     {
         public TreeSet()

--- a/src/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -48,9 +48,7 @@ namespace System.Collections.Generic
     // 
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
     [Serializable]
-#endif
     public class SortedList<TKey, TValue> :
         IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
     {
@@ -61,9 +59,7 @@ namespace System.Collections.Generic
         private IComparer<TKey> _comparer;
         private KeyList _keyList;
         private ValueList _valueList;
-#if netstandard17
         [NonSerialized]
-#endif
         private object _syncRoot;
 
         private const int DefaultCapacity = 4;
@@ -763,9 +759,7 @@ namespace System.Collections.Generic
         }
 
         /// <include file='doc\SortedList.uex' path='docs/doc[@for="SortedListEnumerator"]/*' />
-#if netstandard17
         [Serializable]
-#endif
         private struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator
         {
             private SortedList<TKey, TValue> _sortedList;
@@ -893,9 +887,7 @@ namespace System.Collections.Generic
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private sealed class SortedListKeyEnumerator : IEnumerator<TKey>, IEnumerator
         {
             private SortedList<TKey, TValue> _sortedList;
@@ -966,9 +958,7 @@ namespace System.Collections.Generic
             }
         }
 
-#if netstandard17
         [Serializable]
-#endif
         private sealed class SortedListValueEnumerator : IEnumerator<TValue>, IEnumerator
         {
             private SortedList<TKey, TValue> _sortedList;
@@ -1041,9 +1031,7 @@ namespace System.Collections.Generic
 
         [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
         [Serializable]
-#endif
         private sealed class KeyList : IList<TKey>, ICollection
         {
             private SortedList<TKey, TValue> _dict;
@@ -1162,9 +1150,7 @@ namespace System.Collections.Generic
 
         [DebuggerTypeProxy(typeof(DictionaryValueCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
         [Serializable]
-#endif
         private sealed class ValueList : IList<TValue>, ICollection
         {
             private SortedList<TKey, TValue> _dict;

--- a/src/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -48,6 +48,9 @@ namespace System.Collections.Generic
     // 
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+    [Serializable]
+#endif
     public class SortedList<TKey, TValue> :
         IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
     {
@@ -58,6 +61,9 @@ namespace System.Collections.Generic
         private IComparer<TKey> _comparer;
         private KeyList _keyList;
         private ValueList _valueList;
+#if netstandard17
+        [NonSerialized]
+#endif
         private object _syncRoot;
 
         private const int DefaultCapacity = 4;
@@ -757,6 +763,9 @@ namespace System.Collections.Generic
         }
 
         /// <include file='doc\SortedList.uex' path='docs/doc[@for="SortedListEnumerator"]/*' />
+#if netstandard17
+        [Serializable]
+#endif
         private struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator
         {
             private SortedList<TKey, TValue> _sortedList;
@@ -884,6 +893,9 @@ namespace System.Collections.Generic
             }
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private sealed class SortedListKeyEnumerator : IEnumerator<TKey>, IEnumerator
         {
             private SortedList<TKey, TValue> _sortedList;
@@ -954,6 +966,9 @@ namespace System.Collections.Generic
             }
         }
 
+#if netstandard17
+        [Serializable]
+#endif
         private sealed class SortedListValueEnumerator : IEnumerator<TValue>, IEnumerator
         {
             private SortedList<TKey, TValue> _sortedList;
@@ -1026,6 +1041,9 @@ namespace System.Collections.Generic
 
         [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+        [Serializable]
+#endif
         private sealed class KeyList : IList<TKey>, ICollection
         {
             private SortedList<TKey, TValue> _dict;
@@ -1144,6 +1162,9 @@ namespace System.Collections.Generic
 
         [DebuggerTypeProxy(typeof(DictionaryValueCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+        [Serializable]
+#endif
         private sealed class ValueList : IList<TValue>, ICollection
         {
             private SortedList<TKey, TValue> _dict;

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -12,9 +12,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-#if netstandard17
 using System.Runtime.Serialization;
-#endif
 
 namespace System.Collections.Generic
 {
@@ -48,40 +46,33 @@ namespace System.Collections.Generic
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "by design name choice")]
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
     [Serializable]
-#endif
-    public class SortedSet<T> : ISet<T>, ICollection<T>, ICollection, IReadOnlyCollection<T>
-#if netstandard17
-        , ISerializable, IDeserializationCallback
-#endif
+    public class SortedSet<T> : ISet<T>, ICollection<T>, ICollection, IReadOnlyCollection<T>, ISerializable, IDeserializationCallback
     {
         #region local variables/constants
         private Node _root;
         private IComparer<T> _comparer;
         private int _count;
         private int _version;
-        private object _syncRoot;
-#if netstandard17
-        private SerializationInfo _siInfo; //A temporary variable which we need during deserialization
         [NonSerialized]
+        private object _syncRoot;
+        private SerializationInfo _siInfo; //A temporary variable which we need during deserialization
 
-        private const String ComparerName = "Comparer";
-        private const String CountName = "Count";
-        private const String ItemsName = "Items";
-        private const String VersionName = "Version";
+        private const string ComparerName = "Comparer";
+        private const string CountName = "Count";
+        private const string ItemsName = "Items";
+        private const string VersionName = "Version";
         //needed for enumerator
-        private const String TreeName = "Tree";
-        private const String NodeValueName = "Item";
-        private const String EnumStartName = "EnumStarted";        
-        private const String ReverseName = "Reverse";
-        private const String EnumVersionName = "EnumVersion";
+        private const string TreeName = "Tree";
+        private const string NodeValueName = "Item";
+        private const string EnumStartName = "EnumStarted";        
+        private const string ReverseName = "Reverse";
+        private const string EnumVersionName = "EnumVersion";
         //needed for TreeSubset
-        private const String minName = "Min";
-        private const String maxName = "Max";
-        private const String lBoundActiveName = "lBoundActive";
-        private const String uBoundActiveName = "uBoundActive";
-#endif
+        private const string minName = "Min";
+        private const string maxName = "Max";
+        private const string lBoundActiveName = "lBoundActive";
+        private const string uBoundActiveName = "uBoundActive";
 
         internal const int StackAllocThreshold = 100;
 
@@ -189,12 +180,10 @@ namespace System.Collections.Generic
             }
         }
 
-#if netstandard17
         protected SortedSet(SerializationInfo info, StreamingContext context)
         {
             _siInfo = info;
         }
-#endif
 
         #endregion
 
@@ -1913,13 +1902,8 @@ namespace System.Collections.Generic
         /// are reflected in the actual tree. Uses the Comparator of the underlying tree.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-#if netstandard17
         [Serializable]
-#endif
-        internal sealed class TreeSubSet : SortedSet<T>
-#if netstandard17
-            , ISerializable, IDeserializationCallback
-#endif
+        internal sealed class TreeSubSet : SortedSet<T>, ISerializable, IDeserializationCallback
         {
             private SortedSet<T> _underlying;
             private T _min, _max;
@@ -1951,13 +1935,11 @@ namespace System.Collections.Generic
                 VersionCheckImpl();
             }
 
-#if netstandard17
             private TreeSubSet(SerializationInfo info, StreamingContext context)
             {
                 _siInfo = info;
                 OnDeserializationImpl(info);
             }
-#endif
 
             /// <summary>
             /// Additions to this tree need to be added to the underlying tree as well
@@ -2214,7 +2196,6 @@ namespace System.Collections.Generic
 #endif
             }
 
-#if netstandard17
             void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
             {
                 GetObjectData(info, context);
@@ -2287,10 +2268,8 @@ namespace System.Collections.Generic
 
                 _siInfo = null;
             }
-#endif
         }
 
-#if netstandard17
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
             GetObjectData(info, context);
@@ -2358,13 +2337,10 @@ namespace System.Collections.Generic
 
             _siInfo = null;
         }
-#endif
         #endregion
 
         #region Helper Classes
-#if netstandard17
         [Serializable]
-#endif
         internal sealed class Node
         {
             public bool IsRed;
@@ -2388,13 +2364,8 @@ namespace System.Collections.Generic
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "not an expected scenario")]
-#if netstandard17
         [Serializable]
-#endif
-        public struct Enumerator : IEnumerator<T>, IEnumerator
-#if netstandard17
-            , ISerializable, IDeserializationCallback
-#endif
+        public struct Enumerator : IEnumerator<T>, IEnumerator, ISerializable, IDeserializationCallback
         {
             private SortedSet<T> _tree;
             private int _version;
@@ -2403,10 +2374,8 @@ namespace System.Collections.Generic
             private SortedSet<T>.Node _current;
 
             private bool _reverse;
-#if netstandard17
             private SerializationInfo _siInfo;
             private static SortedSet<T>.Node s_dummyNode = new SortedSet<T>.Node(default(T));
-#endif
 
             internal Enumerator(SortedSet<T> set)
             {
@@ -2420,9 +2389,7 @@ namespace System.Collections.Generic
                 _current = null;
                 _reverse = false;
 
-#if netstandard17
                 _siInfo = null;
-#endif
 
                 Intialize();
             }
@@ -2438,14 +2405,11 @@ namespace System.Collections.Generic
                 _current = null;
                 _reverse = reverse;
 
-#if netstandard17
                 _siInfo = null;
-#endif
 
                 Intialize();
             }
 
-#if netstandard17
             private Enumerator(SerializationInfo info, StreamingContext context)
             {
                 _tree = null;
@@ -2506,7 +2470,6 @@ namespace System.Collections.Generic
                     }
                 }
             }
-#endif
 
             private void Intialize()
             {

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -20,6 +20,9 @@ namespace System.Collections.Generic
 
     [DebuggerTypeProxy(typeof(StackDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
+#if netstandard17
+    [Serializable]
+#endif
     public class Stack<T> : IEnumerable<T>,
         System.Collections.ICollection,
         IReadOnlyCollection<T>
@@ -27,6 +30,9 @@ namespace System.Collections.Generic
         private T[] _array;     // Storage for stack elements
         private int _size;           // Number of items in the stack.
         private int _version;        // Used to keep enumerator in sync w/ collection.
+#if netstandard17
+        [NonSerialized]
+#endif
         private object _syncRoot;
 
         private const int DefaultCapacity = 4;
@@ -255,6 +261,9 @@ namespace System.Collections.Generic
 
         /// <include file='doc\Stack.uex' path='docs/doc[@for="StackEnumerator"]/*' />
         [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "not an expected scenario")]
+#if netstandard17
+        [Serializable]
+#endif
         public struct Enumerator : IEnumerator<T>,
             System.Collections.IEnumerator
         {

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -20,9 +20,7 @@ namespace System.Collections.Generic
 
     [DebuggerTypeProxy(typeof(StackDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
-#if netstandard17
     [Serializable]
-#endif
     public class Stack<T> : IEnumerable<T>,
         System.Collections.ICollection,
         IReadOnlyCollection<T>
@@ -30,9 +28,7 @@ namespace System.Collections.Generic
         private T[] _array;     // Storage for stack elements
         private int _size;           // Number of items in the stack.
         private int _version;        // Used to keep enumerator in sync w/ collection.
-#if netstandard17
         [NonSerialized]
-#endif
         private object _syncRoot;
 
         private const int DefaultCapacity = 4;
@@ -261,11 +257,8 @@ namespace System.Collections.Generic
 
         /// <include file='doc\Stack.uex' path='docs/doc[@for="StackEnumerator"]/*' />
         [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "not an expected scenario")]
-#if netstandard17
         [Serializable]
-#endif
-        public struct Enumerator : IEnumerator<T>,
-            System.Collections.IEnumerator
+        public struct Enumerator : IEnumerator<T>, System.Collections.IEnumerator
         {
             private readonly Stack<T> _stack;
             private readonly int _version;

--- a/src/System.Collections/src/System/Collections/StructuralComparisons.cs
+++ b/src/System.Collections/src/System/Collections/StructuralComparisons.cs
@@ -40,6 +40,9 @@ namespace System.Collections
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class StructuralEqualityComparer : IEqualityComparer
     {
         public new bool Equals(object x, object y)
@@ -81,6 +84,9 @@ namespace System.Collections
         }
     }
 
+#if netstandard17
+    [Serializable]
+#endif
     internal sealed class StructuralComparer : IComparer
     {
         public int Compare(object x, object y)

--- a/src/System.Collections/src/System/Collections/StructuralComparisons.cs
+++ b/src/System.Collections/src/System/Collections/StructuralComparisons.cs
@@ -40,9 +40,7 @@ namespace System.Collections
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class StructuralEqualityComparer : IEqualityComparer
     {
         public new bool Equals(object x, object y)
@@ -84,9 +82,7 @@ namespace System.Collections
         }
     }
 
-#if netstandard17
     [Serializable]
-#endif
     internal sealed class StructuralComparer : IComparer
     {
         public int Compare(object x, object y)

--- a/src/System.Collections/src/project.json
+++ b/src/System.Collections/src/project.json
@@ -1,38 +1,17 @@
 {
   "frameworks": {
-    "netstandard1.3": {
-      "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.1.0-beta-24431-02"
-      },
-      "imports": [
-        "dotnet5.4"
-      ]
-    },
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.1.0-beta-24431-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.1.0-beta-24426-03"
       },
       "imports": [
-        "dotnet5.6"
+        "dotnet5.8"
       ]
     },
     "net463": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
-      }
-    },
-    "netcore50": {
-      "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1",
-        "System.Diagnostics.Contracts": "4.0.0",
-        "System.Diagnostics.Debug": "4.0.0",
-        "System.Diagnostics.Tools": "4.0.0",
-        "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.0.20",
-        "System.Runtime.Extensions": "4.0.10",
-        "System.Threading": "4.0.10"
       }
     }
   }

--- a/src/System.Collections/src/project.json
+++ b/src/System.Collections/src/project.json
@@ -3,7 +3,7 @@
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.1.0-beta-24426-03"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.1.0-beta-24431-02"
       },
       "imports": [
         "dotnet5.8"

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -150,6 +150,19 @@
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'!='netstandard1.7'">
+    <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
+      <Link>Common\System\SerializableAttribute.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs" >
+      <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Serialization.Tests.cs" >
+      <Link>Common\System\Collections\IEnumerable.Generic.Serialization.Tests.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -153,5 +153,11 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <!-- ToDo: Remove this target once the infrastructure for testing in netcoreapp1.1 is ready -->
+  <Target Name="RemoveUnwantedTestMonikers" Condition="'$(TargetGroup)'=='netstandard1.7'" BeforeTargets="CopyTestToTestDirectory">
+    <ItemGroup>
+      <TestNugetTargetMoniker Remove=".NETCoreApp,Version=v1.1" />
+    </ItemGroup>
+  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -10,7 +10,18 @@
     <RootNamespace>System.Collections.Tests</RootNamespace>
     <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
     <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <!--
+        Until we get first class support for NS1.7 and Netcoreapp1.1
+        we need to hard code $(TestTFM) and $(TestNugetTargetMoniker)
+        in the project file.
+      -->
+    <TestTFM Condition="'$(TargetGroup)'=='netstandard1.7'">netcoreapp1.1</TestTFM>
   </PropertyGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
+      <Folder>netcoreapp1.1</Folder>
+    </TestNugetTargetMoniker>
+  </ItemGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -30,6 +30,22 @@
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},
-    "coreFx.Test.net463": {}
+    "coreFx.Test.net463": {},
+    "coreFx.Test.netcoreapp1.1-ns17": {
+      "netstandard1.7": [
+        "win7-x86",
+        "win7-x64",
+        "win10-arm64",
+        "osx.10.10-x64",
+        "centos.7-x64",
+        "debian.8-x64",
+        "rhel.7-x64",
+        "ubuntu.14.04-x64",
+        "ubuntu.16.04-x64",
+        "fedora.23-x64",
+        "linux-x64",
+        "opensuse.13.2-x64"
+      ]
+    }
   }
 }

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -24,7 +24,7 @@
     "netstandard1.3": {},
     "netstandard1.7": {
 		"dependencies": {
-	        "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24422-01",
+	        "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24424-01",
 		}
 	}
   },

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -22,7 +22,11 @@
   },
   "frameworks": {
     "netstandard1.3": {},
-    "netstandard1.7": {}
+    "netstandard1.7": {
+		"dependencies": {
+	        "System.Runtime.Serialization.Formatters": "4.0.1-beta-devapi-24422-01",
+		}
+	}
   },
   "supports": {
     "coreFx.Test.netcore50": {},

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -114,11 +114,5 @@
       <Name>VoidMainWithExitCodeApp</Name>
     </ProjectReference>
   </ItemGroup>
-  <!-- ToDo: Remove this target once the infrastructure for testing in netcoreapp1.1 is ready -->
-  <Target Name="RemoveUnwantedTestMonikers" Condition="'$(TargetGroup)'=='netstandard1.7'" BeforeTargets="CopyTestToTestDirectory">
-    <ItemGroup>
-        <TestNugetTargetMoniker Remove=".NETCoreApp,Version=v1.1" />
-    </ItemGroup>
-  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -114,5 +114,11 @@
       <Name>VoidMainWithExitCodeApp</Name>
     </ProjectReference>
   </ItemGroup>
+  <!-- ToDo: Remove this target once the infrastructure for testing in netcoreapp1.1 is ready -->
+  <Target Name="RemoveUnwantedTestMonikers" Condition="'$(TargetGroup)'=='netstandard1.7'" BeforeTargets="CopyTestToTestDirectory">
+    <ItemGroup>
+      <TestNugetTargetMoniker Remove=".NETCoreApp,Version=v1.1" />
+    </ItemGroup>
+  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -132,5 +132,11 @@
     <ProjectReference Include="..\..\System.Private.Uri\pkg\System.Private.Uri.pkgproj">
     </ProjectReference>
   </ItemGroup>
+  <!-- ToDo: Remove this target once the infrastructure for testing in netcoreapp1.1 is ready -->
+  <Target Name="RemoveUnwantedTestMonikers" Condition="'$(TargetGroup)'=='netstandard1.7'" BeforeTargets="CopyTestToTestDirectory">
+    <ItemGroup>
+      <TestNugetTargetMoniker Remove=".NETCoreApp,Version=v1.1" />
+    </ItemGroup>
+  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -132,11 +132,5 @@
     <ProjectReference Include="..\..\System.Private.Uri\pkg\System.Private.Uri.pkgproj">
     </ProjectReference>
   </ItemGroup>
-  <!-- ToDo: Remove this target once the infrastructure for testing in netcoreapp1.1 is ready -->
-  <Target Name="RemoveUnwantedTestMonikers" Condition="'$(TargetGroup)'=='netstandard1.7'" BeforeTargets="CopyTestToTestDirectory">
-    <ItemGroup>
-        <TestNugetTargetMoniker Remove=".NETCoreApp,Version=v1.1" />
-    </ItemGroup>
-  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Adds serialization implementations to System.Collections, System.Collections.Concurrent, System.Collections.NonGeneric, and System.Collections.Specialized.  These implementations are ported directly from coreclr and/or desktop.

A few notes:
- There are lots of ```#if netstandard17```s scattered throughout.  Once @ericstj's work is done to fix up how we do our builds, we should remove all of these.
- I've not been successful in getting tests to run for netstandard17 in these projects, so this PR unfortunately doesn't include tests.  If @weshaggard or @joperezr can help me to get such tests running, I'd like to add tests (I tried copying from a few different projects, but I hit a variety of issues, such as the tests failing citing a mismatch in versions, the tests not compiling due to not using something that was in the project.json, etc.)  I'm sure it's just user error, but there is a fair amount of mess at the moment in all of these files.
- As a result of not having tests, I'm fairly confident there are numerous bugs; I'll fix those once I'm able to run tests.
- Lots and lots more CoreFx types need to have their serialization implementations ported; this is just the start.
- I've not invested in anything more than superficial cleanup; we can revisit implementations later for things like performance.

cc: @weshaggard, @joperezr, @danmosemsft, @ianhays 