### PR TITLE
Add test coverage for issue#10598

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2559,6 +2559,21 @@ public static partial class DataContractSerializerTests
 
     #endregion
 
+    [Fact]
+    public static void BasicRoundTripResolveDTOTypes()
+    {
+        ObjectContainer instance = new ObjectContainer(new DTOContainer());
+        XmlObjectSerializer serializer = new DataContractSerializer(typeof(ObjectContainer), null, null, null, int.MaxValue, false, false, new DTOResolver());
+        using (MemoryStream ms = new MemoryStream())
+        {
+            serializer.WriteObject(ms, instance);
+            ms.Position = 0;
+            ObjectContainer deserialized = (ObjectContainer)serializer.ReadObject(ms);
+            Assert.Equal(DateTimeOffset.MaxValue, ((DTOContainer)deserialized.Data).nDTO);
+            Assert.Equal(DateTimeOffset.MaxValue, ((DTOContainer)deserialized.Data2).nDTO);
+        }
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2563,17 +2563,11 @@ public static partial class DataContractSerializerTests
     public static void BasicRoundTripResolveDTOTypes()
     {
         ObjectContainer instance = new ObjectContainer(new DTOContainer());
-        XmlObjectSerializer serializer = new DataContractSerializer(typeof(ObjectContainer), null, null, null, int.MaxValue, false, false, new DTOResolver());
-        using (MemoryStream ms = new MemoryStream())
-        {
-            serializer.WriteObject(ms, instance);
-            ms.Position = 0;
-            ObjectContainer deserialized = (ObjectContainer)serializer.ReadObject(ms);
-            Assert.Equal(DateTimeOffset.MaxValue, ((DTOContainer)deserialized.Data).nDTO);
-            Assert.Equal(DateTimeOffset.MaxValue, ((DTOContainer)deserialized.Data2).nDTO);
-        }
+        Func<DataContractSerializer> serializerfunc = () => new DataContractSerializer(typeof(ObjectContainer), null, null, null, int.MaxValue, false, false, new DTOResolver());
+        string expectedxmlstring = "<ObjectContainer xmlns =\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><_data i:type=\"a:DTOContainer\" xmlns:a=\"http://www.default.com\"><nDTO i:type=\"a:DTO\"><DateTime xmlns=\"http://schemas.datacontract.org/2004/07/System\">9999-12-31T23:59:59.9999999Z</DateTime><OffsetMinutes xmlns=\"http://schemas.datacontract.org/2004/07/System\">0</OffsetMinutes></nDTO></_data></ObjectContainer>";
+        ObjectContainer deserialized = SerializeAndDeserialize(instance, expectedxmlstring, null, serializerfunc, false);
+        Assert.Equal(DateTimeOffset.MaxValue, ((DTOContainer)deserialized.Data).nDTO);
     }
-
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -3458,7 +3458,7 @@ public class DTOContainer
 [DataContract]
 public class DTOResolver : DataContractResolver
 {
-    public override bool TryResolveType(Type dcType, Type declaredType, DataContractResolver KTResolver, out XmlDictionaryString typeName, out XmlDictionaryString typeNamespace)
+    public override bool TryResolveType(Type dcType, Type declaredType, DataContractResolver knownTypeResolver, out XmlDictionaryString typeName, out XmlDictionaryString typeNamespace)
     {
         string resolvedTypeName = string.Empty;
         string resolvedNamespace = string.Empty;
@@ -3478,7 +3478,7 @@ public class DTOResolver : DataContractResolver
                 break;
             default:
                 {
-                    return KTResolver.TryResolveType(dcType, declaredType, null, out typeName, out typeNamespace);
+                    return knownTypeResolver.TryResolveType(dcType, declaredType, null, out typeName, out typeNamespace);
                 }
         }
         XmlDictionary dic = new XmlDictionary();
@@ -3487,7 +3487,7 @@ public class DTOResolver : DataContractResolver
         return true;
     }
 
-    public override Type ResolveName(string typeName, string typeNamespace, Type declaredType, DataContractResolver KTResolver)
+    public override Type ResolveName(string typeName, string typeNamespace, Type declaredType, DataContractResolver knownTypeResolver)
     {
         switch (typeNamespace)
         {
@@ -3512,7 +3512,7 @@ public class DTOResolver : DataContractResolver
                 }
                 break;
         }
-        Type result = KTResolver.ResolveName(typeName, typeNamespace, declaredType, null);
+        Type result = knownTypeResolver.ResolveName(typeName, typeNamespace, declaredType, null);
         return result;
     }
 }

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -3431,3 +3431,102 @@ namespace Music
 }
 
 #endregion
