### PR TITLE
Disable failing ServerAsyncAuthenticate test on macOS

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -53,6 +53,7 @@ namespace System.Net.Security.Tests
             });
         }
 
+        [ActiveIssue(11170, Xunit.PlatformID.OSX)]
         [Theory]
         [MemberData(nameof(ProtocolMismatchData))]
         public async Task ServerAsyncAuthenticate_MismatchProtocols_Fails(


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/11170