### PR TITLE
Replace Contract.Asserts with Debug.Asserts

### DIFF
--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 
 namespace System.Collections
@@ -90,8 +91,8 @@ namespace System.Collections
                 j += 4;
             }
 
-            Contract.Assert(bytes.Length - j >= 0, "BitArray byteLength problem");
-            Contract.Assert(bytes.Length - j < 4, "BitArray byteLength problem #2");
+            Debug.Assert(bytes.Length - j >= 0, "BitArray byteLength problem");
+            Debug.Assert(bytes.Length - j < 4, "BitArray byteLength problem #2");
 
             switch (bytes.Length - j)
             {
@@ -479,7 +480,7 @@ namespace System.Collections
         /// <returns></returns>
         private static int GetArrayLength(int n, int div)
         {
-            Contract.Assert(div > 0, "GetArrayLength: div arg must be greater than 0");
+            Debug.Assert(div > 0, "GetArrayLength: div arg must be greater than 0");
             return n > 0 ? (((n - 1) / div) + 1) : 0;
         }
 

--- a/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
@@ -373,7 +373,7 @@ namespace System.Collections.Generic
 
         private void Resize(int newSize, bool forceNewHashCodes)
         {
-            Contract.Assert(newSize >= entries.Length);
+            Debug.Assert(newSize >= entries.Length);
             int[] newBuckets = new int[newSize];
             for (int i = 0; i < newBuckets.Length; i++) newBuckets[i] = -1;
 

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemUnicastIPAddressInformation.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemUnicastIPAddressInformation.cs
@@ -168,7 +168,7 @@ namespace System.Net.NetworkInformation
                 addressBytes = new byte[16];
             }
 
-            Contract.Assert(prefixLength < (addressBytes.Length * 8));
+            Debug.Assert(prefixLength < (addressBytes.Length * 8));
 
             // Enable bits one at a time from left/high to right/low.
             for (int bit = 0; bit < prefixLength; bit++)

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/ACE.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/ACE.cs
@@ -10,9 +10,10 @@
 ===========================================================*/
 
 using System;
-using System.Security.Principal;
-using System.Globalization;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
+using System.Globalization;
+using System.Security.Principal;
 
 namespace System.Security.AccessControl
 {
@@ -139,7 +140,7 @@ nameof(binaryForm),
                 // Indicates a bug in the implementation, not in user's code.
                 //
 
-                Contract.Assert(false, "Length > ushort.MaxValue");
+                Debug.Assert(false, "Length > ushort.MaxValue");
                 // Replacing SystemException with InvalidOperationException. It's not a perfect fit,
                 // but it's the best exception type available to indicate a failure because
                 // of a bug in the ACE itself.
@@ -888,7 +889,7 @@ nameof(opaque),
             {
                 if (OpaqueLength > MaxOpaqueLength)
                 {
-                    Contract.Assert(false, "OpaqueLength somehow managed to exceed MaxOpaqueLength");
+                    Debug.Assert(false, "OpaqueLength somehow managed to exceed MaxOpaqueLength");
                     // Replacing SystemException with InvalidOperationException. It's not a perfect fit,
                     // but it's the best exception type available to indicate a failure because
                     // of a bug in the ACE itself.
@@ -1203,7 +1204,7 @@ nameof(opaque),
                     // Indicates a bug in the implementation, not in user's code
                     //
 
-                    Contract.Assert(false, "Invalid ACE type");
+                    Debug.Assert(false, "Invalid ACE type");
                     // Replacing SystemException with InvalidOperationException. It's not a perfect fit,
                     // but it's the best exception type available to indicate a failure because
                     // of a bug in the ACE itself.
@@ -1644,7 +1645,7 @@ nameof(qualifier),
             {
                 if (OpaqueLength > MaxOpaqueLengthInternal)
                 {
-                    Contract.Assert(false, "OpaqueLength somehow managed to exceed MaxOpaqueLength");
+                    Debug.Assert(false, "OpaqueLength somehow managed to exceed MaxOpaqueLength");
                     // Replacing SystemException with InvalidOperationException. It's not a perfect fit,
                     // but it's the best exception type available to indicate a failure because
                     // of a bug in the ACE itself.
@@ -2208,7 +2209,7 @@ nameof(qualifier),
             {
                 if (OpaqueLength > MaxOpaqueLengthInternal)
                 {
-                    Contract.Assert(false, "OpaqueLength somehow managed to exceed MaxOpaqueLength");
+                    Debug.Assert(false, "OpaqueLength somehow managed to exceed MaxOpaqueLength");
                     // Replacing SystemException with InvalidOperationException. It's not a perfect fit,
                     // but it's the best exception type available to indicate a failure because
                     // of a bug in the ACE itself.

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
@@ -9,14 +9,15 @@
 **
 ===========================================================*/
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Security.Principal;
+
 namespace System.Security.AccessControl
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Security.Principal;
-    using System.Diagnostics.Contracts;
-
     public sealed class AceEnumerator : IEnumerator
     {
         #region Private Members
@@ -377,7 +378,7 @@ nameof(binaryForm));
                     // Binary length of an ace must ALWAYS be divisible by 4.
                     //
 
-                    Contract.Assert( false, "aceLength % 4 != 0" );
+                    Debug.Assert( false, "aceLength % 4 != 0" );
                     // Replacing SystemException with InvalidOperationException. This code path 
                     // indicates a bad ACE, but I don't know of a great exception to represent that. 
                     // InvalidOperation seems to be the closest, though it's definitely not exactly 
@@ -520,7 +521,7 @@ nameof(binaryForm));
                     // Binary length of an ace must ALWAYS be divisible by 4.
                     //
 
-                    Contract.Assert( false, "aceLength % 4 != 0" );
+                    Debug.Assert( false, "aceLength % 4 != 0" );
                     // Replacing SystemException with InvalidOperationException. This code path 
                     // indicates a bad ACE, but I don't know of a great exception to represent that. 
                     // InvalidOperation seems to be the closest, though it's definitely not exactly 
@@ -560,7 +561,7 @@ nameof(binaryForm));
                     // Binary length of an ace must ALWAYS be divisible by 4.
                     //
 
-                    Contract.Assert( false, "aceLength % 4 != 0" );
+                    Debug.Assert( false, "aceLength % 4 != 0" );
                     // Replacing SystemException with InvalidOperationException. This code path 
                     // indicates a bad ACE, but I don't know of a great exception to represent that. 
                     // InvalidOperation seems to be the closest, though it's definitely not exactly 
@@ -1381,7 +1382,7 @@ nameof(binaryForm));
                 // This method is called only when the access masks of the two aces are already confirmed to be exact matches
                 // therefore the second condition of case 2 is already verified
                 //
-                Contract.Assert(( ace.AccessMask & newAce.AccessMask) ==  newAce.AccessMask, "AceFlagsAreMergeable:: AccessMask of existing ace does not contain all access bits of new ace.");
+                Debug.Assert(( ace.AccessMask & newAce.AccessMask) ==  newAce.AccessMask, "AceFlagsAreMergeable:: AccessMask of existing ace does not contain all access bits of new ace.");
                 return true;
             }
 
@@ -1757,7 +1758,7 @@ nameof(binaryForm));
                             // Only allow and deny ACEs are allowed here
                             //
 
-                            Contract.Assert( false, "Audit and alarm ACEs must have been stripped by remove-meaningless logic" );
+                            Debug.Assert( false, "Audit and alarm ACEs must have been stripped by remove-meaningless logic" );
                             return false;
                         }
                     }
@@ -1803,7 +1804,7 @@ nameof(binaryForm));
                         // for fear of destabilization, so adding an assert instead
                         //
 
