### PR TITLE
Fix WinHttpHandler for Basic auth with default credentials

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -311,6 +311,22 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
+        public async Task GetAsync_ServerNeedsBasicAuthAndSetDefaultCredentials_StatusCodeUnauthorized()
+        {
+            var handler = new HttpClientHandler();
+            handler.Credentials = CredentialCache.DefaultCredentials;
+            using (var client = new HttpClient(handler))
+            {
+                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure:false, userName:Username, password:Password);
+                using (HttpResponseMessage response = await client.GetAsync(uri))
+                {
+                    Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                }
+            }
+        }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
         public async Task GetAsync_ServerNeedsAuthAndSetCredential_StatusCodeOK()
         {
             var handler = new HttpClientHandler();


### PR DESCRIPTION
We were getting an error "The parameter is incorrect" from WinHTTP when we tried to invoke default credential handling even for cases where the server doesn't use Negotiate or NTLM. Negotiate and NTLM are the only schemes that can use default credentials since they need to be transmitted via a challenge-response mechanism.

The fix here is to only set WinHTTP default credentials handling for Negotiate or NTLM schemes. Otherwise, it should behave as-if there were no credentials set.

Fixes #11266