### PR TITLE
Target compatible NuGet moniker

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <PackageTargetFramework>netstandard1.0</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.0</NuGetTargetMoniker>
     <DocumentationFile>$(MSBuildThisFileDirectory)System.Runtime.CompilerServices.Unsafe.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -12,6 +12,7 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <!-- System.IO.Path conflicts between type in partial facade and in mscorlib -->
     <NoWarn>0436</NoWarn>
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">.NETStandard,Version=v1.5</NuGetTargetMoniker>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.5</PackageTargetFramework>
     <CoreClrOrCorRt Condition="'$(TargetGroup)' == '' Or '$(TargetGroup)' == 'netstandard15aot'">true</CoreClrOrCorRt>
   </PropertyGroup>

--- a/src/System.Runtime.Extensions/src/netstandard15aot/project.json
+++ b/src/System.Runtime.Extensions/src/netstandard15aot/project.json
@@ -1,0 +1,12 @@
+{
+  "frameworks": {
+    "netstandard1.5": {
+      "imports": [
+        "netcore50"
+      ],
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24430-00"
+      }
+    }
+  }
+}

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -1,6 +1,6 @@
 {
   "frameworks": {
-    "netcoreapp1.0": {
+    "netstandard1.5": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.CoreCLR": "1.1.0-beta-24430-01"
       },
@@ -17,14 +17,6 @@
       "dependencies": {
         "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24430-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1"
-      }
-    },
-    "netstandard1.5": {
-      "imports": [
-        "netcore50"
-      ],
-      "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24430-00"
       }
     }
   }


### PR DESCRIPTION
This updates two projects which were targeting NuGet monikers which were
incompatible with how they were being packaged.

This prepares for a buildtools change which will allow us to remove
PackageTargetFramework & validate against NuGetTargetMoniker.

System.Runtime.CompilerServices.Unsafe was not using NuGet but I
specified NuGetTargetMoniker to be consistent with how it was being
packaged.  A future change will remove PackageTargetFramework from this
project once we have a buildtools update.

System.Runtime.Extensions was building against netcoreapp1.0 but
packaging as netstandard1.5.  It didn't matter in this case since it was
only referencing the coreclr targeting pack, but we'd flag this during
validation.

This change can and should be merged independent of the buildtools 
update so that buildtools can be picked up at will without blocking on 
this.

/cc @weshaggard @chcosta @joperezr 