-                        Contract.Assert( ace != null, "How did a null ACE end up in a SACL?" );
+                        Debug.Assert( ace != null, "How did a null ACE end up in a SACL?" );
                         continue;
                     }
 
@@ -1835,7 +1836,7 @@ nameof(binaryForm));
                             // Only audit and alarm ACEs are allowed here
                             //
 
-                            Contract.Assert( false, "Allow and deny ACEs must have been stripped by remove-meaningless logic" );
+                            Debug.Assert( false, "Allow and deny ACEs must have been stripped by remove-meaningless logic" );
                             return false;
                         }
                     }

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/CommonObjectSecurity.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/CommonObjectSecurity.cs
@@ -12,9 +12,10 @@
 using Microsoft.Win32;
 using System;
 using System.Collections;
-using System.Security.Principal;
-using System.Runtime.InteropServices;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
 
 namespace System.Security.AccessControl
 {
@@ -276,7 +277,7 @@ nameof(targetType));
                             result = _securityDescriptor.DiscretionaryAcl.RemoveAccess(AccessControlType.Allow, sid, -1, InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit, 0);
                             if (result == false)
                             {
-                                Contract.Assert(false, "Invalid operation");
+                                Debug.Assert(false, "Invalid operation");
                                 throw new InvalidOperationException();
                             }
 
