### PR TITLE
Move some flaky FSW tests to Outerloop

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Create.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Create.cs
@@ -45,34 +45,22 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [OuterLoop]
         public void FileSystemWatcher_Directory_Create_DeepDirectoryStructure()
         {
-            // List of created directories
-            List<TempDirectory> lst = new List<TempDirectory>();
-
-            using (var testDirectory = new TempDirectory(GetTestFilePath()))
-            using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))
-            using (var watcher = new FileSystemWatcher(Path.GetFullPath(dir.Path), "*"))
+            using (var dir = new TempDirectory(GetTestFilePath()))
+            using (var deepDir = new TempDirectory(Path.Combine(dir.Path, "dir", "dir", "dir", "dir", "dir", "dir", "dir")))
+            using (var watcher = new FileSystemWatcher(dir.Path, "*"))
             {
                 watcher.IncludeSubdirectories = true;
                 watcher.NotifyFilter = NotifyFilters.DirectoryName;
 
-                // Priming directory
-                lst.Add(new TempDirectory(Path.Combine(dir.Path, "dir")));
+                // Put a directory at the very bottom and expect it to raise an event
+                string dirPath = Path.Combine(deepDir.Path, "leafdir");
+                Action action = () => Directory.CreateDirectory(dirPath);
+                Action cleanup = () => Directory.Delete(dirPath);
 
-                // Create a deep directory structure and expect things to work
-                for (int i = 1; i < 20; i++)
-                {
-                    // Test that the creation triggers an event correctly
-                    string dirPath = Path.Combine(lst[i - 1].Path, String.Format("dir{0}", i));
-                    Action action = () => Directory.CreateDirectory(dirPath);
-                    Action cleanup = () => Directory.Delete(dirPath);
-
-                    ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup);
-
-                    // Create the directory so subdirectories may be created from it.
-                    lst.Add(new TempDirectory(dirPath));
-                }
+                ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup, dirPath, timeout: 10000);
             }
         }
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Delete.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Delete.cs
@@ -48,35 +48,23 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [OuterLoop]
         public void FileSystemWatcher_Directory_Delete_DeepDirectoryStructure()
         {
-            // List of created directories
-            List<TempDirectory> lst = new List<TempDirectory>();
-
-            using (var testDirectory = new TempDirectory(GetTestFilePath()))
-            using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))
+            using (var dir = new TempDirectory(GetTestFilePath()))
+            using (var deepDir = new TempDirectory(Path.Combine(dir.Path, "dir", "dir", "dir", "dir", "dir", "dir", "dir")))
             using (var watcher = new FileSystemWatcher(dir.Path, "*"))
             {
                 watcher.IncludeSubdirectories = true;
                 watcher.NotifyFilter = NotifyFilters.DirectoryName;
 
-                // Priming directory
-                lst.Add(new TempDirectory(Path.Combine(dir.Path, "dir")));
+                // Put a directory at the very bottom and expect it to raise an event
+                string dirPath = Path.Combine(deepDir.Path, "leafdir");
+                Action action = () => Directory.Delete(dirPath);
+                Action cleanup = () => Directory.CreateDirectory(dirPath);
+                cleanup();
 
-                // Create a deep directory structure and expect things to work
-                for (int i = 1; i < 20; i++)
-                {
-                    // Test that the creation triggers an event correctly
-                    string dirPath = Path.Combine(lst[i - 1].Path, String.Format("dir{0}", i));
-                    Action action = () => Directory.Delete(dirPath);
-                    Action cleanup = () => Directory.CreateDirectory(dirPath);
-                    cleanup();
-
-                    ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup);
-
-                    // Create the directory so subdirectories may be created from it.
-                    lst.Add(new TempDirectory(dirPath));
-                }
+                ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup, dirPath, timeout: 10000);
             }
         }
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
@@ -66,7 +66,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue(8410, PlatformID.Linux)]
+        [OuterLoop]
         public void FileSystemWatcher_File_Create_DeepDirectoryStructure()
         {
             using (var dir = new TempDirectory(GetTestFilePath()))
@@ -81,7 +81,7 @@ namespace System.IO.Tests
                 Action action = () => File.Create(fileName).Dispose();
                 Action cleanup = () => File.Delete(fileName);
 
-                ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup, fileName);
+                ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup, fileName, timeout: 10000);
             }
         }
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
@@ -69,34 +69,23 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue(8410, PlatformID.Linux)]
+        [OuterLoop]
         public void FileSystemWatcher_File_Delete_DeepDirectoryStructure()
         {
-            // List of created directories
-            List<TempDirectory> lst = new List<TempDirectory>();
-
-            using (var testDirectory = new TempDirectory(GetTestFilePath()))
-            using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))
+            using (var dir = new TempDirectory(GetTestFilePath()))
+            using (var deepDir = new TempDirectory(Path.Combine(dir.Path, "dir", "dir", "dir", "dir", "dir", "dir", "dir")))
             using (var watcher = new FileSystemWatcher(dir.Path, "*"))
             {
                 watcher.IncludeSubdirectories = true;
                 watcher.NotifyFilter = NotifyFilters.FileName;
 
-                // Create a deep directory structure
-                lst.Add(new TempDirectory(Path.Combine(dir.Path, "dir")));
-                for (int i = 1; i < 20; i++)
-                {
-                    string dirPath = Path.Combine(lst[i - 1].Path, String.Format("dir{0}", i));
-                    lst.Add(new TempDirectory(dirPath));
-                }
-
                 // Put a file at the very bottom and expect it to raise an event
-                string fileName = Path.Combine(lst[lst.Count - 1].Path, "file");
+                string fileName = Path.Combine(deepDir.Path, "file");
                 Action action = () => File.Delete(fileName);
                 Action cleanup = () => File.Create(fileName).Dispose();
                 cleanup();
 
-                ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup, fileName);
+                ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup, fileName, timeout: 10000);
             }
         }
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
@@ -126,6 +126,7 @@ namespace System.IO.Tests
         }
 
         [Theory]
