### PR TITLE
Disable most networking tests for default CI runs

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
@@ -28,6 +28,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             _validationCallbackHistory = new ValidationCallbackHistory();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task NoCallback_ValidCertificate_CallbackNotCalled()
         {
@@ -40,6 +41,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task UseCallback_NotSecureConnection_CallbackNotCalled()
         {
@@ -53,6 +55,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task UseCallback_ValidCertificate_ExpectedValuesDuringCallback()
         {
@@ -68,6 +71,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task UseCallback_RedirectandValidCertificate_ExpectedValuesDuringCallback()
         {
@@ -85,6 +89,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task UseCallback_CallbackReturnsFailure_ThrowsInnerSecurityFailureException()
         {
@@ -103,6 +108,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task UseCallback_CallbackThrowsSpecificException_ThrowsInnerSpecificException()
         {

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -30,6 +30,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             _output = output;
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendAsync_SimpleGet_Success()
         {
@@ -44,6 +45,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(CookieUsePolicy.UseInternalCookieStoreOnly, "cookieName1", "cookieValue1")]
         [InlineData(CookieUsePolicy.UseSpecifiedCookieContainer, "cookieName2", "cookieValue2")]
@@ -75,6 +77,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }            
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [OuterLoop]
         public async Task SendAsync_SlowServerAndCancel_ThrowsTaskCanceledException()
@@ -93,6 +96,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
         }        
         
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [OuterLoop]
         public void SendAsync_SlowServerRespondsAfterDefaultReceiveTimeout_ThrowsHttpRequestException()

--- a/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
@@ -40,6 +40,7 @@ namespace System.Net.Http.Functional.Tests
             _output.WriteLine(s_authenticatedServer.ToString());
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(10041)]
         [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
@@ -56,6 +57,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(10041)]
         [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
@@ -71,6 +73,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(10041)]
         [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
@@ -91,6 +94,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(10041)]
         [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
@@ -111,6 +115,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(10041)]
         [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
@@ -132,6 +137,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(10041)]
         [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
@@ -157,6 +163,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(10041)]
         [ConditionalFact(nameof(DomainProxyTestsEnabled))]
         public async Task Proxy_UseAuthenticatedProxyWithNoCredentials_ProxyAuthenticationRequired()
@@ -171,6 +178,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(10041)]
         [ConditionalFact(nameof(DomainProxyTestsEnabled))]
         public async Task Proxy_UseAuthenticatedProxyWithDefaultCredentials_OK()
@@ -185,6 +193,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
         
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(DomainProxyTestsEnabled))]
         public async Task Proxy_UseAuthenticatedProxyWithWrappedDefaultCredentials_OK()
         {

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -25,6 +25,7 @@ namespace System.Net.Http.Functional.Tests
         /// This test must be in the same test collection as any others testing HttpClient/WinHttpHandler
         /// DiagnosticSources, since the global logging mechanism makes them conflict inherently.
         /// </remarks>
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceLogging()
         {
@@ -79,6 +80,7 @@ namespace System.Net.Http.Functional.Tests
         /// This test must be in the same test collection as any others testing HttpClient/WinHttpHandler
         /// DiagnosticSources, since the global logging mechanism makes them conflict inherently.
         /// </remarks>
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceNoLogging()
         {
@@ -113,6 +115,7 @@ namespace System.Net.Http.Functional.Tests
             }).Dispose();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendAsync_HttpTracingEnabled_Succeeds()
         {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -46,6 +46,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendDoesNotSupportCustomCertificateHandling))]
         public async Task Automatic_SSLBackendNotSupported_ThrowsPlatformNotSupportedException()
         {
@@ -55,6 +56,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendDoesNotSupportCustomCertificateHandling))]
         public async Task Manual_SSLBackendNotSupported_ThrowsPlatformNotSupportedException()
         {
@@ -66,6 +68,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(9543, PlatformID.Windows)] // reuseClient==false fails in debug/release, reuseClient==true fails sporadically in release
         [ConditionalTheory(nameof(BackendSupportsCustomCertificateHandling))]
         [InlineData(6, false)]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -35,6 +35,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void ProxyExplicitlyProvided_DefaultCredentials_Ignored()
         {
@@ -63,6 +64,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)] // proxies set via the http_proxy environment variable are specific to Unix
         public void ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -59,6 +59,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n", 37, false)]
         [InlineData("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n", 38, true)]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -15,6 +15,7 @@ namespace System.Net.Http.Functional.Tests
 {
     public class HttpClientHandler_ServerCertificates_Test
     {
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task NoCallback_ValidCertificate_CallbackNotCalled()
         {
@@ -34,6 +35,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendSupportsCustomCertificateHandling))]
         public async Task UseCallback_NotSecureConnection_CallbackNotCalled()
         {
@@ -67,6 +69,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(BackendSupportsCustomCertificateHandling))]
         [MemberData(nameof(UseCallback_ValidCertificate_ExpectedValuesDuringCallback_Urls))]
         public async Task UseCallback_ValidCertificate_ExpectedValuesDuringCallback(Uri url, bool checkRevocation)
@@ -95,6 +98,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendSupportsCustomCertificateHandling))]
         public async Task UseCallback_CallbackReturnsFailure_ThrowsException()
         {
@@ -106,6 +110,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendSupportsCustomCertificateHandling))]
         public async Task UseCallback_CallbackThrowsException_ExceptionPropagates()
         {
@@ -125,6 +130,7 @@ namespace System.Net.Http.Functional.Tests
             new object[] { Configuration.Http.WrongHostNameCertRemoteServer },
         };
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(CertificateValidationServers))]
         public async Task NoCallback_BadCertificate_ThrowsException(string url)
@@ -135,6 +141,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task NoCallback_RevokedCertificate_NoRevocationChecking_Succeeds()
         {
@@ -145,6 +152,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendSupportsCustomCertificateHandling))]
         public async Task NoCallback_RevokedCertificate_RevocationChecking_Fails()
         {
@@ -162,6 +170,7 @@ namespace System.Net.Http.Functional.Tests
             new object[] { Configuration.Http.WrongHostNameCertRemoteServer , SslPolicyErrors.RemoteCertificateNameMismatch},
         };
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(7812, PlatformID.Windows)]
         [ConditionalTheory(nameof(BackendSupportsCustomCertificateHandling))]
         [MemberData(nameof(CertificateValidationServersAndExpectedPolicies))]
