### PR TITLE
Adding support for emitting nullable constants

### DIFF
--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public static class CompilerTests
+    {
+#if FEATURE_COMPILE
+        [Fact]
+        public static void EmitConstantsToIL_NonNullableValueTypes()
+        {
+            VerifyEmitConstantsToIL((bool)true);
+
+            VerifyEmitConstantsToIL((char)'a');
+
+            VerifyEmitConstantsToIL((sbyte)42);
+            VerifyEmitConstantsToIL((byte)42);
+            VerifyEmitConstantsToIL((short)42);
+            VerifyEmitConstantsToIL((ushort)42);
+            VerifyEmitConstantsToIL((int)42);
+            VerifyEmitConstantsToIL((uint)42);
+            VerifyEmitConstantsToIL((long)42);
+            VerifyEmitConstantsToIL((ulong)42);
+
+            VerifyEmitConstantsToIL((float)3.14);
+            VerifyEmitConstantsToIL((double)3.14);
+            VerifyEmitConstantsToIL((decimal)49.95m);
+        }
+
+        [Fact]
+        public static void EmitConstantsToIL_NullableValueTypes()
+        {
+            VerifyEmitConstantsToIL((bool?)null);
+            VerifyEmitConstantsToIL((bool?)true);
+
+            VerifyEmitConstantsToIL((char?)null);
+            VerifyEmitConstantsToIL((char?)'a');
+
+            VerifyEmitConstantsToIL((sbyte?)null);
+            VerifyEmitConstantsToIL((sbyte?)42);
+            VerifyEmitConstantsToIL((byte?)null);
+            VerifyEmitConstantsToIL((byte?)42);
+            VerifyEmitConstantsToIL((short?)null);
+            VerifyEmitConstantsToIL((short?)42);
+            VerifyEmitConstantsToIL((ushort?)null);
+            VerifyEmitConstantsToIL((ushort?)42);
+            VerifyEmitConstantsToIL((int?)null);
+            VerifyEmitConstantsToIL((int?)42);
+            VerifyEmitConstantsToIL((uint?)null);
+            VerifyEmitConstantsToIL((uint?)42);
+            VerifyEmitConstantsToIL((long?)null);
+            VerifyEmitConstantsToIL((long?)42);
+            VerifyEmitConstantsToIL((ulong?)null);
+            VerifyEmitConstantsToIL((ulong?)42);
+
+            VerifyEmitConstantsToIL((float?)null);
+            VerifyEmitConstantsToIL((float?)3.14);
+            VerifyEmitConstantsToIL((double?)null);
+            VerifyEmitConstantsToIL((double?)3.14);
+            VerifyEmitConstantsToIL((decimal?)null);
+            VerifyEmitConstantsToIL((decimal?)49.95m);
+
+            VerifyEmitConstantsToIL((DateTime?)null);
+        }
+
+        [Fact]
+        public static void EmitConstantsToIL_ReferenceTypes()
+        {
+            VerifyEmitConstantsToIL((string)null);
+            VerifyEmitConstantsToIL((string)"bar");
+        }
+
+        [Fact]
+        public static void EmitConstantsToIL_Enums()
+        {
+            VerifyEmitConstantsToIL(ConstantsEnum.A);
+            VerifyEmitConstantsToIL((ConstantsEnum?)null);
+            VerifyEmitConstantsToIL((ConstantsEnum?)ConstantsEnum.A);
+        }
+
+        [Fact]
+        public static void EmitConstantsToIL_ShareReferences()
+        {
+            var o = new object();
+            VerifyEmitConstantsToIL(Expression.Equal(Expression.Constant(o), Expression.Constant(o)), 1, true);
+        }
+
+        [Fact]
+        public static void EmitConstantsToIL_LiftedToClosure()
+        {
+            VerifyEmitConstantsToIL(DateTime.Now, 1);
+            VerifyEmitConstantsToIL((DateTime?)DateTime.Now, 1);
+        }
+
+        private static void VerifyEmitConstantsToIL<T>(T value)
+        {
+            VerifyEmitConstantsToIL<T>(value, 0);
+        }
+
+        private static void VerifyEmitConstantsToIL<T>(T value, int expectedCount)
+        {
+            VerifyEmitConstantsToIL(Expression.Constant(value, typeof(T)), expectedCount, value);
+        }
+
+        private static void VerifyEmitConstantsToIL(Expression e, int expectedCount, object expectedValue)
+        {
+            var f = Expression.Lambda(e).Compile();
+
+            var c = f.Target as Closure;
+            Assert.NotNull(c);
+            Assert.Equal(expectedCount, c.Constants.Length);
+
+            var o = f.DynamicInvoke();
+            Assert.Equal(expectedValue, o);
+        }
+#endif
+    }
+
+    public enum ConstantsEnum
+    {
+        A
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -12,6 +12,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Linq.Expressions.Tests</AssemblyName>
     <RootNamespace>System.Linq.Expressions.Tests</RootNamespace>
+    <IsInterpreting Condition="'$(PackageTargetFramework)' == 'netcore50'">true</IsInterpreting>
+    <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
     <KeepAllProjectReferences>true</KeepAllProjectReferences>
     <NugetTargetMoniker>.NETStandard,Version=v1.6</NugetTargetMoniker>
@@ -25,6 +27,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CompilerTests.cs" />
     <Compile Include="Array\ArrayAccessTests.cs" />
     <Compile Include="Array\ArrayArrayIndexTests.cs" />
     <Compile Include="Array\ArrayArrayLengthTests.cs" />


### PR DESCRIPTION
This addresses issue #11188 by adding support to emit IL code for constants of nullable types.

The case where the value is `null` was already covered; the case where the value is non-null is added by emitting the constant for the non-nullable type and invoking the `Nullable<T>(T)` constructor using `newobj`.

By doing so, we reduce the number of slots in `Closure.Constants` (possibly eliminating the allocation of the whole array if there are no such constants), and also avoid boxing a nullable (primitive) value. The resulting code involves two instructions (`ldc*` and `newobj`) where loading a constant from the `Constants` array involves loading the field (`ldfld`), indexing into it (`ldelem`), and converting it to the requested type (`castclass` `unbox`, etc.).