### PR TITLE
Conditional compilation of MethodBuilder support in LambdaCompiler

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -432,9 +432,6 @@
   <data name="UnhandledConvert" xml:space="preserve">
     <value>Unhandled convert: {0}</value>
   </data>
-  <data name="UnhandledExpressionType" xml:space="preserve">
-    <value>Unhandled Expression Type: {0}</value>
-  </data>
   <data name="UnhandledUnary" xml:space="preserve">
     <value>Unhandled unary: {0}</value>
   </data>
@@ -560,9 +557,6 @@
   </data>
   <data name="EnumerationIsDone" xml:space="preserve">
     <value>Enumeration has either not started or has already finished.</value>
-  </data>
-  <data name="HomogeneousAppDomainRequired" xml:space="preserve">
-    <value>Dynamic operations can only be performed in homogeneous AppDomain.</value>
   </data>
   <data name="TestValueTypeDoesNotMatchComparisonMethodParameter" xml:space="preserve">
     <value>Test value of type '{0}' cannot be used for the comparison method parameter of type '{1}'</value>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/BoundConstants.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/BoundConstants.cs
@@ -101,10 +101,12 @@ namespace System.Linq.Expressions.Compiler
         {
             Debug.Assert(!ILGen.CanEmitConstant(value, type));
 
+#if FEATURE_COMPILE_TO_METHODBUILDER
             if (!lc.CanEmitBoundConstants)
             {
                 throw Error.CannotCompileConstant(value);
             }
+#endif
 
             LocalBuilder local;
             if (_cache.TryGetValue(new TypedConstant(value, type), out local))
@@ -125,10 +127,12 @@ namespace System.Linq.Expressions.Compiler
             int count = 0;
             foreach (var reference in _references)
             {
+#if FEATURE_COMPILE_TO_METHODBUILDER
                 if (!lc.CanEmitBoundConstants)
                 {
                     throw Error.CannotCompileConstant(reference.Key.Value);
                 }
+#endif
 
                 if (ShouldCache(reference.Value))
                 {
@@ -172,7 +176,9 @@ namespace System.Linq.Expressions.Compiler
 
         private static void EmitConstantsArray(LambdaCompiler lc)
         {
+#if FEATURE_COMPILE_TO_METHODBUILDER
             Debug.Assert(lc.CanEmitBoundConstants); // this should've been checked already
+#endif
 
             lc.EmitClosureArgument();
             lc.IL.Emit(OpCodes.Ldfld, typeof(Closure).GetField("Constants"));

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -565,10 +565,14 @@ namespace System.Linq.Expressions.Compiler
 
         private void EmitDynamicExpression(Expression expr)
         {
+#if FEATURE_COMPILE_TO_METHODBUILDER
             if (!(_method is DynamicMethod))
             {
                 throw Error.CannotCompileDynamic();
             }
+#else
+            Debug.Assert(_method is DynamicMethod);
+#endif
 
             var node = (IDynamicExpression)expr;
 
@@ -917,7 +921,7 @@ namespace System.Linq.Expressions.Compiler
             throw Error.ExtensionNotReduced();
         }
 
-        #region ListInit, MemberInit
+#region ListInit, MemberInit
 
         private void EmitListInitExpression(Expression expr)
         {
@@ -1107,9 +1111,9 @@ namespace System.Linq.Expressions.Compiler
             throw Error.MemberNotFieldOrProperty(member, nameof(member));
         }
 
-        #endregion
+#endregion
 
-        #region Expression helpers
+#region Expression helpers
 
         internal static void ValidateLift(IList<ParameterExpression> variables, IList<Expression> arguments)
         {
@@ -1306,6 +1310,6 @@ namespace System.Linq.Expressions.Compiler
             }
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -723,13 +723,6 @@ namespace System.Linq.Expressions
             return new ArgumentException(Strings.UnhandledConvert(p0));
         }
         /// <summary>
-        /// ArgumentException with message like "Unhandled Expression Type: {0}"
-        /// </summary>
-        internal static Exception UnhandledExpressionType(object p0)
-        {
-            return new ArgumentException(Strings.UnhandledExpressionType(p0));
-        }
-        /// <summary>
         /// ArgumentException with message like "Unhandled unary: {0}"
         /// </summary>
         internal static Exception UnhandledUnary(object p0)
@@ -890,6 +883,7 @@ namespace System.Linq.Expressions
         {
             return new InvalidOperationException(Strings.ExtensionNotReduced);
         }
+#if FEATURE_COMPILE_TO_METHODBUILDER
         /// <summary>
         /// InvalidOperationException with message like "CompileToMethod cannot compile constant '{0}' because it is a non-trivial value, such as a live object. Instead, create an expression tree that can construct this value."
         /// </summary>
@@ -904,6 +898,14 @@ namespace System.Linq.Expressions
         {
             return new NotSupportedException(Strings.CannotCompileDynamic);
         }
+        /// <summary>
+        /// ArgumentException with message like "MethodBuilder does not have a valid TypeBuilder"
+        /// </summary>
+        internal static Exception MethodBuilderDoesNotHaveTypeBuilder()
+        {
+            return new ArgumentException(Strings.MethodBuilderDoesNotHaveTypeBuilder);
+        }
+#endif
         /// <summary>
         /// InvalidOperationException with message like "Invalid lvalue for assignment: {0}."
         /// </summary>
@@ -1004,13 +1006,6 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// InvalidOperationException with message like "Dynamic operations can only be performed in homogeneous AppDomain."
-        /// </summary>
-        internal static Exception HomogeneousAppDomainRequired()
-        {
-            return new InvalidOperationException(Strings.HomogeneousAppDomainRequired);
-        }
-        /// <summary>
         /// ArgumentException with message like "Test value of type '{0}' cannot be used for the comparison method parameter of type '{1}'"
         /// </summary>
         internal static Exception TestValueTypeDoesNotMatchComparisonMethodParameter(object p0, object p1)
@@ -1024,6 +1019,8 @@ namespace System.Linq.Expressions
         {
             return new ArgumentException(Strings.SwitchValueTypeDoesNotMatchComparisonMethodParameter(p0, p1));
         }
+
+#if FEATURE_COMPILE_TO_METHODBUILDER && FEATURE_PDB_GENERATOR
         /// <summary>
         /// NotSupportedException with message like "DebugInfoGenerator created by CreatePdbGenerator can only be used with LambdaExpression.CompileToMethod."
         /// </summary>
@@ -1031,6 +1028,7 @@ namespace System.Linq.Expressions
         {
             return new NotSupportedException(Strings.PdbGeneratorNeedsExpressionCompiler);
         }
+#endif
 
         /// <summary>
         /// The exception that is thrown when the value of an argument is outside the allowable range of values as defined by the invoked method.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -2,16 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Dynamic.Utils;
-using System.Linq.Expressions.Compiler;
 using System.Reflection;
-using System.Threading;
-using System.Runtime.CompilerServices;
-using System.Linq.Expressions;
 
 namespace System.Linq.Expressions
 {
@@ -128,14 +123,31 @@ namespace System.Linq.Expressions
 #if FEATURE_INTERPRET
             if (preferInterpretation)
             {
-                return new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+                return new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
             }
 #endif
             return Compiler.LambdaCompiler.Compile(this);
 #else
-            return new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+            return new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
 #endif
         }
+
+#if FEATURE_COMPILE_TO_METHODBUILDER
+        /// <summary>
+        /// Compiles the lambda into a method definition.
+        /// </summary>
+        /// <param name="method">A <see cref="System.Reflection.Emit.MethodBuilder"/> which will be used to hold the lambda's IL.</param>
+        public void CompileToMethod(System.Reflection.Emit.MethodBuilder method)
+        {
+            ContractUtils.RequiresNotNull(method, nameof(method));
+            ContractUtils.Requires(method.IsStatic, nameof(method));
+            var type = method.DeclaringType.GetTypeInfo() as System.Reflection.Emit.TypeBuilder;
+            if (type == null) throw Error.MethodBuilderDoesNotHaveTypeBuilder();
+
+            Compiler.LambdaCompiler.Compile(this, method);
+        }
+#endif
+
 
 #if FEATURE_COMPILE
         internal abstract LambdaExpression Accept(Compiler.StackSpiller spiller);
@@ -177,12 +189,12 @@ namespace System.Linq.Expressions
 #if FEATURE_INTERPRET
             if (preferInterpretation)
             {
-                return (TDelegate)(object)new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+                return (TDelegate)(object)new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
             }
 #endif
             return (TDelegate)(object)Compiler.LambdaCompiler.Compile(this);
 #else
-            return (TDelegate)(object)new System.Linq.Expressions.Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+            return (TDelegate)(object)new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
 #endif
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -985,14 +985,6 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// A string like "Unhandled Expression Type: {0}"
-        /// </summary>
-        internal static string UnhandledExpressionType(object p0)
-        {
-            return SR.Format(SR.UnhandledExpressionType, p0);
-        }
-
-        /// <summary>
         /// A string like "Unhandled unary: {0}"
         /// </summary>
         internal static string UnhandledUnary(object p0)
@@ -1203,6 +1195,7 @@ namespace System.Linq.Expressions
             }
         }
 
+#if FEATURE_COMPILE_TO_METHODBUILDER
         /// <summary>
         /// A string like "CompileToMethod cannot compile constant '{0}' because it is a non-trivial value, such as a live object. Instead, create an expression tree that can construct this value."
         /// </summary>
@@ -1221,6 +1214,18 @@ namespace System.Linq.Expressions
                 return SR.CannotCompileDynamic;
             }
         }
