### PR TITLE
Fix misleading message in SafeDeleteContext assert

### DIFF
--- a/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
@@ -872,7 +872,7 @@ namespace System.Net.Security
                     GlobalLog.Assert("SafeDeleteContext::AcceptSecurityContext()|inSecBuffer == null || inSecBuffers == null");
                 }
 
-                Debug.Fail("SafeDeleteContext::AcceptSecurityContext()|outSecBuffer != null");
+                Debug.Fail("SafeDeleteContext::AcceptSecurityContext()|inSecBuffer == null || inSecBuffers == null");
             }
 
             if (inCredentials == null)


### PR DESCRIPTION
Copy-and-paste error.

Found by a coverity scan.

cc: @cipop