### PR TITLE
Fix a few minor issues in System.Security

### DIFF
--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
@@ -1711,7 +1711,6 @@ nameof(binaryForm));
                 const int AccessDenied = 0;
                 const int AccessAllowed = 1;
                 const int Inherited = 2;
-                const int Unknown = 3;
 
                 int currentStage = AccessDenied;
 
@@ -1723,7 +1722,7 @@ nameof(binaryForm));
 
                 for ( int i = 0; i < _acl.Count; i++ )
                 {
-                    int aceStage = Unknown;
+                    int aceStage;
 
                     GenericAce ace = _acl[i];
 
@@ -1763,11 +1762,6 @@ nameof(binaryForm));
                         }
                     }
 
-                    if ( aceStage == Unknown )
-                    {
-                        continue;
-                    }
-
                     if ( aceStage > currentStage )
                     {
                         currentStage = aceStage;
@@ -1787,7 +1781,6 @@ nameof(binaryForm));
 
                 const int Explicit = 0;
                 const int Inherited = 1;
-                const int Unknown = 2;
 
                 int currentStage = Explicit;
 
@@ -1799,7 +1792,7 @@ nameof(binaryForm));
 
                 for ( int i = 0; i < _acl.Count; i++ )
                 {
-                    int aceStage = Unknown;
+                    int aceStage;
 
                     GenericAce ace = _acl[i];
 

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -448,15 +448,9 @@ namespace Internal.NativeCrypto
             {
                 safeKeyHandle.Dispose();
             }
-            if (returnType == 0)
-            {
-                return retVal;
-            }
-            else if (returnType == 1)
-            {
-                return retStr;
-            }
-            return null;
+
+            Debug.Assert(returnType == 0 || returnType == 1);
+            return returnType == 0 ? (object)retVal : retStr;
         }
 
         /// <summary>

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslCertificateFinder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslCertificateFinder.cs
@@ -326,24 +326,25 @@ namespace Internal.Cryptography.Pal
             {
                 // This needs to be kept in sync with VerifyCertificateIgnoringErrors in the
                 // Windows PAL version (and potentially any other PALs that come about)
-                X509Chain chain = new X509Chain
+                using (X509Chain chain = new X509Chain
                 {
                     ChainPolicy =
                     {
                         RevocationMode = X509RevocationMode.NoCheck,
                         RevocationFlag = X509RevocationFlag.ExcludeRoot
                     }
-                };
-
-                bool valid = chain.Build(cert);
-                int elementCount = chain.ChainElements.Count;
-
-                for (int i = 0; i < elementCount; i++)
+                })
                 {
-                    chain.ChainElements[i].Certificate.Dispose();
-                }
+                    bool valid = chain.Build(cert);
+                    int elementCount = chain.ChainElements.Count;
 
-                return valid;
+                    for (int i = 0; i < elementCount; i++)
+                    {
+                        chain.ChainElements[i].Certificate.Dispose();
+                    }
+
+                    return valid;
+                }
             }
             catch (CryptographicException)
             {

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
@@ -25,7 +25,12 @@ namespace System.Security.Cryptography.X509Certificates
 
         public X509ChainElementCollection ChainElements
         {
-            get { return _chainElements; }
+            get
+            {
+                if (_chainElements == null)
+                    _chainElements = new X509ChainElementCollection();
+                return _chainElements;
+            }
         }
 
         public X509ChainPolicy ChainPolicy
@@ -118,7 +123,7 @@ namespace System.Security.Cryptography.X509Certificates
         private void Reset()
         {
             _lazyChainStatus = null;
-            _chainElements = new X509ChainElementCollection();
+            _chainElements = null;
 
             IChainPal pal = _pal;
             _pal = null;
@@ -133,4 +138,3 @@ namespace System.Security.Cryptography.X509Certificates
         private readonly object _syncRoot = new object();
     }
 }
-


### PR DESCRIPTION
- OpenSslCertificateFinder on Unix was not disposing of the created X509Chain (found by coverity scan)
- X509Chain.Reset is allocating a new ChainElements collection, and Reset is called by ctor, Build, and Dispose... that means in a typical X509Chain lifecycle, we end up allocating three collections instead of one.  Changed Reset to null out the field and changed the property accessor for it to lazily initialize.
- Remove a dead return from CapiHelper.GetProviderParameter (found by coverity scan)
- Remove a little dead code from CommonAcl.CanonicalCheck (found by coverity scan)

cc: @bartonjs 