### PR TITLE
Allow Math.Min to inline

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -886,7 +886,8 @@ namespace System.Collections.Concurrent
             {
                 get
                 {
-                    return Math.Min(_low, SEGMENT_SIZE);
+                    int low = _low; // jit won't inline Math.Min if passed a volatile
+                    return Math.Min(low, SEGMENT_SIZE);
                 }
             }
 
@@ -900,7 +901,8 @@ namespace System.Collections.Concurrent
                 {
                     //if _high > SEGMENT_SIZE, it means it's out of range, we should return
                     //SEGMENT_SIZE-1 as the logical position
-                    return Math.Min(_high, SEGMENT_SIZE - 1);
+                    int high = _high; // jit won't inline Math.Min if passed a volatile
+                    return Math.Min(high, SEGMENT_SIZE - 1);
                 }
             }
         }


### PR DESCRIPTION
Changes `[FAILED: argument has side effect] Math:Min(int,int):int`
To: `[below ALWAYS_INLINE size] Math:Min(int,int):int`

Post
```
Inlines into 060000E7 ConcurrentQueue`1:get_IsEmpty():bool:this
  [1 IL=0010 TR=000007 06000151] [below ALWAYS_INLINE size] Segment:get_IsEmpty():bool:this
    [2 IL=0001 TR=000076 06000159] [profitable inline] Segment:get_Low():int:this
      [3 IL=0012 TR=000099 06003842] [below ALWAYS_INLINE size] Math:Min(int,int):int
    [4 IL=0007 TR=000080 0600015A] [profitable inline] Segment:get_High():int:this
      [5 IL=0012 TR=000134 06003842] [below ALWAYS_INLINE size] Math:Min(int,int):int
  [6 IL=0020 TR=000016 06000150] [below ALWAYS_INLINE size] Segment:get_Next():ref:this
  [7 IL=0040 TR=000042 06000150] [below ALWAYS_INLINE size] Segment:get_Next():ref:this
  [0 IL=0051 TR=000052 06002394] [FAILED: noinline per IL/cached result] SpinWait:SpinOnce():this
  [8 IL=0066 TR=000033 06000151] [below ALWAYS_INLINE size] Segment:get_IsEmpty():bool:this
    [9 IL=0001 TR=000169 06000159] [profitable inline] Segment:get_Low():int:this
      [10 IL=0012 TR=000192 06003842] [below ALWAYS_INLINE size] Math:Min(int,int):int
    [11 IL=0007 TR=000173 0600015A] [profitable inline] Segment:get_High():int:this
      [12 IL=0012 TR=000227 06003842] [below ALWAYS_INLINE size] Math:Min(int,int):int
Budget: initialTime=285, finalTime=421, initialBudget=2850, currentBudget=2850
Budget: initialSize=1841, finalSize=2073
```
```
Inlines into 06000156 Segment:TryRemove(byref):bool:this
  [1 IL=0009 TR=000009 06000159] [profitable inline] Segment:get_Low():int:this
    [2 IL=0012 TR=000178 06003842] [below ALWAYS_INLINE size] Math:Min(int,int):int
  [3 IL=0016 TR=000016 0600015A] [profitable inline] Segment:get_High():int:this
    [4 IL=0012 TR=000213 06003842] [below ALWAYS_INLINE size] Math:Min(int,int):int
  [0 IL=0060 TR=000082 06002394] [FAILED: noinline per IL/cached result] SpinWait:SpinOnce():this
  [0 IL=0169 TR=000130 06002394] [FAILED: noinline per IL/cached result] SpinWait:SpinOnce():this
  [0 IL=0211 TR=000044 06002394] [FAILED: noinline per IL/cached result] SpinWait:SpinOnce():this
  [5 IL=0217 TR=000047 06000159] [profitable inline] Segment:get_Low():int:this
    [6 IL=0012 TR=000248 06003842] [below ALWAYS_INLINE size] Math:Min(int,int):int
  [7 IL=0224 TR=000054 0600015A] [profitable inline] Segment:get_High():int:this
    [8 IL=0012 TR=000283 06003842] [below ALWAYS_INLINE size] Math:Min(int,int):int
Budget: initialTime=798, finalTime=894, initialBudget=7980, currentBudget=7980
Budget: initialSize=5740, finalSize=5972
```
Resolves https://github.com/dotnet/corefx/issues/11441