### PR TITLE
Using TypeCode for ldind and stind emit

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -96,52 +96,46 @@ namespace System.Linq.Expressions.Compiler
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
 
-            if (type.GetTypeInfo().IsValueType)
+            switch (type.GetTypeCode())
             {
-                if (type == typeof(int))
-                {
+                case TypeCode.Int32:
                     il.Emit(OpCodes.Ldind_I4);
-                }
-                else if (type == typeof(uint))
-                {
+                    break;
+                case TypeCode.UInt32:
                     il.Emit(OpCodes.Ldind_U4);
-                }
-                else if (type == typeof(short))
-                {
+                    break;
+                case TypeCode.Int16:
                     il.Emit(OpCodes.Ldind_I2);
-                }
-                else if (type == typeof(ushort))
-                {
+                    break;
+                case TypeCode.UInt16:
                     il.Emit(OpCodes.Ldind_U2);
-                }
-                else if (type == typeof(long) || type == typeof(ulong))
-                {
+                    break;
+                case TypeCode.Int64:
+                case TypeCode.UInt64:
                     il.Emit(OpCodes.Ldind_I8);
-                }
-                else if (type == typeof(char))
-                {
+                    break;
+                case TypeCode.Char:
                     il.Emit(OpCodes.Ldind_I2);
-                }
-                else if (type == typeof(bool))
-                {
+                    break;
+                case TypeCode.Boolean:
                     il.Emit(OpCodes.Ldind_I1);
-                }
-                else if (type == typeof(float))
-                {
+                    break;
+                case TypeCode.Single:
                     il.Emit(OpCodes.Ldind_R4);
-                }
-                else if (type == typeof(double))
-                {
+                    break;
+                case TypeCode.Double:
                     il.Emit(OpCodes.Ldind_R8);
-                }
-                else
-                {
-                    il.Emit(OpCodes.Ldobj, type);
-                }
-            }
-            else
-            {
-                il.Emit(OpCodes.Ldind_Ref);
+                    break;
+                default:
+                    if (type.GetTypeInfo().IsValueType)
+                    {
+                        il.Emit(OpCodes.Ldobj, type);
+                    }
+                    else
+                    {
+                        il.Emit(OpCodes.Ldind_Ref);
+                    }
+                    break;
             }
         }
 
@@ -153,44 +147,40 @@ namespace System.Linq.Expressions.Compiler
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
 
-            if (type.GetTypeInfo().IsValueType)
+            switch (type.GetTypeCode())
             {
-                if (type == typeof(int))
-                {
+                case TypeCode.Int32:
                     il.Emit(OpCodes.Stind_I4);
-                }
-                else if (type == typeof(short))
-                {
+                    break;
+                case TypeCode.Int16:
                     il.Emit(OpCodes.Stind_I2);
-                }
-                else if (type == typeof(long) || type == typeof(ulong))
-                {
+                    break;
+                case TypeCode.Int64:
+                case TypeCode.UInt64:
                     il.Emit(OpCodes.Stind_I8);
-                }
-                else if (type == typeof(char))
-                {
+                    break;
+                case TypeCode.Char:
                     il.Emit(OpCodes.Stind_I2);
-                }
-                else if (type == typeof(bool))
-                {
+                    break;
+                case TypeCode.Boolean:
                     il.Emit(OpCodes.Stind_I1);
-                }
-                else if (type == typeof(float))
-                {
+                    break;
+                case TypeCode.Single:
                     il.Emit(OpCodes.Stind_R4);
-                }
-                else if (type == typeof(double))
-                {
+                    break;
+                case TypeCode.Double:
                     il.Emit(OpCodes.Stind_R8);
-                }
-                else
-                {
-                    il.Emit(OpCodes.Stobj, type);
-                }
-            }
-            else
-            {
-                il.Emit(OpCodes.Stind_Ref);
+                    break;
+                default:
+                    if (type.GetTypeInfo().IsValueType)
+                    {
+                        il.Emit(OpCodes.Stobj, type);
+                    }
+                    else
+                    {
+                        il.Emit(OpCodes.Stind_Ref);
+                    }
+                    break;
             }
         }
 

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -287,4 +287,13 @@ namespace System.Linq.Expressions.Tests
         public void GenericMethod<T>() { }
         public static void StaticMethod() { }
     }
