### PR TITLE
Uses uint.MaxValue for 32-bit arch

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
@@ -115,7 +115,7 @@ namespace System.IO.MemoryMappedFiles.Tests
             // on what backing store is being used.
             Assert.Throws<IOException>(() =>
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, long.MaxValue))
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, (IntPtr.Size == 4) ? uint.MaxValue : long.MaxValue))
                 {
                     mmf.CreateViewAccessor().Dispose();
                 }


### PR DESCRIPTION
This commit uses ``uint.MaxValue`` instead of  ``long.MaxValue`` for 32-bit arch when running 'System.IO.MemoryMappedFiles.Tests.MemoryMappedFileTests_CreateNew.TooLargeCapacity_Unix' test in order to fix #11368.