### PR TITLE
Fix CookieContainer dead code masquerading as a race condition

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -99,7 +99,7 @@ namespace System.Net
         };
 
         // NOTE: all accesses of _domainTable must be performed with _domainTable locked.
-        private Dictionary<string, PathList> _domainTable = new Dictionary<string, PathList>();
+        private readonly Dictionary<string, PathList> _domainTable = new Dictionary<string, PathList>();
         private int _maxCookieSize = DefaultCookieLengthLimit;
         private int _maxCookies = DefaultCookieLimit;
         private int _maxCookiesPerDomain = DefaultPerDomainCookieLimit;
@@ -356,13 +356,8 @@ namespace System.Net
         // Param. 'domain' == null means to age in the whole container.
         private bool AgeCookies(string domain)
         {
-            // Border case: shrunk to zero
-            if (_maxCookies == 0 || _maxCookiesPerDomain == 0)
-            {
-                _domainTable = new Dictionary<string, PathList>();
-                _count = 0;
-                return false;
-            }
+            Debug.Assert(_maxCookies != 0);
+            Debug.Assert(_maxCookiesPerDomain != 0);
 
             int removed = 0;
             DateTime oldUsed = DateTime.MaxValue;


### PR DESCRIPTION
A coverity scan suggested that _domainTable might be unsafe to be locked on, as it's replaced.  But closer inspection shows that it's only re-assigned to in code that's actually dead, as the condition guarding the if block containing the assignment will never be true.  This commit just replaces the dead code with some asserts and makes the lockable field readonly so as to highlight that it won't change.

cc: @davidsh, @cipop, @ericeil