### PR TITLE
Fix System.Runtime.Test: GC.AddMemoryPressure test

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.cs
+++ b/src/System.Runtime/tests/System/GCTests.cs
@@ -19,7 +19,7 @@ namespace System.Tests
 
             if (s_is32Bits)
             {
-                Assert.Throws<ArgumentOutOfRangeException>("bytesAllocated", () => GC.AddMemoryPressure((long)int.MaxValue + 1)); // Bytes allocated > int.MaxValue on 32 bit platforms
+                Assert.Throws<ArgumentOutOfRangeException>("pressure", () => GC.AddMemoryPressure((long)int.MaxValue + 1)); // Bytes allocated > int.MaxValue on 32 bit platforms
             }
         }
 


### PR DESCRIPTION
Fix issue: dotnet/coreclr#7005

Fix exception message: byteallocated > Int32.MaxValue on 32bit architecture