### PR TITLE
Adding tests for ExpressionStringBuilder

### DIFF
--- a/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
@@ -2710,5 +2710,16 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
+        #region ToString
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.ArrayIndex(Expression.Parameter(typeof(int[]), "xs"), Expression.Parameter(typeof(int), "i"));
+            Assert.Equal("xs[i]", e.ToString());
+        }
+
+        #endregion
     }
 }

--- a/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
@@ -1556,5 +1556,16 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
+        #region ToString
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.ArrayLength(Expression.Parameter(typeof(int[]), "xs"));
+            Assert.Equal("ArrayLength(xs)", e.ToString());
+        }
+
+        #endregion
     }
 }

--- a/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
@@ -860,6 +860,19 @@ namespace System.Linq.Expressions.Tests
             Assert.ThrowsAny<Exception>(() => Expression.NewArrayInit(typeof(int), new BogusReadOnlyCollection<Expression>()));
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.NewArrayInit(typeof(int));
+            Assert.Equal("new [] {}", e1.ToString());
+
+            var e2 = Expression.NewArrayInit(typeof(int), Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("new [] {x}", e2.ToString());
+
+            var e3 = Expression.NewArrayInit(typeof(int), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            Assert.Equal("new [] {x, y}", e3.ToString());
+        }
+
         #endregion
 
         #region Helper methods
@@ -1622,6 +1635,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
         [Fact]
         public static void NullType()
         {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
@@ -559,5 +559,15 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.Add(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.Add(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a + b)", e1.ToString());
+
+            var e2 = Expression.AddChecked(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a + b)", e2.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
@@ -378,5 +378,12 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.Divide(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.Divide(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a / b)", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
@@ -378,5 +378,12 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.Modulo(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.Modulo(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a % b)", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
@@ -567,5 +567,15 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.MultiplyChecked(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.Multiply(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a * b)", e1.ToString());
+
+            var e2 = Expression.MultiplyChecked(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a * b)", e2.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryPowerTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryPowerTests.cs
@@ -1,0 +1,427 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public static class BinaryPowerTests
+    {
+        #region Test methods
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckBytePowerTest(bool useInterpreter)
+        {
+            byte[] array = new byte[] { 0, 1, byte.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifyBytePower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckSBytePowerTest(bool useInterpreter)
+        {
+            sbyte[] array = new sbyte[] { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifySBytePower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckUShortPowerTest(bool useInterpreter)
+        {
+            ushort[] array = new ushort[] { 0, 1, ushort.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifyUShortPower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckShortPowerTest(bool useInterpreter)
+        {
+            short[] array = new short[] { 0, 1, -1, short.MinValue, short.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifyShortPower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckUIntPowerTest(bool useInterpreter)
+        {
+            uint[] array = new uint[] { 0, 1, uint.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifyUIntPower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIntPowerTest(bool useInterpreter)
+        {
+            int[] array = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifyIntPower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckULongPowerTest(bool useInterpreter)
+        {
+            ulong[] array = new ulong[] { 0, 1, ulong.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifyULongPower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLongPowerTest(bool useInterpreter)
+        {
+            long[] array = new long[] { 0, 1, -1, long.MinValue, long.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifyLongPower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckFloatPowerTest(bool useInterpreter)
+        {
+            float[] array = new float[] { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifyFloatPower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckDoublePowerTest(bool useInterpreter)
+        {
+            double[] array = new double[] { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifyDoublePower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckDecimalPowerTest(bool useInterpreter)
+        {
+            decimal[] array = new decimal[] { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifyDecimalPower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCharPowerTest(bool useInterpreter)
+        {
+            char[] array = new char[] { '\0', '\b', 'A', '\uffff' };
+            for (int i = 0; i < array.Length; i++)
+            {
+                for (int j = 0; j < array.Length; j++)
+                {
+                    VerifyCharPower(array[i], array[j], useInterpreter);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Test verifiers
+
+        private static void VerifyBytePower(byte a, byte b, bool useInterpreter)
+        {
+            Expression<Func<byte>> e =
+                Expression.Lambda<Func<byte>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(byte)),
+                        Expression.Constant(b, typeof(byte)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerByte")
+                    ));
+            Func<byte> f = e.Compile(useInterpreter);
+
+            Assert.Equal(PowerByte(a, b), f());
+        }
+
+        private static void VerifySBytePower(sbyte a, sbyte b, bool useInterpreter)
+        {
+            Expression<Func<sbyte>> e =
+                Expression.Lambda<Func<sbyte>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(sbyte)),
+                        Expression.Constant(b, typeof(sbyte)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerSByte")
+                    ));
+            Func<sbyte> f = e.Compile(useInterpreter);
+
+            Assert.Equal(PowerSByte(a, b), f());
+        }
+
+        private static void VerifyUShortPower(ushort a, ushort b, bool useInterpreter)
+        {
+            Expression<Func<ushort>> e =
+                Expression.Lambda<Func<ushort>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(ushort)),
+                        Expression.Constant(b, typeof(ushort)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerUShort")
+                    ));
+            Func<ushort> f = e.Compile(useInterpreter);
+
+            Assert.Equal(PowerUShort(a, b), f());
+        }
+
+        private static void VerifyShortPower(short a, short b, bool useInterpreter)
+        {
+            Expression<Func<short>> e =
+                Expression.Lambda<Func<short>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(short)),
+                        Expression.Constant(b, typeof(short)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerShort")
+                    ));
+            Func<short> f = e.Compile(useInterpreter);
+
+            Assert.Equal(PowerShort(a, b), f());
+        }
+
+        private static void VerifyUIntPower(uint a, uint b, bool useInterpreter)
+        {
+            Expression<Func<uint>> e =
+                Expression.Lambda<Func<uint>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(uint)),
+                        Expression.Constant(b, typeof(uint)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerUInt")
+                    ));
+            Func<uint> f = e.Compile(useInterpreter);
+
+            Assert.Equal(PowerUInt(a, b), f());
+        }
+
+        private static void VerifyIntPower(int a, int b, bool useInterpreter)
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(int)),
+                        Expression.Constant(b, typeof(int)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerInt")
+                    ));
+            Func<int> f = e.Compile(useInterpreter);
+
+            Assert.Equal(PowerInt(a, b), f());
+        }
+
+        private static void VerifyULongPower(ulong a, ulong b, bool useInterpreter)
+        {
+            Expression<Func<ulong>> e =
+                Expression.Lambda<Func<ulong>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(ulong)),
+                        Expression.Constant(b, typeof(ulong)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerULong")
+                    ));
+            Func<ulong> f = e.Compile(useInterpreter);
+
+            Assert.Equal(PowerULong(a, b), f());
+        }
+
+        private static void VerifyLongPower(long a, long b, bool useInterpreter)
+        {
+            Expression<Func<long>> e =
+                Expression.Lambda<Func<long>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(long)),
+                        Expression.Constant(b, typeof(long)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerLong")
+                    ));
+            Func<long> f = e.Compile(useInterpreter);
+
+            Assert.Equal(PowerLong(a, b), f());
+        }
+
+        private static void VerifyFloatPower(float a, float b, bool useInterpreter)
+        {
+            Expression<Func<float>> e =
+                Expression.Lambda<Func<float>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(float)),
+                        Expression.Constant(b, typeof(float)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerFloat")
+                    ));
+            Func<float> f = e.Compile(useInterpreter);
+
+            Assert.Equal(PowerFloat(a, b), f());
+        }
+
+        private static void VerifyDoublePower(double a, double b, bool useInterpreter)
+        {
+            Expression<Func<double>> e =
+                Expression.Lambda<Func<double>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(double)),
+                        Expression.Constant(b, typeof(double)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerDouble")
+                    ));
+            Func<double> f = e.Compile(useInterpreter);
+
+            Assert.Equal(PowerDouble(a, b), f());
+        }
+
+        private static void VerifyDecimalPower(decimal a, decimal b, bool useInterpreter)
+        {
+            Expression<Func<decimal>> e =
+                Expression.Lambda<Func<decimal>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(decimal)),
+                        Expression.Constant(b, typeof(decimal)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerDecimal")
+                    ));
+            Func<decimal> f = e.Compile(useInterpreter);
+
+            decimal expected = 0;
+            try
+            {
+                expected = PowerDecimal(a, b);
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
+        private static void VerifyCharPower(char a, char b, bool useInterpreter)
+        {
+            Expression<Func<char>> e =
+                Expression.Lambda<Func<char>>(
+                    Expression.Power(
+                        Expression.Constant(a, typeof(char)),
+                        Expression.Constant(b, typeof(char)),
+                        typeof(BinaryPowerTests).GetTypeInfo().GetDeclaredMethod("PowerChar")
+                    ));
+            Func<char> f = e.Compile(useInterpreter);
+
+            Assert.Equal(PowerChar(a, b), f());
+        }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.Power(Expression.Parameter(typeof(double), "a"), Expression.Parameter(typeof(double), "b"));
+            Assert.Equal("(a ^ b)", e.ToString()); // QUIRK: Same output as ExclusiveOr, see https://github.com/dotnet/corefx/issues/11415
+        }
+
+        #endregion
+
+        #region Helper methods
+
+        public static byte PowerByte(byte a, byte b)
+        {
+            return (byte)Math.Pow(a, b);
+        }
+
+        public static sbyte PowerSByte(sbyte a, sbyte b)
+        {
+            return (sbyte)Math.Pow(a, b);
+        }
+
+        public static ushort PowerUShort(ushort a, ushort b)
+        {
+            return (ushort)Math.Pow(a, b);
+        }
+
+        public static short PowerShort(short a, short b)
+        {
+            return (short)Math.Pow(a, b);
+        }
+
+        public static uint PowerUInt(uint a, uint b)
+        {
+            return (uint)Math.Pow(a, b);
+        }
+
+        public static int PowerInt(int a, int b)
+        {
+            return (int)Math.Pow(a, b);
+        }
+
+        public static ulong PowerULong(ulong a, ulong b)
+        {
+            return (ulong)Math.Pow(a, b);
+        }
+
+        public static long PowerLong(long a, long b)
+        {
+            return (long)Math.Pow(a, b);
+        }
+
+        public static float PowerFloat(float a, float b)
+        {
+            return (float)Math.Pow(a, b);
+        }
+
+        public static double PowerDouble(double a, double b)
+        {
+            return Math.Pow(a, b);
+        }
+
+        public static decimal PowerDecimal(decimal a, decimal b)
+        {
+            return (decimal)Math.Pow((double)a, (double)b);
+        }
+
+        public static char PowerChar(char a, char b)
+        {
+            return (char)Math.Pow(a, b);
+        }
+
+        #endregion
+    }
+}

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
@@ -408,5 +408,15 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.RightShift(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.LeftShift(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a << b)", e1.ToString());
+
+            var e2 = Expression.RightShift(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a >> b)", e2.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -551,5 +551,15 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.SubtractChecked(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.Subtract(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a - b)", e1.ToString());
+
+            var e2 = Expression.SubtractChecked(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a - b)", e2.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -78,6 +78,25 @@ namespace System.Linq.Expressions.Tests
             yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.StringProperty)), "d" };
         }
 
+        [Fact]
+        public static void BasicAssignmentExpressionTest()
+        {
+            var left = Expression.Parameter(typeof(int));
+            var right = Expression.Parameter(typeof(int));
+
+            BinaryExpression actual = Expression.Assign(left, right);
+
+            Assert.Same(left, actual.Left);
+            Assert.Same(right, actual.Right);
+            Assert.Null(actual.Conversion);
+
+            Assert.False(actual.IsLifted);
+            Assert.False(actual.IsLiftedToNull);
+
+            Assert.Equal(typeof(int), actual.Type);
+            Assert.Equal(ExpressionType.Assign, actual.NodeType);
+        }
+
         [Theory, ClassData(typeof(CompilationTypes))]
         public void SimpleAssignment(bool useInterpreter)
         {
@@ -179,6 +198,13 @@ namespace System.Linq.Expressions.Tests
         {
             ParameterExpression variable = Expression.Variable(writeOnlyExp.Type);
             Assert.Throws<ArgumentException>("right", () => Expression.Assign(variable, writeOnlyExp));
+        }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.Assign(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a = b)", e.ToString());
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
@@ -308,5 +308,39 @@ namespace System.Linq.Expressions.Tests
             else
                 yield return Tuple.Create("Power", "PowerAssign");
         }
+
+        [Theory]
+        [MemberData(nameof(ToStringData))]
+        public static void ToStringTest(ExpressionType kind, string symbol, Type type)
+        {
+            var e = Expression.MakeBinary(kind, Expression.Parameter(type, "a"), Expression.Parameter(type, "b"));
+            Assert.Equal($"(a {symbol} b)", e.ToString());
+        }
+
+        private static IEnumerable<object[]> ToStringData()
+        {
+            return ToStringDataImpl().Select(t => new object[] { t.Item1, t.Item2, t.Item3 });
+        }
+
+        private static IEnumerable<Tuple<ExpressionType, string, Type>> ToStringDataImpl()
+        {
+            yield return Tuple.Create(ExpressionType.AddAssign, "+=", typeof(int));
+            yield return Tuple.Create(ExpressionType.AddAssignChecked, "+=", typeof(int));
+            yield return Tuple.Create(ExpressionType.SubtractAssign, "-=", typeof(int));
+            yield return Tuple.Create(ExpressionType.SubtractAssignChecked, "-=", typeof(int));
+            yield return Tuple.Create(ExpressionType.MultiplyAssign, "*=", typeof(int));
+            yield return Tuple.Create(ExpressionType.MultiplyAssignChecked, "*=", typeof(int));
+            yield return Tuple.Create(ExpressionType.DivideAssign, "/=", typeof(int));
+            yield return Tuple.Create(ExpressionType.ModuloAssign, "%=", typeof(int));
+            yield return Tuple.Create(ExpressionType.PowerAssign, "**=", typeof(double));
+            yield return Tuple.Create(ExpressionType.LeftShiftAssign, "<<=", typeof(int));
+            yield return Tuple.Create(ExpressionType.RightShiftAssign, ">>=", typeof(int));
+            yield return Tuple.Create(ExpressionType.AndAssign, "&=", typeof(int));
+            yield return Tuple.Create(ExpressionType.AndAssign, "&&=", typeof(bool));
+            yield return Tuple.Create(ExpressionType.OrAssign, "|=", typeof(int));
+            yield return Tuple.Create(ExpressionType.OrAssign, "||=", typeof(bool));
+            yield return Tuple.Create(ExpressionType.ExclusiveOrAssign, "^=", typeof(int));
+            yield return Tuple.Create(ExpressionType.ExclusiveOrAssign, "^=", typeof(bool));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
@@ -267,5 +267,18 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.And(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.And(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a & b)", e1.ToString());
+
+            var e2 = Expression.And(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
+            Assert.Equal("(a And b)", e2.ToString());
+
+            var e3 = Expression.And(Expression.Parameter(typeof(bool?), "a"), Expression.Parameter(typeof(bool?), "b"));
+            Assert.Equal("(a And b)", e3.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
@@ -267,5 +267,14 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.ExclusiveOr(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.ExclusiveOr(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a ^ b)", e.ToString());
+
+            // NB: Unlike And and Or, there's no special case for bool and bool? here.
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
@@ -267,5 +267,18 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.Or(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.Or(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a | b)", e1.ToString());
+
+            var e2 = Expression.Or(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
+            Assert.Equal("(a Or b)", e2.ToString());
+
+            var e3 = Expression.Or(Expression.Parameter(typeof(bool?), "a"), Expression.Parameter(typeof(bool?), "b"));
+            Assert.Equal("(a Or b)", e3.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -383,5 +383,12 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.Coalesce(Expression.Constant(""), Expression.Constant(""), boolNotEquivilent));
             Assert.Throws<InvalidOperationException>(() => Expression.Coalesce(Expression.Constant(0, typeof(int?)), Expression.Constant(""), boolNotEquivilent));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.Coalesce(Expression.Parameter(typeof(string), "a"), Expression.Parameter(typeof(string), "b"));
+            Assert.Equal("(a ?? b)", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryEqualTests.cs
@@ -397,5 +397,12 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.Equal(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.Equal(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a == b)", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanOrEqualTests.cs
@@ -371,5 +371,12 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.GreaterThanOrEqual(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.GreaterThanOrEqual(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a >= b)", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanTests.cs
@@ -371,5 +371,12 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.GreaterThan(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.GreaterThan(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a > b)", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanOrEqualTests.cs
@@ -371,5 +371,12 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.LessThanOrEqual(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.LessThanOrEqual(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a <= b)", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanTests.cs
@@ -371,5 +371,12 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.LessThan(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.LessThan(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a < b)", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNotEqualTests.cs
@@ -397,5 +397,12 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.NotEqual(Expression.Constant(1), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.NotEqual(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("(a != b)", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -200,5 +200,17 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<bool>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.OrElse(Expression.Constant(false), value));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            // NB: These were && and || in .NET 3.5 but shipped as AndAlso and OrElse in .NET 4.0; we kept the latter.
+
+            var e1 = Expression.AndAlso(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
+            Assert.Equal("(a AndAlso b)", e1.ToString());
+
+            var e2 = Expression.OrElse(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
+            Assert.Equal("(a OrElse b)", e2.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
@@ -173,5 +173,31 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<string>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.ReferenceEqual(Expression.Constant(""), value));
         }
+
+        [Fact]
+        public void Update()
+        {
+            Expression e1 = Expression.Constant("bar");
+            Expression e2 = Expression.Constant("foo");
+            Expression e3 = Expression.Constant("qux");
+
+            var eq = Expression.ReferenceEqual(e1, e2);
+
+            Assert.Same(eq, eq.Update(e1, null, e2));
+
+            var eq1 = eq.Update(e1, null, e3);
+            Assert.Equal(ExpressionType.Equal, eq1.NodeType);
+            Assert.Same(e1, eq1.Left);
+            Assert.Same(e3, eq1.Right);
+            Assert.Null(eq1.Conversion);
+            Assert.Null(eq1.Method);
+
+            var eq2 = eq.Update(e3, null, e2);
+            Assert.Equal(ExpressionType.Equal, eq2.NodeType);
+            Assert.Same(e3, eq2.Left);
+            Assert.Same(e2, eq2.Right);
+            Assert.Null(eq2.Conversion);
+            Assert.Null(eq2.Method);
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
@@ -173,5 +173,31 @@ namespace System.Linq.Expressions.Tests
             Expression value = Expression.Property(null, typeof(Unreadable<string>), "WriteOnly");
             Assert.Throws<ArgumentException>("right", () => Expression.ReferenceNotEqual(Expression.Constant(""), value));
         }
+
+        [Fact]
+        public void Update()
+        {
+            Expression e1 = Expression.Constant("bar");
+            Expression e2 = Expression.Constant("foo");
+            Expression e3 = Expression.Constant("qux");
+
+            var ne = Expression.ReferenceNotEqual(e1, e2);
+
+            Assert.Same(ne, ne.Update(e1, null, e2));
+
+            var ne1 = ne.Update(e1, null, e3);
+            Assert.Equal(ExpressionType.NotEqual, ne1.NodeType);
+            Assert.Same(e1, ne1.Left);
+            Assert.Same(e3, ne1.Right);
+            Assert.Null(ne1.Conversion);
+            Assert.Null(ne1.Method);
+
+            var ne2 = ne.Update(e3, null, e2);
+            Assert.Equal(ExpressionType.NotEqual, ne2.NodeType);
+            Assert.Same(e3, ne2.Left);
+            Assert.Same(e2, ne2.Right);
+            Assert.Null(ne2.Conversion);
+            Assert.Null(ne2.Method);
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -210,5 +210,18 @@ namespace System.Linq.Expressions.Tests
                 new[] { Expression.Parameter(typeof(int), "x") },
                 new Expression[0]));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.Block(Expression.Empty());
+            Assert.Equal("{ ... }", e1.ToString());
+
+            var e2 = Expression.Block(new[] { Expression.Parameter(typeof(int), "x") }, Expression.Empty());
+            Assert.Equal("{var x; ... }", e2.ToString());
+
+            var e3 = Expression.Block(new[] { Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y") }, Expression.Empty());
+            Assert.Equal("{var x;var y; ... }", e3.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -225,5 +225,56 @@ namespace System.Linq.Expressions.Tests
             var m = new Mutable() { X = 41 };
             Assert.Equal(42, lambda(m));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            // NB: Static methods are inconsistent compared to static members; the declaring type is not included
+
+            var e1 = Expression.Call(null, typeof(SomeMethods).GetMethod(nameof(SomeMethods.S0), BindingFlags.Static | BindingFlags.Public));
+            Assert.Equal("S0()", e1.ToString());
+
+            var e2 = Expression.Call(null, typeof(SomeMethods).GetMethod(nameof(SomeMethods.S1), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("S1(x)", e2.ToString());
+
+            var e3 = Expression.Call(null, typeof(SomeMethods).GetMethod(nameof(SomeMethods.S2), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            Assert.Equal("S2(x, y)", e3.ToString());
+
+            var e4 = Expression.Call(Expression.Parameter(typeof(SomeMethods), "o"), typeof(SomeMethods).GetMethod(nameof(SomeMethods.I0), BindingFlags.Instance | BindingFlags.Public));
+            Assert.Equal("o.I0()", e4.ToString());
+
+            var e5 = Expression.Call(Expression.Parameter(typeof(SomeMethods), "o"), typeof(SomeMethods).GetMethod(nameof(SomeMethods.I1), BindingFlags.Instance | BindingFlags.Public), Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("o.I1(x)", e5.ToString());
+
+            var e6 = Expression.Call(Expression.Parameter(typeof(SomeMethods), "o"), typeof(SomeMethods).GetMethod(nameof(SomeMethods.I2), BindingFlags.Instance | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            Assert.Equal("o.I2(x, y)", e6.ToString());
+
+            var e7 = Expression.Call(null, typeof(ExtensionMethods).GetMethod(nameof(ExtensionMethods.E0), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("x.E0()", e7.ToString());
+
+            var e8 = Expression.Call(null, typeof(ExtensionMethods).GetMethod(nameof(ExtensionMethods.E1), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            Assert.Equal("x.E1(y)", e8.ToString());
+
+            var e9 = Expression.Call(null, typeof(ExtensionMethods).GetMethod(nameof(ExtensionMethods.E2), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"), Expression.Parameter(typeof(int), "z"));
+            Assert.Equal("x.E2(y, z)", e9.ToString());
+        }
+    }
+
+    class SomeMethods
+    {
+        public static void S0() {}
+        public static void S1(int x) {}
+        public static void S2(int x, int y) {}
+
+        public void I0() {}
+        public void I1(int x) {}
+        public void I2(int x, int y) {}
+    }
+
+    static class ExtensionMethods
+    {
+         public static void E0(this int x) {}
+         public static void E1(this int x, int y) {}
+         public static void E2(this int x, int y, int z) {}
     }
 }

--- a/src/System.Linq.Expressions/tests/Cast/AsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsTests.cs
@@ -840,6 +840,13 @@ namespace System.Linq.Expressions.Tests
             CheckGenericWithStructRestrictionAsValueTypeHelper<Scs>(useInterpreter);
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.TypeAs(Expression.Parameter(typeof(object), "o"), typeof(string));
+            Assert.Equal("(o As String)", e.ToString());
+        }
+
         #endregion
 
         #region Generic helpers

--- a/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
+++ b/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
@@ -229,6 +229,15 @@ namespace System.Linq.Expressions.Tests
                 typeof(List<>).MakeGenericType(typeof(List<>))));
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.Condition(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(int), "b"), Expression.Parameter(typeof(int), "c"));
+            Assert.Equal("IIF(a, b, c)", e1.ToString());
+
+            var e2 = Expression.IfThen(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(int), "b"));
+            Assert.Equal("IIF(a, b, default(Void))", e2.ToString());
+        }
 
         private static IEnumerable<object[]> ConditionalValues()
         {

--- a/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -356,6 +356,61 @@ namespace System.Linq.Expressions.Tests
             CheckGenericWithSubClassAndNewRestrictionHelper<C>(useInterpreter);
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void BoundConstantCaching1(bool useInterpreter)
+        {
+            var c = Expression.Constant(new Bar());
+
+            var e =
+                Expression.Add(
+                    Expression.Field(c, "Foo"),
+                    Expression.Subtract(
+                        Expression.Field(c, "Baz"),
+                        Expression.Field(c, "Qux")
+                    )
+                );
+
+            Assert.Equal(42, Expression.Lambda<Func<int>>(e).Compile(useInterpreter)());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void BoundConstantCaching2(bool useInterpreter)
+        {
+            var b = new Bar();
+            var c1 = Expression.Constant(b);
+            var c2 = Expression.Constant(b);
+            var c3 = Expression.Constant(b);
+
+            var e =
+                Expression.Add(
+                    Expression.Field(c1, "Foo"),
+                    Expression.Subtract(
+                        Expression.Field(c2, "Baz"),
+                        Expression.Field(c3, "Qux")
+                    )
+                );
+
+            Assert.Equal(42, Expression.Lambda<Func<int>>(e).Compile(useInterpreter)());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void BoundConstantCaching3(bool useInterpreter)
+        {
+            var b = new Bar() { Foo = 1 };
+
+            for (var i = 1; i <= 10; i++)
+            {
+                var e = (Expression)Expression.Constant(0);
+
+                for (var j = 1; j <= i; j++)
+                {
+                    e = Expression.Add(e, Expression.Field(Expression.Constant(b), "Foo"));
+                }
+
+                Assert.Equal(i, Expression.Lambda<Func<int>>(e).Compile(useInterpreter)());
+            }
+        }
+
         #endregion
 
         #region Generic helpers
@@ -806,6 +861,42 @@ namespace System.Linq.Expressions.Tests
         {
             Assert.Throws<ArgumentException>(() => Expression.Constant(null, typeof(List<>.Enumerator)));
             Assert.Throws<ArgumentException>(() => Expression.Constant(null, typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.Constant(1);
+            Assert.Equal("1", e1.ToString());
+
+            var e2 = Expression.Constant("bar");
+            Assert.Equal("\"bar\"", e2.ToString());
+
+            var e3 = Expression.Constant(null, typeof(object));
+            Assert.Equal("null", e3.ToString());
+
+            var b = new Bar();
+            var e4 = Expression.Constant(b);
+            Assert.Equal($"value({b.ToString()})", e4.ToString());
+
+            var f = new Foo();
+            var e5 = Expression.Constant(f);
+            Assert.Equal(f.ToString(), e5.ToString());
+        }
+
+        class Bar
+        {
+            public int Foo = 41;
+            public int Qux = 43;
+            public int Baz = 44;
+        }
+
+        class Foo
+        {
+            public override string ToString()
+            {
+                return "Bar";
+            }
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/DebugInfo/DebugInfoExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/DebugInfo/DebugInfoExpressionTests.cs
@@ -45,6 +45,13 @@ namespace System.Linq.Expressions.Tests
             VerifyDebugInfoExpression(ex, document, 0xfeefee, 0, 0xfeefee, 0, true);
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.DebugInfo(Expression.SymbolDocument("foo.cs"), 12, 23, 34, 45);
+            Assert.Equal("<DebugInfo(foo.cs: 12, 23, 34, 45)>", e.ToString());
+        }
+
         private static void VerifyDebugInfoExpression(DebugInfoExpression ex, SymbolDocumentInfo document, int startLine, int startColumn, int endLine, int endColumn, bool isClear)
         {
             Assert.Same(document, ex.Document);

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -1233,5 +1233,32 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("type", () => Expression.Catch(typeof(int).MakeByRefType(), Expression.Constant(0), Expression.Constant(true)));
             Assert.Throws<ArgumentException>("type", () => Expression.MakeCatchBlock(typeof(int).MakeByRefType(), null, Expression.Constant(0), null));
         }
+
+        [Fact]
+        public void ToStringTest()
+        {
+            var e1 = Expression.Throw(Expression.Parameter(typeof(Exception), "ex"));
+            Assert.Equal("throw(ex)", e1.ToString());
+
+            var e2 = Expression.TryFinally(Expression.Empty(), Expression.Empty());
+            Assert.Equal("try { ... }", e2.ToString());
+
+            var e3 = Expression.TryFault(Expression.Empty(), Expression.Empty());
+            Assert.Equal("try { ... }", e3.ToString());
+
+            var e4 = Expression.TryCatch(Expression.Empty(), Expression.Catch(typeof(Exception), Expression.Empty()));
+            Assert.Equal("try { ... }", e4.ToString());
+
+            var e5 = Expression.Catch(typeof(Exception), Expression.Empty());
+            Assert.Equal("catch (Exception) { ... }", e5.ToString());
+
+            var e6 = Expression.Catch(Expression.Parameter(typeof(Exception), "ex"), Expression.Empty());
+            Assert.Equal("catch (Exception ex) { ... }", e6.ToString());
+
+            // NB: No ToString form for filters
+
+            var e7 = Expression.Catch(Expression.Parameter(typeof(Exception), "ex"), Expression.Empty(), Expression.Constant(true));
+            Assert.Equal("catch (Exception ex) { ... }", e7.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/ExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ExpressionTests.cs
@@ -136,6 +136,22 @@ namespace System.Linq.Expressions.Tests
             public override ExpressionType NodeType => (ExpressionType)(-1);
         }
 
+        private class ExtensionNoToString : Expression
+        {
+            public override ExpressionType NodeType => ExpressionType.Extension;
+            public override Type Type => typeof(int);
+            public override bool CanReduce => false;
+        }
+
+        private class ExtensionToString : Expression
+        {
+            public override ExpressionType NodeType => ExpressionType.Extension;
+            public override Type Type => typeof(int);
+            public override bool CanReduce => false;
+
+            public override string ToString() => "bar";
+        }
+
         public static IEnumerable<object[]> AllNodeTypesPlusSomeInvalid
         {
             get
@@ -435,6 +451,16 @@ namespace System.Linq.Expressions.Tests
         {
             var exp = Expression.Lambda<Func<int>>(new ReducesFromStrangeNodeType());
             Assert.Equal(3, exp.Compile(useInterpreter)());
+        }
+
+        [Fact]
+        public void ToStringTest()
+        {
+            var e1 = new ExtensionNoToString();
+            Assert.Equal($"[{typeof(ExtensionNoToString).FullName}]", e1.ToString());
+
+            var e2 = Expression.Add(Expression.Constant(1), new ExtensionToString());
+            Assert.Equal($"(1 + bar)", e2.ToString());
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
@@ -51,5 +51,34 @@ namespace System.Linq.Expressions.Tests
             IndexExpressionHelpers.AssertInvokeCorrect(100, expr);
             IndexExpressionHelpers.AssertInvokeCorrect(201, exprUpdated);
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.MakeIndex(Expression.Parameter(typeof(Vector1), "v"), typeof(Vector1).GetProperty("Item"), new[] { Expression.Parameter(typeof(int), "i") });
+            Assert.Equal("v.Item[i]", e1.ToString());
+
+            var e2 = Expression.MakeIndex(Expression.Parameter(typeof(Vector2), "v"), typeof(Vector2).GetProperty("Item"), new[] { Expression.Parameter(typeof(int), "i"), Expression.Parameter(typeof(int), "j") });
+            Assert.Equal("v.Item[i, j]", e2.ToString());
+
+            var e3 = Expression.ArrayAccess(Expression.Parameter(typeof(int[,]), "xs"), Expression.Parameter(typeof(int), "i"), Expression.Parameter(typeof(int), "j"));
+            Assert.Equal("xs[i, j]", e3.ToString());
+        }
+
+        class Vector1
+        {
+            public int this[int x]
+            {
+                get { return 0; }
+            }
+        }
+
+        class Vector2
+        {
+            public int this[int x, int y]
+            {
+                get { return 0; }
+            }
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -92,5 +92,15 @@ namespace System.Linq.Expressions.Tests
             act();
             Assert.Equal(1, holder.Function());
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.Invoke(Expression.Parameter(typeof(Action), "f"));
+            Assert.Equal("Invoke(f)", e1.ToString());
+
+            var e2 = Expression.Invoke(Expression.Parameter(typeof(Action<int>), "f"), Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("Invoke(f, x)", e2.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
@@ -214,5 +214,15 @@ namespace System.Linq.Expressions.Tests
             var init = Expression.ListInit(Expression.New(typeof(List<int>)), inits);
             Assert.NotSame(init, init.Update(Expression.New(typeof(List<int>)), inits));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.ListInit(Expression.New(typeof(List<int>)), Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("new List`1() {Void Add(Int32)(x)}", e1.ToString());
+
+            var e2 = Expression.ListInit(Expression.New(typeof(List<int>)), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            Assert.Equal("new List`1() {Void Add(Int32)(x), Void Add(Int32)(y)}", e2.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Loop/LoopTests.cs
+++ b/src/System.Linq.Expressions/tests/Loop/LoopTests.cs
@@ -285,5 +285,12 @@ namespace System.Linq.Expressions.Tests
             var loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
             Assert.NotSame(loop, loop.Update(loop.BreakLabel, Expression.Label(), loop.Body));
         }
+
+        [Fact]
+        public void ToStringTest()
+        {
+            var e = Expression.Loop(Expression.Empty());
+            Assert.Equal("loop { ... }", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -536,5 +536,15 @@ namespace System.Linq.Expressions.Tests
 
             Assert.Throws<ArgumentException>("property", () => Expression.MakeMemberAccess(expression, createdProperty));
         }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.Property(null, typeof(DateTime).GetProperty(nameof(DateTime.Now)));
+            Assert.Equal("DateTime.Now", e1.ToString());
+
+            var e2 = Expression.Property(Expression.Parameter(typeof(DateTime), "d"), typeof(DateTime).GetProperty(nameof(DateTime.Year)));
+            Assert.Equal("d.Year", e2.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -453,6 +453,22 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentNullException>("type", () => Expression.New((Type)null));
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e1 = Expression.New(typeof(Bar).GetConstructor(Type.EmptyTypes));
+            Assert.Equal("new Bar()", e1.ToString());
+
+            var e2 = Expression.New(typeof(Bar).GetConstructor(new[] { typeof(int) }), Expression.Parameter(typeof(int), "foo"));
+            Assert.Equal("new Bar(foo)", e2.ToString());
+
+            var e3 = Expression.New(typeof(Bar).GetConstructor(new[] { typeof(int), typeof(int) }), Expression.Parameter(typeof(int), "foo"), Expression.Parameter(typeof(int), "qux"));
+            Assert.Equal("new Bar(foo, qux)", e3.ToString());
+
+            var e4 = Expression.New(typeof(Bar).GetConstructor(new[] { typeof(int), typeof(int) }), new[] { Expression.Parameter(typeof(int), "foo"), Expression.Parameter(typeof(int), "qux") }, new[] { typeof(Bar).GetProperty(nameof(Bar.Foo)), typeof(Bar).GetProperty(nameof(Bar.Qux)) });
+            Assert.Equal("new Bar(Foo = foo, Qux = qux)", e4.ToString());
+        }
+
         public static IEnumerable<object[]> Type_InvalidType_TestData()
         {
             yield return new object[] { typeof(void) };
@@ -512,6 +528,24 @@ namespace System.Linq.Expressions.Tests
         static class Unreachable<T>
         {
             public static T WriteOnly { set { } }
+        }
+
+        class Bar
+        {
+            public Bar()
+            {
+            }
+
+            public Bar(int foo)
+            {
+            }
+
+            public Bar(int foo, int qux)
+            {
+            }
+
+            public int Foo { get; set; }
+            public int Qux { get; set; }
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
+++ b/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
@@ -617,5 +617,17 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("case (0, \"A\"): ...", sc.ToString());
         }
 
+        [Fact]
+        public void ToStringTest()
+        {
+            var e1 = Expression.Switch(Expression.Parameter(typeof(int), "x"), Expression.SwitchCase(Expression.Empty(), Expression.Constant(1)));
+            Assert.Equal("switch (x) { ... }", e1.ToString());
+
+            var e2 = Expression.SwitchCase(Expression.Parameter(typeof(int), "x"), Expression.Constant(1));
+            Assert.Equal("case (1): ...", e2.ToString());
+
+            var e3 = Expression.SwitchCase(Expression.Parameter(typeof(int), "x"), Expression.Constant(1), Expression.Constant(2));
+            Assert.Equal("case (1, 2): ...", e3.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="BinaryOperators\Arithmetic\BinaryNullableMultiplyTests.cs" />
     <Compile Include="BinaryOperators\Arithmetic\BinaryNullablePowerTests.cs" />
     <Compile Include="BinaryOperators\Arithmetic\BinaryNullableSubtractTests.cs" />
+    <Compile Include="BinaryOperators\Arithmetic\BinaryPowerTests.cs" />
     <Compile Include="BinaryOperators\Arithmetic\BinarySubtractTests.cs" />
     <Compile Include="BinaryOperators\Assignment\Assign.cs" />
     <Compile Include="BinaryOperators\Assignment\OpAssign.cs" />

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
@@ -187,5 +187,12 @@ namespace System.Linq.Expressions.Tests
 
             Assert.False(isNullOfType());
         }
+
+        [Fact]
+        public void ToStringTest()
+        {
+            var e = Expression.TypeEqual(Expression.Parameter(typeof(string), "s"), typeof(string));
+            Assert.Equal("(s TypeEqual String)", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
@@ -135,5 +135,12 @@ namespace System.Linq.Expressions.Tests
             visitor.Visit(expression);
             Assert.Same(expression, visitor.LastTypeBinaryVisited);
         }
+
+        [Fact]
+        public void ToStringTest()
+        {
+            var e = Expression.TypeIs(Expression.Parameter(typeof(object), "o"), typeof(string));
+            Assert.Equal("(o Is String)", e.ToString());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
@@ -101,6 +101,13 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.NegateChecked(Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("-x", e.ToString());
+        }
+
         #endregion
 
         #region Test verifiers

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
@@ -101,6 +101,13 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.Negate(Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("-x", e.ToString());
+        }
+
         #endregion
 
         #region Test verifiers

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
@@ -101,6 +101,13 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.Not(Expression.Parameter(typeof(bool), "x"));
+            Assert.Equal("Not(x)", e.ToString());
+        }
+
         #endregion
 
         #region Test verifiers

--- a/src/System.Linq.Expressions/tests/Unary/UnaryConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryConvertTests.cs
@@ -102,6 +102,18 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            // NB: Unlike TypeAs, the output does not include the type we're converting to
+
+            var e1 = Expression.Convert(Expression.Parameter(typeof(object), "o"), typeof(int));
+            Assert.Equal("Convert(o)", e1.ToString());
+
+            var e2 = Expression.ConvertChecked(Expression.Parameter(typeof(long), "x"), typeof(int));
+            Assert.Equal("ConvertChecked(x)", e2.ToString());
+        }
+
         private static IEnumerable<KeyValuePair<Expression, object>> ConvertBooleanToNumeric()
         {
             var boolF = Expression.Constant(false);
@@ -251,7 +263,7 @@ namespace System.Linq.Expressions.Tests
         private static IEnumerable<Expression> ConvertUnboxing()
         {
             // C# Language Specification - 4.3.2 Unboxing conversions
-            // ----------------------------------------------------
+            // ------------------------------------------------------
 
             var factories = new Func<Expression, Type, Expression>[] { Expression.Convert, Expression.ConvertChecked };
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
@@ -91,6 +91,13 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.Decrement(Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("Decrement(x)", e.ToString());
+        }
+
         #endregion
 
         #region Test verifiers

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
@@ -91,6 +91,13 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.Increment(Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("Increment(x)", e.ToString());
+        }
+
         #endregion
 
         #region Test verifiers

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
@@ -22,6 +22,13 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.IsFalse(Expression.Parameter(typeof(bool), "x"));
+            Assert.Equal("IsFalse(x)", e.ToString());
+        }
+
         #endregion
 
         #region Test verifiers

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
@@ -22,6 +22,13 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.IsTrue(Expression.Parameter(typeof(bool), "x"));
+            Assert.Equal("IsTrue(x)", e.ToString());
+        }
+
         #endregion
 
         #region Test verifiers

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
@@ -92,6 +92,13 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.OnesComplement(Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("~(x)", e.ToString());
+        }
+
         #endregion
 
         #region Test verifiers

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
@@ -102,6 +102,13 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.UnaryPlus(Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("+x", e.ToString());
+        }
+
         #endregion
 
         #region Test verifiers

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
@@ -21,6 +21,13 @@ namespace System.Linq.Expressions.Tests
             VerifyUnbox(null, typeof(int), true, useInterpreter);
         }
 
+        [Fact]
+        public static void ToStringTest()
+        {
+            var e = Expression.Unbox(Expression.Parameter(typeof(object), "x"), typeof(int));
+            Assert.Equal("Unbox(x)", e.ToString());
+        }
+
         #endregion
 
         #region Test verifiers

--- a/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
@@ -174,5 +174,18 @@ namespace System.Linq.Expressions.Tests
             RuntimeVariablesExpression varExp = Expression.RuntimeVariables(Enumerable.Repeat(Expression.Variable(typeof(RuntimeVariablesTests)), 1));
             Assert.NotSame(varExp, varExp.Update(new[] { Expression.Variable(typeof(RuntimeVariablesTests)) }));
         }
+
+        [Fact]
+        public void ToStringTest()
+        {
+            var e1 = Expression.RuntimeVariables();
+            Assert.Equal("()", e1.ToString());
+
+            var e2 = Expression.RuntimeVariables(Expression.Parameter(typeof(int), "x"));
+            Assert.Equal("(x)", e2.ToString());
+
+            var e3 = Expression.RuntimeVariables(Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            Assert.Equal("(x, y)", e3.ToString());
+        }
     }
 }


### PR DESCRIPTION
This addresses issue #11444. It excludes tests for `Label`, `Goto`, and the unary assignment nodes, which were also subject to some code fixes in https://github.com/dotnet/corefx/issues/11426 and https://github.com/dotnet/corefx/issues/11421, so tests are included there. This PR doesn't make any changes to `ExpressionStringBuilder` and purely consists of tests.