+
+    public enum ByteEnum : byte { A = Byte.MaxValue }
+    public enum SByteEnum : sbyte { A = SByte.MaxValue }
+    public enum Int16Enum : short { A = Int16.MaxValue }
+    public enum UInt16Enum : ushort { A = UInt16.MaxValue }
+    public enum Int32Enum : int { A = Int32.MaxValue }
+    public enum UInt32Enum : uint { A = UInt32.MaxValue }
+    public enum Int64Enum : long { A = Int64.MaxValue }
+    public enum UInt64Enum : ulong { A = UInt64.MaxValue }
 }

--- a/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
@@ -120,6 +120,124 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(6, argument);
         }
 
+        public delegate T ByRefReadFunc<T>(ref T arg);
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public void CanReadFromRefParameter(bool useInterpreter)
+        {
+            AssertCanReadFromRefParameter<byte>(byte.MaxValue, useInterpreter);
+            AssertCanReadFromRefParameter<sbyte>(sbyte.MaxValue, useInterpreter);
+            AssertCanReadFromRefParameter<short>(short.MaxValue, useInterpreter);
+            AssertCanReadFromRefParameter<ushort>(ushort.MaxValue, useInterpreter);
+            AssertCanReadFromRefParameter<int>(int.MaxValue, useInterpreter);
+            AssertCanReadFromRefParameter<uint>(uint.MaxValue, useInterpreter);
+            AssertCanReadFromRefParameter<long>(long.MaxValue, useInterpreter);
+            AssertCanReadFromRefParameter<ulong>(ulong.MaxValue, useInterpreter);
+
+            AssertCanReadFromRefParameter<decimal>(49.94m, useInterpreter);
+            AssertCanReadFromRefParameter<float>(3.1415926535897931f, useInterpreter);
+            AssertCanReadFromRefParameter<double>(2.7182818284590451, useInterpreter);
+
+            AssertCanReadFromRefParameter('a', useInterpreter);
+
+            AssertCanReadFromRefParameter(ByteEnum.A, useInterpreter);
+            AssertCanReadFromRefParameter(SByteEnum.A, useInterpreter);
+            AssertCanReadFromRefParameter(Int16Enum.A, useInterpreter);
+            AssertCanReadFromRefParameter(UInt16Enum.A, useInterpreter);
+            AssertCanReadFromRefParameter(Int32Enum.A, useInterpreter);
+            AssertCanReadFromRefParameter(UInt32Enum.A, useInterpreter);
+            AssertCanReadFromRefParameter(Int64Enum.A, useInterpreter);
+            AssertCanReadFromRefParameter(UInt64Enum.A, useInterpreter);
+
+            AssertCanReadFromRefParameter(new DateTime(1983, 2, 11), useInterpreter);
+
+            AssertCanReadFromRefParameter<object>(null, useInterpreter);
+            AssertCanReadFromRefParameter<object>(new object(), useInterpreter);
+            AssertCanReadFromRefParameter<string>("bar", useInterpreter);
+
+            AssertCanReadFromRefParameter<int?>(null, useInterpreter);
+            AssertCanReadFromRefParameter<int?>(int.MaxValue, useInterpreter);
+            AssertCanReadFromRefParameter<Int64Enum?>(null, useInterpreter);
+            AssertCanReadFromRefParameter<Int64Enum?>(Int64Enum.A, useInterpreter);
+            AssertCanReadFromRefParameter<DateTime?>(null, useInterpreter);
+            AssertCanReadFromRefParameter<DateTime?>(new DateTime(1983, 2, 11), useInterpreter);
+        }
+
+        private void AssertCanReadFromRefParameter<T>(T value, bool useInterpreter)
+        {
+            ParameterExpression @ref = Expression.Parameter(typeof(T).MakeByRefType());
+
+            ByRefReadFunc<T> f =
+                Expression.Lambda<ByRefReadFunc<T>>(
+                    @ref,
+                    @ref
+                ).Compile(useInterpreter);
+
+            Assert.Equal(value, f(ref value));
+        }
+
+        public delegate void ByRefWriteAction<T>(ref T arg, T value);
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public void CanWriteToRefParameter(bool useInterpreter)
+        {
+            AssertCanWriteToRefParameter<byte>(byte.MaxValue, useInterpreter);
+            AssertCanWriteToRefParameter<sbyte>(sbyte.MaxValue, useInterpreter);
+            AssertCanWriteToRefParameter<short>(short.MaxValue, useInterpreter);
+            AssertCanWriteToRefParameter<ushort>(ushort.MaxValue, useInterpreter);
+            AssertCanWriteToRefParameter<int>(int.MaxValue, useInterpreter);
+            AssertCanWriteToRefParameter<uint>(uint.MaxValue, useInterpreter);
+            AssertCanWriteToRefParameter<long>(long.MaxValue, useInterpreter);
+            AssertCanWriteToRefParameter<ulong>(ulong.MaxValue, useInterpreter);
+
+            AssertCanWriteToRefParameter<decimal>(49.94m, useInterpreter);
+            AssertCanWriteToRefParameter<float>(3.1415926535897931f, useInterpreter);
+            AssertCanWriteToRefParameter<double>(2.7182818284590451, useInterpreter);
+
+            AssertCanWriteToRefParameter('a', useInterpreter);
+
+            AssertCanWriteToRefParameter(ByteEnum.A, useInterpreter);
+            AssertCanWriteToRefParameter(SByteEnum.A, useInterpreter);
+            AssertCanWriteToRefParameter(Int16Enum.A, useInterpreter);
+            AssertCanWriteToRefParameter(UInt16Enum.A, useInterpreter);
+            AssertCanWriteToRefParameter(Int32Enum.A, useInterpreter);
+            AssertCanWriteToRefParameter(UInt32Enum.A, useInterpreter);
+            AssertCanWriteToRefParameter(Int64Enum.A, useInterpreter);
+            AssertCanWriteToRefParameter(UInt64Enum.A, useInterpreter);
+
+            AssertCanWriteToRefParameter(new DateTime(1983, 2, 11), useInterpreter);
+
+            AssertCanWriteToRefParameter<object>(null, useInterpreter);
+            AssertCanWriteToRefParameter<object>(new object(), useInterpreter);
+            AssertCanWriteToRefParameter<string>("bar", useInterpreter);
+
+            AssertCanWriteToRefParameter<int?>(null, useInterpreter, original: 42);
+            AssertCanWriteToRefParameter<int?>(int.MaxValue, useInterpreter);
+            AssertCanWriteToRefParameter<Int64Enum?>(null, useInterpreter, original: Int64Enum.A);
+            AssertCanWriteToRefParameter<Int64Enum?>(Int64Enum.A, useInterpreter);
+            AssertCanWriteToRefParameter<DateTime?>(null, useInterpreter, original: new DateTime(1983, 2, 11));
+            AssertCanWriteToRefParameter<DateTime?>(new DateTime(1983, 2, 11), useInterpreter);
+        }
+
+        private void AssertCanWriteToRefParameter<T>(T value, bool useInterpreter, T original = default(T))
+        {
+            ParameterExpression @ref = Expression.Parameter(typeof(T).MakeByRefType());
+            ParameterExpression val = Expression.Parameter(typeof(T));
+
+            ByRefWriteAction<T> f = 
+                Expression.Lambda<ByRefWriteAction<T>>(
+                    Expression.Assign(@ref, val),
+                    @ref, val
+                ).Compile(useInterpreter);
+
+            T res = original;
+            f(ref res, value);
+
+            Assert.Equal(res, value);
+        }
+
         [Fact]
         public void CannotReduce()
         {


### PR DESCRIPTION
This is part of issue #11328 on re-introducing `Type.GetTypeCode()`. However, it doesn't seem that member is already exposed for use on our side (need to confirm whether that's the plan). In the meantime, this PR simplified the code to emit `Ldind` and `Stind` instructions by using a `switch` over `TypeCode` values. It also adds a bunch of tests; only the `Int32` case was covered before.