### PR TITLE
66% speedup for Path.Combine on Windows

### DIFF
--- a/src/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.cs
@@ -188,9 +188,36 @@ namespace System.IO
         /// NUL, or any ASCII char whose integer representation is in the range of 1 through 31).
         /// Does not check for wild card characters ? and *.
         /// </summary>
-        internal static bool HasIllegalCharacters(string path, bool checkAdditional = false)
+        internal static bool HasIllegalCharacters(string path)
         {
-            return path.IndexOfAny(InvalidPathChars) >= 0;
+            // This is equivalent to IndexOfAny(InvalidPathChars) >= 0,
+            // except faster since IndexOfAny grows slower as the input
+            // array grows larger.
+            // Since we know that some of the characters we're looking
+            // for are contiguous in the alphabet-- the path cannot contain
+            // characters 0-31-- we can optimize this for our specific use
+            // case and use simple comparison operations.
+
+            for (int i = 0; i < path.Length; i++)
+            {
+                char c = path[i];
+
+                if (c <= '\u001f')
+                {
+                    return true;
+                }
+
+                switch (c)
+                {
+                    case '"':
+                    case '<':
+                    case '>':
+                    case '|':
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
I ran some iterations of `Path.Combine` through PerfView recently to see if there was anything that could be optimized. It turns out that [this check](https://github.com/dotnet/corefx/blob/master/src/Common/src/System/IO/PathInternal.Windows.cs#L193), which calls `IndexOfAny` with a gigantic char array, was taking up as much of 80% of CPU time; in fact [this method](https://github.com/dotnet/coreclr/blob/master/src/classlibnative/bcltype/stringnative.cpp#L495) alone, which initializes a "probabilistic map" to represent if a char is in the array, was where the program spent 60% of its time.

Changing the method to use a manual, "naive" implementation of `IndexOfAny` results in an approximately 3x speedup for `Path.Combine`, from ~2.3s to 0.7s. You can see the test app and results I made for benchmarking [here](https://gist.github.com/jamesqo/594d7c5b81228d25a569ad52e6e20779).

Other note: I also removed an apparently dead optional parameter that's not being used anywhere.

cc @JeremyKuhne, @stephentoub 