### PR TITLE
Fix FVI handling of AssemblyInformationalVersionAttribute

### DIFF
--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.TestAssembly/Assembly1.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.TestAssembly/Assembly1.cs
@@ -10,8 +10,10 @@ using System.Reflection;
 [assembly:AssemblyCompanyAttribute("The name of the company.")]
 // FileDescription
 [assembly:AssemblyTitleAttribute("My File")]
-// FileVersion & ProductVersion
+// FileVersion
 [assembly:AssemblyFileVersionAttribute("4.3.2.1")]
+// ProductVersion (overrides FileVersion to be the ProductVersion)
+[assembly: AssemblyInformationalVersionAttribute("1.2.3-beta.4")]
 // LegalCopyright
 [assembly:AssemblyCopyrightAttribute("Copyright, you betcha!")]
 // LegalTrademarks

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
@@ -159,12 +159,12 @@ namespace System.Diagnostics.Tests
                 LegalTrademarks = "TM",
                 OriginalFilename = TestAssemblyFileName,
                 PrivateBuild = "",
-                ProductBuildPart = 2,
-                ProductMajorPart = 4,
-                ProductMinorPart = 3,
+                ProductBuildPart = 3,
+                ProductMajorPart = 1,
+                ProductMinorPart = 2,
                 ProductName = "The greatest product EVER",
-                ProductPrivatePart = 1,
-                ProductVersion = "4.3.2.1",
+                ProductPrivatePart = 0,
+                ProductVersion = "1.2.3-beta.4",
                 SpecialBuild = "",
             });
         }


### PR DESCRIPTION
AssemblyInformationalVersionAttribute isn't being factored into the computation of the product version.  Our version parsing is also different than what's done on the Windows side.

Fixes https://github.com/dotnet/corefx/issues/11163
cc: @nguerrera, @weshaggard, @ianhays 