### PR TITLE
Improve Enumerable.ToArray to avoid excessive copying for lazy enumerables

### DIFF
--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -2,23 +2,222 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System.Collections.Generic
 {
     /// <summary>Internal helper functions for working with enumerables.</summary>
     internal static class EnumerableHelpers
     {
-        /// <summary>Converts an enumerable to an array using the same logic as does List{T}.</summary>
+        /// <summary>Converts an enumerable to an array.</summary>
         /// <param name="source">The enumerable to convert.</param>
         /// <returns>The resulting array.</returns>
         internal static T[] ToArray<T>(IEnumerable<T> source)
         {
-            int count;
-            T[] results = ToArray(source, out count);
-            Array.Resize(ref results, count);
-            return results;
+            Debug.Assert(source != null);
+
+            var collection = source as ICollection<T>;
+            if (collection != null)
+            {
+                int count = collection.Count;
+                if (count == 0)
+                    return Array.Empty<T>();
+                
+                var result = new T[count];
+                collection.CopyTo(result, arrayIndex: 0);
+                return result;
+            }
+
+            // Generic methods are compiled per-instantiation for value types.
+            // Do not force the jit to compile a bunch of code it will never
+            // use if we only go down the ICollection path.
+            return LazyToArray(source);
         }
 
-        /// <summary>Converts an enumerable to an array using the same logic as does List{T}.</summary>
+        private static T[] LazyToArray<T>(IEnumerable<T> source)
+        {
+            Debug.Assert(source != null);
+            Debug.Assert(!(source is ICollection<T>), $"We should have gone down the optimized route if {nameof(source)} was a regular collection.");
+
+            const int InitialCapacity = 4;
+            const int BufferListThreshold = 32;
+
+            using (var en = source.GetEnumerator())
+            {
+                if (!en.MoveNext())
+                    return Array.Empty<T>();
+
+                T[] buffer = null;
+                int index = 0; // index into the buffer we are reading into
+
+                do
+                {
+                    if (buffer == null)
+                    {
+                        // First iteration: allocate an array with the initial capacity
+                        buffer = new T[InitialCapacity];
+                    }
+                    else
+                    {
+                        // Resize from a previous iteration
+                        T[] last = buffer;
+                        int newLength = last.Length * 2;
+                        buffer = new T[newLength];
+
+                        // We are using a for-loop instead of Array.Resize under the assumption
+                        // we are copying < 32 elements.
+                        Debug.Assert(last.Length < BufferListThreshold);
+                        for (int i = 0; i < last.Length; i++) buffer[i] = last[i];
+                    }
+
+                    do
+                    {
+                        buffer[index++] = en.Current;
+
+                        if (index == buffer.Length)
+                        {
+                            // We used up the last slot
+                            break;
+                        }
+                    }
+                    while (en.MoveNext());
+
+                    if (index < buffer.Length)
+                    {
+                        // Since MoveNext returned false, this means that we finished enumerating
+                        // before we reached the end of the buffer.
+                        int finalLength = index;
+                        Debug.Assert(finalLength < buffer.Length); // case where they're == is taken care of below
+                        
+                        // Since we only arrive here for enumerables of length < 32,
+                        // copy using a manual for-loop rather than Array.Resize, which
+                        // does not perform as well for smaller arrays.
+                        var result = new T[finalLength];
+                        for (int i = 0; i < result.Length; i++) result[i] = buffer[i];
+                        return result;
+                    }
+
+                    // We called Current last, but the loop expects MoveNext to be called
+                    // before it is entered. So we need to call it again here.
+                    if (!en.MoveNext())
+                    {
+                        // The enumerable fits perfectly into the buffer, so no resizing to do
+                        return buffer;
+                    }
+                }
+                while (buffer.Length != BufferListThreshold);
+
+                Debug.Assert(buffer.Length == BufferListThreshold); // The only way we should have exited the loop was if the loop condition was false
+
+                // Since this path is only going to get called for lazy enumerables of length > 32, do not
+                // force the jit to compile lots of code it will never use (esp. since this method is generic).
+                return LazyToArrayUsingBufferList(en, buffer);
+            }
+        }
+
+        private static T[] LazyToArrayUsingBufferList<T>(IEnumerator<T> en, T[] first)
+        {
+            // NOTE: You are expected to call MoveNext after the last call to Current
+            // before passing in the enumerator to this method.
+
+            Debug.Assert(en != null);
+            Debug.Assert(first != null);
+
+            // Instead of further resizing the array, we're going to maintain a list
+            // of buffers. Each time we can't fit the sequence into a buffer, we're
+            // going to store the buffer in this list, create a new one 2x the size,
+            // and continue reading in the sequence.
+            // The data is no longer going to be contiguous in memory, but that doesn't
+            // matter since even if we were using the resize-every-time approach, we'd
+            // still have to resize again at the end to make the array exactly the right size.
+
+            // Here's a visualization showing what first, buffers, and current
+            // might look like for a 200-length enumerable:
+            //
+            // first: [items 0-31]
+            //
+            // buffers:
+            // [0]: [items 32-63]
+            // [1]: [items 64-127]
+            // [2]: null
+            // [3]: null
+            //
+            // current: [items 128-199], [slots 200-255 empty]
+
+            // The up-front allocation for the list will not be that much since
+            // the backing store will be Array.Empty<T>() if you do not pass in a
+            // capacity. It only starts allocating arrays when we add the first item.
+
+            var buffers = new List<T[]>(); // list of previous buffers
+            var current = new T[first.Length]; // the current buffer we're reading the sequence into
+            int read = first.Length; // number of items we've read so far, updated every time we exhaust a buffer
+
+            while (true)
+            {
+                int index = 0; // index into the current buffer
+
+                // Continue reading the data into the current buffer
+                do
+                {
+                    current[index++] = en.Current;
+
+                    if (index == current.Length)
+                    {
+                        index = -1;
+                        break;
+                    }
+                }
+                while (en.MoveNext());
+
+                // If the index is -1, we called Current but not MoveNext, however
+                // the loop expects to be entered with MoveNext already having been
+                // called. So we need to call MoveNext ourselves in that case.
+                if (index >= 0 || !en.MoveNext())
+                {
+                    // We've finished enumerating the sequence.
+                    // Copy the data from the first buffer, then walk the list of buffers
+                    // and copy the data from those. Finally, copy the data from the
+                    // buffer we were just processing.
+                    
+                    int remainder = index >= 0 ? index : current.Length; // If we got here from !en.MoveNext() that means index == -1 and there was just enough space
+                    int finalLength = read + remainder;
+
+                    var result = new T[finalLength];
+
+                    // Use Array.Copy for everything, since this codepath is only taken for
+                    // buffers of length > 32
+                    Array.Copy(first, 0, result, 0, first.Length);
+
+                    // Copy from the buffers in the list that came before this one
+                    int copied = first.Length;
+                    for (int i = 0; i < buffers.Count; i++)
+                    {
+                        T[] previous = buffers[i];
+                        Array.Copy(previous, 0, result, copied, previous.Length);
+                        copied += previous.Length;
+                    }
+
+                    // Copy the remaining data from this buffer
+                    Debug.Assert(remainder <= current.Length);
+                    Debug.Assert(copied + remainder == result.Length);
+                    Array.Copy(current, 0, result, copied, remainder);
+
+                    // Done!
+                    return result;
+                }
+
+                // Since we exhausted the buffer, update read
+                read += current.Length;
+
+                // There was not enough space in the current buffer- add it to the list,
+                // and allocate a new buffer twice our size for the next iteration.
+                buffers.Add(current);
+                int nextCapacity = current.Length * 2;
+                current = new T[nextCapacity];
+            }
+        }
+
+        /// <summary>Converts an enumerable to an array using the same logic as List{T}.</summary>
         /// <param name="source">The enumerable to convert.</param>
         /// <param name="length">The number of items stored in the resulting array, 0-indexed.</param>
         /// <returns>

--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -139,8 +139,6 @@ namespace System.Collections.Generic
             // buffers:
             // [0]: [items 32-63]
             // [1]: [items 64-127]
-            // [2]: null
-            // [3]: null
             //
             // current: [items 128-199], [slots 200-255 empty]
 

--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -172,11 +172,10 @@ namespace System.Collections.Generic
 
                     // Copy from the buffers in the list that came before this one
                     int copied = first.Length;
-                    for (int i = 0; i < buffers.Count; i++)
+                    foreach (T[] buffer in buffers)
                     {
-                        T[] previous = buffers[i];
-                        Array.Copy(previous, 0, result, copied, previous.Length);
-                        copied += previous.Length;
+                        Array.Copy(buffer, 0, result, copied, buffer.Length);
+                        copied += buffer.Length;
                     }
 
                     // Copy the remaining data from this buffer


### PR DESCRIPTION
The idea that instead of resizing the array (aka throwing it out and allocating a new one) and re-copying the data every time the sequence doesn't fit, we can instead keep the old array around, allocate a new one of size * 2, and just continue reading into the new array at index 0. This will require keeping around a list of arrays we've filled up so far, however the overhead of this list will be substantially less than the size of the data itself.

A visualization of what I'm talking about for a 300-length enumerable:

```
First array: [items 0-31]

List of arrays:
[0]: [items 32-63]
[1]: [items 64-127]
[2]: [items 128-255]

Current array: [items 256-299]
```

(I also put this in the comments to help future readers understand.)

Then when we need the final array to return from the method, we just calculate `first.Length + list.Sum(a => a.Length) + indexWeFinishedReadingIntoInCurrentArray`, pre-allocate an array of that size, and then copy each of the arrays into that array.

I opted to only use this algorithm for enumerables of > length 32, since for smaller sizes it will lead to increased fragmentation, and the overhead of the list allocation will probably be noticeable in comparison to, say, 20 elements. ~32 is also the threshold at around which `Array.Copy` starts getting faster than a for-loop.

## Benchmark results

https://gist.github.com/jamesqo/399b72bf5de8e2cbd83d044836cbefa4 (includes results/source code)

You can see that the new implementation consistently has about 2/3 the gen0 collections as the old one.

The timings are somewhat inconsistent (disclaimer: I only did 100,000 iterations since the tests were taking way too long to run), but you can see that the new implementation is generally faster/the same speed as the old one. (I suspect it may be hard to measure the differences due to all of the interface invocations that are going on, in addition to the covariant array type checks if T is a reference type.)

cc @stephentoub @VSadov @JonHanna 