### PR TITLE
Fixing compilation of Coalesce nodes with implicit numeric conversions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -605,7 +605,7 @@ namespace System.Dynamic.Utils
                 case TypeCode.UInt32:
                     switch (tcDest)
                     {
-                        case TypeCode.UInt32:
+                        case TypeCode.Int64:
                         case TypeCode.UInt64:
                         case TypeCode.Single:
                         case TypeCode.Double:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -810,6 +810,24 @@ namespace System.Linq.Expressions.Compiler
                     il.Emit(OpCodes.Conv_R_Un);
                 il.Emit(OpCodes.Conv_R8);
             }
+            else if (typeTo == typeof(Decimal))
+            {
+                // NB: TypeUtils.IsImplicitNumericConversion makes the promise that implicit conversions
+                //     from various integral types and char to decimal are possible. Coalesce allows the
+                //     conversion lambda to be omitted in these cases, so we have to handle this case in
+                //     here as well, by using the op_Implicit operator implementation on System.Decimal
+                //     because there are no opcodes for System.Decimal.
+
+                Debug.Assert(typeFrom != typeTo);
+
+                MethodInfo method = typeof(Decimal).GetMethod("op_Implicit", new[] { typeFrom });
+                if (method == null)
+                {
+                    throw Error.UnhandledConvert(typeTo);
+                }
+
+                il.Emit(OpCodes.Call, method);
+            }
             else
             {
                 TypeCode tc = typeTo.GetTypeCode();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Dynamic.Utils;
 
 namespace System.Linq.Expressions.Interpreter
@@ -110,6 +105,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
+                        case TypeCode.Decimal: return (Decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
@@ -132,6 +128,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
+                        case TypeCode.Decimal: return (Decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
@@ -154,6 +151,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
+                        case TypeCode.Decimal: return (Decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
@@ -176,6 +174,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
+                        case TypeCode.Decimal: return (Decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
@@ -229,6 +228,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
+                        case TypeCode.Decimal: return (Decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
@@ -251,6 +251,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
+                        case TypeCode.Decimal: return (Decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
@@ -273,6 +274,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
+                        case TypeCode.Decimal: return (Decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
@@ -295,6 +297,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
+                        case TypeCode.Decimal: return (Decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -67,6 +67,25 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        public static IEnumerable<object> ImplicitNumericConversionData()
+        {
+            foreach (bool useInterpreter in new bool[] { true, false })
+            {
+                yield return new object[] { new byte?[] { null, 1 }, new object[] { (byte)2, (short)3, (ushort)3, (int)4, (uint)4, (long)5, (ulong)5, (float)3.14, (double)3.14, (decimal)49.95 }, useInterpreter };
+                yield return new object[] { new sbyte?[] { null, 1 }, new object[] { (sbyte)2, (short)3, (int)4, (long)5, (float)3.14, (double)3.14, (decimal)49.95 }, useInterpreter };
+                yield return new object[] { new ushort?[] { null, 1 }, new object[] { (ushort)3, (int)4, (uint)4, (long)5, (ulong)5, (float)3.14, (double)3.14, (decimal)49.95 }, useInterpreter };
+                yield return new object[] { new short?[] { null, 1 }, new object[] { (short)3, (int)4, (long)5, (float)3.14, (double)3.14, (decimal)49.95 }, useInterpreter };
+                yield return new object[] { new uint?[] { null, 1 }, new object[] { (uint)4, (long)5, (ulong)5, (float)3.14, (double)3.14, (decimal)49.95 }, useInterpreter };
+                yield return new object[] { new int?[] { null, 1 }, new object[] { (int)4, (long)5, (float)3.14, (double)3.14, (decimal)49.95 }, useInterpreter };
+                yield return new object[] { new ulong?[] { null, 1 }, new object[] { (ulong)5, (float)3.14, (double)3.14, (decimal)49.95 }, useInterpreter };
+                yield return new object[] { new long?[] { null, 1 }, new object[] { (long)5, (float)3.14, (double)3.14, (decimal)49.95 }, useInterpreter };
+                yield return new object[] { new char?[] { null, 'a' }, new object[] { (ushort)3, (int)4, (uint)4, (long)5, (ulong)5, (float)3.14, (double)3.14, (decimal)49.95 }, useInterpreter };
+                yield return new object[] { new float?[] { null, 1F }, new object[] { (float)3.14, (double)3.14 }, useInterpreter };
+                yield return new object[] { new double?[] { null, 1D }, new object[] { (double)3.14 }, useInterpreter };
+                yield return new object[] { new decimal?[] { null, 1M }, new object[] { (decimal)49.95 }, useInterpreter };
+            }
+        }
+
         [Theory]
         [MemberData(nameof(TestData))]
         public static void Coalesce(Array array1, Array array2, bool useInterpreter)
@@ -75,9 +94,40 @@ namespace System.Linq.Expressions.Tests
             Type type2 = array2.GetType().GetElementType();
             for (int i = 0; i < array1.Length; i++)
             {
+                var value1 = array1.GetValue(i);
                 for (int j = 0; j < array2.Length; j++)
                 {
-                    VerifyCoalesce(array1.GetValue(i), type1, array2.GetValue(j), type2, useInterpreter);
+                    VerifyCoalesce(value1, type1, array2.GetValue(j), type2, useInterpreter);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ImplicitNumericConversionData))]
+        public static void ImplicitNumericConversions(Array array1, Array array2, bool useInterpreter)
+        {
+            Type type1 = array1.GetType().GetElementType();
+            for (int i = 0; i < array1.Length; i++)
+            {
+                var value1 = array1.GetValue(i);
+                for (int j = 0; j < array2.Length; j++)
+                {
+                    var value2 = array2.GetValue(j);
+                    var type2 = value2.GetType();
+
+                    var result = value1 != null ? value1 : value2;
+                    if (result.GetType() == typeof(char))
+                    {
+                        // ChangeType does not support conversion of char to float, double, or decimal,
+                        // although these are classified as implicit numeric conversions, so we widen
+                        // the value to Int32 first as a workaround
+
+                        result = Convert.ChangeType(result, typeof(int));
+                    }
+
+                    var expected = Convert.ChangeType(result, type2);
+
+                    VerifyCoalesce(value1, type1, value2, type2, useInterpreter, expected);
                 }
             }
         }
@@ -232,12 +282,12 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-        public static void VerifyCoalesce(object obj1, Type type1, object obj2, Type type2, bool useInterpreter)
+        public static void VerifyCoalesce(object obj1, Type type1, object obj2, Type type2, bool useInterpreter, object expected = null)
         {
             BinaryExpression expression = Expression.Coalesce(Expression.Constant(obj1, type1), Expression.Constant(obj2, type2));
             Delegate lambda = Expression.Lambda(expression).Compile(useInterpreter);
 
-            object expected = obj1 == null ? obj2 : obj1;
+            expected = expected ?? (obj1 == null ? obj2 : obj1);
             Assert.Equal(expected, lambda.DynamicInvoke());
         }
 


### PR DESCRIPTION
This fixes issues #11411 and #11412 for the compilation / interpretation of `Coalesce` nodes with implicit numeric conversions. There are a few issues in this area, as discussed below.

First, handling of the `decimal` type was broken in both the compiler and the interpreter. All misery comes from the promise made by `TypeUtils.IsImplicitNumericConversion` that `decimal` is a valid target for an implicit numeric conversion (which is in agreement with C# specification section 6.1.2), while the back-ends of the expression compilers do not expect this type to come up. This holds true for the compiler's `ILGen.EmitNumericConversion` method (which expects only conversions involving built-in opcodes rather than a call to an `op_Implicit` method on `System.Decimal`) and for the interpreter's `NumericConvertInstruction` types that don't check for `TypeCode.Decimal` as a valid target type.

Second, `TypeUtils.ImplicitNumericConversion` contains a quirk for conversion from `UInt32` to `Int64` (which is valid according to C# specification section 6.1.2). This entry is omitted and an entry for the (unreachable) identity conversion to `UInt32` is in its spot. This causes a `Coalesce` on a `uint?` with a right-hand side of type `long` to fail.

Note that `TypeUtils.ImplicitNumericConversion` is only used for `Coalesce` expressions. For things like `Convert` expressions involving e.g. `decimal`, the implicit conversion method will be populated on the node. `Coalesce` doesn't automatically build a lambda expression for its `Conversion` property to represent such a conversion. It'd be a valid option to construct such a lambda during compilation (but no earlier - i.e. in factories or in a `Reduce` call - to avoid breaking changes), but code emitted for a `Coalesce` node with a conversion is suboptimal and involves calling the compiled lambda's delegate, so it makes more sense to fix the emitted IL and interpreter instructions instead.

Third, the `LightCompiler.CompileCoalesceBinaryExpression` method omits logic for the implicit numeric conversion case altogether, so any `Coalesce` hitting this code path caused an `InvalidCastException` in the generated `Thunk` method.

Note that the third case would correspond to a verification error in case IL instructions were emitted and compiled. We lack a verifier in the interpreter, so errors with invalid (box) types tend to come out as runtime exceptions. We could look separately into a debug-mode switch that adds a "verification instruction" after the instructions emitted for a non-void expression, effectively checking whether the object on top of the interpreted frame's evaluation stack has a type that's assignment compatible with the static type of the compiled expression node. This may catch some issues earlier.