### PR TITLE
Verify static NETNative targeting pack version individually

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -84,6 +84,14 @@
       <Version>1.0.0-prerelease-00704-03</Version>
     </StaticDependency>
 
+    <!--
+      The NETNative targeting pack is in the projectn-tfs build-info, but auto-upgrade isn't wanted.
+      Verify it at a static version rather than referencing the build-info.
+    -->
+    <StaticDependency Include="Microsoft.TargetingPack.Private.NETNative">
+      <Version>1.0.1-beta-24430-00</Version>
+    </StaticDependency>
+
     <DependencyBuildInfo Include="@(StaticDependency)">
       <PackageId>%(Identity)</PackageId>
       <UpdateStableVersions>true</UpdateStableVersions>


### PR DESCRIPTION
`Microsoft.TargetingPack.Private.NETNative` will no longer be produced from ProjectK, and will from now on be in ProjectN (projectn-tfs buildinfo). There's no need to upgrade this package in master, so here I'm adding a static dependency.

I added a ProjectN build-info in https://github.com/dotnet/versions/pull/60. I mentioned there that I'm removing this package from the ProjectK `Packages_List.txt` so when projectn-tfs is updated, auto-upgrade can go smoothly. (The potential conflict is between this static dependency and the ProjectK build-info.)

/cc @SedarG @stephentoub @weshaggard 