### PR TITLE
Add SpecialFolderOptions to GetFolderPath tests

### DIFF
--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -27,9 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU' " />
   <ItemGroup>
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
-    <!-- Disable System.EnvironmentTests because they are failing on non-Windows. Issue: https://github.com/dotnet/corefx/issues/11306
     <Compile Include="System\EnvironmentTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
-    -->
     <Compile Include="System\Environment.MachineName.cs" />
     <Compile Include="System\IO\Path.Combine.cs" />
     <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -208,31 +208,42 @@ namespace System.Tests
 
         [Theory]
         [PlatformSpecific(Xunit.PlatformID.AnyUnix)]
-        [InlineData(Environment.SpecialFolder.CommonApplicationData)]
-        [InlineData(Environment.SpecialFolder.CommonTemplates)]
-        [InlineData(Environment.SpecialFolder.ApplicationData)]
-        [InlineData(Environment.SpecialFolder.LocalApplicationData)]
-        [InlineData(Environment.SpecialFolder.Desktop)]
-        [InlineData(Environment.SpecialFolder.DesktopDirectory)]
-        [InlineData(Environment.SpecialFolder.Templates)]
-        [InlineData(Environment.SpecialFolder.MyVideos)]
-        [InlineData(Environment.SpecialFolder.MyMusic)]
-        [InlineData(Environment.SpecialFolder.MyPictures)]
-        [InlineData(Environment.SpecialFolder.Fonts)]
-        public void GetFolderPath_Unix_NonEmptyFolderPaths(Environment.SpecialFolder folder)
+        [InlineData(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.None)]
+        [InlineData(Environment.SpecialFolder.Personal, Environment.SpecialFolderOption.None)]
+        [InlineData(Environment.SpecialFolder.MyDocuments, Environment.SpecialFolderOption.None)]
+        [InlineData(Environment.SpecialFolder.CommonApplicationData, Environment.SpecialFolderOption.None)]
+        [InlineData(Environment.SpecialFolder.CommonTemplates, Environment.SpecialFolderOption.DoNotVerify)]
+        [InlineData(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify)]
+        [InlineData(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.None)]
+        [InlineData(Environment.SpecialFolder.Desktop, Environment.SpecialFolderOption.DoNotVerify)]
+        [InlineData(Environment.SpecialFolder.DesktopDirectory, Environment.SpecialFolderOption.DoNotVerify)]
+        [InlineData(Environment.SpecialFolder.Templates, Environment.SpecialFolderOption.DoNotVerify)]
+        [InlineData(Environment.SpecialFolder.MyVideos, Environment.SpecialFolderOption.DoNotVerify)]
+        [InlineData(Environment.SpecialFolder.MyMusic, Environment.SpecialFolderOption.DoNotVerify)]
+        [InlineData(Environment.SpecialFolder.MyPictures, Environment.SpecialFolderOption.DoNotVerify)]
+        [InlineData(Environment.SpecialFolder.Fonts, Environment.SpecialFolderOption.DoNotVerify)]
+        public void GetFolderPath_Unix_NonEmptyFolderPaths(Environment.SpecialFolder folder, Environment.SpecialFolderOption option)
         {
-            Assert.NotEmpty(Environment.GetFolderPath(folder));
+            Assert.NotEmpty(Environment.GetFolderPath(folder, option));
+            if (option == Environment.SpecialFolderOption.None)
+            {
+                Assert.NotEmpty(Environment.GetFolderPath(folder));
+            }
         }
 
         [Theory]
         [PlatformSpecific(Xunit.PlatformID.OSX)]
-        [InlineData(Environment.SpecialFolder.Favorites)]
-        [InlineData(Environment.SpecialFolder.InternetCache)]
-        [InlineData(Environment.SpecialFolder.ProgramFiles)]
-        [InlineData(Environment.SpecialFolder.System)]
-        public void GetFolderPath_OSX_NonEmptyFolderPaths(Environment.SpecialFolder folder)
+        [InlineData(Environment.SpecialFolder.Favorites, Environment.SpecialFolderOption.DoNotVerify)]
+        [InlineData(Environment.SpecialFolder.InternetCache, Environment.SpecialFolderOption.DoNotVerify)]
+        [InlineData(Environment.SpecialFolder.ProgramFiles, Environment.SpecialFolderOption.None)]
+        [InlineData(Environment.SpecialFolder.System, Environment.SpecialFolderOption.None)]
+        public void GetFolderPath_OSX_NonEmptyFolderPaths(Environment.SpecialFolder folder, Environment.SpecialFolderOption option)
         {
-            Assert.NotEmpty(Environment.GetFolderPath(folder));
+            Assert.NotEmpty(Environment.GetFolderPath(folder, option));
+            if (option == Environment.SpecialFolderOption.None)
+            {
+                Assert.NotEmpty(Environment.GetFolderPath(folder));
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Incorporate options into GetFolderPath tests.  Some folders may not always exist, and for those we want to override the default option of None to be DoNotVerify.

Fixes #11306 
cc: @joperezr 