### PR TITLE
Changing some runtime checks into asserts in ILGen

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -94,7 +94,7 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitLoadValueIndirect(this ILGenerator il, Type type)
         {
-            ContractUtils.RequiresNotNull(type, nameof(type));
+            Debug.Assert(type != null);
 
             if (type.GetTypeInfo().IsValueType)
             {
@@ -151,7 +151,7 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitStoreValueIndirect(this ILGenerator il, Type type)
         {
-            ContractUtils.RequiresNotNull(type, nameof(type));
+            Debug.Assert(type != null);
 
             if (type.GetTypeInfo().IsValueType)
             {
@@ -198,7 +198,7 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitLoadElement(this ILGenerator il, Type type)
         {
-            ContractUtils.RequiresNotNull(type, nameof(type));
+            Debug.Assert(type != null);
 
             if (!type.GetTypeInfo().IsValueType)
             {
@@ -254,7 +254,7 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitStoreElement(this ILGenerator il, Type type)
         {
-            ContractUtils.RequiresNotNull(type, nameof(type));
+            Debug.Assert(type != null);
 
             if (type.GetTypeInfo().IsEnum)
             {
@@ -302,7 +302,7 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitType(this ILGenerator il, Type type)
         {
-            ContractUtils.RequiresNotNull(type, nameof(type));
+            Debug.Assert(type != null);
 
             il.Emit(OpCodes.Ldtoken, type);
             il.Emit(OpCodes.Call, typeof(Type).GetMethod("GetTypeFromHandle"));
@@ -314,7 +314,7 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitFieldAddress(this ILGenerator il, FieldInfo fi)
         {
-            ContractUtils.RequiresNotNull(fi, nameof(fi));
+            Debug.Assert(fi != null);
 
             if (fi.IsStatic)
             {
@@ -328,7 +328,7 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitFieldGet(this ILGenerator il, FieldInfo fi)
         {
-            ContractUtils.RequiresNotNull(fi, nameof(fi));
+            Debug.Assert(fi != null);
 
             if (fi.IsStatic)
             {
@@ -342,7 +342,7 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitFieldSet(this ILGenerator il, FieldInfo fi)
         {
-            ContractUtils.RequiresNotNull(fi, nameof(fi));
+            Debug.Assert(fi != null);
 
             if (fi.IsStatic)
             {
@@ -357,7 +357,7 @@ namespace System.Linq.Expressions.Compiler
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix")]
         internal static void EmitNew(this ILGenerator il, ConstructorInfo ci)
         {
-            ContractUtils.RequiresNotNull(ci, nameof(ci));
+            Debug.Assert(ci != null);
 
             if (ci.DeclaringType.GetTypeInfo().ContainsGenericParameters)
             {
@@ -370,8 +370,8 @@ namespace System.Linq.Expressions.Compiler
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix")]
         internal static void EmitNew(this ILGenerator il, Type type, Type[] paramTypes)
         {
-            ContractUtils.RequiresNotNull(type, nameof(type));
-            ContractUtils.RequiresNotNull(paramTypes, nameof(paramTypes));
+            Debug.Assert(type != null);
+            Debug.Assert(paramTypes != null);
 
             ConstructorInfo ci = type.GetConstructor(paramTypes);
             if (ci == null) throw Error.TypeDoesNotHaveConstructorForTheSignature();
@@ -389,7 +389,8 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitString(this ILGenerator il, string value)
         {
-            ContractUtils.RequiresNotNull(value, nameof(value));
+            Debug.Assert(value != null);
+
             il.Emit(OpCodes.Ldstr, value);
         }
 
@@ -1066,7 +1067,7 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitArray<T>(this ILGenerator il, IList<T> items)
         {
-            ContractUtils.RequiresNotNull(items, nameof(items));
+            Debug.Assert(items != null);
 
             il.EmitInt(items.Count);
             il.Emit(OpCodes.Newarr, typeof(T));
@@ -1085,8 +1086,8 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitArray(this ILGenerator il, Type elementType, int count, Action<int> emit)
         {
-            ContractUtils.RequiresNotNull(elementType, nameof(elementType));
-            ContractUtils.RequiresNotNull(emit, nameof(emit));
+            Debug.Assert(elementType != null);
+            Debug.Assert(emit != null);
             Debug.Assert(count >= 0);
 
             il.EmitInt(count);
@@ -1109,7 +1110,7 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitArray(this ILGenerator il, Type arrayType)
         {
-            ContractUtils.RequiresNotNull(arrayType, nameof(arrayType));
+            Debug.Assert(arrayType != null);
             Debug.Assert(arrayType.IsArray);
 
             if (arrayType.IsVector())


### PR DESCRIPTION
These invariants are guaranteed higher up, all the way in expression factories or in the `LambdaCompiler`, so we can simply use asserts.

CC @VSadov