@@ -191,6 +200,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendDoesNotSupportCustomCertificateHandling))]
         public async Task SSLBackendNotSupported_Callback_ThrowsPlatformNotSupportedException()
         {
@@ -200,6 +210,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendDoesNotSupportCustomCertificateHandling))]
         public async Task SSLBackendNotSupported_Revocation_ThrowsPlatformNotSupportedException()
         {
@@ -209,6 +220,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [PlatformSpecific(PlatformID.Windows)] // CopyToAsync(Stream, TransportContext) isn't used on unix
         [Fact]
         public async Task PostAsync_Post_ChannelBinding_ConfiguredCorrectly()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -43,6 +43,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendSupportsSslConfiguration))]
         public async Task SetProtocols_AfterRequest_ThrowsException()
         {
@@ -59,6 +60,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(~SslProtocols.None)]
 #pragma warning disable 0618 // obsolete warning
@@ -75,6 +77,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(BackendSupportsSslConfiguration))]
         [InlineData(SslProtocols.Tls, false)]
         [InlineData(SslProtocols.Tls, true)]
@@ -144,6 +147,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendSupportsSslConfiguration), nameof(SslDefaultsToTls12))]
         public async Task GetAsync_NoSpecifiedProtocol_DefaultsToTls12()
         {
@@ -165,6 +169,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(BackendSupportsSslConfiguration))]
         [InlineData(SslProtocols.Tls11, SslProtocols.Tls, typeof(IOException))]
         [InlineData(SslProtocols.Tls12, SslProtocols.Tls11, typeof(IOException))]
@@ -185,6 +190,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(8538, PlatformID.Windows)]
         [Fact]
         public async Task GetAsync_DisallowTls10_AllowTls11_AllowTls12()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -176,6 +176,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(item, value);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task SendAsync_SimpleGet_Success(Uri remoteServer)
         {
@@ -194,6 +195,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(GetAsync_IPBasedUri_Success_MemberData))]
         public async Task GetAsync_IPBasedUri_Success(IPAddress address)
@@ -221,6 +223,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_MultipleRequestsReusingSameClient_Success()
         {
@@ -236,6 +239,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
         
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_ResponseContentAfterClientAndHandlerDispose_Success()
         {
@@ -255,6 +259,7 @@ namespace System.Net.Http.Functional.Tests
                 null);                    
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_Cancel_CancellationTokenPropagates()
         {
@@ -270,6 +275,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(CompressedServers))]
         public async Task GetAsync_DefaultAutomaticDecompression_ContentDecompressed(Uri server)
         {
@@ -289,6 +295,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(CompressedServers))]
         public async Task GetAsync_DefaultAutomaticDecompression_HeadersRemoved(Uri server)
         {
@@ -302,6 +309,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_ServerNeedsAuthAndSetCredential_StatusCodeOK()
         {
@@ -317,6 +325,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_ServerNeedsAuthAndNoCredential_StatusCodeUnauthorized()
         {
@@ -330,6 +339,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_AllowAutoRedirectFalse_RedirectFromHttpToHttp_StatusCodeRedirect(int statusCode)
         {
@@ -351,6 +361,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpToHttp_StatusCodeOK(int statusCode)
         {
@@ -372,6 +383,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpToHttps_StatusCodeOK()
         {
@@ -393,6 +405,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpsToHttp_StatusCodeRedirect()
         {
@@ -414,6 +427,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectToUriWithParams_RequestMsgUriSet()
         {
@@ -436,6 +450,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(8945, PlatformID.Windows)]
         [Theory]
         [InlineData(3, 2)]
@@ -466,6 +481,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectWithRelativeLocation()
         {
@@ -487,6 +503,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(200)]
         [InlineData(201)]
@@ -521,6 +538,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [PlatformSpecific(PlatformID.AnyUnix)]
         [InlineData("#origFragment", "", "#origFragment", false)]
@@ -566,6 +584,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_CredentialIsNetworkCredentialUriRedirect_StatusCodeUnauthorized()
         {
@@ -585,6 +604,7 @@ namespace System.Net.Http.Functional.Tests
             }
        }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK(int statusCode)
         {
@@ -611,6 +631,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_DefaultCoookieContainer_NoCookieSent()
         {
@@ -625,6 +646,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("cookieName1", "cookieValue1")]
         public async Task GetAsync_SetCookieContainer_CookieSent(string cookieName, string cookieValue)
@@ -645,6 +667,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("cookieName1", "cookieValue1")]
         public async Task GetAsync_RedirectResponseHasCookie_CookieSentToFinalUri(string cookieName, string cookieValue)
@@ -668,6 +691,7 @@ namespace System.Net.Http.Functional.Tests
             }            
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(HeaderValueAndUris))]
         public async Task GetAsync_RequestHeadersAddCustomHeaders_HeaderAndValueSent(string name, string value, Uri uri)
         {
@@ -729,6 +753,7 @@ namespace System.Net.Http.Functional.Tests
             }
         };
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(CookieNameValues))]
         public async Task GetAsync_ResponseWithSetCookieHeaders_AllCookiesRead(KeyValuePair<string, string> cookie1)
@@ -765,6 +790,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_ResponseHeadersRead_ReadFromEachIterativelyDoesntDeadlock()
         {
@@ -789,6 +815,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_HttpRequestMsgResponseHeadersRead_StatusCodeOK()
         {
@@ -808,6 +835,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_ReadFromSlowStreamingServer_PartialDataReturned()
         {
@@ -844,6 +872,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task Dispose_DisposingHandlerCancelsActiveOperationsWithoutResponses()
         {
@@ -910,6 +939,7 @@ namespace System.Net.Http.Functional.Tests
 
         #region Post Methods Tests
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(VerifyUploadServers))]
         public async Task PostAsync_CallMethodTwice_StringContent(Uri remoteServer)
         {
@@ -934,6 +964,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(VerifyUploadServers))]
         public async Task PostAsync_CallMethod_UnicodeStringContent(Uri remoteServer)
         {
@@ -950,6 +981,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(VerifyUploadServersStreamsAndExpectedData))]
         public async Task PostAsync_CallMethod_StreamContent(Uri remoteServer, HttpContent content, byte[] expectedData)
         {
@@ -1090,6 +1122,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostAsync_CallMethod_NullContent(Uri remoteServer)
         {
@@ -1110,6 +1143,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostAsync_CallMethod_EmptyContent(Uri remoteServer)
         {
@@ -1131,6 +1165,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -1182,6 +1217,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task PostAsync_ResponseContentRead_RequestContentDisposedAfterResponseBuffered()
         {
@@ -1230,6 +1266,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task PostAsync_ResponseHeadersRead_RequestContentDisposedAfterRequestFullySentAndResponseHeadersReceived()
         {
@@ -1323,6 +1360,7 @@ namespace System.Net.Http.Functional.Tests
                 DisposeDelegate?.Invoke(disposing);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(HttpStatusCode.MethodNotAllowed, "Custom description")]
         [InlineData(HttpStatusCode.MethodNotAllowed, "")]
@@ -1341,6 +1379,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [PlatformSpecific(PlatformID.Windows)] // CopyToAsync(Stream, TransportContext) isn't used on unix
         [Fact]
         public async Task PostAsync_Post_ChannelBindingHasExpectedValue()
@@ -1364,6 +1403,7 @@ namespace System.Net.Http.Functional.Tests
 
         #region Various HTTP Method Tests
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(HttpMethods))]
         public async Task SendAsync_SendRequestUsingMethodToEchoServerWithNoContent_MethodCorrectlySent(
             string method,
@@ -1382,6 +1422,7 @@ namespace System.Net.Http.Functional.Tests
             }        
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(HttpMethodsThatAllowContent))]
         public async Task SendAsync_SendRequestUsingMethodToEchoServerWithContent_Success(
             string method,
@@ -1410,6 +1451,7 @@ namespace System.Net.Http.Functional.Tests
             }        
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("12345678910", 0)]
         [InlineData("12345678910", 5)]
