### PR TITLE
Fix WinHttpHandler uri escaping for HTTP requests

### DIFF
--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
@@ -61,6 +61,7 @@ internal partial class Interop
         public const ushort INTERNET_DEFAULT_HTTPS_PORT = 443;
 
         public const uint WINHTTP_FLAG_SECURE = 0x00800000;
+        public const uint WINHTTP_FLAG_ESCAPE_DISABLE = 0x00000040;
 
         public const StringBuilder WINHTTP_NO_ADDITIONAL_HEADERS = null;
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -801,6 +801,15 @@ namespace System.Net.Http
                     httpVersion = "HTTP/1.1";
                 }
 
+                // Turn off additional URI reserved character escaping (percent-encoding). This matches
+                // .NET Framework behavior. System.Uri establishes the baseline rules for percent-encoding
+                // of reserved characters.
+                uint flags = Interop.WinHttp.WINHTTP_FLAG_ESCAPE_DISABLE;
+                if (secureConnection)
+                {
+                    flags |= Interop.WinHttp.WINHTTP_FLAG_SECURE;
+                }
+
                 // Create an HTTP request handle.
                 state.RequestHandle = Interop.WinHttp.WinHttpOpenRequest(
                     connectHandle,
@@ -809,7 +818,7 @@ namespace System.Net.Http
                     httpVersion,
                     Interop.WinHttp.WINHTTP_NO_REFERER,
                     Interop.WinHttp.WINHTTP_DEFAULT_ACCEPT_TYPES,
-                    secureConnection ? Interop.WinHttp.WINHTTP_FLAG_SECURE : 0);
+                    flags);
                 ThrowOnInvalidHandle(state.RequestHandle);
                 state.RequestHandle.SetParentHandle(connectHandle);
 


### PR DESCRIPTION
There is a behavior difference between .NET Framework (Desktop) and
CoreFx. Desktop will send some reserved characters (such as square
brackets) on the wire as-is without any percent-encoding. CoreFx using
WinHttpHandler is doing additional percent-encoding on those characters.

This fix changes WinHttpHandler behavior so that it won't do any additional
percent-encoding. Whatever encoding System.Uri has done will be
transmitted as-is.

There is a separate problem where System.Uri itself doesn't
percent-encode these characters during normalization. That is due to
changes in the .NET Framework 4.5 timeframe (2012) where System.Uri was changed to
follow more IRI (RFC 3987) rules. One could argue that was the real
problem. But since this behavior is already baked into .NET Framework,
the right fix for the below issue is to match Desktop behavior.

We will be having a separate discussion/issue to analyze/debate whether System.Uri
needs to be changed (or not) in the future. The various URI and HTTP RFCs have
ambiguous language in these areas.

Fixes #11156