### PR TITLE
DeflateStream: Allow inflation without input

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/Inflater.cs
@@ -52,13 +52,6 @@ namespace System.IO.Compression
 
         public unsafe bool Inflate(out byte b)
         {
-            // If Inflate is called on an invalid or unready inflater, return 0 to indicate no bytes have been read.
-            if (NeedsInput() || _inputBufferHandle == null || !_inputBufferHandle.IsAllocated)
-            {
-                b = 0;
-                return false;
-            }
-
             fixed (byte* bufPtr = &b)
             {
                 int bytesRead = InflateVerified(bufPtr, 1);
@@ -70,7 +63,7 @@ namespace System.IO.Compression
         public unsafe int Inflate(byte[] bytes, int offset, int length)
         {
             // If Inflate is called on an invalid or unready inflater, return 0 to indicate no bytes have been read.
-            if (NeedsInput() || _inputBufferHandle == null || !_inputBufferHandle.IsAllocated || length == 0)
+            if (length == 0)
                 return 0;
 
             Debug.Assert(null != bytes, "Can't pass in a null output buffer!");
@@ -83,7 +76,6 @@ namespace System.IO.Compression
         public unsafe int InflateVerified(byte* bufPtr, int length)
         {
             // State is valid; attempt inflation
-            Debug.Assert(!NeedsInput() && _inputBufferHandle != null && _inputBufferHandle.IsAllocated && length != 0);
             try
             {
                 int bytesRead;


### PR DESCRIPTION
Our implementation of DeflateStream only allows inflation when there is input to pass to the inflater. Because of how the stream was coded, this would raise the potential issue where we would be out of input but there could still be inflated bytes cached ready to read. This commit removes the checks for valid input and allows inflation regardless of input.
- This does have the downside of reducing efficiency in the scenario where we are actually out of bytes to read. We were previously operating under the incorrect assumption that no input implies no output, but that isn't strictly true.

resolves #11161

@stephentoub @qmfrederik