### PR TITLE
Fix FileStreamBase Begin/End race condition

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileStreamBase.NetStandard17.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStreamBase.NetStandard17.cs
@@ -21,7 +21,7 @@ namespace System.IO
             if (array.Length - offset < numBytes)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
-            if (SafeFileHandle.IsClosed) throw new ObjectDisposedException(SR.ObjectDisposed_FileClosed);
+            if (IsClosed) throw new ObjectDisposedException(SR.ObjectDisposed_FileClosed);
             if (!CanRead) throw new NotSupportedException(SR.NotSupported_UnreadableStream);
 
             if (!IsAsync)
@@ -41,7 +41,7 @@ namespace System.IO
             if (array.Length - offset < numBytes)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
-            if (SafeFileHandle.IsClosed) throw new ObjectDisposedException(SR.ObjectDisposed_FileClosed);
+            if (IsClosed) throw new ObjectDisposedException(SR.ObjectDisposed_FileClosed);
             if (!CanWrite) throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
             if (!IsAsync)

--- a/src/System.IO.FileSystem/src/System/IO/FileStreamBase.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStreamBase.cs
@@ -25,6 +25,7 @@ namespace System.IO
         public abstract bool IsAsync { get; }
         public abstract string Name { get; }
         public abstract SafeFileHandle SafeFileHandle { get; }
+        internal abstract bool IsClosed { get; }
 
         public abstract void Flush(bool flushToDisk);
     }

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -359,6 +359,8 @@ namespace System.IO
             }
         }
 
+        internal override bool IsClosed => _fileHandle.IsClosed;
+
         /// <summary>Gets or sets the position within the current stream</summary>
         public override long Position
         {

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
@@ -601,6 +601,8 @@ namespace System.IO
             }
         }
 
+        internal override bool IsClosed => _handle.IsClosed;
+
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override void SetLength(long value)
         {

--- a/src/System.IO.FileSystem/src/System/IO/WinRTFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/WinRTFileStream.cs
@@ -41,6 +41,7 @@ namespace System.IO
         public override bool IsAsync { get { return true; } }
         public override string Name { get { return _file.Name; } }
         public override Microsoft.Win32.SafeHandles.SafeFileHandle SafeFileHandle { get { return s_invalidHandle; } }
+        internal override bool IsClosed => false;
 
         public override void Flush(bool flushToDisk)
         {

--- a/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -364,7 +364,10 @@ namespace System.IO.Tests
 
             byte[] actualData = File.ReadAllBytes(path);
             Assert.Equal(expectedData.Length, actualData.Length);
-            Assert.Equal<byte>(expectedData, actualData);
+            if (useAsync)
+            {
+                Assert.Equal<byte>(expectedData, actualData);
+            }
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -61,8 +61,7 @@
     <Compile Include="FileStream\Buffering_regression.cs" />
     <Compile Include="FileStream\Flush.cs" />
     <Compile Include="FileStream\Dispose.cs" />
-    <!-- Disable the FileStream.WriteAsync tests for netcoreapp1.1 since one of them is failing. Issue: https://github.com/dotnet/corefx/issues/11303 -->
-    <Compile Condition="'$(TargetGroup)'!='netstandard1.7'" Include="FileStream\WriteAsync.cs" />
+    <Compile Include="FileStream\WriteAsync.cs" />
     <Compile Include="FileStream\Write.cs" />
     <Compile Include="FileStream\ToString.cs" />
     <Compile Include="FileStream\WriteByte.cs" />


### PR DESCRIPTION
The new FileStreamBase.Begin/End overloads do argument and state validation similar to that of desktop.  There is a subtle but critical difference, however: in this validation, desktop checks to see whether the stream is closed via ```_handle.IsClosed```, whereas FileStreamBase does it via ```SafeFileHandle.IsClosed```.  ```SafeFileHandle``` is an abstract property that returns the handle... but it also flushes.  The base Stream's Begin/End implementation has synchronization to ensure that only one async operation is in flight at a time, but this call to ```SafeFileHandle.IsClosed``` comes before that synchronization kicks in (it's in the base), and as such we end up potentially having a Flush invocations concurrently with Write invocations (Write is called asynchronously from the base BeginWrite), which is very unsafe.

This commit fixes it by adding an IsClosed property that goes directly to the underlying handle, bypassing the publicly exposed SafeFileHandle (that flushes so that direct access to the file via the handle is consistent with operations already performed on the FileStream).

(I also fixed a small issue in the ManyConcurrentWriteAsyncs that highlighted the issue.  Order of async read/write operations is only guaranteed on FileStream when in async mode; in non-async mode, it's theoretically possible (though unlikely) for operations to complete out-of-order, but the test is validating that the operations completed in order.  While I've never seen this fail, I'm proactively fixing it.)

Fixes https://github.com/dotnet/corefx/issues/11303
cc: @JeremyKuhne, @joperezr, @ericstj