+        [OuterLoop]
         [InlineData(WatcherChangeTypes.Created)]
         [InlineData(WatcherChangeTypes.Deleted)]
         public void CreatedDeleted_Success(WatcherChangeTypes changeType)
@@ -154,6 +155,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [OuterLoop]
         public void Changed_Success()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -178,6 +180,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [OuterLoop]
         public void Renamed_Success()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -575,6 +575,7 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.Linux)]
+        [OuterLoop]
         public void FileSystemWatcher_CreateManyConcurrentWatches()
         {
             int maxUserWatches = int.Parse(File.ReadAllText("/proc/sys/fs/inotify/max_user_watches"));

--- a/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -141,9 +141,9 @@ namespace System.IO.Tests
         /// <param name="cleanup">Optional. Undoes the action and cleans up the watcher so the test may be run again if necessary.</param>
         /// <param name="expectedPath">Optional. Adds path verification to all expected events.</param>
         /// <param name="attempts">Optional. Number of times the test should be executed if it's failing.</param>
-        public static void ExpectEvent(FileSystemWatcher watcher, WatcherChangeTypes expectedEvents, Action action, Action cleanup = null, string expectedPath = null, int attempts = DefaultAttemptsForExpectedEvent)
+        public static void ExpectEvent(FileSystemWatcher watcher, WatcherChangeTypes expectedEvents, Action action, Action cleanup = null, string expectedPath = null, int attempts = DefaultAttemptsForExpectedEvent, int timeout = WaitForExpectedEventTimeout)
         {
-            ExpectEvent(watcher, expectedEvents, action, cleanup, expectedPath == null ? null : new string[] { expectedPath }, attempts);
+            ExpectEvent(watcher, expectedEvents, action, cleanup, expectedPath == null ? null : new string[] { expectedPath }, attempts, timeout);
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace System.IO.Tests
         /// <param name="cleanup">Optional. Undoes the action and cleans up the watcher so the test may be run again if necessary.</param>
         /// <param name="expectedPath">Optional. Adds path verification to all expected events.</param>
         /// <param name="attempts">Optional. Number of times the test should be executed if it's failing.</param>
-        public static void ExpectEvent(FileSystemWatcher watcher, WatcherChangeTypes expectedEvents, Action action, Action cleanup = null, string[] expectedPaths = null, int attempts = DefaultAttemptsForExpectedEvent)
+        public static void ExpectEvent(FileSystemWatcher watcher, WatcherChangeTypes expectedEvents, Action action, Action cleanup = null, string[] expectedPaths = null, int attempts = DefaultAttemptsForExpectedEvent, int timeout = WaitForExpectedEventTimeout)
         {
             int attemptsCompleted = 0;
             bool result = false;
@@ -179,7 +179,7 @@ namespace System.IO.Tests
                     Thread.Sleep(500); 
                 }
 
-                result = ExecuteAndVerifyEvents(watcher, expectedEvents, action, attemptsCompleted == attempts, expectedPaths);
+                result = ExecuteAndVerifyEvents(watcher, expectedEvents, action, attemptsCompleted == attempts, expectedPaths, timeout);
 
                 if (cleanup != null)
                     cleanup();
@@ -195,7 +195,7 @@ namespace System.IO.Tests
         /// <param name="assertExpected">True if results should be asserted. Used if there is no retry.</param>
         /// <param name="expectedPath"> Adds path verification to all expected events.</param>
         /// <returns>True if the events raised correctly; else, false.</returns>
-        private static bool ExecuteAndVerifyEvents(FileSystemWatcher watcher, WatcherChangeTypes expectedEvents, Action action, bool assertExpected, string[] expectedPaths)
+        private static bool ExecuteAndVerifyEvents(FileSystemWatcher watcher, WatcherChangeTypes expectedEvents, Action action, bool assertExpected, string[] expectedPaths, int timeout)
         {
             bool result = true, verifyChanged = true, verifyCreated = true, verifyDeleted = true, verifyRenamed = true;
             AutoResetEvent changed = null, created = null, deleted = null, renamed = null;
@@ -229,7 +229,7 @@ namespace System.IO.Tests
             if (verifyChanged)
             {
                 bool Changed_expected = ((expectedEvents & WatcherChangeTypes.Changed) > 0);
-                bool Changed_actual = changed.WaitOne(WaitForExpectedEventTimeout);
+                bool Changed_actual = changed.WaitOne(timeout);
                 result = Changed_expected == Changed_actual;
                 if (assertExpected)
                     Assert.True(Changed_expected == Changed_actual, "Changed event did not occur as expected");
@@ -239,7 +239,7 @@ namespace System.IO.Tests
             if (verifyCreated)
             {
                 bool Created_expected = ((expectedEvents & WatcherChangeTypes.Created) > 0);
-                bool Created_actual = created.WaitOne(verifyChanged ? SubsequentExpectedWait : WaitForExpectedEventTimeout);
+                bool Created_actual = created.WaitOne(verifyChanged ? SubsequentExpectedWait : timeout);
                 result = result && Created_expected == Created_actual;
                 if (assertExpected)
                     Assert.True(Created_expected == Created_actual, "Created event did not occur as expected");
@@ -249,7 +249,7 @@ namespace System.IO.Tests
             if (verifyDeleted)
             {
                 bool Deleted_expected = ((expectedEvents & WatcherChangeTypes.Deleted) > 0);
-                bool Deleted_actual = deleted.WaitOne(verifyChanged || verifyCreated ? SubsequentExpectedWait : WaitForExpectedEventTimeout);
+                bool Deleted_actual = deleted.WaitOne(verifyChanged || verifyCreated ? SubsequentExpectedWait : timeout);
                 result = result && Deleted_expected == Deleted_actual;
                 if (assertExpected)
                     Assert.True(Deleted_expected == Deleted_actual, "Deleted event did not occur as expected");
@@ -259,7 +259,7 @@ namespace System.IO.Tests
             if (verifyRenamed)
             {
                 bool Renamed_expected = ((expectedEvents & WatcherChangeTypes.Renamed) > 0);
-                bool Renamed_actual = renamed.WaitOne(verifyChanged || verifyCreated  || verifyDeleted? SubsequentExpectedWait : WaitForExpectedEventTimeout);
+                bool Renamed_actual = renamed.WaitOne(verifyChanged || verifyCreated  || verifyDeleted? SubsequentExpectedWait : timeout);
                 result = result && Renamed_expected == Renamed_actual;
                 if (assertExpected)
                     Assert.True(Renamed_expected == Renamed_actual, "Renamed event did not occur as expected");


### PR DESCRIPTION
All of the FSW tests are potentially subject to intermittent failures because of the inherent flakiness of the underlying OS file system watching APIs. Although we do some manual stuff to get around that flakiness (e.g. retries, long timeouts), some scenarios aren't reliable enough to make it through. This commit moves those to Outerloop so they don't get in the way of our gated check in tests.

resolves https://github.com/dotnet/corefx/issues/8916, https://github.com/dotnet/corefx/issues/10873