### PR TITLE
Fix a few minor issues with TypeConverter

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComponentModelExtensions.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComponentModelExtensions.cs
@@ -74,7 +74,7 @@ namespace System.ComponentModel
             { typeof(RefreshPropertiesAttribute), attr => attr.Equals(RefreshPropertiesAttribute.Default) },
             { typeof(DesignerSerializationVisibilityAttribute), attr => attr.Equals(DesignerSerializationVisibilityAttribute.Default) },
             { typeof(ExtenderProvidedPropertyAttribute), attr => ((ExtenderProvidedPropertyAttribute)attr).ReceiverType == null },
-            { typeof(DesignerCategoryAttribute), attr => attr.Equals(DesignerCategoryAttribute.Default.Category) }
+            { typeof(DesignerCategoryAttribute), attr => attr.Equals(DesignerCategoryAttribute.Default) }
         };
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
@@ -36,15 +36,15 @@ namespace System.ComponentModel
         /// </summary>
         public EventDescriptorCollection(EventDescriptor[] events)
         {
-            _events = events;
             if (events == null)
             {
-                _events = new EventDescriptor[0];
+                _events = Array.Empty<EventDescriptor>();
                 _eventCount = 0;
             }
             else
             {
-                _eventCount = _events.Length;
+                _events = events;
+                _eventCount = events.Length;
             }
             _eventsOwned = true;
         }
@@ -185,7 +185,7 @@ namespace System.ComponentModel
                 return;
             }
 
-            if (_events == null || _events.Length == 0)
+            if (_events.Length == 0)
             {
                 _eventCount = 0;
                 _events = new EventDescriptor[sizeNeeded];
@@ -371,7 +371,7 @@ namespace System.ComponentModel
         /// </summary>
         protected void InternalSort(string[] names)
         {
-            if (_events == null || _events.Length == 0)
+            if (_events.Length == 0)
             {
                 return;
             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
@@ -47,7 +47,7 @@ namespace System.ComponentModel
         {
             if (properties == null)
             {
-                _properties = new PropertyDescriptor[0];
+                _properties = Array.Empty<PropertyDescriptor>();
                 _propCount = 0;
             }
             else
@@ -197,7 +197,7 @@ namespace System.ComponentModel
                 return;
             }
 
-            if (_properties == null || _properties.Length == 0)
+            if (_properties.Length == 0)
             {
                 _propCount = 0;
                 _properties = new PropertyDescriptor[sizeNeeded];
@@ -388,7 +388,7 @@ namespace System.ComponentModel
         /// </summary>
         protected void InternalSort(string[] names)
         {
-            if (_properties == null || _properties.Length == 0)
+            if (_properties.Length == 0)
             {
                 return;
             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
@@ -83,7 +83,7 @@ namespace System.ComponentModel
                                          Attribute[] attributes)
         : base(name, attributes)
         {
-            Debug.WriteLine($"Creating ReflectPropertyDescriptor for {componentClass.FullName}.{name}");
+            Debug.WriteLine($"Creating ReflectPropertyDescriptor for {componentClass?.FullName}.{name}");
 
             try
             {
@@ -436,10 +436,6 @@ namespace System.ComponentModel
                     {
                         for (Type t = ComponentType.GetTypeInfo().BaseType; t != null && t != typeof(object); t = t.GetTypeInfo().BaseType)
                         {
-                            if (t == null)
-                            {
-                                break;
-                            }
 #if VERIFY_REFLECTION_CHANGE
                             BindingFlags bindingFlags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
                             PropertyInfo p = t.GetProperty(name, bindingFlags, null, PropertyType, new Type[0], null);


### PR DESCRIPTION
- Event/PropertyDescriptorCollections' ctors should use Array.Empty rather than new[]
- Several checks for null are useless as it's never null
- ReflectPropertyDescriptor Debug.WriteLine will cause a null ref exception if an input is null, rather than allowing the subsequent code to throw an ArgumentException
- The ComponentModelExtensions.s_defaultAttributes support for DesignerCategoryAttribute would never return true, as it was passing a string rather than an attribute into Equals.

Found by a coverity scan
cc: @ianhays, @twsouthwick 