@@ -317,7 +318,7 @@ nameof(modification),
                             result = _securityDescriptor.DiscretionaryAcl.RemoveAccess(AccessControlType.Deny, sid, -1, InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit, 0);
                             if (result == false)
                             {
-                                Contract.Assert(false, "Invalid operation");
+                                Debug.Assert(false, "Invalid operation");
                                 throw new InvalidOperationException();
                             }
 
@@ -335,7 +336,7 @@ nameof(modification),
                 }
                 else
                 {
-                    Contract.Assert(false, "rule.AccessControlType unrecognized");
+                    Debug.Assert(false, "rule.AccessControlType unrecognized");
                     throw new ArgumentException(SR.Format(SR.Arg_EnumIllegalVal, (int)rule.AccessControlType), "rule.AccessControlType");
                 }
 

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
@@ -12,12 +12,13 @@
 using Microsoft.Win32;
 using System;
 using System.Collections;
-using System.Security.Principal;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Security.Principal;
 using FileNotFoundException = System.IO.FileNotFoundException;
-using System.Globalization;
-using System.Diagnostics.Contracts;
 
 namespace System.Security.AccessControl
 {
@@ -153,7 +154,7 @@ nameof(name));
                     }
                     else
                     {
-                        Contract.Assert(false, string.Format(CultureInfo.InvariantCulture, "Win32GetSecurityInfo() failed with unexpected error code {0}", error));
+                        Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Win32GetSecurityInfo() failed with unexpected error code {0}", error));
                         exception = new InvalidOperationException(SR.Format(SR.AccessControl_UnexpectedError, error));
                     }
                 }
@@ -295,7 +296,7 @@ nameof(name));
                         }
                         else
                         {
-                            Contract.Assert(false, string.Format(CultureInfo.InvariantCulture, "Unexpected error code {0}", error));
+                            Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Unexpected error code {0}", error));
                             exception = new InvalidOperationException(SR.Format(SR.AccessControl_UnexpectedError, error));
                         }
                     }

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurity.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurity.cs
@@ -12,12 +12,13 @@
 using Microsoft.Win32;
 using System;
 using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Threading;
-using System.Diagnostics.Contracts;
-using System.Reflection;
 
 namespace System.Security.AccessControl
 {
@@ -94,7 +95,7 @@ namespace System.Security.AccessControl
 
         private void UpdateWithNewSecurityDescriptor( RawSecurityDescriptor newOne, AccessControlSections includeSections )
         {
-            Contract.Assert( newOne != null, "Must not supply a null parameter here" );
+            Debug.Assert( newOne != null, "Must not supply a null parameter here" );
 
             if (( includeSections & AccessControlSections.Owner ) != 0 )
             {

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
@@ -16,12 +16,13 @@ using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Principal;
 using System.Threading;
-using System.Runtime.Versioning;
-using System.Diagnostics.Contracts;
 using CultureInfo = System.Globalization.CultureInfo;
 using FCall = System.Security.Principal.Win32;
 using Luid = Interop.mincore.LUID;
@@ -129,7 +130,7 @@ namespace System.Security.AccessControl
                         }
                         else
                         {
-                            Contract.Assert(false, string.Format(CultureInfo.InvariantCulture, "LookupPrivilegeValue() failed with unrecognized error code {0}", error));
+                            System.Diagnostics.Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "LookupPrivilegeValue() failed with unrecognized error code {0}", error));
                             throw new InvalidOperationException();
                         }
                     }
@@ -228,7 +229,7 @@ namespace System.Security.AccessControl
                                     success = false;
                                 }
 
