### PR TITLE
Fix potential null ref in ReflectionXmlSerializationReader

### DIFF
--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -368,7 +368,7 @@ namespace System.Xml.Serialization
             }
             else
             {
-                if (anyElementMember!= null & anyElementMember.Mapping != null)
+                if (anyElementMember!= null && anyElementMember.Mapping != null)
                 {
                     var anyElement = anyElementMember.Mapping;
 


### PR DESCRIPTION
A typo using & instead of && leads to a potential null dereference.

(Note that code coverage shows zero tests executed for this class.  I'm not sure if the code is in use or not.)

Found by a coverity scan
cc: @shmao 