@@ -1443,6 +1485,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(HttpMethodsThatDontAllowContent))]
         public async Task SendAsync_SendRequestUsingNoBodyMethodToEchoServerWithContent_NoBodySent(
             string method,
@@ -1477,6 +1520,7 @@ namespace System.Net.Http.Functional.Tests
         #endregion
 
         #region Version tests
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_RequestVersion10_ServerReceivesVersion10Request()
         {
@@ -1484,6 +1528,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(new Version(1, 0), receivedRequestVersion);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_RequestVersion11_ServerReceivesVersion11Request()
         {
@@ -1491,6 +1536,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(new Version(1, 1), receivedRequestVersion);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_RequestVersionNotSpecified_ServerReceivesVersion11Request()
         {
@@ -1500,6 +1546,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(new Version(1, 1), receivedRequestVersion);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(Http2Servers))]
         [ActiveIssue(10958, PlatformID.Windows)]
         public async Task SendAsync_RequestVersion20_ResponseVersion20IfHttp2Supported(Uri server)
@@ -1545,6 +1592,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(IsWindows10Version1607OrGreater)), MemberData(nameof(Http2NoPushServers))]
         public async Task SendAsync_RequestVersion20_ResponseVersion20(Uri server)
         {
@@ -1605,6 +1653,7 @@ namespace System.Net.Http.Functional.Tests
         #endregion
         
         #region Proxy tests
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(CredentialsForProxy))]
         public void Proxy_BypassFalse_GetRequestGoesThroughCustomProxy(ICredentials creds, bool wrapCredsInCache)
@@ -1644,6 +1693,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(BypassedProxies))]
         public async Task Proxy_BypassTrue_GetRequestDoesntGoesThroughCustomProxy(IWebProxy proxy)
@@ -1659,6 +1709,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Proxy_HaveNoCredsAndUseAuthenticatedCustomProxy_ProxyAuthenticationRequiredStatusCode()
         {
@@ -1699,6 +1750,7 @@ namespace System.Net.Http.Functional.Tests
         #endregion
 
         #region Uri wire transmission encoding tests
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendRequest_UriPathHasReservedChars_ServerReceivedExpectedPath()
         {

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -43,6 +43,7 @@ namespace System.Net.Http.Functional.Tests
             _output = output;
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostNoContentUsingContentLengthSemantics_Success(Uri serverUri)
         {
@@ -50,6 +51,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: true, useChunkedEncodingUpload: false);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostEmptyContentUsingContentLengthSemantics_Success(Uri serverUri)
         {
@@ -57,6 +59,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: true, useChunkedEncodingUpload: false);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(5485, PlatformID.Windows)]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostEmptyContentUsingChunkedEncoding_Success(Uri serverUri)
@@ -65,6 +68,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: false, useChunkedEncodingUpload: true);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostUsingContentLengthSemantics_Success(Uri serverUri)
         {
@@ -72,6 +76,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: true, useChunkedEncodingUpload: false);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostUsingChunkedEncoding_Success(Uri serverUri)
         {
@@ -79,6 +84,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: false, useChunkedEncodingUpload: true);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostSyncBlockingContentUsingChunkedEncoding_Success(Uri serverUri)
         {
@@ -86,6 +92,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: false, useChunkedEncodingUpload: true);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostRepeatedFlushContentUsingChunkedEncoding_Success(Uri serverUri)
         {
@@ -93,6 +100,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: false, useChunkedEncodingUpload: true);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostUsingUsingConflictingSemantics_UsesChunkedSemantics(Uri serverUri)
         {
@@ -100,6 +108,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: true, useChunkedEncodingUpload: true);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostUsingNoSpecifiedSemantics_UsesChunkedSemantics(Uri serverUri)
         {
@@ -107,6 +116,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: false, useChunkedEncodingUpload: false);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(5 * 1024)]
         [InlineData(63 * 1024)]
