### PR TITLE
Add init-tools output to standard output

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -22,7 +22,7 @@ if [%1]==[force] (
 
 :: If sempahore exists do nothing
 if exist "%BUILD_TOOLS_SEMAPHORE%" (
-  echo Tools are already initialized. >> "%INIT_TOOLS_LOG%"
+  echo Tools are already initialized.
   goto :EOF
 )
 
@@ -34,7 +34,7 @@ echo Running %0 > "%INIT_TOOLS_LOG%"
 
 if exist "%DOTNET_CMD%" goto :afterdotnetrestore
 
-echo Installing dotnet cli... >> "%INIT_TOOLS_LOG%"
+echo Installing dotnet cli...
 if NOT exist "%DOTNET_PATH%" mkdir "%DOTNET_PATH%"
 set /p DOTNET_VERSION=< "%~dp0DotnetCLIVersion.txt"
 set DOTNET_ZIP_NAME=dotnet-dev-win-x64.%DOTNET_VERSION%.zip
@@ -43,32 +43,32 @@ set DOTNET_LOCAL_PATH=%DOTNET_PATH%%DOTNET_ZIP_NAME%
 echo Installing '%DOTNET_REMOTE_PATH%' to '%DOTNET_LOCAL_PATH%' >> "%INIT_TOOLS_LOG%"
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "$retryCount = 0; $success = $false; do { try { (New-Object Net.WebClient).DownloadFile('%DOTNET_REMOTE_PATH%', '%DOTNET_LOCAL_PATH%'); $success = $true; } catch { if ($retryCount -ge 6) { throw; } else { $retryCount++; Start-Sleep -Seconds (5 * $retryCount); } } } while ($success -eq $false); Add-Type -Assembly 'System.IO.Compression.FileSystem' -ErrorVariable AddTypeErrors; if ($AddTypeErrors.Count -eq 0) { [System.IO.Compression.ZipFile]::ExtractToDirectory('%DOTNET_LOCAL_PATH%', '%DOTNET_PATH%') } else { (New-Object -com shell.application).namespace('%DOTNET_PATH%').CopyHere((new-object -com shell.application).namespace('%DOTNET_LOCAL_PATH%').Items(),16) }" >> "%INIT_TOOLS_LOG%"
 if NOT exist "%DOTNET_LOCAL_PATH%" (
-  echo ERROR: Could not install dotnet cli correctly. See '%INIT_TOOLS_LOG%' for more details.
+  echo ERROR: Could not install dotnet cli correctly. See '%INIT_TOOLS_LOG%' for more details. 1>&2
   exit /b 1
 )
 
 :afterdotnetrestore
 
 if exist "%BUILD_TOOLS_PATH%" goto :afterbuildtoolsrestore
-echo Restoring BuildTools version %BUILDTOOLS_VERSION%... >> "%INIT_TOOLS_LOG%"
+echo Restoring BuildTools version %BUILDTOOLS_VERSION%...
 echo Running: "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --no-cache --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> "%INIT_TOOLS_LOG%"
 call "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --no-cache --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> "%INIT_TOOLS_LOG%"
 if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
-  echo ERROR: Could not restore build tools correctly. See '%INIT_TOOLS_LOG%' for more details.
+  echo ERROR: Could not restore build tools correctly. See '%INIT_TOOLS_LOG%' for more details. 1>&2
   exit /b 1
 )
 
 :afterbuildtoolsrestore
 
-echo Initializing BuildTools ... >> "%INIT_TOOLS_LOG%"
+echo Initializing BuildTools ...
 echo Running: "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
 call "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
 set INIT_TOOLS_ERRORLEVEL=%ERRORLEVEL%
 if not [%INIT_TOOLS_ERRORLEVEL%]==[0] (
-	echo ERROR: An error occured when trying to initialize the tools. Please check '%INIT_TOOLS_LOG%' for more details.
+	echo ERROR: An error occured when trying to initialize the tools. Please check '%INIT_TOOLS_LOG%' for more details. 1>&2
 	exit /b %INIT_TOOLS_ERRORLEVEL%
 )
 
 :: Create sempahore file
-echo Done initializing tools. >> "%INIT_TOOLS_LOG%"
+echo Done initializing tools.
 echo Init-Tools.cmd completed for BuildTools Version: %BUILDTOOLS_VERSION% > "%BUILD_TOOLS_SEMAPHORE%"

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -51,7 +51,7 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
     if [ -e $__TOOLRUNTIME_DIR ]; then rm -rf -- $__TOOLRUNTIME_DIR; fi
     echo "Running: $__scriptpath/init-tools.sh" > $__init_tools_log
     if [ ! -e $__DOTNET_PATH ]; then
-        echo "Installing dotnet cli..." >> $__init_tools_log
+        echo "Installing dotnet cli..."
         __DOTNET_LOCATION="https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/${__DOTNET_TOOLS_VERSION}/${__DOTNET_PKG}.${__DOTNET_TOOLS_VERSION}.tar.gz"
         # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
         echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> $__init_tools_log
@@ -72,21 +72,21 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
     echo $__PROJECT_JSON_CONTENTS > "$__PROJECT_JSON_FILE"
 
     if [ ! -e $__BUILD_TOOLS_PATH ]; then
-        echo "Restoring BuildTools version $__BUILD_TOOLS_PACKAGE_VERSION..." >> $__init_tools_log
+        echo "Restoring BuildTools version $__BUILD_TOOLS_PACKAGE_VERSION..."
         echo "Running: $__DOTNET_CMD restore \"$__PROJECT_JSON_FILE\" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE" >> $__init_tools_log
         $__DOTNET_CMD restore "$__PROJECT_JSON_FILE" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE >> $__init_tools_log
-        if [ ! -e "$__BUILD_TOOLS_PATH/init-tools.sh" ]; then echo "ERROR: Could not restore build tools correctly. See '$__init_tools_log' for more details."; fi
+        if [ ! -e "$__BUILD_TOOLS_PATH/init-tools.sh" ]; then echo "ERROR: Could not restore build tools correctly. See '$__init_tools_log' for more details."1>&2; fi
     fi
 
-    echo "Initializing BuildTools..." >> $__init_tools_log
+    echo "Initializing BuildTools..."
     echo "Running: $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR" >> $__init_tools_log
     $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR >> $__init_tools_log
     if [ "$?" != "0" ]; then
-        echo "ERROR: An error occured when trying to initialize the tools. Please check '$__init_tools_log' for more details."
+        echo "ERROR: An error occured when trying to initialize the tools. Please check '$__init_tools_log' for more details."1>&2
         exit 1
     fi
     touch $__INIT_TOOLS_DONE_MARKER
-    echo "Done initializing tools." >> $__init_tools_log
+    echo "Done initializing tools."
 else
-    echo "Tools are already initialized" > $__init_tools_log
+    echo "Tools are already initialized"
 fi


### PR DESCRIPTION
Add back init-tools output which was aggressively removed in https://github.com/dotnet/corefx/commit/6445e82cceae75fa07fe5123ee290579c78864d5

Adds back standard output devs are used to, and also redirects error output to error stream so that if someone wants to wrap the script and silence the standard output, they can still decide what to do with the error stream.

/cc @weshaggard @ericstj @Petermarcu 