### PR TITLE
Add internal AsyncBuilderAttribute to ValueTask

### DIFF
--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -21,8 +21,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="System\Runtime\CompilerServices\ConfiguredValueTaskAwaitable.cs" />
+    <Compile Include="System\Runtime\CompilerServices\AsyncBuilderAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\AsyncValueTaskMethodBuilder.cs" />
+    <Compile Include="System\Runtime\CompilerServices\ConfiguredValueTaskAwaitable.cs" />
     <Compile Include="System\Runtime\CompilerServices\ValueTaskAwaiter.cs" />
     <Compile Include="System\Threading\Tasks\ValueTask.cs" />
   </ItemGroup>

--- a/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncBuilderAttribute.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncBuilderAttribute.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates the async method builder that should be used by the C# compiler to build
+    /// the attributed type when used as the return type of an async method.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
+    internal sealed class AsyncBuilderAttribute : Attribute
+    {
+        /// <summary>Initializes the <see cref="AsyncBuilderAttribute"/>.</summary>
+        /// <param name="builderType">The associated builder type.</param>
+        public AsyncBuilderAttribute(Type builderType) { }
+    }
+}

--- a/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
@@ -48,6 +48,7 @@ namespace System.Threading.Tasks
     /// a <see cref="Task"/>-returning method completes synchronously and successfully.
     /// </para>
     /// </remarks>
+    [AsyncBuilder(typeof(AsyncValueTaskMethodBuilder<>))]
     [StructLayout(LayoutKind.Auto)]
     public struct ValueTask<TResult> : IEquatable<ValueTask<TResult>>
     {
@@ -175,6 +176,8 @@ namespace System.Threading.Tasks
                     string.Empty;
             }
         }
+
+        // TODO: Remove CreateAsyncMethodBuilder once the C# compiler relies on the AsyncBuilder attribute.
 
         /// <summary>Creates a method builder for use with an async method.</summary>
         /// <returns>The created builder.</returns>

--- a/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Threading.Tasks.Tests
@@ -309,6 +312,18 @@ namespace System.Threading.Tasks.Tests
             Assert.Same(string.Empty, new ValueTask<string>(Task.FromResult<string>(null)).ToString());
 
             Assert.Same(string.Empty, new ValueTask<DateTime>(new TaskCompletionSource<DateTime>().Task).ToString());
+        }
+
+        [Theory]
+        [InlineData(typeof(ValueTask<>))]
+        [InlineData(typeof(ValueTask<int>))]
+        [InlineData(typeof(ValueTask<string>))]
+        public void AsyncBuilderAttribute_ValueTaskAttributed(Type valueTaskType)
+        {
+            CustomAttributeData aba = valueTaskType.GetTypeInfo().CustomAttributes.Single(
+                attr => attr.AttributeType.FullName == "System.Runtime.CompilerServices.AsyncBuilderAttribute");
+            Assert.True(aba.AttributeType.GetTypeInfo().IsNotPublic);
+            Assert.Equal(typeof(AsyncValueTaskMethodBuilder<>), aba.ConstructorArguments[0].Value);
         }
 
         private sealed class TrackingSynchronizationContext : SynchronizationContext

--- a/src/System.Threading.Tasks.Extensions/tests/project.json
+++ b/src/System.Threading.Tasks.Extensions/tests/project.json
@@ -3,6 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24422-01",
     "System.Linq.Expressions": "4.1.1-beta-24422-01",
     "System.ObjectModel": "4.0.13-beta-24422-01",
+    "System.Reflection": "4.1.1-beta-24422-01",
     "System.Runtime": "4.1.1-beta-24422-01",
     "System.Text.RegularExpressions": "4.2.0-beta-24422-01",
     "System.Threading.Tasks": "4.0.12-beta-24422-01",


### PR DESCRIPTION
Per a recent C# language design decision.  Such an attribute will be used by the compiler instead of a public static CreateAsyncMethodBuilder method, enabling interfaces to be used as the return type of async methods, keeping unnecessary surface area off of the return type, annotating the type in a way that's friendlier to it impacting language semantics, etc.

cc: @ljw1004, @jaredpar, @cston, @madstorgersen, @terrajobst