@@ -124,6 +134,7 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: true, useChunkedEncodingUpload: false);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(BasicAuthEchoServers))]
         public async Task PostRewindableContentUsingAuth_NoPreAuthenticate_Success(Uri serverUri)
         {
@@ -132,6 +143,7 @@ namespace System.Net.Http.Functional.Tests
             await PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, false);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(BasicAuthEchoServers))]
         public async Task PostNonRewindableContentUsingAuth_NoPreAuthenticate_ThrowsInvalidOperationException(Uri serverUri)
         {
@@ -141,6 +153,7 @@ namespace System.Net.Http.Functional.Tests
                 PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, preAuthenticate: false));
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(BasicAuthEchoServers))]
         public async Task PostNonRewindableContentUsingAuth_PreAuthenticate_Success(Uri serverUri)
         {

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -23,6 +23,7 @@ namespace System.Net.Http.Functional.Tests
             _output = output;
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetStreamAsync_ReadToEnd_Success()
         {
@@ -43,6 +44,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_UseResponseHeadersReadAndCallLoadIntoBuffer_Success()
         {
@@ -61,6 +63,7 @@ namespace System.Net.Http.Functional.Tests
                 null);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_UseResponseHeadersReadAndCopyToMemoryStream_Success()
         {
@@ -85,6 +88,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ReadAsStreamAsync_Cancel_TaskIsCanceled()
         {
@@ -105,6 +109,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(LoopbackServer.TransferType.ContentLength, LoopbackServer.TransferError.ContentLengthTooLarge)]
         [InlineData(LoopbackServer.TransferType.Chunked, LoopbackServer.TransferError.MissingChunkTerminator)]
@@ -121,6 +126,7 @@ namespace System.Net.Http.Functional.Tests
             await serverTask;
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(LoopbackServer.TransferType.None, LoopbackServer.TransferError.None)]
         [InlineData(LoopbackServer.TransferType.ContentLength, LoopbackServer.TransferError.None)]

--- a/src/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
@@ -22,6 +22,7 @@ namespace System.Net.Http.Functional.Tests
             _output = output;
         }
         
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public async Task HttpClient_ClientUsesAuxRecord_Ok()

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -24,18 +24,21 @@ namespace System.Net.Security.Tests
             _log = TestLogging.GetInstance();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ClientAsyncAuthenticate_ServerRequireEncryption_ConnectWithEncryption()
         {
             await ClientAsyncSslHelper(EncryptionPolicy.RequireEncryption);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ClientAsyncAuthenticate_ServerNoEncryption_NoConnect()
         {
             await Assert.ThrowsAsync<IOException>(() => ClientAsyncSslHelper(EncryptionPolicy.NoEncryption));
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
         public async Task ClientAsyncAuthenticate_EachSupportedProtocol_Success(SslProtocols protocol)
@@ -43,6 +46,7 @@ namespace System.Net.Security.Tests
             await ClientAsyncSslHelper(protocol, protocol);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [ClassData(typeof(SslProtocolSupport.UnsupportedSslProtocolsTestData))]
         public async Task ClientAsyncAuthenticate_EachClientUnsupportedProtocol_Fail(SslProtocols protocol)
@@ -53,6 +57,7 @@ namespace System.Net.Security.Tests
             });
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(ProtocolMismatchData))]
         public async Task ClientAsyncAuthenticate_MismatchProtocols_Fails(
@@ -63,6 +68,7 @@ namespace System.Net.Security.Tests
             await Assert.ThrowsAsync(expectedException, () => ClientAsyncSslHelper(serverProtocol, clientProtocol));
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ClientAsyncAuthenticate_AllServerAllClient_Success()
         {
@@ -71,6 +77,7 @@ namespace System.Net.Security.Tests
                 SslProtocolSupport.SupportedSslProtocols);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ClientAsyncAuthenticate_UnsuportedAllClient_Fail()
         {
@@ -82,6 +89,7 @@ namespace System.Net.Security.Tests
             });
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
         public async Task ClientAsyncAuthenticate_AllServerVsIndividualClientSupportedProtocols_Success(
@@ -90,6 +98,7 @@ namespace System.Net.Security.Tests
             await ClientAsyncSslHelper(clientProtocol, SslProtocolSupport.SupportedSslProtocols);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
         public async Task ClientAsyncAuthenticate_IndividualServerVsAllClientSupportedProtocols_Success(

--- a/src/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
@@ -33,6 +33,7 @@ namespace System.Net.Security.Tests
             return true;  // allow everything
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ClientDefaultEncryption_ServerRequireEncryption_ConnectWithEncryption()
         {
@@ -53,6 +54,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ClientDefaultEncryption_ServerAllowNoEncryption_ConnectWithEncryption()
         {
@@ -73,6 +75,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ClientDefaultEncryption_ServerNoEncryption_NoConnect()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -17,6 +17,7 @@ namespace System.Net.Security.Tests
     {
         private readonly byte[] _sampleMsg = Encoding.UTF8.GetBytes("Sample Test Message");
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void NegotiateStream_StreamToStream_Authentication_Success()
         {
@@ -68,6 +69,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void NegotiateStream_StreamToStream_Authentication_TargetName_Success()
         {
@@ -122,6 +124,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void NegotiateStream_StreamToStream_Authentication_EmptyCredentials_Fails()
         {
@@ -185,6 +188,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void NegotiateStream_StreamToStream_Successive_ClientWrite_Sync_Success()
         {
@@ -218,6 +222,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void NegotiateStream_StreamToStream_Successive_ClientWrite_Async_Success()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
@@ -32,6 +32,7 @@ namespace System.Net.Security.Tests
             return true;  // allow everything
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ServerAllowNoEncryption_ClientRequireEncryption_ConnectWithEncryption()
         {
@@ -52,6 +53,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ServerAllowNoEncryption_ClientAllowNoEncryption_ConnectWithEncryption()
         {
@@ -72,6 +74,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(SupportsNullEncryption))]
         public async Task ServerAllowNoEncryption_ClientNoEncryption_ConnectWithNoEncryption()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -33,6 +33,7 @@ namespace System.Net.Security.Tests
             _serverCertificate.Dispose();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
         public async Task ServerAsyncAuthenticate_EachSupportedProtocol_Success(SslProtocols protocol)
@@ -40,6 +41,7 @@ namespace System.Net.Security.Tests
             await ServerAsyncSslHelper(protocol, protocol);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [ClassData(typeof(SslProtocolSupport.UnsupportedSslProtocolsTestData))]
         public async Task ServerAsyncAuthenticate_EachServerUnsupportedProtocol_Fail(SslProtocols protocol)
@@ -53,7 +55,8 @@ namespace System.Net.Security.Tests
             });
         }
 
-        [ActiveIssue(11170, Xunit.PlatformID.OSX)]
+        [OuterLoop] // TODO: Issue #11345
+        [ActiveIssue(11170)]
         [Theory]
         [MemberData(nameof(ProtocolMismatchData))]
         public async Task ServerAsyncAuthenticate_MismatchProtocols_Fails(
@@ -72,6 +75,7 @@ namespace System.Net.Security.Tests
                 });
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ServerAsyncAuthenticate_UnsuportedAllServer_Fail()
         {
@@ -84,6 +88,7 @@ namespace System.Net.Security.Tests
             });
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
         public async Task ServerAsyncAuthenticate_AllClientVsIndividualServerSupportedProtocols_Success(

--- a/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -32,6 +32,7 @@ namespace System.Net.Security.Tests
             return true;  // allow everything
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ServerNoEncryption_ClientRequireEncryption_NoConnect()
         {
@@ -49,6 +50,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(SupportsNullEncryption))]
         public async Task ServerNoEncryption_ClientAllowNoEncryption_ConnectWithNoEncryption()
         {
@@ -72,6 +74,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ServerNoEncryption_ClientNoEncryption_ConnectWithNoEncryption()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
@@ -32,6 +32,7 @@ namespace System.Net.Security.Tests
             return true;  // allow everything
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ServerRequireEncryption_ClientRequireEncryption_ConnectWithEncryption()
         {
@@ -52,6 +53,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ServerRequireEncryption_ClientAllowNoEncryption_ConnectWithEncryption()
         {
@@ -72,6 +74,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(SupportsNullEncryption))]
         public async Task ServerRequireEncryption_ClientNoEncryption_NoConnect()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -14,6 +14,7 @@ namespace System.Net.Security.Tests
 {
     public class SslStreamNetworkStreamTest
     {
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async void SslStream_SendReceiveOverNetworkStream_Ok()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSchSendAuxRecordTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSchSendAuxRecordTest.cs
@@ -22,6 +22,7 @@ namespace System.Net.Security.Tests
             _output = output;
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public async Task SslStream_ClientAndServerUsesAuxRecord_Ok()

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -17,6 +17,7 @@ namespace System.Net.Security.Tests
     {
         private readonly byte[] _sampleMsg = Encoding.UTF8.GetBytes("Sample Test Message");
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SslStream_StreamToStream_Authentication_Success()
         {
@@ -37,6 +38,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SslStream_StreamToStream_Authentication_IncorrectServerName_Fail()
         {
@@ -61,6 +63,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SslStream_StreamToStream_Successive_ClientWrite_Sync_Success()
         {
@@ -90,6 +93,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -138,6 +142,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SslStream_StreamToStream_Successive_ClientWrite_Async_Success()
         {
@@ -169,6 +174,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SslStream_StreamToStream_Write_ReadByte_Success()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
@@ -24,6 +24,7 @@ namespace System.Net.Security.Tests
             return true;  // allow everything
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task TransportContext_ConnectToServerWithSsl_GetExpectedChannelBindings()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/AcceptAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/AcceptAsync.cs
@@ -32,6 +32,7 @@ namespace System.Net.Sockets.Tests
             handle.Set();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [Trait("IPv4", "true")]
         public void AcceptAsync_IpV4_Success()
@@ -73,6 +74,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [Trait("IPv6", "true")]
         public void AcceptAsync_IPv6_Success()
@@ -114,6 +116,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public void AcceptAsync_WithReceiveBuffer_Success()
@@ -164,6 +167,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
         public void AcceptAsync_WithReceiveBuffer_Failure()
@@ -193,6 +197,7 @@ namespace System.Net.Sockets.Tests
         #region GC Finalizer test
         // This test assumes sequential execution of tests and that it is going to be executed after other tests
         // that used Sockets. 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void TestFinalizers()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/AgnosticListenerTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/AgnosticListenerTest.cs
@@ -19,6 +19,7 @@ namespace System.Net.Sockets.Tests
             Assert.True(Capability.IPv4Support() && Capability.IPv6Support());
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Create_Success()
         {
@@ -30,6 +31,7 @@ namespace System.Net.Sockets.Tests
             listener.Stop();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void ConnectWithV4_Success()
         {
@@ -46,6 +48,7 @@ namespace System.Net.Sockets.Tests
             listener.Stop();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void ConnectWithV6_Success()
         {
@@ -62,6 +65,7 @@ namespace System.Net.Sockets.Tests
             listener.Stop();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void ConnectWithV4AndV6_Success()
         {
@@ -96,7 +100,8 @@ namespace System.Net.Sockets.Tests
 
         #region GC Finalizer test
         // This test assumes sequential execution of tests and that it is going to be executed after other tests
-        // that used Sockets. 
+        // that used Sockets.
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void TestFinalizers()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/ConnectAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ConnectAsync.cs
@@ -26,6 +26,7 @@ namespace System.Net.Sockets.Tests
             handle.Set();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -53,6 +54,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]

--- a/src/System.Net.Sockets/tests/FunctionalTests/ConnectExTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ConnectExTest.cs
@@ -25,6 +25,7 @@ namespace System.Net.Sockets.Tests
             complete.Set();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -76,7 +77,8 @@ namespace System.Net.Sockets.Tests
 
         #region GC Finalizer test
         // This test assumes sequential execution of tests and that it is going to be executed after other tests
-        // that used Sockets. 
+        // that used Sockets.
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void TestFinalizers()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
@@ -31,6 +31,7 @@ namespace System.Net.Sockets.Tests
 */
         };
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(DualModeSuccessInputs))]
         public void DualMode_Success(SocketType socketType, ProtocolType protocolType)
         {
@@ -39,6 +40,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(DualModeFailureInputs))]
         public void DualMode_Failure(SocketType socketType, ProtocolType protocolType)
         {
@@ -52,6 +54,7 @@ namespace System.Net.Sockets.Tests
             new object[] { AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp },
         };
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(CtorSuccessInputs))]
         public void Ctor_Success(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {
@@ -79,6 +82,7 @@ namespace System.Net.Sockets.Tests
 */
         };
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(CtorFailureInputs))]
         public void Ctor_Failure(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -28,6 +28,7 @@ namespace System.Net.Sockets.Tests
             complete.Set();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -44,6 +45,7 @@ namespace System.Net.Sockets.Tests
             server.Dispose();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public void Socket_ConnectDnsEndPoint_Failure()
@@ -68,6 +70,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Socket_SendToDnsEndPoint_ArgumentException()
         {
@@ -80,6 +83,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Socket_ReceiveFromDnsEndPoint_ArgumentException()
         {
@@ -95,6 +99,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -112,6 +117,7 @@ namespace System.Net.Sockets.Tests
             server.Dispose();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public void Socket_BeginConnectDnsEndPoint_Failure()
@@ -138,6 +144,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Socket_BeginSendToDnsEndPoint_ArgumentException()
         {
@@ -150,6 +157,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -185,6 +193,7 @@ namespace System.Net.Sockets.Tests
             server.Dispose();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [Trait("IPv4", "true")]
         [PlatformSpecific(PlatformID.Windows)]
@@ -213,6 +222,7 @@ namespace System.Net.Sockets.Tests
             sock.Dispose();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [Trait("IPv4", "true")]
         [PlatformSpecific(PlatformID.Windows)]
@@ -243,6 +253,7 @@ namespace System.Net.Sockets.Tests
             sock.Dispose();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -295,6 +306,7 @@ namespace System.Net.Sockets.Tests
             server6.Dispose();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Socket_StaticConnectAsync_HostNotFound()
         {
@@ -320,6 +332,7 @@ namespace System.Net.Sockets.Tests
             complete.Dispose();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Socket_StaticConnectAsync_ConnectionRefused()
         {
@@ -351,6 +364,7 @@ namespace System.Net.Sockets.Tests
             Assert.True(false, "This Callback should not be called");
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [Trait("IPv6", "true")]
         public void Socket_StaticConnectAsync_SyncFailure()
@@ -381,7 +395,8 @@ namespace System.Net.Sockets.Tests
 
         #region GC Finalizer test
         // This test assumes sequential execution of tests and that it is going to be executed after other tests
-        // that used Sockets. 
+        // that used Sockets.
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void TestFinalizers()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/LingerStateTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/LingerStateTest.cs
@@ -25,6 +25,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Socket_LingerState_Common_Boundaries_CorrectBehavior()
         {
@@ -41,6 +42,7 @@ namespace System.Net.Sockets.Tests
             TestLingerState_ArgumentException(sock, true, UInt16.MaxValue + 1);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(~PlatformID.OSX)]
         public void Socket_LingerState_Upper_Boundaries_CorrectBehavior()
@@ -52,6 +54,7 @@ namespace System.Net.Sockets.Tests
             TestLingerState_Success(sock, true, UInt16.MaxValue);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.OSX)]
         public void Socket_LingerState_Upper_Boundaries_CorrectBehavior_OSX()
@@ -75,6 +78,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(false, 0)]
         [InlineData(true, 0)]

--- a/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
@@ -10,6 +10,7 @@ namespace System.Net.Sockets.Tests
 {
     public class NetworkStreamTest
     {
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(NonCanceledTokens))]
         public async Task ReadWriteAsync_NonCanceled_Success(CancellationToken nonCanceledToken)
@@ -26,6 +27,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ReadWriteAsync_Canceled_ThrowsOperationCanceledException()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
@@ -8,6 +8,7 @@ namespace System.Net.Sockets.Tests
 {
     public class ReceiveMessageFrom
     {
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Success()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFromAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFromAsync.cs
@@ -17,6 +17,7 @@ namespace System.Net.Sockets.Tests
             handle.Set();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Success()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -53,6 +53,7 @@ namespace System.Net.Sockets.Tests
 
         #region Basic Arguments
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -70,6 +71,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -91,6 +93,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -125,6 +128,7 @@ namespace System.Net.Sockets.Tests
             Assert.Equal("e.SendPacketsElements", ex.ParamName);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -138,6 +142,7 @@ namespace System.Net.Sockets.Tests
             Assert.Equal("e.SendPacketsElements", ex.ParamName);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -147,6 +152,7 @@ namespace System.Net.Sockets.Tests
             SendPackets(type, (SendPacketsElement)null, 0);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -156,6 +162,7 @@ namespace System.Net.Sockets.Tests
             SendPackets(type, new SendPacketsElement[0], SocketError.Success, 0);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SocketAsyncEventArgs_DefaultSendSize_0()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -528,72 +528,84 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendToRecvFrom_Single_Datagram_UDP_IPv6()
         {
             SendToRecvFrom_Datagram_UDP(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendToRecvFromAPM_Single_Datagram_UDP_IPv6()
         {
             SendToRecvFromAPM_Datagram_UDP(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendToRecvFrom_Single_Datagram_UDP_IPv4()
         {
             SendToRecvFrom_Datagram_UDP(IPAddress.Loopback, IPAddress.Loopback);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendToRecvFromAPM_Single_Datagram_UDP_IPv4()
         {
             SendToRecvFromAPM_Datagram_UDP(IPAddress.Loopback, IPAddress.Loopback);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendRecv_Multiple_Stream_TCP_IPv6()
         {
             SendRecv_Stream_TCP(IPAddress.IPv6Loopback, useMultipleBuffers: true);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendRecvAPM_Multiple_Stream_TCP_IPv6()
         {
             SendRecvAPM_Stream_TCP(IPAddress.IPv6Loopback, useMultipleBuffers: true);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendRecv_Single_Stream_TCP_IPv6()
         {
             SendRecv_Stream_TCP(IPAddress.IPv6Loopback, useMultipleBuffers: false);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendRecvAPM_Single_Stream_TCP_IPv6()
         {
             SendRecvAPM_Stream_TCP(IPAddress.IPv6Loopback, useMultipleBuffers: false);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendRecv_Multiple_Stream_TCP_IPv4()
         {
             SendRecv_Stream_TCP(IPAddress.Loopback, useMultipleBuffers: true);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendRecvAPM_Multiple_Stream_TCP_IPv4()
         {
             SendRecvAPM_Stream_TCP(IPAddress.Loopback, useMultipleBuffers: true);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendRecv_Single_Stream_TCP_IPv4()
         {
             SendRecv_Stream_TCP(IPAddress.Loopback, useMultipleBuffers: false);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SendRecvAPM_Single_Stream_TCP_IPv4()
         {
@@ -606,6 +618,7 @@ namespace System.Net.Sockets.Tests
             new object[] { IPAddress.Loopback, IPAddress.Loopback }
         };
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(SendToRecvFromAsync_Datagram_UDP_Socket_MemberData))]
         public void SendToRecvFromAsync_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
@@ -739,6 +752,7 @@ namespace System.Net.Sockets.Tests
             new object[] { IPAddress.Loopback, IPAddress.Loopback }
         };
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(SendToRecvFromAsync_Datagram_UDP_Socket_MemberData))]
         public void SendToRecvFromAsync_Datagram_UDP_UdpClient(IPAddress leftAddress, IPAddress rightAddress)
@@ -822,6 +836,7 @@ namespace System.Net.Sockets.Tests
             new object[] { IPAddress.Loopback, false },
         };
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(SendRecvAsync_Stream_TCP_MemberData))]
         public void SendRecvAsync_Stream_TCP(IPAddress listenAt, bool useMultipleBuffers)
@@ -1015,6 +1030,7 @@ namespace System.Net.Sockets.Tests
             new object[] { IPAddress.IPv6Loopback },
         };
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(SendRecvAsync_TcpListener_TcpClient_MemberData))]
         public void SendRecvAsync_TcpListener_TcpClient(IPAddress listenAt)
@@ -1093,6 +1109,7 @@ namespace System.Net.Sockets.Tests
             new object[] { IPAddress.IPv6Loopback, false },
         };
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(SendRecvPollSync_TcpListener_TcpClient_MemberData))]
         public void SendRecvPollSync_TcpListener_Socket(IPAddress listenAt, bool pollBeforeOperation)

--- a/src/System.Net.Sockets/tests/FunctionalTests/Shutdown.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Shutdown.cs
@@ -58,6 +58,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Shutdown_TCP_CLOSED_Success()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -30,6 +30,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(11088, PlatformID.Windows)]
         [ConditionalFact(nameof(NoSocketsReuseUnicastPortSupport))]
         public void ReuseUnicastPort_CreateSocketGetOption_NoSocketsReuseUnicastPortSupport_Throws()
@@ -40,6 +41,7 @@ namespace System.Net.Sockets.Tests
                 socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort));
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(SocketsReuseUnicastPortSupport))]
         public void ReuseUnicastPort_CreateSocketGetOption_SocketsReuseUnicastPortSupport_OptionIsZero()
         {
@@ -49,6 +51,7 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(0, optionValue);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(11088, PlatformID.Windows)]
         [ConditionalFact(nameof(NoSocketsReuseUnicastPortSupport))]
         public void ReuseUnicastPort_CreateSocketSetOption_NoSocketsReuseUnicastPortSupport_Throws()
@@ -59,6 +62,7 @@ namespace System.Net.Sockets.Tests
                 socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort, 1));
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(SocketsReuseUnicastPortSupport))]
         public void ReuseUnicastPort_CreateSocketSetOptionToZeroAndGetOption_SocketsReuseUnicastPortSupport_OptionIsZero()
         {
@@ -73,6 +77,7 @@ namespace System.Net.Sockets.Tests
         // The socket option 'ReuseUnicastPost' only works on Windows 10 systems. In addition, setting the option
         // is a no-op unless specialized network settings using PowerShell configuration are first applied to the
         // machine. This is currently difficult to test in the CI environment. So, this ests will be disabled for now
+        [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(4887)]
         public void ReuseUnicastPort_CreateSocketSetOptionToOneAndGetOption_SocketsReuseUnicastPortSupport_OptionIsOne()
         {
@@ -83,6 +88,7 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(1, optionValue);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void MulticastOption_CreateSocketSetGetOption_GroupAndInterfaceIndex_SetSucceeds_GetThrows()
         {
@@ -97,6 +103,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task MulticastInterface_Set_AnyInterface_Succeeds()
         {
@@ -104,6 +111,7 @@ namespace System.Net.Sockets.Tests
             await MulticastInterface_Set_Helper(0);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.Windows)] // see comment below
         public async Task MulticastInterface_Set_Loopback_Succeeds()
@@ -145,6 +153,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void MulticastInterface_Set_InvalidIndex_Throws()
         {
@@ -156,6 +165,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -22,6 +22,7 @@ namespace System.Net.Sockets.Tests
             _log = output;
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
@@ -60,6 +61,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void ConnectedAvailable_InitialValues_Default()
         {
@@ -70,6 +72,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void ConnectedAvailable_NullClient()
         {
@@ -82,6 +85,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public void ExclusiveAddressUse_NullClient()
@@ -94,6 +98,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public void Roundtrip_ExclusiveAddressUse_GetEqualsSet()
@@ -107,6 +112,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
         public void ExclusiveAddressUse_NotSupported()
@@ -121,6 +127,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Roundtrip_LingerOption_GetEqualsSet()
         {
@@ -135,6 +142,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Roundtrip_NoDelay_GetEqualsSet()
         {
@@ -147,6 +155,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Roundtrip_ReceiveBufferSize_GetEqualsSet()
         {
@@ -159,6 +168,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Roundtrip_SendBufferSize_GetEqualsSet()
         {
@@ -171,6 +181,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Roundtrip_ReceiveTimeout_GetEqualsSet()
         {
@@ -183,6 +194,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Roundtrip_SendTimeout_GetEqualsSet()
         {
@@ -195,6 +207,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task Properties_PersistAfterConnect()
         {
@@ -220,6 +233,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
@@ -8,6 +8,7 @@ namespace System.Net.Sockets.Tests
 {
     public class TimeoutTest
     {
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void GetAndSet_Success()
         {
@@ -17,6 +18,7 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(100, socket.ReceiveTimeout);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SocketSendTimeout_GetAndSet_Success()
         {
@@ -26,6 +28,7 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(100, socket.SendTimeout);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void ReceiveTimesOut_Throws()
         {
@@ -53,6 +56,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SocketSendTimeout_Send_Success()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -16,6 +16,7 @@ namespace System.Net.Sockets.Tests
 
         private ManualResetEvent _waitHandle = new ManualResetEvent(false);
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void BeginSend_NegativeBytes_Throws()
         {
@@ -29,6 +30,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void BeginSend_BytesMoreThanArrayLength_Throws()
         {
@@ -42,6 +44,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void BeginSend_AsyncOperationCompletes_Success()
         {
@@ -54,6 +57,7 @@ namespace System.Net.Sockets.Tests
             Assert.True(_waitHandle.WaitOne(TestSettings.PassingTestTimeout), "Timed out while waiting for connection");
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Client_Idempotent()
         {
@@ -65,6 +69,7 @@ namespace System.Net.Sockets.Tests
             }
         }
         
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [ActiveIssue(9189, PlatformID.AnyUnix)]
         public async Task ConnectAsync_StringHost_Success()
@@ -75,6 +80,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task ConnectAsync_IPAddressHost_Success()
         {
@@ -84,6 +90,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [ActiveIssue(9189, PlatformID.AnyUnix)]
         public void Connect_StringHost_Success()
@@ -94,6 +101,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Connect_IPAddressHost_Success()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
@@ -23,6 +23,7 @@ namespace System.Net.Sockets.Tests
             _log = TestLogging.GetInstance();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public void Socket_CreateUnixDomainSocket_Throws_OnWindows()
@@ -31,6 +32,7 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(SocketError.AddressFamilyNotSupported, e.SocketErrorCode);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
         public async Task Socket_ConnectAsyncUnixDomainSocketEndPoint_Success()
@@ -85,6 +87,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
         public async Task Socket_ConnectAsyncUnixDomainSocketEndPoint_NotServer()
@@ -118,6 +121,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
         public void Socket_SendReceive_Success()
@@ -156,6 +160,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
         public async Task Socket_SendReceiveAsync_Success()
@@ -194,6 +199,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)] 
         public void ConcurrentSendReceive()

--- a/src/System.Net.WebSockets.Client/tests/AbortTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/AbortTest.cs
@@ -16,6 +16,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public AbortTest(ITestOutputHelper output) : base(output) { }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public void Abort_ConnectAndAbort_ThrowsWebSocketExceptionWithmessage(Uri server)
         {
@@ -37,6 +38,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task Abort_SendAndAbort_Success(Uri server)
         {
@@ -56,6 +58,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task Abort_ReceiveAndAbort_Success(Uri server)
         {
@@ -79,6 +82,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task Abort_CloseAndAbort_Success(Uri server)
         {
@@ -102,6 +106,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ClientWebSocket_Abort_CloseOutputAsync(Uri server)
         {

--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -16,6 +16,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public CancelTest(ITestOutputHelper output) : base(output) { }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ConnectAsync_Cancel_ThrowsWebSocketExceptionWithMessage(Uri server)
         {
@@ -36,6 +37,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendAsync_Cancel_Success(Uri server)
         {
@@ -50,6 +52,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ReceiveAsync_Cancel_Success(Uri server)
         {
@@ -71,6 +74,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_Cancel_Success(Uri server)
         {
@@ -92,6 +96,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_Cancel_Success(Uri server)
         {
@@ -114,6 +119,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ReceiveAsync_CancelAndReceive_ThrowsWebSocketExceptionWithMessage(Uri server)
         {

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
@@ -24,6 +24,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         private static bool WebSocketsSupported { get { return WebSocketHelper.WebSocketsSupported; } }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void Ctor_Success()
         {
@@ -31,6 +32,7 @@ namespace System.Net.WebSockets.Client.Tests
             cws.Dispose();
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void Abort_CreateAndAbort_StateIsClosed()
         {
@@ -42,6 +44,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_CreateAndClose_ThrowsInvalidOperationException()
         {
@@ -54,6 +57,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_CreateAndCloseOutput_ThrowsInvalidOperationExceptionWithMessage()
         {
@@ -68,6 +72,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_CreateAndReceive_ThrowsInvalidOperationException()
         {
@@ -84,6 +89,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_CreateAndReceive_ThrowsInvalidOperationExceptionWithMessage()
         {
@@ -101,6 +107,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_CreateAndSend_ThrowsInvalidOperationException()
         {
@@ -117,6 +124,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_CreateAndSend_ThrowsInvalidOperationExceptionWithMessage()
         {
@@ -134,6 +142,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void Ctor_ExpectedPropertyValues()
         {
@@ -148,6 +157,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void Abort_CreateAndDisposeAndAbort_StateIsClosedSuccess()
         {
@@ -158,6 +168,7 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_DisposeAndClose_ThrowsObjectDisposedException()
         {
@@ -170,6 +181,7 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_DisposeAndCloseOutput_ThrowsObjectDisposedExceptionWithMessage()
         {
@@ -186,6 +198,7 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void ReceiveAsync_CreateAndDisposeAndReceive_ThrowsObjectDisposedExceptionWithMessage()
         {
@@ -205,6 +218,7 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void SendAsync_CreateAndDisposeAndSend_ThrowsObjectDisposedExceptionWithMessage()
         {
@@ -224,6 +238,7 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void Dispose_CreateAndDispose_ExpectedPropertyValues()
         {

--- a/src/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -17,6 +17,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public CloseTest(ITestOutputHelper output) : base(output) { }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_ServerInitiatedClose_Success(Uri server)
         {
@@ -61,6 +62,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_ClientInitiatedClose_Success(Uri server)
         {
@@ -80,6 +82,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_CloseDescriptionIsMaxLength_Success(Uri server)
         {
@@ -93,6 +96,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_CloseDescriptionIsMaxLengthPlusOne_ThrowsArgumentException(Uri server)
         {
@@ -117,6 +121,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_CloseDescriptionHasUnicode_Success(Uri server)
         {
@@ -134,6 +139,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_CloseDescriptionIsNull_Success(Uri server)
         {
@@ -150,6 +156,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_ClientInitiated_CanReceive_CanClose(Uri server)
         {
@@ -187,6 +194,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_ServerInitiated_CanSend(Uri server)
         {
@@ -233,6 +241,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_CloseDescriptionIsNull_Success(Uri server)
         {
@@ -247,6 +256,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_DuringConcurrentReceiveAsync_ExpectedStates(Uri server)
         {
@@ -284,6 +294,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_DuringConcurrentReceiveAsync_ExpectedStates(Uri server)
         {

--- a/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -16,6 +16,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public ConnectTest(ITestOutputHelper output) : base(output) { }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(UnavailableWebSocketServers))]
         public async Task ConnectAsync_NotWebSocketServer_ThrowsWebSocketExceptionWithMessage(Uri server)
         {
@@ -31,18 +32,21 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task EchoBinaryMessage_Success(Uri server)
         {
             await WebSocketHelper.TestEcho(server, WebSocketMessageType.Binary, TimeOutMilliseconds, _output);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task EchoTextMessage_Success(Uri server)
         {
             await WebSocketHelper.TestEcho(server, WebSocketMessageType.Text, TimeOutMilliseconds, _output);
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoHeadersServers))]
         public async Task ConnectAsync_AddCustomHeaders_Success(Uri server)
         {
@@ -80,6 +84,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoHeadersServers))]
         public async Task ConnectAsync_CookieHeaders_Success(Uri server)
         {
@@ -120,6 +125,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ConnectAsync_PassNoSubProtocol_ServerRequires_ThrowsWebSocketExceptionWithMessage(Uri server)
         {
@@ -141,6 +147,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ConnectAsync_PassMultipleSubProtocols_ServerRequires_ConnectionUsesAgreedSubProtocol(Uri server)
         {

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -16,6 +16,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public SendReceiveTest(ITestOutputHelper output) : base(output) { }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendReceive_PartialMessage_Success(Uri server)
         {
@@ -50,6 +51,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendAsync_SendCloseMessageType_ThrowsArgumentExceptionWithMessage(Uri server)
         {
@@ -77,6 +79,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendAsync_MultipleOutstandingSendOperations_Throws(Uri server)
         {
@@ -134,6 +137,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ReceiveAsync_MultipleOutstandingReceiveOperations_Throws(Uri server)
         {
@@ -195,6 +199,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendAsync_SendZeroLengthPayloadAsEndOfMessage_Success(Uri server)
         {
@@ -230,6 +235,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendReceive_VaryingLengthBuffers_Success(Uri server)
         {
@@ -267,6 +273,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendReceive_Concurrent_Success(Uri server)
         {


### PR DESCRIPTION
Lately, the CI system and test server infrastructure has been overloaded with many PRs. This is causing many networking tests to randomly fail due to resource exhaustion caused by so many simultaneous PR runs on the same CI machines. This occurrs not only when using an external test server endpoint (corefx-net.cloudapp.net) but also loopback servers.

To improve engineering efficiency for the team, we are moving most of the tests in the networking libraries from the default CI runs (innerloop). For developers working on networking libraries, the networking tests can be run by invoking the "outerloop" tests.

We will not be allowing any merges of PRs in the networking libraries unless the outerloop tests are also run by the developer.

This affects tests in the following libraries right now:
- System.Net.Http
- System.Net.Http.WinHttpHandler
- System.Net.Sockets
- System.Net.Security
- System.Net.WebSockets.Client

I will be working on fine tuning these exclusions (issue https://github.com/dotnet/runtime/issues/18406) to try to bring back tests into the innerloop runs when we have begun to address the infrastructure issues.
