### PR TITLE
Fix specialized collections serialization tests

### DIFF
--- a/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Serialization.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Serialization.Tests.cs
@@ -18,6 +18,14 @@ namespace System.Collections.Tests
         public void IGenericSharedAPI_SerializeDeserialize(int count)
         {
             IEnumerable expected = NonGenericIEnumerableFactory(count);
+            if (!SupportsSerialization)
+            {
+                // No assert for !IsSerializable here, as some collections are only serializable sometimes,
+                // e.g. HybridDictionary.Keys is serializable when using Hashtable.Keys but not when
+                // using ListDictionary.Keys.
+                return;
+            }
+            Assert.True(expected.GetType().GetTypeInfo().IsSerializable, "Expected IsSerializable");
 
             var bf = new BinaryFormatter();
             using (var ms = new MemoryStream())

--- a/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Tests.cs
@@ -60,6 +60,11 @@ namespace System.Collections.Tests
         protected virtual bool Enumerator_Current_UndefinedOperation_Throws => false;
 
         /// <summary>
+        /// Whether the collection can be serialized.
+        /// </summary>
+        protected virtual bool SupportsSerialization => true;
+
+        /// <summary>
         /// Specifies whether this IEnumerable follows some sort of ordering pattern.
         /// </summary>
         protected virtual EnumerableOrder Order => EnumerableOrder.Sequential;

--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.KeysTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.KeysTests.cs
@@ -18,6 +18,7 @@ namespace System.Collections.Specialized.Tests
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
 
         protected override bool IsReadOnly => true;
+        protected override bool SupportsSerialization => false;
 
         protected override ICollection NonGenericICollectionFactory() => new HybridDictionary().Keys;
 

--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.ValuesTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.ValuesTests.cs
@@ -18,6 +18,7 @@ namespace System.Collections.Specialized.Tests
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
 
         protected override bool IsReadOnly => true;
+        protected override bool SupportsSerialization => false;
 
         protected override ICollection NonGenericICollectionFactory() => new HybridDictionary().Values;
 

--- a/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Keys.Tests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Keys.Tests.cs
@@ -20,6 +20,7 @@ namespace System.Collections.Specialized.Tests
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
 
         protected override bool IsReadOnly => true;
+        protected override bool SupportsSerialization => false;
 
         protected override ICollection NonGenericICollectionFactory() => new ListDictionary().Keys;
 

--- a/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Values.Tests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Values.Tests.cs
@@ -20,6 +20,7 @@ namespace System.Collections.Specialized.Tests
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
 
         protected override bool IsReadOnly => true;
+        protected override bool SupportsSerialization => false;
 
         protected override ICollection NonGenericICollectionFactory() => new ListDictionary().Values;
 

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -8,11 +8,6 @@
     <RootNamespace>System.Collections.Specialized.Tests</RootNamespace>
     <AssemblyName>System.Collections.Specialized.Tests</AssemblyName>
     <ProjectGuid>{7F5F5134-00FE-4DE8-B20C-3DA8BA2EBA68}</ProjectGuid>
-    <!--
-    TODO: Uncomment once a System.Collection.NonGeneric is published containing the serialization changes.
-          System.Collections.Specialized collections depend on those types being serializable.
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
-    -->
     <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
     <!-- 
         Until we get first class support for NS1.7 and Netcoreapp1.1 
@@ -113,13 +108,11 @@
       <Link>Common\System\SerializableAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <!-- Disabling the Serialization tests since they are currently failing for netcoreapp1.1 runs. Issue: https://github.com/dotnet/corefx/issues/11313
   <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs" >
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
     </Compile>
   </ItemGroup>
-  -->
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Collections.Specialized.pkgproj">
       <Project>{63634289-90d7-4947-8bf3-dbbe98d76c85}</Project>


### PR DESCRIPTION
Now that System.Collections.NonGeneric is published with serialization support, we can enable serialization tests for System.Collection.Specialized.

Fixes https://github.com/dotnet/corefx/issues/11313
cc: @joperezr 