### PR TITLE
Fix ImmutableArray.Builder.Sort(Comparer) to pass correct bounds

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -651,7 +651,11 @@ namespace System.Collections.Immutable
 
                 if (Count > 1)
                 {
-                    Array.Sort(_elements, comparison);
+                    // Array.Sort does not have an overload that takes both bounds and a Comparison.
+                    // We could special case _count == _elements.Length in order to try to avoid
+                    // the IComparer allocation, but the Array.Sort overload that takes a Comparison
+                    // allocates such an IComparer internally, anyway.
+                    Array.Sort(_elements, 0, _count, Comparer<T>.Create(comparison));
                 }
             }
 

--- a/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -288,10 +288,18 @@ namespace System.Collections.Immutable.Tests
         [Fact]
         public void Sort_Comparison()
         {
-            var builder = new ImmutableArray<int>.Builder();
+            var builder = new ImmutableArray<int>.Builder(4);
+
+            builder.Sort((x, y) => y.CompareTo(x));
+            Assert.Equal(Array.Empty<int>(), builder);
+
             builder.AddRange(2, 4, 1, 3);
             builder.Sort((x, y) => y.CompareTo(x));
             Assert.Equal(new[] { 4, 3, 2, 1 }, builder);
+
+            builder.Add(5);
+            builder.Sort((x, y) => x.CompareTo(y));
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, builder);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/11173
cc: @CyrusNajmabadi, @AArnott 