### PR TITLE
Fix System.Runtime.Test for 32bit architecture

### DIFF
--- a/src/System.Runtime/tests/System/IntPtrTests.cs
+++ b/src/System.Runtime/tests/System/IntPtrTests.cs
@@ -160,11 +160,12 @@ namespace System.Tests
                 return;
             }
 
+
             int i = ptr.ToInt32();
             Assert.Equal(expected32, ptr.ToInt32());
 
             Assert.Equal(expected.ToString(), ptr.ToString());
-            Assert.Equal(expected.ToString("x"), ptr.ToString("x"));
+            Assert.Equal(expected.ToString("x"), ptr.ToInt64().ToString("x"));
 
             Assert.Equal(ptr, new IntPtr(expected));
             Assert.True(ptr == new IntPtr(expected));

--- a/src/System.Runtime/tests/System/IntPtrTests.cs
+++ b/src/System.Runtime/tests/System/IntPtrTests.cs
@@ -160,7 +160,6 @@ namespace System.Tests
                 return;
             }
 
-
             int i = ptr.ToInt32();
             Assert.Equal(expected32, ptr.ToInt32());
 

--- a/src/System.Runtime/tests/System/IntPtrTests.cs
+++ b/src/System.Runtime/tests/System/IntPtrTests.cs
@@ -164,6 +164,8 @@ namespace System.Tests
             Assert.Equal(expected32, ptr.ToInt32());
 
             Assert.Equal(expected.ToString(), ptr.ToString());
+            Assert.Equal(IntPtr.Size == 4 ? expected32.ToString("x") : expected.ToString("x"), ptr.ToString("x"));
+
             Assert.Equal(expected.ToString("x"), ptr.ToInt64().ToString("x"));
 
             Assert.Equal(ptr, new IntPtr(expected));

--- a/src/System.Runtime/tests/System/IntPtrTests.cs
+++ b/src/System.Runtime/tests/System/IntPtrTests.cs
@@ -166,8 +166,6 @@ namespace System.Tests
             Assert.Equal(expected.ToString(), ptr.ToString());
             Assert.Equal(IntPtr.Size == 4 ? expected32.ToString("x") : expected.ToString("x"), ptr.ToString("x"));
 
-            Assert.Equal(expected.ToString("x"), ptr.ToInt64().ToString("x"));
-
             Assert.Equal(ptr, new IntPtr(expected));
             Assert.True(ptr == new IntPtr(expected));
             Assert.False(ptr != new IntPtr(expected));


### PR DESCRIPTION
Fix issue #11243 

modify VerifyPointer for correct string comparison in 32bit architecture 
when input argument is negative value