### PR TITLE
Enhance LoopbackServer to return received data

### DIFF
--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -83,11 +83,10 @@ namespace System.Net.Test.Common
         {
             // Read request line and headers. Skip any request body.
             var lines = new List<string>();
-            string line = await reader.ReadLineAsync().ConfigureAwait(false);
-            while (!string.IsNullOrEmpty(line))
+            string line;
+            while (!string.IsNullOrEmpty(line = await reader.ReadLineAsync().ConfigureAwait(false)))
             {
                 lines.Add(line);
-                line = await reader.ReadLineAsync().ConfigureAwait(false);
             }
 
             await writer.WriteAsync(response ?? DefaultHttpResponse).ConfigureAwait(false);
@@ -119,8 +118,7 @@ namespace System.Net.Test.Common
                 using (var reader = new StreamReader(stream, Encoding.ASCII))
                 using (var writer = new StreamWriter(stream, Encoding.ASCII) { AutoFlush = true })
                 {
-                    List<string> result = await funcAsync(s, stream, reader, writer).ConfigureAwait(false);
-                    return result;
+                    return await funcAsync(s, stream, reader, writer).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -73,19 +74,29 @@ namespace System.Net.Test.Common
                 .Where(a => a.IsIPv6LinkLocal)
                 .FirstOrDefault();
 
-        public static Task ReadRequestAndSendResponseAsync(Socket server, string response = null, Options options = null)
+        public static Task<List<string>> ReadRequestAndSendResponseAsync(Socket server, string response = null, Options options = null)
         {
             return AcceptSocketAsync(server, (s, stream, reader, writer) => ReadWriteAcceptedAsync(s, reader, writer, response), options);
         }
 
-        public static async Task ReadWriteAcceptedAsync(Socket s, StreamReader reader, StreamWriter writer, string response = null)
+        public static async Task<List<string>> ReadWriteAcceptedAsync(Socket s, StreamReader reader, StreamWriter writer, string response = null)
         {
-            while (!string.IsNullOrEmpty(await reader.ReadLineAsync().ConfigureAwait(false))) ;
+            // Read request line and headers. Skip any request body.
+            var lines = new List<string>();
+            string line = await reader.ReadLineAsync().ConfigureAwait(false);
+            while (!string.IsNullOrEmpty(line))
+            {
+                lines.Add(line);
+                line = await reader.ReadLineAsync().ConfigureAwait(false);
+            }
+
             await writer.WriteAsync(response ?? DefaultHttpResponse).ConfigureAwait(false);
             s.Shutdown(SocketShutdown.Send);
+
+            return lines;
         }
 
-        public static async Task AcceptSocketAsync(Socket server, Func<Socket, Stream, StreamReader, StreamWriter, Task> funcAsync, Options options = null)
+        public static async Task<List<string>> AcceptSocketAsync(Socket server, Func<Socket, Stream, StreamReader, StreamWriter, Task<List<string>>> funcAsync, Options options = null)
         {
             options = options ?? new Options();
             using (Socket s = await server.AcceptAsync().ConfigureAwait(false))
@@ -108,7 +119,8 @@ namespace System.Net.Test.Common
                 using (var reader = new StreamReader(stream, Encoding.ASCII))
                 using (var writer = new StreamWriter(stream, Encoding.ASCII) { AutoFlush = true })
                 {
-                    await funcAsync(s, stream, reader, writer).ConfigureAwait(false);
+                    List<string> result = await funcAsync(s, stream, reader, writer).ConfigureAwait(false);
+                    return result;
                 }
             }
         }
@@ -182,6 +194,8 @@ namespace System.Net.Test.Common
                 }
 
                 client.Shutdown(SocketShutdown.Both);
+                
+                return null;
             }), out localEndPoint);
         }
     }

