### PR TITLE
Remove unreachable throw statement

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -300,7 +300,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             return ctor;
-            throw Error.InternalCompilerError();
         }
 
         // property specific helpers


### PR DESCRIPTION
The compiler doesn't warn about this particular case: https://github.com/dotnet/roslyn/issues/9138

Found by a coverity scan

cc: @VSadov 