### PR TITLE
Add missing token property to System.Security.Principal.WindowsIdentity

### DIFF
--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -232,7 +232,7 @@ namespace System.Security.Principal
         //
         // Factory methods.
         //
-        
+
         public static WindowsIdentity GetCurrent()
         {
             return GetCurrentInternal(TokenAccessLevels.MaximumAllowed, false);
@@ -254,7 +254,7 @@ namespace System.Security.Principal
         // the request is anonymous. It does not represent a real process or thread token so
         // it cannot impersonate or do anything useful. Note this identity does not represent the
         // usual concept of an anonymous token, and the name is simply misleading but we cannot change it now.
-        
+
         public static WindowsIdentity GetAnonymous()
         {
             return new WindowsIdentity();
@@ -344,12 +344,12 @@ namespace System.Security.Principal
             {
                 if (_isAuthenticated == -1)
                 {
-                        // This approach will not work correctly for domain guests (will return false
-                        // instead of true). This is a corner-case that is not very interesting.
-                        _isAuthenticated = CheckNtTokenForSid(new SecurityIdentifier(IdentifierAuthority.NTAuthority,
-                                                                        new int[] { Interop.SecurityIdentifier.SECURITY_AUTHENTICATED_USER_RID })) ? 1 : 0;
+                    // This approach will not work correctly for domain guests (will return false
+                    // instead of true). This is a corner-case that is not very interesting.
+                    _isAuthenticated = CheckNtTokenForSid(new SecurityIdentifier(IdentifierAuthority.NTAuthority,
+                                                                    new int[] { Interop.SecurityIdentifier.SECURITY_AUTHENTICATED_USER_RID })) ? 1 : 0;
                 }
-                return _isAuthenticated == 1;                
+                return _isAuthenticated == 1;
             }
         }
         private bool CheckNtTokenForSid(SecurityIdentifier sid)
@@ -556,6 +556,14 @@ namespace System.Security.Principal
             }
         }
 
+        public virtual IntPtr Token
+        {
+            get
+            {
+                return _safeTokenHandle.DangerousGetHandle();
+            }
+        }
+
         //
         // Public methods.
         //
@@ -600,9 +608,9 @@ namespace System.Security.Principal
         //
         // internal.
         //
-        
+
         private static AsyncLocal<SafeAccessTokenHandle> s_currentImpersonatedToken = new AsyncLocal<SafeAccessTokenHandle>(CurrentImpersonatedTokenChanged);
-        
+
         private static void RunImpersonatedInternal(SafeAccessTokenHandle token, Action action)
         {
             bool isImpersonating;
@@ -635,7 +643,7 @@ namespace System.Security.Principal
                 },
                 null);
         }
-        
+
         private static void CurrentImpersonatedTokenChanged(AsyncLocalValueChangedArgs<SafeAccessTokenHandle> args)
         {
             if (!args.ThreadContextChanged)
@@ -650,7 +658,7 @@ namespace System.Security.Principal
                     Environment.FailFast(new Win32Exception().Message);
             }
         }
-        
+
         internal static WindowsIdentity GetCurrentInternal(TokenAccessLevels desiredAccess, bool threadOnly)
         {
             int hr = 0;
@@ -680,7 +688,7 @@ namespace System.Security.Principal
             else
                 return (dwLastError & 0x0000FFFF) | unchecked((int)0x80070000);
         }
-        
+
         private static Exception GetExceptionFromNtStatus(int status)
         {
             if ((uint)status == Interop.StatusOptions.STATUS_ACCESS_DENIED)
@@ -692,7 +700,7 @@ namespace System.Security.Principal
             int win32ErrorCode = Interop.mincore.RtlNtStatusToDosError(status);
             return new SecurityException(new Win32Exception(win32ErrorCode).Message);
         }
-        
+
         private static SafeAccessTokenHandle GetCurrentToken(TokenAccessLevels desiredAccess, bool threadOnly, out bool isImpersonating, out int hr)
         {
             isImpersonating = true;


### PR DESCRIPTION
fixes #11297
Adding missing property `Token`.