### PR TITLE
ARM-CI:Enable automatic checks of PRs again

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -445,7 +445,7 @@ def osShortName = ['Windows 10': 'win10',
             // Set up triggers
             if (isPR) {
                 if (osName == 'LinuxARMEmulator') {
-                    Utilities.addGithubPRTriggerForBranch(newJob, branch, "Innerloop Linux ARM Emulator ${configurationGroup} Cross Build", "(?i).*test\\W+Innerloop\\W+Linux\\W+ARM\\W+Emulator\\W+${configurationGroup}\\W+Cross\\W+Build.*")
+                    Utilities.addGithubPRTriggerForBranch(newJob, branch, "Innerloop Linux ARM Emulator ${configurationGroup} Cross Build")
                 }
             }
             else {


### PR DESCRIPTION
Because #10482 is merged, No more 'device is busy' error will not occur.
So I apply to enable automatic checks of PRs again.