### PR TITLE
Avoid array cloning in Path.Get*Chars

### DIFF
--- a/src/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/Common/src/System/IO/PathInternal.Unix.cs
@@ -12,7 +12,7 @@ namespace System.IO
     {
         // There is only one invalid path character in Unix
         private const char InvalidPathChar = '\0';
-        internal static readonly char[] InvalidPathChars = { InvalidPathChar };
+        internal static char[] GetInvalidPathChars() => new char[] { InvalidPathChar };
 
         internal static readonly int MaxComponentLength = Interop.Sys.MaxName;
 

--- a/src/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.cs
@@ -51,7 +51,7 @@ namespace System.IO
         internal const int DevicePrefixLength = 4;
         internal static readonly int MaxComponentLength = 255;
 
-        internal static readonly char[] InvalidPathChars =
+        internal static char[] GetInvalidPathChars() => new char[]
         {
             '\"', '<', '>', '|', '\0',
             (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -16,7 +16,7 @@ namespace System.IO
 
         private const string DirectorySeparatorCharAsString = "/";
 
-        private static readonly char[] InvalidFileNameChars = { '\0', '/' };
+        public static char[] GetInvalidFileNameChars() => new char[] { '\0', '/' };
 
         private static readonly int MaxPath = Interop.Sys.MaxPath;
         private static readonly int MaxLongPath = MaxPath;

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
@@ -15,7 +15,7 @@ namespace System.IO
 
         private const string DirectorySeparatorCharAsString = "\\";
 
-        private static readonly char[] InvalidFileNameChars = 
+        public static char[] GetInvalidFileNameChars() => new char[]
         { 
             '\"', '<', '>', '|', '\0', 
             (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10, 

--- a/src/System.Runtime.Extensions/src/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.cs
@@ -85,12 +85,7 @@ namespace System.IO
 
         public static char[] GetInvalidPathChars()
         {
-            return (char[])PathInternal.InvalidPathChars.Clone();
-        }
-
-        public static char[] GetInvalidFileNameChars()
-        {
-            return (char[])InvalidFileNameChars.Clone();
+            return PathInternal.GetInvalidPathChars();
         }
 
         // Returns the extension of the given path. The returned value includes the


### PR DESCRIPTION
It's faster to just allocate a new array.
Per comment at https://github.com/dotnet/corefx/pull/11293#issuecomment-243810859
cc: @jkotas 