### PR TITLE
Make Unix root certs be findable again when validOnly: true is specified

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -500,16 +500,24 @@ namespace Internal.Cryptography.Pal
                 // fill the system trusted collection
                 foreach (X509Certificate2 userRootCert in userRootCerts)
                 {
-                    systemTrusted.Add(userRootCert);
+                    if (!systemTrusted.Add(userRootCert))
+                    {
+                        // If we have already (effectively) added another instance of this certificate,
+                        // then this one provides no value. A Disposed cert won't harm the matching logic.
+                        userRootCert.Dispose();
+                    }
                 }
 
                 foreach (X509Certificate2 systemRootCert in systemRootCerts)
                 {
-                    systemTrusted.Add(systemRootCert);
+                    if (!systemTrusted.Add(systemRootCert))
+                    {
+                        // If we have already (effectively) added another instance of this certificate,
+                        // (for example, because another copy of it was in the user store)
+                        // then this one provides no value. A Disposed cert won't harm the matching logic.
+                        systemRootCert.Dispose();
+                    }
                 }
-
-                // ordering in storesToCheck must match how we read into the systemTrusted collection, that is 
-                // first in first checked due to how we eventually use the collection in candidatesByReference 
 
                 X509Certificate2Collection[] storesToCheck =
                 {
@@ -550,26 +558,35 @@ namespace Internal.Cryptography.Pal
                     candidates,
                     ReferenceEqualityComparer<X509Certificate2>.Instance);
 
-                // Dispose any certificates we cloned in, but didn't end up needing.
-                // Since extraStore was provided by users, don't dispose anything it contains.
-                Debug.Assert(storesToCheck.Length > 0, "storesToCheck.Length > 0");
-                Debug.Assert(storesToCheck[0] == extraStore, "storesToCheck[0] == extraStore");
-
-                for (int i = 1; i < storesToCheck.Length; i++)
-                {
-                    X509Certificate2Collection collection = storesToCheck[i];
-
-                    foreach (X509Certificate2 cert in collection)
-                    {
-                        if (!candidatesByReference.Contains(cert))
-                        {
-                            cert.Dispose();
-                        }
-                    }
-                }
+                // Certificates come from 5 sources:
+                //  1) extraStore.
+                //     These are cert objects that are provided by the user, we shouldn't dispose them.
+                //  2) the machine root store
+                //     These certs are moving on to the "was I a system trust?" test, and we shouldn't dispose them.
+                //  3) the user root store
+                //     These certs are moving on to the "was I a system trust?" test, and we shouldn't dispose them.
+                //  4) the machine intermediate store
+                //     These certs were either path candidates, or not. If they were, don't dispose them. Otherwise do.
+                //  5) the user intermediate store
+                //     These certs were either path candidates, or not. If they were, don't dispose them. Otherwise do.
+                DisposeUnreferenced(candidatesByReference, systemIntermediateCerts);
+                DisposeUnreferenced(candidatesByReference, userIntermediateCerts);
             }
 
             return candidates;
+        }
+
+        private static void DisposeUnreferenced(
+            ISet<X509Certificate2> referencedSet,
+            X509Certificate2Collection storeCerts)
+        {
+            foreach (X509Certificate2 cert in storeCerts)
+            {
+                if (!referencedSet.Contains(cert))
+                {
+                    cert.Dispose();
+                }
+            }
         }
 
         private static HashSet<X509Certificate2> FindIssuer(
@@ -592,7 +609,14 @@ namespace Internal.Cryptography.Pal
 
                 foreach (X509Certificate2 candidate in store)
                 {
-                    SafeX509Handle candidateHandle = ((OpenSslX509CertificateReader)candidate.Pal).SafeHandle;
+                    var certPal = (OpenSslX509CertificateReader)candidate.Pal;
+
+                    if (certPal == null)
+                    {
+                        continue;
+                    }
+
+                    SafeX509Handle candidateHandle = certPal.SafeHandle;
 
                     int issuerError = Interop.Crypto.X509CheckIssued(candidateHandle, certHandle);
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
@@ -138,14 +138,17 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
                         Assert.Equal(1, Directory.GetFiles(storeDirectory).Length);
 
-                        X509Certificate2Collection storeCerts = store.Certificates;
-
-                        Assert.Equal(1, storeCerts.Count);
-
-                        using (X509Certificate2 storeCert = storeCerts[0])
+                        using (var coll = new ImportedCollection(store.Certificates))
                         {
-                            Assert.Equal(cert, storeCert);
-                            Assert.NotSame(cert, storeCert);
+                            X509Certificate2Collection storeCerts = coll.Collection;
+
+                            Assert.Equal(1, storeCerts.Count);
+
+                            using (X509Certificate2 storeCert = storeCerts[0])
+                            {
+                                Assert.Equal(cert, storeCert);
+                                Assert.NotSame(cert, storeCert);
+                            }
                         }
                     }
                 });
