### PR TITLE
Enable Reflection Based Serialization on Net Native.

### DIFF
--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -10,7 +10,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Extensions;
 using System.Xml.Schema;
-using static System.Xml.Serialization.XmlSerializationReaderILGen;
 
 namespace System.Xml.Serialization
 {


### PR DESCRIPTION
The changes are to enable XmlSerializer's reflection based serialization on Net Native. 

The changes would also fix #https://github.com/dotnet/corefx/issues/7991, some constructors of XmlSerializer's don't work on Net Native.

@mconnew @roncain  @huanwu @zhenlan can you please review the PR? Thanks.