### PR TITLE
Add a help job to corefx

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -457,3 +457,8 @@ def osShortName = ['Windows 10': 'win10',
 }
 
 JobReport.Report.generateJobReport(out)
+
+// Make the call to generate the help job
+Utilities.createHelperJob(this, project, branch,
+    "Welcome to the ${project} Repository",  // This is prepended to the help message
+    "Have a nice day!")  // This is appended to the help message.  You might put known issues here.


### PR DESCRIPTION
This adds a help job to corefx.  commenting @dotnet-bot help on a PR will trigger the help job