@@ -175,14 +178,17 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
                         Assert.Equal(1, Directory.GetFiles(storeDirectory).Length);
 
-                        X509Certificate2Collection storeCerts = store.Certificates;
-
-                        Assert.Equal(1, storeCerts.Count);
-
-                        using (X509Certificate2 storeCert = storeCerts[0])
+                        using (var coll = new ImportedCollection(store.Certificates))
                         {
-                            Assert.Equal(cert, storeCert);
-                            Assert.NotSame(cert, storeCert);
+                            X509Certificate2Collection storeCerts = coll.Collection;
+
+                            Assert.Equal(1, storeCerts.Count);
+
+                            using (X509Certificate2 storeCert = storeCerts[0])
+                            {
+                                Assert.Equal(cert, storeCert);
+                                Assert.NotSame(cert, storeCert);
+                            }
                         }
                     }
                 });

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -24,11 +24,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
             {
                 store.Open(OpenFlags.ReadOnly);
-                int certCount = store.Certificates.Count;
 
-                // This assert is just so certCount appears to be used, the test really
-                // is that store.get_Certificates didn't throw.
-                Assert.True(certCount >= 0);
+                using (var coll = new ImportedCollection(store.Certificates))
+                {
+                    int certCount = coll.Collection.Count;
+
+                    // This assert is just so certCount appears to be used, the test really
+                    // is that store.get_Certificates didn't throw.
+                    Assert.True(certCount >= 0);
+                }
             }
         }
 
@@ -49,12 +53,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             {
                 store.Open(OpenFlags.ReadOnly);
 
-                // Add only throws when it has to do work.  If, for some reason, this certificate
-                // is already present in the CurrentUser\My store, we can't really test this
-                // functionality.
-                if (!store.Certificates.Contains(cert))
+                using (var coll = new ImportedCollection(store.Certificates))
                 {
-                    Assert.ThrowsAny<CryptographicException>(() => store.Add(cert));
+                    // Add only throws when it has to do work.  If, for some reason, this certificate
+                    // is already present in the CurrentUser\My store, we can't really test this
+                    // functionality.
+                    if (!coll.Collection.Contains(cert))
+                    {
+                        Assert.ThrowsAny<CryptographicException>(() => store.Add(cert));
+                    }
                 }
             }
         }
@@ -71,12 +78,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 // Look through the certificates to find one with no private key to call add on.
                 // (The private key restriction is so that in the event of an "accidental success"
                 // that no potential permissions would be modified)
-                foreach (X509Certificate2 cert in store.Certificates)
+                using (var coll = new ImportedCollection(store.Certificates))
                 {
-                    if (!cert.HasPrivateKey)
+                    foreach (X509Certificate2 cert in coll.Collection)
                     {
-                        toAdd = cert;
-                        break;
+                        if (!cert.HasPrivateKey)
+                        {
+                            toAdd = cert;
+                            break;
+                        }
                     }
                 }
 
@@ -104,9 +114,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             {
                 store.Open(OpenFlags.ReadOnly);
 
-                if (store.Certificates.Contains(cert))
+                using (var coll = new ImportedCollection(store.Certificates))
                 {
-                    Assert.ThrowsAny<CryptographicException>(() => store.Remove(cert));
+                    if (coll.Collection.Contains(cert))
+                    {
+                        Assert.ThrowsAny<CryptographicException>(() => store.Remove(cert));
+                    }
                 }
             }
         }


### PR DESCRIPTION
The X509 finalization cleanup (#9510) went a little further than required.
For non-root certificates the cleanup logic was fine, but for a root certificate
the following erroneous logic happened:

* Build trusted certs list
* FindIssuer(cert)
  * This cert is self-signed, it has no candidate parents
  * (candidates.Count == 0)
* For every trusted cert which wasn't already known to be a candidate, Dispose it.
  * This disposed all of the trusted certs.
* Now ask "is the root cert of the chain in the trusted certs set?".
  * The answer is no, since everything was disposed.

The caller, which received the candidates list and the trusted certs list, was
already disposing the trusted certs, so there's no reason to do that in the
inner method.  That realization then lets the cleanup logic be simplified to no
longer have an indexing dependency.

The new test which has the same root cert in both the user and machine root
store showed that there was a "didn't get added to the HashSet"-induced
finalization, and that has been cleaned up (and guarded against). The new
Dispose logic has been proven resilient to the system trust list being populated
in a different order than the FindIssuer presentation list.

Fixes #10801.
cc: @stephentoub @iamjasonp 
