### PR TITLE
Changes I had to make for ValueTuple in mscorlib

### DIFF
--- a/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/TupleExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
-
 namespace System
 {
     /// <summary>
@@ -15,7 +13,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 1 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1>(
             this Tuple<T1> value,
             out T1 item1)
@@ -26,7 +23,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 2 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2>(
             this Tuple<T1, T2> value,
             out T1 item1, out T2 item2)
@@ -38,7 +34,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 3 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3>(
             this Tuple<T1, T2, T3> value,
             out T1 item1, out T2 item2, out T3 item3)
@@ -51,7 +46,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 4 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4>(
             this Tuple<T1, T2, T3, T4> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4)
@@ -65,7 +59,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 5 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5>(
             this Tuple<T1, T2, T3, T4, T5> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5)
@@ -80,7 +73,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 6 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6>(
             this Tuple<T1, T2, T3, T4, T5, T6> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6)
@@ -96,7 +88,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 7 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7)
@@ -113,7 +104,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 8 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8)
@@ -131,7 +121,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 9 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9)
@@ -150,7 +139,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 10 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10)
@@ -170,7 +158,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 11 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11)
@@ -191,7 +178,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 12 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12)
@@ -213,7 +199,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 13 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13)
@@ -236,7 +221,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 14 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14)
@@ -260,7 +244,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 15 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15)
@@ -285,7 +268,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 16 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16)
@@ -311,7 +293,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 17 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17)
@@ -338,7 +319,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 18 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18)
@@ -366,7 +346,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 19 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19)
@@ -395,7 +374,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 20 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20)
@@ -425,7 +403,6 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 21 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20, out T21 item21)

--- a/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
@@ -4,7 +4,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Numerics.Hashing;
 
 namespace System
@@ -59,7 +59,7 @@ namespace System
 
             if (!(other is ValueTuple))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return 0;
@@ -84,7 +84,7 @@ namespace System
 
             if (!(other is ValueTuple))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return 0;
@@ -248,7 +248,7 @@ namespace System
             // Forward to helper class in Common for this
             // We keep the actual hashing logic there, so
             // other classes can use it for hashing
-            return HashHelpers.Combine(h1, h2);
+            return System.Numerics.Hashing.HashHelpers.Combine(h1, h2);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3)
@@ -349,7 +349,7 @@ namespace System
 
             if (!(other is ValueTuple<T1>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1>)other;
@@ -376,7 +376,7 @@ namespace System
 
             if (!(other is ValueTuple<T1>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1>)other;
@@ -522,7 +522,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2>)other);
@@ -550,7 +550,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2>)other;
@@ -697,7 +697,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3>)other);
@@ -728,7 +728,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3>)other;
@@ -887,7 +887,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4>)other);
@@ -921,7 +921,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4>)other;
@@ -1094,7 +1094,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5>)other);
@@ -1131,7 +1131,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5>)other;
@@ -1318,7 +1318,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6>)other);
@@ -1358,7 +1358,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6>)other;
@@ -1559,7 +1559,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other);
@@ -1602,7 +1602,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other;
@@ -1748,7 +1748,7 @@ namespace System
         {
             if (!(rest is ITupleInternal))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleLastArgumentNotAValueTuple);
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleLastArgumentNotAValueTuple"));
             }
 
             Item1 = item1;
@@ -1823,7 +1823,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other);
@@ -1869,7 +1869,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other;
@@ -1969,7 +1969,7 @@ namespace System
                                                        rest.GetHashCode());
             }
 
-            Debug.Assert(false, "Missed all cases for computing ValueTuple hash code");
+            Contract.Assert(false, "Missed all cases for computing ValueTuple hash code");
             return -1;
         }
 
@@ -2020,7 +2020,7 @@ namespace System
                                                        comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
             }
 
-            Debug.Assert(false, "Missed all cases for computing ValueTuple hash code");
+            Contract.Assert(false, "Missed all cases for computing ValueTuple hash code");
             return -1;
         }
 


### PR DESCRIPTION
Update: This PR is not for merging, only to provide a convenient diff while we review the mscorlib change.

I have had to make a few changes to the ValueTuple source to get it to build in NetFxDev1 branch:
•	Removed EditorBrowsableAttribute and the importing of ComponentModel namespace
•	Replaced getting resource strings via SR to use Environment.GetResourceString instead
•	Replaced Debug.Assert with Contract.Assert
•	Replaced nameof(param) with hardcoded “param”
•	Replaced references to HashHelpers.Combine with fully qualified references to System.Numerics.Hashing.HashHelpers.Combine (otherwise there was an ambiguity)