+
+        /// <summary>
+        /// A string like "MethodBuilder does not have a valid TypeBuilder"
+        /// </summary>
+        internal static string MethodBuilderDoesNotHaveTypeBuilder
+        {
+            get
+            {
+                return SR.MethodBuilderDoesNotHaveTypeBuilder;
+            }
+        }
+#endif
 
         /// <summary>
         /// A string like "Invalid lvalue for assignment: {0}."
@@ -1341,17 +1346,6 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// A string like "Dynamic operations can only be performed in homogeneous AppDomain."
-        /// </summary>
-        internal static string HomogeneousAppDomainRequired
-        {
-            get
-            {
-                return SR.HomogeneousAppDomainRequired;
-            }
-        }
-
-        /// <summary>
         /// A string like "Test value of type '{0}' cannot be used for the comparison method parameter of type '{1}'"
         /// </summary>
         internal static string TestValueTypeDoesNotMatchComparisonMethodParameter(object p0, object p1)
@@ -1367,6 +1361,7 @@ namespace System.Linq.Expressions
             return SR.Format(SR.SwitchValueTypeDoesNotMatchComparisonMethodParameter, p0, p1);
         }
 
+#if FEATURE_COMPILE_TO_METHODBUILDER && FEATURE_PDB_GENERATOR
         /// <summary>
         /// A string like "DebugInfoGenerator created by CreatePdbGenerator can only be used with LambdaExpression.CompileToMethod."
         /// </summary>
@@ -1377,6 +1372,7 @@ namespace System.Linq.Expressions
                 return SR.PdbGeneratorNeedsExpressionCompiler;
             }
         }
+#endif
 
 #if FEATURE_COMPILE
         /// <summary>


### PR DESCRIPTION
This addresses issue #11408 and conditionally compiles the code that supported `CompileToMethod` using an `#if`. All the types to support this method seem to be present, and most of the code is still there, so I decided to keep the code and include it conditionally.

We can also remove it if we decide this functionality is deprecated altogether, though in my opinion and from my experience it has value in some service scenarios where computational expressions are constructed at runtime and need to be persisted in order to be reloaded at a later time (*).

Also removing some other things that were found to be dead code, and reducing some `using` directives.

(*) Some restrictions are bothersome though, in particular the restriction to emit to `static` methods and the lack of support for `Quote` nodes (though we worked around that by translating `Quote` nodes into a series of `Call` nodes to call the expression factory methods at runtime, effectively quoting the data as code).