--- a/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
@@ -55,6 +55,8 @@ namespace System.Net.Http.Functional.Tests
                         await Task.Delay(1000);
                         triggerRequestCancel.SetResult(true); // allow request to cancel
                         await triggerResponseWrite.Task; // pause until we're released
+                        
+                        return null;
                     });
 
                     var stopwatch = Stopwatch.StartNew();
@@ -104,6 +106,8 @@ namespace System.Net.Http.Functional.Tests
                             (startResponseBody ? "20 bytes of the body" : ""));
 
                         await triggerResponseWrite.Task; // pause until we're released
+                        
+                        return null;
                     });
 
                     using (HttpResponseMessage response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead))

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -93,6 +93,7 @@ namespace System.Net.Http.Functional.Tests
                             SslStream sslStream = Assert.IsType<SslStream>(stream);
                             Assert.Equal(cert, sslStream.RemoteCertificate);
                             await LoopbackServer.ReadWriteAcceptedAsync(socket, reader, writer);
+                            return null;
                         }, options));
                 };
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -91,6 +91,8 @@ namespace System.Net.Http.Functional.Tests
                         {
                             await Assert.ThrowsAsync<HttpRequestException>(() => getAsync);
                         }
+                        
+                        return null;
                     });
                 }
             });

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -159,6 +159,7 @@ namespace System.Net.Http.Functional.Tests
                         {
                             Assert.Equal(SslProtocols.Tls12, Assert.IsType<SslStream>(stream).SslProtocol);
                             await LoopbackServer.ReadWriteAcceptedAsync(s, reader, writer);
+                            return null;
                         }, options));
                 }, options);
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -837,6 +837,8 @@ namespace System.Net.Http.Functional.Tests
                                 Assert.True(bytesRead < buffer.Length, "bytesRead should be less than buffer.Length");
                             }
                         }
+                        
+                        return null;
                     });
                 }
             });
@@ -857,6 +859,7 @@ namespace System.Net.Http.Functional.Tests
                         Task server1 = LoopbackServer.AcceptSocketAsync(socket1, async (s, stream, reader, writer) =>
                         {
                             await unblockServers.Task;
+                            return null;
                         });
 
                         // Second server connects and sends some but not all headers
@@ -865,6 +868,7 @@ namespace System.Net.Http.Functional.Tests
                             while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) ;
                             await writer.WriteAsync($"HTTP/1.1 200 OK\r\n");
                             await unblockServers.Task;
+                            return null;
                         });
 
                         // Third server connects and sends all headers and some but not all of the body
@@ -876,6 +880,7 @@ namespace System.Net.Http.Functional.Tests
                             await unblockServers.Task;
                             await writer.WriteAsync("1234567890");
                             s.Shutdown(SocketShutdown.Send);
+                            return null;
                         });
 
                         // Make three requests
@@ -1218,6 +1223,8 @@ namespace System.Net.Http.Functional.Tests
                             Assert.True(contentDisposed, "Expected request content to be disposed");
                             Assert.Equal("abcdefghij", await response.Content.ReadAsStringAsync());
                         }
+                        
+                        return null;
                     });
                 });
             }
@@ -1279,6 +1286,8 @@ namespace System.Net.Http.Functional.Tests
                             Assert.True(contentDisposed, "Expected request content to be disposed");
                             Assert.Equal("abcdefghij", await response.Content.ReadAsStringAsync());
                         }
+                        
+                        return null;
                     });
                 });
             }
