### PR TITLE
Remove UpdateInvalidPackageVersions from Run config, fix doc for UpdateDependencies

### DIFF
--- a/Documentation/project-docs/project-nuget-dependencies.md
+++ b/Documentation/project-docs/project-nuget-dependencies.md
@@ -10,21 +10,15 @@ As a historical note, `project.json` files in CoreFX previously had floating dep
 Dependency version validation
 -----------------------------
 
-The dependencies in each CoreFX project.json file are validated by a few rules to ensure package versions across the repository stay in sync. These rules are in `dir.props`, as `ValidationPattern` items. Each `ValidationPattern` item includes a regular expression that matches a set of package identities and metadata describing which version is expected for that regular expression. The metadata must be one of these:
-
-* `ExpectedPrerelease`: a prerelease version is expected, but any major, minor, and patch versions are fine. For example, an `ExpectedVersion` of `rc-12345` is valid for `1.0.0-rc-12345`, `5.4.3-rc-12345`, or any other `*-rc-12345`
-* `ExpectedVersion`: the full version string needs to match exactly. An example is `1.0.0-prerelease`. 
+The dependencies in each CoreFX project.json file are validated by a few rules in `dependencies.props` to ensure package versions across the repository stay in sync.
 
 Errors you can expect from failed dependency version validation are like the following:
 
-    error : Dependency validation error: for System.IO 4.0.10-rc2-10000 in src\System.Collections\tests\project.json package prerelease is 'rc2-10000', but expected 'rc2-23604' for packages matching '^((System\..*)|(Microsoft\.CSharp)|(Microsoft\.NETCore.*)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?<!TestData)$'
+    C:\git\corefx\Tools\VersionTools.targets(47,5): error : Dependency verification errors detected. To automatically fix based on dependency rules, run the msbuild target 'UpdateDependencies' [C:\git\corefx\build.proj]
+    C:\git\corefx\Tools\VersionTools.targets(47,5): error : Dependencies invalid: In 'C:\git\corefx\src\Common\test-runtime\project.json', 'Microsoft.DotNet.BuildTools.TestSuite 1.0.0-prerelease-00704-04' must be '1.0.0-prerelease-00704-05' (Microsoft.DotNet.BuildTools.TestSuite) [C:\git\corefx\build.proj]
+    C:\git\corefx\Tools\VersionTools.targets(47,5): error : Dependencies invalid: In 'C:\git\corefx\src\Common\tests\project.json', 'Microsoft.xunit.netcore.extensions 1.0.0-prerelease-00704-04' must be '1.0.0-prerelease-00704-05' (Microsoft.xunit.netcore.extensions) [C:\git\corefx\build.proj]
 
-    error : Dependency validation error: for System.Linq 4.0.0-beta-* in src\System.Collections\tests\project.json package prerelease is 'beta-', but expected 'rc2-23604' for packages matching '^((System\..*)|(Microsoft\.CSharp)|(Microsoft\.NETCore.*)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?<!TestData)$'
-    error : Floating dependency detected: System.Linq 4.0.0-beta-* in src\System.Collections\tests\project.json
-
-    error : Dependency validation error: for xunit 2.0.0 in src\System.Collections\tests\project.json package version is '2.0.0' but expected '2.1.0' for packages matching '^xunit$'
-
-To fix these, you can manually modify the `project.json` files mentioned or automatically fix them using the `UpdateInvalidPackageVersions` target described in the next section.
+To fix these, you can manually modify the `project.json` files mentioned or automatically fix them using the `UpdateDependencies` target described in the next section.
 
 Upgrading a package dependency
 ------------------------------
@@ -33,22 +27,11 @@ To update a package that isn't validated by a rule, simply change the project.js
 
 To update a package that is validated, follow these steps:
 
-1. Edit `ValidationPattern` item(s) in `dir.props` in the CoreFX root.
+1. Edit the versions repo commit hashes in `(CoreFx|CoreClr|External)CurrentRef` and `StaticDependency` versions in `dependencies.props` in the CoreFX root.
 2. Run the dependency update target in the repository root using this command:
 
-        build.cmd -UpdateInvalidPackageVersions
+        build-managed.cmd -- /t:UpdateDependencies
 
 3. Commit the automated updates in an independent commit, isolating them from other changes. This makes pull requests easier to review.
 
-The `UpdateInvalidPackageVersions` target looks through all dependencies, using the validation rules to update any invalid versions. The build prints out which dependencies are updated and which project.json files are written.
-
-Recovering from a non-existent prerelease dependency
-----------------------------------------------------
-
-Sometimes upgrading the prerelease version can make `project.json` files contain dependencies that don't exist. For example, if you update a rule's valid prerelease from `beta-100` to `beta-200`, but around `beta-150` a stable version of `System.Foo` was released and prereleases changed from `1.0.0-beta-...` to `1.1.0-beta-...`, automatic package updating would result in a dependency on `1.0.0-beta-200`. However, only `1.1.0-beta-200` exists.
-
-To fix this, use the `UpdatePackageDependencyVersion` target:
-
-    msbuild /t:UpdatePackageDependencyVersion /p:PackageId=System.Foo;OldVersion=1.0.0-beta-200;NewVersion=1.1.0-beta-200
-
-This updates the `System.Foo` version in all `project.json` files in CoreFX.
+The `UpdateDependencies` target looks through all dependencies, using the validation rules to update any invalid versions. On `/verbosity:Normal` or higher, it logs which files were changed.

--- a/config.json
+++ b/config.json
@@ -216,12 +216,6 @@
       "values": [],
       "defaultValue": ""
     },
-    "UpdateInvalidPackageVersions": {
-      "description": "MsBuild target that looks through all dependencies and using the validation rules, updates any invalid versions.",
-      "valueType": "target",
-      "values": [],
-      "defaultValue": ""
-    },
     "CleanAllProjects": {
       "description": "MsBuild target that deletes the binary output directory.",
       "valueType": "target",


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/10868 removed the old validation system that used `UpdateInvalidPackageVersions` and replaced it with `UpdateDependencies`. (There are more than just project.jsons now.) This removes `UpdateInvalidPackageVersions` from config.json to avoid misleading anyone and briefly fixes the doc to point to the new way to upgrade. I plan to write better docs in buildtools that's shared between repos as mentioned in https://github.com/dotnet/corefx/issues/11189.

These new targets come from [`VersionTools.targets`](https://github.com/dotnet/buildtools/blob/58d6135652b49fc13ca7fc7c37ea38a4979d4846/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets), part of buildtools.

@maririos I decided a while ago that I would wait to add the repo-independent version-related commands until there was a way to share them somehow through buildtools, so after removing this command here I didn't add one back in. Is it reasonable to wait?

/cc @markwilkie @stephentoub @chcosta 