### PR TITLE
Add new compression tests

### DIFF
--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -58,7 +58,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.3-prerelease\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.4-prerelease\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ManualAndCompatibilityTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ManualAndCompatibilityTests.cs
@@ -11,6 +11,7 @@ namespace System.IO.Compression.Tests
     {
         [Theory]
         [InlineData("7zip.zip", "normal", false, false)]
+        [InlineData("deflate64.zip", "normal", false, false)]
         [InlineData("windows.zip", "normalWithoutEmptyDir", true, false)]
         [InlineData("dotnetzipstreaming.zip", "normal", true, true)]
         [InlineData("sharpziplib.zip", "normalWithoutEmptyDir", true, true)]

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -5,7 +5,7 @@
     "System.Console": "4.3.0-beta-24507-02",
     "System.Diagnostics.Debug": "4.3.0-beta-24507-02",
     "System.IO": "4.3.0-beta-24507-02",
-    "System.IO.Compression.TestData": "1.0.3-prerelease",
+    "System.IO.Compression.TestData": "1.0.4-prerelease",
     "System.IO.FileSystem": "4.3.0-beta-24507-02",
     "System.Linq": "4.3.0-beta-24507-02",
     "System.Linq.Expressions": "4.3.0-beta-24507-02",


### PR DESCRIPTION
Adds tests to cover deflate64 zips and zips with sparse files that currently fail with some buffer sizes

related to: #11264, #11235

requires: https://github.com/dotnet/corefx-testdata/pull/11 and a manual publish of the new testdata package to myget

@stephentoub 