### PR TITLE
Remove unnecessary null check in DomainNameHelper

### DIFF
--- a/src/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -324,7 +324,7 @@ namespace System
             {
                 // just lowercase for ascii
                 string unescapedHostname = new string(hostname, start, end - start);
-                return ((unescapedHostname != null) ? unescapedHostname.ToLowerInvariant() : null);
+                return unescapedHostname.ToLowerInvariant();
             }
             else
             {


### PR DESCRIPTION
Found by a coverity scan

cc: @cipop, @davidsh