### PR TITLE
Reduce compiled size of HttpKnownHeaderNames.TryGetHeaderName

### DIFF
--- a/src/Common/src/System/Net/HttpKnownHeaderNames.TryGetHeaderName.cs
+++ b/src/Common/src/System/Net/HttpKnownHeaderNames.TryGetHeaderName.cs
@@ -9,8 +9,8 @@ namespace System.Net
     internal static partial class HttpKnownHeaderNames
     {
         /// <summary>
-        /// Gets a known header name string from a matching char[] array segment, using an ordinal comparison.
-        /// Used to avoid allocating new strings for known header names.
+        /// Gets a known header name string from a matching char[] array segment, using a case-sensitive
+        /// ordinal comparison. Used to avoid allocating new strings for known header names.
         /// </summary>
         public static bool TryGetHeaderName(char[] array, int startIndex, int length, out string name)
         {
@@ -24,8 +24,8 @@ namespace System.Net
         }
 
         /// <summary>
-        /// Gets a known header name string from a matching IntPtr buffer, using an ordinal comparison.
-        /// Used to avoid allocating new strings for known header names.
+        /// Gets a known header name string from a matching IntPtr buffer, using a case-sensitive
+        /// ordinal comparison. Used to avoid allocating new strings for known header names.
         /// </summary>
         public unsafe static bool TryGetHeaderName(IntPtr buffer, int length, out string name)
         {
@@ -63,187 +63,196 @@ namespace System.Net
 
             // The lookup works as follows: first switch on the length of the passed-in key.
             //
-            //  - If there is only one known header of that length and the key matches that
-            //    known header, set it as the out param and return true.
+            //  - If there is only one known header of that length, set potentialHeader to that known header
+            //    and goto TryMatch to see if the key fully matches potentialHeader.
             //
             //  - If there are more than one known headers of that length, switch on a unique char from that
             //    set of same-length known headers. Typically this will be the first char, but some sets of
             //    same-length known headers do not have unique chars in the first position, so a char in a
-            //    position further in the strings is used. If the key matches one of the known headers,
-            //    set it as the out param and return true.
+            //    position further in the strings is used. If the char from the key matches one of the
+            //    known headers, set potentialHeader to that known header and goto TryMatch to see if the key
+            //    fully matches potentialHeader.
             //
-            //  - Otherwise, set the out param to null and return false.
+            //  - Otherwise, there is no match, so set the out param to null and return false.
+            //
+            // Matching is case-sensitive: we only want to return a known header that exactly matches the key.
+
+            string potentialHeader = null;
 
             switch (length)
             {
                 case 2:
-                    return TryMatch(TE, key, startIndex, length, equals, out name); // TE
+                    potentialHeader = TE; goto TryMatch; // TE
 
                 case 3:
                     switch (charAt(key, startIndex))
                     {
-                        case 'A': return TryMatch(Age, key, startIndex, length, equals, out name); // [A]ge
-                        case 'P': return TryMatch(P3P, key, startIndex, length, equals, out name); // [P]3P
-                        case 'V': return TryMatch(Via, key, startIndex, length, equals, out name); // [V]ia
+                        case 'A': potentialHeader = Age; goto TryMatch; // [A]ge
+                        case 'P': potentialHeader = P3P; goto TryMatch; // [P]3P
+                        case 'V': potentialHeader = Via; goto TryMatch; // [V]ia
                     }
                     break;
 
                 case 4:
                     switch (charAt(key, startIndex))
                     {
-                        case 'D': return TryMatch(Date, key, startIndex, length, equals, out name); // [D]ate
-                        case 'E': return TryMatch(ETag, key, startIndex, length, equals, out name); // [E]Tag
-                        case 'F': return TryMatch(From, key, startIndex, length, equals, out name); // [F]rom
-                        case 'H': return TryMatch(Host, key, startIndex, length, equals, out name); // [H]ost
-                        case 'V': return TryMatch(Vary, key, startIndex, length, equals, out name); // [V]ary
+                        case 'D': potentialHeader = Date; goto TryMatch; // [D]ate
+                        case 'E': potentialHeader = ETag; goto TryMatch; // [E]Tag
+                        case 'F': potentialHeader = From; goto TryMatch; // [F]rom
+                        case 'H': potentialHeader = Host; goto TryMatch; // [H]ost
+                        case 'V': potentialHeader = Vary; goto TryMatch; // [V]ary
                     }
                     break;
 
                 case 5:
                     switch (charAt(key, startIndex))
                     {
-                        case 'A': return TryMatch(Allow, key, startIndex, length, equals, out name); // [A]llow
-                        case 'R': return TryMatch(Range, key, startIndex, length, equals, out name); // [R]ange
+                        case 'A': potentialHeader = Allow; goto TryMatch; // [A]llow
+                        case 'R': potentialHeader = Range; goto TryMatch; // [R]ange
                     }
                     break;
 
                 case 6:
                     switch (charAt(key, startIndex))
                     {
-                        case 'A': return TryMatch(Accept, key, startIndex, length, equals, out name); // [A]ccept
-                        case 'C': return TryMatch(Cookie, key, startIndex, length, equals, out name); // [C]ookie
-                        case 'E': return TryMatch(Expect, key, startIndex, length, equals, out name); // [E]xpect
-                        case 'O': return TryMatch(Origin, key, startIndex, length, equals, out name); // [O]rigin
-                        case 'P': return TryMatch(Pragma, key, startIndex, length, equals, out name); // [P]ragma
-                        case 'S': return TryMatch(Server, key, startIndex, length, equals, out name); // [S]erver
+                        case 'A': potentialHeader = Accept; goto TryMatch; // [A]ccept
+                        case 'C': potentialHeader = Cookie; goto TryMatch; // [C]ookie
+                        case 'E': potentialHeader = Expect; goto TryMatch; // [E]xpect
+                        case 'O': potentialHeader = Origin; goto TryMatch; // [O]rigin
+                        case 'P': potentialHeader = Pragma; goto TryMatch; // [P]ragma
+                        case 'S': potentialHeader = Server; goto TryMatch; // [S]erver
                     }
                     break;
 
                 case 7:
                     switch (charAt(key, startIndex))
                     {
-                        case 'C': return TryMatch(Cookie2, key, startIndex, length, equals, out name); // [C]ookie2
-                        case 'E': return TryMatch(Expires, key, startIndex, length, equals, out name); // [E]xpires
-                        case 'R': return TryMatch(Referer, key, startIndex, length, equals, out name); // [R]eferer
-                        case 'T': return TryMatch(Trailer, key, startIndex, length, equals, out name); // [T]railer
-                        case 'U': return TryMatch(Upgrade, key, startIndex, length, equals, out name); // [U]pgrade
-                        case 'W': return TryMatch(Warning, key, startIndex, length, equals, out name); // [W]arning
+                        case 'C': potentialHeader = Cookie2; goto TryMatch; // [C]ookie2
+                        case 'E': potentialHeader = Expires; goto TryMatch; // [E]xpires
+                        case 'R': potentialHeader = Referer; goto TryMatch; // [R]eferer
+                        case 'T': potentialHeader = Trailer; goto TryMatch; // [T]railer
+                        case 'U': potentialHeader = Upgrade; goto TryMatch; // [U]pgrade
+                        case 'W': potentialHeader = Warning; goto TryMatch; // [W]arning
                     }
                     break;
 
                 case 8:
                     switch (charAt(key, startIndex + 3))
                     {
-                        case 'M': return TryMatch(IfMatch, key, startIndex, length, equals, out name);  // If-[M]atch
-                        case 'R': return TryMatch(IfRange, key, startIndex, length, equals, out name);  // If-[R]ange
-                        case 'a': return TryMatch(Location, key, startIndex, length, equals, out name); // Loc[a]tion
+                        case 'M': potentialHeader = IfMatch; goto TryMatch;  // If-[M]atch
+                        case 'R': potentialHeader = IfRange; goto TryMatch;  // If-[R]ange
+                        case 'a': potentialHeader = Location; goto TryMatch; // Loc[a]tion
                     }
                     break;
 
                 case 10:
                     switch (charAt(key, startIndex))
                     {
-                        case 'C': return TryMatch(Connection, key, startIndex, length, equals, out name); // [C]onnection
-                        case 'K': return TryMatch(KeepAlive, key, startIndex, length, equals, out name);  // [K]eep-Alive
-                        case 'S': return TryMatch(SetCookie, key, startIndex, length, equals, out name);  // [S]et-Cookie
-                        case 'U': return TryMatch(UserAgent, key, startIndex, length, equals, out name);  // [U]ser-Agent
+                        case 'C': potentialHeader = Connection; goto TryMatch; // [C]onnection
+                        case 'K': potentialHeader = KeepAlive; goto TryMatch;  // [K]eep-Alive
+                        case 'S': potentialHeader = SetCookie; goto TryMatch;  // [S]et-Cookie
+                        case 'U': potentialHeader = UserAgent; goto TryMatch;  // [U]ser-Agent
                     }
                     break;
 
                 case 11:
                     switch (charAt(key, startIndex))
                     {
-                        case 'C': return TryMatch(ContentMD5, key, startIndex, length, equals, out name); // [C]ontent-MD5
-                        case 'R': return TryMatch(RetryAfter, key, startIndex, length, equals, out name); // [R]etry-After
-                        case 'S': return TryMatch(SetCookie2, key, startIndex, length, equals, out name); // [S]et-Cookie2
+                        case 'C': potentialHeader = ContentMD5; goto TryMatch; // [C]ontent-MD5
+                        case 'R': potentialHeader = RetryAfter; goto TryMatch; // [R]etry-After
+                        case 'S': potentialHeader = SetCookie2; goto TryMatch; // [S]et-Cookie2
                     }
                     break;
 
                 case 12:
                     switch (charAt(key, startIndex))
                     {
-                        case 'C': return TryMatch(ContentType, key, startIndex, length, equals, out name); // [C]ontent-Type
-                        case 'M': return TryMatch(MaxForwards, key, startIndex, length, equals, out name); // [M]ax-Forwards
-                        case 'X': return TryMatch(XPoweredBy, key, startIndex, length, equals, out name);  // [X]-Powered-By
+                        case 'C': potentialHeader = ContentType; goto TryMatch; // [C]ontent-Type
+                        case 'M': potentialHeader = MaxForwards; goto TryMatch; // [M]ax-Forwards
+                        case 'X': potentialHeader = XPoweredBy; goto TryMatch;  // [X]-Powered-By
                     }
                     break;
 
                 case 13:
                     switch (charAt(key, startIndex + 6))
                     {
-                        case '-': return TryMatch(AcceptRanges, key, startIndex, length, equals, out name);  // Accept[-]Ranges
-                        case 'i': return TryMatch(Authorization, key, startIndex, length, equals, out name); // Author[i]zation
-                        case 'C': return TryMatch(CacheControl, key, startIndex, length, equals, out name);  // Cache-[C]ontrol
-                        case 't': return TryMatch(ContentRange, key, startIndex, length, equals, out name);  // Conten[t]-Range
-                        case 'e': return TryMatch(IfNoneMatch, key, startIndex, length, equals, out name);   // If-Non[e]-Match
-                        case 'o': return TryMatch(LastModified, key, startIndex, length, equals, out name);  // Last-M[o]dified
+                        case '-': potentialHeader = AcceptRanges; goto TryMatch;  // Accept[-]Ranges
+                        case 'i': potentialHeader = Authorization; goto TryMatch; // Author[i]zation
+                        case 'C': potentialHeader = CacheControl; goto TryMatch;  // Cache-[C]ontrol
+                        case 't': potentialHeader = ContentRange; goto TryMatch;  // Conten[t]-Range
+                        case 'e': potentialHeader = IfNoneMatch; goto TryMatch;   // If-Non[e]-Match
+                        case 'o': potentialHeader = LastModified; goto TryMatch;  // Last-M[o]dified
                     }
                     break;
 
                 case 14:
                     switch (charAt(key, startIndex))
                     {
-                        case 'A': return TryMatch(AcceptCharset, key, startIndex, length, equals, out name); // [A]ccept-Charset
-                        case 'C': return TryMatch(ContentLength, key, startIndex, length, equals, out name); // [C]ontent-Length
+                        case 'A': potentialHeader = AcceptCharset; goto TryMatch; // [A]ccept-Charset
+                        case 'C': potentialHeader = ContentLength; goto TryMatch; // [C]ontent-Length
                     }
                     break;
 
                 case 15:
                     switch (charAt(key, startIndex + 7))
                     {
-                        case 'E': return TryMatch(AcceptEncoding, key, startIndex, length, equals, out name); // Accept-[E]ncoding
-                        case 'L': return TryMatch(AcceptLanguage, key, startIndex, length, equals, out name); // Accept-[L]anguage
+                        case 'E': potentialHeader = AcceptEncoding; goto TryMatch; // Accept-[E]ncoding
+                        case 'L': potentialHeader = AcceptLanguage; goto TryMatch; // Accept-[L]anguage
                     }
                     break;
 
                 case 16:
                     switch (charAt(key, startIndex + 11))
                     {
-                        case 'o': return TryMatch(ContentEncoding, key, startIndex, length, equals, out name); // Content-Enc[o]ding
-                        case 'g': return TryMatch(ContentLanguage, key, startIndex, length, equals, out name); // Content-Lan[g]uage
-                        case 'a': return TryMatch(ContentLocation, key, startIndex, length, equals, out name); // Content-Loc[a]tion
-                        case 'c': return TryMatch(ProxyConnection, key, startIndex, length, equals, out name); // Proxy-Conne[c]tion
-                        case 'i': return TryMatch(WWWAuthenticate, key, startIndex, length, equals, out name); // WWW-Authent[i]cate
-                        case 'r': return TryMatch(XAspNetVersion, key, startIndex, length, equals, out name);  // X-AspNet-Ve[r]sion
+                        case 'o': potentialHeader = ContentEncoding; goto TryMatch; // Content-Enc[o]ding
+                        case 'g': potentialHeader = ContentLanguage; goto TryMatch; // Content-Lan[g]uage
+                        case 'a': potentialHeader = ContentLocation; goto TryMatch; // Content-Loc[a]tion
+                        case 'c': potentialHeader = ProxyConnection; goto TryMatch; // Proxy-Conne[c]tion
+                        case 'i': potentialHeader = WWWAuthenticate; goto TryMatch; // WWW-Authent[i]cate
+                        case 'r': potentialHeader = XAspNetVersion; goto TryMatch;  // X-AspNet-Ve[r]sion
                     }
                     break;
 
                 case 17:
                     switch (charAt(key, startIndex))
                     {
-                        case 'I': return TryMatch(IfModifiedSince, key, startIndex, length, equals, out name);  // [I]f-Modified-Since
-                        case 'S': return TryMatch(SecWebSocketKey, key, startIndex, length, equals, out name);  // [S]ec-WebSocket-Key
-                        case 'T': return TryMatch(TransferEncoding, key, startIndex, length, equals, out name); // [T]ransfer-Encoding
+                        case 'I': potentialHeader = IfModifiedSince; goto TryMatch;  // [I]f-Modified-Since
+                        case 'S': potentialHeader = SecWebSocketKey; goto TryMatch;  // [S]ec-WebSocket-Key
+                        case 'T': potentialHeader = TransferEncoding; goto TryMatch; // [T]ransfer-Encoding
                     }
                     break;
 
                 case 18:
-                    return TryMatch(ProxyAuthenticate, key, startIndex, length, equals, out name); // Proxy-Authenticate
+                    potentialHeader = ProxyAuthenticate; goto TryMatch; // Proxy-Authenticate
 
                 case 19:
                     switch (charAt(key, startIndex))
                     {
-                        case 'C': return TryMatch(ContentDisposition, key, startIndex, length, equals, out name); // [C]ontent-Disposition
-                        case 'I': return TryMatch(IfUnmodifiedSince, key, startIndex, length, equals, out name);  // [I]f-Unmodified-Since
-                        case 'P': return TryMatch(ProxyAuthorization, key, startIndex, length, equals, out name); // [P]roxy-Authorization
+                        case 'C': potentialHeader = ContentDisposition; goto TryMatch; // [C]ontent-Disposition
+                        case 'I': potentialHeader = IfUnmodifiedSince; goto TryMatch;  // [I]f-Unmodified-Since
+                        case 'P': potentialHeader = ProxyAuthorization; goto TryMatch; // [P]roxy-Authorization
                     }
                     break;
 
                 case 20:
-                    return TryMatch(SecWebSocketAccept, key, startIndex, length, equals, out name); // Sec-WebSocket-Accept
+                    potentialHeader = SecWebSocketAccept; goto TryMatch; // Sec-WebSocket-Accept
 
                 case 21:
-                    return TryMatch(SecWebSocketVersion, key, startIndex, length, equals, out name); // Sec-WebSocket-Version
+                    potentialHeader = SecWebSocketVersion; goto TryMatch; // Sec-WebSocket-Version
 
                 case 22:
-                    return TryMatch(SecWebSocketProtocol, key, startIndex, length, equals, out name); // Sec-WebSocket-Protocol
+                    potentialHeader = SecWebSocketProtocol; goto TryMatch; // Sec-WebSocket-Protocol
 
                 case 24:
-                    return TryMatch(SecWebSocketExtensions, key, startIndex, length, equals, out name); // Sec-WebSocket-Extensions
+                    potentialHeader = SecWebSocketExtensions; goto TryMatch; // Sec-WebSocket-Extensions
             }
 
             name = null;
             return false;
+
+            TryMatch:
+            Debug.Assert(potentialHeader != null);
+            return TryMatch(potentialHeader, key, startIndex, length, equals, out name);
         }
 
         /// <summary>


### PR DESCRIPTION
This reduces the compiled IL size of `TryGetHeaderName<T>` from 916 lines to 515 lines, and the jitted x64 code from 7,520 bytes to 2,031 bytes.

Minor speed improvement as a result (10,000,000 iteration microbenchmark on Windows 10 x64):

```
Looking for: Last-Modified
Old: Time: 0.2407542    GC0: 0
Old: Time: 0.2318401    GC0: 0
Old: Time: 0.2312379    GC0: 0
Old: Time: 0.2317734    GC0: 0
Old: Time: 0.2326793    GC0: 0
New: Time: 0.2151386    GC0: 0
New: Time: 0.2152126    GC0: 0
New: Time: 0.2141634    GC0: 0
New: Time: 0.2165665    GC0: 0
New: Time: 0.2144604    GC0: 0

Looking for: Should-Not-Be-Found
Old: Time: 0.1017941    GC0: 0
Old: Time: 0.0980346    GC0: 0
Old: Time: 0.0976804    GC0: 0
Old: Time: 0.0974459    GC0: 0
Old: Time: 0.0981378    GC0: 0
New: Time: 0.0785356    GC0: 0
New: Time: 0.0800044    GC0: 0
New: Time: 0.0804539    GC0: 0
New: Time: 0.0792069    GC0: 0
New: Time: 0.080225     GC0: 0
```

Also updated/improved some comments while making changes here.

cc: @stephentoub, @davidsh 