@@ -1567,36 +1576,27 @@ namespace System.Net.Http.Functional.Tests
                 {
                     Task<HttpResponseMessage> getResponse = client.SendAsync(request);
 
-                    await LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
-                    {
-                        string statusLine = reader.ReadLine();
-                        while (!string.IsNullOrEmpty(reader.ReadLine())) ;
-
-                        if (statusLine.Contains("/1.0"))
-                        {
-                            receivedRequestVersion = new Version(1, 0);
-                        }
-                        else if (statusLine.Contains("/1.1"))
-                        {
-                            receivedRequestVersion = new Version(1, 1);
-                        }
-                        else
-                        {
-                            Assert.True(false, "Invalid HTTP request version");
-                        }
-
-                        await writer.WriteAsync(
-                            $"HTTP/1.1 200 OK\r\n" +
-                            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                            "Content-Length: 0\r\n" +
-                            "\r\n");
-                        s.Shutdown(SocketShutdown.Send);
-                    });
+                    List<string> receivedRequest = await LoopbackServer.ReadRequestAndSendResponseAsync(server);
 
                     using (HttpResponseMessage response = await getResponse)
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                     }
+
+                    string statusLine = receivedRequest[0];
+                    if (statusLine.Contains("/1.0"))
+                    {
+                        receivedRequestVersion = new Version(1, 0);
+                    }
+                    else if (statusLine.Contains("/1.1"))
+                    {
+                        receivedRequestVersion = new Version(1, 1);
+                    }
+                    else
+                    {
+                        Assert.True(false, "Invalid HTTP request version");
+                    }
+                    
                 }
             });
             
@@ -1713,24 +1713,12 @@ namespace System.Net.Http.Functional.Tests
                 {
                     Task<HttpResponseMessage> getResponse = client.SendAsync(request);
 
-                    await LoopbackServer.AcceptSocketAsync(server, async (s, stream, reader, writer) =>
-                    {
-                        statusLine = reader.ReadLine();
-                        _output.WriteLine(statusLine);
-                        while (!string.IsNullOrEmpty(reader.ReadLine())) ;
-
-                        await writer.WriteAsync(
-                            $"HTTP/1.1 200 OK\r\n" +
-                            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
-                            "Content-Length: 0\r\n" +
-                            "\r\n");
-                        s.Shutdown(SocketShutdown.Send);
-                    });
+                    List<string> receivedRequest = await LoopbackServer.ReadRequestAndSendResponseAsync(server);
 
                     using (HttpResponseMessage response = await getResponse)
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                        Assert.True(statusLine.Contains(uri.PathAndQuery), $"statusLine should contain {uri.PathAndQuery}");
+                        Assert.True(receivedRequest[0].Contains(uri.PathAndQuery), $"statusLine should contain {uri.PathAndQuery}");
                     }
                 }
             });

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -127,7 +127,7 @@ namespace System.Net.Http.Functional.Tests
                     writer.Write(responseText);
                     s.Shutdown(SocketShutdown.Send);
 
-                    return Task.CompletedTask;
+                    return Task.FromResult<List<string>>(null);
                 }).GetAwaiter().GetResult();
 
                 getAsync.GetAwaiter().GetResult().Dispose();
@@ -147,6 +147,8 @@ namespace System.Net.Http.Functional.Tests
 
                     await writer.WriteAsync(responseText).ConfigureAwait(false);
                     s.Shutdown(SocketShutdown.Send);
+                    
+                    return null;
                 });
 
                 (await getAsync.ConfigureAwait(false)).Dispose();
@@ -175,6 +177,8 @@ namespace System.Net.Http.Functional.Tests
 
                     await writer.WriteAsync(responseText).ConfigureAwait(false);
                     s.Shutdown(SocketShutdown.Send);
+                    
+                    return null;
                 });
 
                 (await postAsync.ConfigureAwait(false)).Dispose();
@@ -204,6 +208,8 @@ namespace System.Net.Http.Functional.Tests
                             GC.Collect();
                             return !wr.IsAlive;
                         }, 10 * 1000), "Response object should have been collected");
+                        
+                        return null;
                     });
                 }
             });


### PR DESCRIPTION
Modified the test LoopbackServer so that it can return the received data in the helper methods. This allows more use of the
simple ReadRequestAndSendResponseAsync() method instead of having to use the more complex methods.

Modified a few HttpClient tests to take advantage of this. More tests will be simplified in future PRs.