-                                Contract.Assert(this.isImpersonating == false, "Incorrect isImpersonating state");
+                                System.Diagnostics.Debug.Assert(this.isImpersonating == false, "Incorrect isImpersonating state");
 
                                 if (success == true)
                                 {
@@ -292,7 +293,7 @@ namespace System.Security.AccessControl
                 }
                 else if (error != 0)
                 {
-                    Contract.Assert(false, string.Format(CultureInfo.InvariantCulture, "WindowsIdentity.GetCurrentThreadToken() failed with unrecognized error code {0}", error));
+                    System.Diagnostics.Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "WindowsIdentity.GetCurrentThreadToken() failed with unrecognized error code {0}", error));
                     throw new InvalidOperationException();
                 }
             }
@@ -397,7 +398,7 @@ namespace System.Security.AccessControl
 
         ~Privilege()
         {
-            Contract.Assert(!this.needToRevert, "Must revert privileges that you alter!");
+            System.Diagnostics.Debug.Assert(!this.needToRevert, "Must revert privileges that you alter!");
 
             if (this.needToRevert)
             {
@@ -548,7 +549,7 @@ namespace System.Security.AccessControl
             }
             else if (error != 0)
             {
-                Contract.Assert(false, string.Format(CultureInfo.InvariantCulture, "AdjustTokenPrivileges() failed with unrecognized error code {0}", error));
+                System.Diagnostics.Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "AdjustTokenPrivileges() failed with unrecognized error code {0}", error));
                 throw new InvalidOperationException();
             }
         }
@@ -638,7 +639,7 @@ namespace System.Security.AccessControl
             }
             else if (error != 0)
             {
-                Contract.Assert(false, string.Format(CultureInfo.InvariantCulture, "AdjustTokenPrivileges() failed with unrecognized error code {0}", error));
+                System.Diagnostics.Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "AdjustTokenPrivileges() failed with unrecognized error code {0}", error));
                 throw new InvalidOperationException();
             }
         }

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
@@ -11,10 +11,11 @@
 
 using Microsoft.Win32;
 using System;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
-using System.Globalization;
-using System.Diagnostics.Contracts;
 
 namespace System.Security.AccessControl
 {
@@ -240,12 +241,12 @@ namespace System.Security.AccessControl
                 // Indicates that the marshaling logic in GetBinaryForm is busted
                 //
 
-                Contract.Assert(false, "binaryForm produced invalid output");
+                Debug.Assert(false, "binaryForm produced invalid output");
                 throw new InvalidOperationException();
             }
             else if (error != Interop.mincore.Errors.ERROR_SUCCESS)
             {
-                Contract.Assert(false, string.Format(CultureInfo.InvariantCulture, "Win32.ConvertSdToSddl returned {0}", error));
+                Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Win32.ConvertSdToSddl returned {0}", error));
                 throw new InvalidOperationException();
             }
 
@@ -669,7 +670,7 @@ nameof(sddlForm));
                     }
                     else if (error != Interop.mincore.Errors.ERROR_SUCCESS)
                     {
-                        Contract.Assert(false, string.Format(CultureInfo.InvariantCulture, "Unexpected error out of Win32.ConvertStringSdToSd: {0}", error));
+                        Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Unexpected error out of Win32.ConvertStringSdToSd: {0}", error));
                         // TODO : This should be a Win32Exception once that type is available
                         throw new Exception();
                     }

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/Win32.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/Win32.cs
@@ -6,12 +6,13 @@ using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security;
 using System.Security.Principal;
-using System.Diagnostics.Contracts;
 
 namespace System.Security.AccessControl
 {
@@ -300,7 +301,7 @@ nameof(handle));
                 else
                 {
                     // both are null, shouldn't happen
-                    Contract.Assert(false, "Internal error: both name and handle are null");
+                    Debug.Assert(false, "Internal error: both name and handle are null");
                     throw new ArgumentException();
                 }
 


### PR DESCRIPTION
I noticed a few more places where Contract.Asserts have snuck into the corefx codebase.  Following our decision to standardize on Debug.Assert, this just replaces all of them (with the exception of tests explicitly testing Contract, and uses in System.Diagnostics.Tracing, where there's a goal of sharing the same code with coreclr).

cc: @ianhays, @ellismg 