+[DataContract]
+public class ObjectContainer
+{
+    [DataMember]
+    private object data;
+
+    [DataMember]
+    private object data2;
+
+    public ObjectContainer(object input)
+    {
+        data = input;
+        data2 = data;
+    }
+
+    public object Data
+    {
+        get { return data; }
+    }
+
+    public object Data2
+    {
+        get { return data2; }
+    }
+}
+
+[DataContract]
+public class DTOContainer
+{
+    public DTOContainer()
+    {
+
+    }
+
+    [DataMember]
+    public object nDTO = DateTimeOffset.MaxValue;
+}
+
+[DataContract]
+public class DTOResolver : DataContractResolver
+{
+    public override bool TryResolveType(Type dcType, Type declaredType, DataContractResolver KTResolver, out XmlDictionaryString typeName, out XmlDictionaryString typeNamespace)
+    {
+        string resolvedTypeName = string.Empty;
+        string resolvedNamespace = string.Empty;
+        resolvedNamespace = "http://www.default.com";
+        switch (dcType.Name)
+        {
+            case "ObjectContainer":
+            case "DTOContainer":
+                {
+                    resolvedTypeName = dcType.Name;
+                }
+                break;
+            case "DateTimeOffset":
+                {
+                    resolvedTypeName = "DTO";
+                }
+                break;
+            default:
+                {
+                    return KTResolver.TryResolveType(dcType, declaredType, null, out typeName, out typeNamespace);
+                }
+        }
+        XmlDictionary dic = new XmlDictionary();
+        typeName = dic.Add(resolvedTypeName);
+        typeNamespace = dic.Add(resolvedNamespace);
+        return true;
+    }
+
+    public override Type ResolveName(string typeName, string typeNamespace, Type declaredType, DataContractResolver KTResolver)
+    {
+        switch (typeNamespace)
+        {
+            case "http://www.default.com":
+                {
+                    switch (typeName)
+                    {
+                        case "ObjectContainer":
+                            {
+                                return typeof(ObjectContainer);
+                            }
+                        case "DTOContainer":
+                            {
+                                return typeof(DTOContainer);
+                            }
+                        case "DTO":
+                            {
+                                return typeof(DateTimeOffset);
+                            }
+                        default: break;
+                    }
+                }
+                break;
+        }
+        Type result = KTResolver.ResolveName(typeName, typeNamespace, declaredType, null);
+        return result;
+    }
+}

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -3435,36 +3435,22 @@ namespace Music
 public class ObjectContainer
 {
     [DataMember]
-    private object data;
-
-    [DataMember]
-    private object data2;
+    private object _data;
 
     public ObjectContainer(object input)
     {
-        data = input;
-        data2 = data;
+        _data = input;
     }
 
     public object Data
     {
-        get { return data; }
-    }
-
-    public object Data2
-    {
-        get { return data2; }
+        get { return _data; }
     }
 }
 
 [DataContract]
 public class DTOContainer
 {
-    public DTOContainer()
-    {
-
-    }
-
     [DataMember]
     public object nDTO = DateTimeOffset.MaxValue;
 }


### PR DESCRIPTION
Add a test to cover the scenario: The serializer contains a DataContractResolver. It serializes a object with DateTimeOffset property.

#10598 
#11056 

@shmao @mconnew @zhenlan 