### PR TITLE
Fix minor precedence error in SafeCloseSocket

### DIFF
--- a/src/Common/src/System/Net/SafeCloseSocket.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.cs
@@ -146,7 +146,7 @@ namespace System.Net.Sockets
             {
                 GlobalLog.Print(
                     "SafeCloseSocket#" + LoggingHash.HashString(this) + "::ReleaseHandle() m_InnerSocket=" +
-                    _innerSocket == null ? "null" : LoggingHash.HashString(_innerSocket));
+                    (_innerSocket == null ? "null" : LoggingHash.HashString(_innerSocket)));
             }
 
             _released = true;
@@ -173,7 +173,7 @@ namespace System.Net.Sockets
             {
                 GlobalLog.Print(
                     "SafeCloseSocket#" + LoggingHash.HashString(this) + "::CloseAsIs() m_InnerSocket=" +
-                    _innerSocket == null ? "null" : LoggingHash.HashString(_innerSocket));
+                    (_innerSocket == null ? "null" : LoggingHash.HashString(_innerSocket)));
             }
 
 #if DEBUG


### PR DESCRIPTION
The expression
```C#
"somestring" + obj == null ? "null" : Method(obj)
```
involves operator precedence that leads to:
```C#
("somestring" + obj) == null ? "null" : Method(obj)
```
rather than the intended:
```C#
"somestring" + (obj == null ? "null" : Method(obj))
```

Found by a coverity scan

cc: @davidsh, @cipop