### PR TITLE
Resolve aliased device names in SystemNative_EnumerateInterfaceAddresses

### DIFF
--- a/src/Native/Unix/System.Native/pal_interfaceaddresses.cpp
+++ b/src/Native/Unix/System.Native/pal_interfaceaddresses.cpp
@@ -48,8 +48,13 @@ extern "C" int32_t SystemNative_EnumerateInterfaceAddresses(IPv4AddressFound onI
         // Use if_indextoname to map back to the true device name.
         char actualName[IF_NAMESIZE];
         char* result = if_indextoname(interfaceIndex, actualName);
-        assert(result == actualName && result != nullptr);
-        (void)result; // Silence compiler warnings about unused variables on release mode
+        if (result == nullptr)
+        {
+            freeifaddrs(headAddr);
+            return -1;
+        }
+        
+        assert(result == actualName);
         int family = current->ifa_addr->sa_family;
         if (family == AF_INET)
         {

--- a/src/Native/Unix/System.Native/pal_interfaceaddresses.cpp
+++ b/src/Native/Unix/System.Native/pal_interfaceaddresses.cpp
@@ -44,6 +44,12 @@ extern "C" int32_t SystemNative_EnumerateInterfaceAddresses(IPv4AddressFound onI
     for (ifaddrs* current = headAddr; current != nullptr; current = current->ifa_next)
     {
         uint32_t interfaceIndex = if_nametoindex(current->ifa_name);
+        // ifa_name may be an aliased interface name.
+        // Use if_indextoname to map back to the true device name.
+        char actualName[IF_NAMESIZE];
+        char* result = if_indextoname(interfaceIndex, actualName);
+        assert(result == actualName && result != nullptr);
+        (void)result; // Silence compiler warnings about unused variables on release mode
         int family = current->ifa_addr->sa_family;
         if (family == AF_INET)
         {
@@ -67,7 +73,7 @@ extern "C" int32_t SystemNative_EnumerateInterfaceAddresses(IPv4AddressFound onI
                 sockaddr_in* mask_sain = reinterpret_cast<sockaddr_in*>(current->ifa_netmask);
                 memcpy(maskInfo.AddressBytes, &mask_sain->sin_addr.s_addr, sizeof(mask_sain->sin_addr.s_addr));
 
-                onIpv4Found(current->ifa_name, &iai, &maskInfo);
+                onIpv4Found(actualName, &iai, &maskInfo);
             }
         }
         else if (family == AF_INET6)
@@ -82,7 +88,7 @@ extern "C" int32_t SystemNative_EnumerateInterfaceAddresses(IPv4AddressFound onI
                 sockaddr_in6* sain6 = reinterpret_cast<sockaddr_in6*>(current->ifa_addr);
                 memcpy(iai.AddressBytes, sain6->sin6_addr.s6_addr, sizeof(sain6->sin6_addr.s6_addr));
                 uint32_t scopeId = sain6->sin6_scope_id;
-                onIpv6Found(current->ifa_name, &iai, &scopeId);
+                onIpv6Found(actualName, &iai, &scopeId);
             }
         }
 

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -29,24 +29,36 @@ namespace System.Net.NetworkInformation
         public unsafe static NetworkInterface[] GetLinuxNetworkInterfaces()
         {
             Dictionary<string, LinuxNetworkInterface> interfacesByName = new Dictionary<string, LinuxNetworkInterface>();
-            Interop.Sys.EnumerateInterfaceAddresses(
-                (name, ipAddr, maskAddr) =>
+            const int MaxTries = 3;
+            for (int attempt = 0; attempt < MaxTries; attempt++)
+            {
+                int result = Interop.Sys.EnumerateInterfaceAddresses(
+                    (name, ipAddr, maskAddr) =>
+                    {
+                        LinuxNetworkInterface lni = GetOrCreate(interfacesByName, name);
+                        lni.ProcessIpv4Address(ipAddr, maskAddr);
+                    },
+                    (name, ipAddr, scopeId) =>
+                    {
+                        LinuxNetworkInterface lni = GetOrCreate(interfacesByName, name);
+                        lni.ProcessIpv6Address( ipAddr, *scopeId);
+                    },
+                    (name, llAddr) =>
+                    {
+                        LinuxNetworkInterface lni = GetOrCreate(interfacesByName, name);
+                        lni.ProcessLinkLayerAddress(llAddr);
+                    });
+                if (result == 0)
                 {
-                    LinuxNetworkInterface lni = GetOrCreate(interfacesByName, name);
-                    lni.ProcessIpv4Address(ipAddr, maskAddr);
-                },
-                (name, ipAddr, scopeId) =>
+                    return interfacesByName.Values.ToArray();
+                }
+                else
                 {
-                    LinuxNetworkInterface lni = GetOrCreate(interfacesByName, name);
-                    lni.ProcessIpv6Address( ipAddr, *scopeId);
-                },
-                (name, llAddr) =>
-                {
-                    LinuxNetworkInterface lni = GetOrCreate(interfacesByName, name);
-                    lni.ProcessLinkLayerAddress(llAddr);
-                });
+                    interfacesByName.Clear();
+                }
+            }
 
-            return interfacesByName.Values.ToArray();
+            throw new NetworkInformationException(SR.net_PInvokeError);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #11217 

Interface names returned from `getifaddrs` may refer to an aliased network device, i.e. "wlan:0". Previously, we were returning this value from the shim function, and managed code was then treating "wlan" and "wlan:0" to be distinct network interfaces. This caused problems because aliased device names do not refer to an actual network device, and there will be no filesystem entries for its configuration. To avoid that, we normalize the interface names returned from the shim by calling if_indextoname to obtain the "true" interface name. All aliased network addresses therefore resolve back to the original device they were aliased from.

@parjong , @stephentoub 