### PR TITLE
Add missing token property to System.Security.Principal.WindowsIdentity

### DIFF
--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -556,6 +556,14 @@ namespace System.Security.Principal
             }
         }
 
+        public virtual IntPtr Token
+        {
+            get
+            {
+                return _safeTokenHandle.DangerousGetHandle();
+            }
+        }
+
         //
         // Public methods.
         //

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -60,6 +60,18 @@ public class WindowsIdentityTests
         CheckDispose(cloneWinId);        
     }
 
+    [Fact]
+    public static void GetTokenHandle()
+    {
+        IntPtr logonToken = WindowsIdentity.GetCurrent().Token;
+        WindowsIdentity winId = new WindowsIdentity(logonToken);
+
+        Assert.NotNull(winId);
+        Assert.Equal(winId.Token, logonToken);
+
+        CheckDispose(winId);
+    }
+
     private static void CheckDispose(WindowsIdentity identity, bool anonymous = false)
     {
         Assert.False(identity.AccessToken.IsClosed);


### PR DESCRIPTION
fixes #11297
Add missing property `Token`.