### PR TITLE
Start using projectn-tfs build-info for NETNative targeting pack version

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -4,6 +4,7 @@
     <CoreFxCurrentRef>f704e1b0f02874713803d3db713bdc6773a3aff6</CoreFxCurrentRef>
     <CoreClrCurrentRef>b4a6eb15a48473adef5506c606b431955409e087</CoreClrCurrentRef>
     <ExternalCurrentRef>b4a6eb15a48473adef5506c606b431955409e087</ExternalCurrentRef>
+    <ProjectNTfsCurrentRef>b4a6eb15a48473adef5506c606b431955409e087</ProjectNTfsCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
@@ -26,14 +27,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--
-      Disabling validation of NetNative targeting pack. The TP used by netcore50 target frameworks
-      is different than the one that's used by uap10.1 target frameworks. VerifyDependencies
-      currently doesn't support multi-value Version. We need to figure out how we compose the
-      new TP, such that it's consumable by both frameworks.
-    -->
-    <DisabledBuildInfoPackages Include="Microsoft.TargetingPack.Private.NETNative" />
-
     <RemoteDependencyBuildInfo Include="CoreFx">
       <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/dev/api</BuildInfoPath>
       <CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
@@ -46,10 +39,13 @@
       <BuildInfoPath>$(BaseDotNetBuildInfo)projectk-tfs/$(DependencyBranch)</BuildInfoPath>
       <CurrentRef>$(ExternalCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
+    <RemoteDependencyBuildInfo Include="ProjectNTfs">
+      <BuildInfoPath>$(BaseDotNetBuildInfo)projectn-tfs/$(DependencyBranch)</BuildInfoPath>
+      <CurrentRef>$(ProjectNTfsCurrentRef)</CurrentRef>
+    </RemoteDependencyBuildInfo>
 
     <DependencyBuildInfo Include="@(RemoteDependencyBuildInfo)">
       <RawVersionsBaseUrl>https://raw.githubusercontent.com/dotnet/versions</RawVersionsBaseUrl>
-      <DisabledPackages>@(DisabledBuildInfoPackages)</DisabledPackages>
     </DependencyBuildInfo>
 
     <XmlUpdateStep Include="CoreFx">

--- a/src/System.Diagnostics.Contracts/src/netcore50aot/project.json
+++ b/src/System.Diagnostics.Contracts/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.Diagnostics.Debug/src/project.json
+++ b/src/System.Diagnostics.Debug/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.StackTrace/src/project.json
+++ b/src/System.Diagnostics.StackTrace/src/project.json
@@ -13,7 +13,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.Tools/src/project.json
+++ b/src/System.Diagnostics.Tools/src/project.json
@@ -15,7 +15,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.Globalization.Calendars/src/netcore50aot/project.json
+++ b/src/System.Globalization.Calendars/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.Globalization/src/netcore50aot/project.json
+++ b/src/System.Globalization/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.IO.FileSystem/src/netcore50/project.json
+++ b/src/System.IO.FileSystem/src/netcore50/project.json
@@ -23,7 +23,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Globalization": "4.0.10",
         "System.Reflection": "4.0.10",

--- a/src/System.IO/src/project.json
+++ b/src/System.IO/src/project.json
@@ -19,7 +19,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
@@ -46,7 +46,7 @@
       ],
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
@@ -59,7 +59,7 @@
     },
     "uap10.1": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24410-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.Linq.Expressions/src/netcore50/project.json
+++ b/src/System.Linq.Expressions/src/netcore50/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
-    "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+    "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Private.DataContractSerialization/src/netcore50aot/project.json
+++ b/src/System.Private.DataContractSerialization/src/netcore50aot/project.json
@@ -3,7 +3,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "System.Collections": "4.0.10",
         "System.Collections.Concurrent": "4.0.10",
         "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Private.Uri/src/project.json
+++ b/src/System.Private.Uri/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     },
     "netstandard1.3": {
@@ -18,7 +18,7 @@
         "netcore50"
       ],
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.Reflection.DispatchProxy/src/project.json
+++ b/src/System.Reflection.DispatchProxy/src/project.json
@@ -21,7 +21,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "System.Runtime": "4.0.20"
       }
     }

--- a/src/System.Reflection.Extensions/src/project.json
+++ b/src/System.Reflection.Extensions/src/project.json
@@ -12,7 +12,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.IO": "4.0.10",

--- a/src/System.Reflection.Primitives/src/project.json
+++ b/src/System.Reflection.Primitives/src/project.json
@@ -24,7 +24,7 @@
     },
     "uap10.1": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24410-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.Reflection.TypeExtensions/src/project.json
+++ b/src/System.Reflection.TypeExtensions/src/project.json
@@ -13,7 +13,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "System.Collections": "4.0.0",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Linq": "4.0.0",

--- a/src/System.Reflection/src/netcore50aot/project.json
+++ b/src/System.Reflection/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.Resources.ResourceManager/src/netcore50aot/project.json
+++ b/src/System.Resources.ResourceManager/src/netcore50aot/project.json
@@ -3,7 +3,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Diagnostics.Debug": "4.0.0",
         "System.Diagnostics.Tools": "4.0.0",

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -20,7 +20,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1"
       }
     },
@@ -29,7 +29,7 @@
         "netcore50"
       ],
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.Runtime.Handles/src/project.json
+++ b/src/System.Runtime.Handles/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     },
     "net46": {

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "System.Runtime": "4.0.20"
       }
     },

--- a/src/System.Runtime.InteropServices/src/project.json
+++ b/src/System.Runtime.InteropServices/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     },
     "net463": {

--- a/src/System.Runtime.WindowsRuntime/src/netcore50aot/project.json
+++ b/src/System.Runtime.WindowsRuntime/src/netcore50aot/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.NETCore.Targets": "1.0.1",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Collections": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Runtime/src/project.json
+++ b/src/System.Runtime/src/project.json
@@ -15,7 +15,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     },
     "net462": {

--- a/src/System.Text.Encoding.Extensions/src/netcore50aot/project.json
+++ b/src/System.Text.Encoding.Extensions/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.Text.Encoding/src/netcore50aot/project.json
+++ b/src/System.Text.Encoding/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.Threading.Tasks/src/project.json
+++ b/src/System.Threading.Tasks/src/project.json
@@ -15,7 +15,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00"
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00"
       }
     }
   }

--- a/src/System.Threading.Timer/src/netcore50aot/project.json
+++ b/src/System.Threading.Timer/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "System.Runtime": "4.0.20"
       }
     }

--- a/src/System.Threading/src/project.json
+++ b/src/System.Threading/src/project.json
@@ -10,7 +10,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.1-beta-24415-00",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24430-00",
         "System.Runtime": "4.0.20"
       }
     },


### PR DESCRIPTION
The NETNative targeting pack will soon be auto-published to the new projectn-tfs build-info, and dev/api will use auto-upgrades.

Upgraded the External dependency to take https://github.com/dotnet/versions/pull/61, which makes `DisabledPackages` unnecessary and makes it so there won't be a conflict between projectk-tfs's targetingpack and projectn-tfs's.

Related NETNative targeting pack change on master: https://github.com/dotnet/corefx/pull/11267

/cc @SedarG @stephentoub @weshaggard 