### PR TITLE
fix #11309 in WebSockets by throwing when the underlying connection is closed

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -615,12 +615,7 @@ namespace System.Net.WebSockets
                             // Make sure we have the first two bytes, which includes the start of the payload length.
                             if (_receiveBufferCount < 2)
                             {
-                                await EnsureBufferContainsAsync(2, cancellationToken, throwOnPrematureClosure: false).ConfigureAwait(false);
-                                if (_receiveBufferCount < 2)
-                                {
-                                    // The connection closed; nothing more to read.
-                                    return new WebSocketReceiveResult(0, WebSocketMessageType.Text, true);
-                                }
+                                await EnsureBufferContainsAsync(2, cancellationToken, throwOnPrematureClosure: true).ConfigureAwait(false);
                             }
 
                             // Then make sure we have the full header based on the payload length.


### PR DESCRIPTION
/cc @stephentoub @Tratcher @moozzyk 

Fixes #11309 

The `if` clause is also no longer needed because the only way it could be triggered is if `EnsureBufferContainsAsync` completed successfully but hadn't read enough data (which only occurs when `throwOnPrematureClosure` is `true`).