### PR TITLE
Remove unnecessary duplicate expression in assert

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -421,7 +421,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private CType LoadTypeFromSignature(int[] signature, ref int indexIntoSignatures, TypeArray classTyVars)
         {
-            Debug.Assert(signature != null && signature != null);
+            Debug.Assert(signature != null);
 
             MethodSignatureEnum current = (MethodSignatureEnum)signature[indexIntoSignatures];
             indexIntoSignatures++;


### PR DESCRIPTION
Found by a coverity scan.
cc: @VSadov 