### PR TITLE
Remove unnecessary comparison in SequencePointCollection

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/SequencePointCollection.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/SequencePointCollection.cs
@@ -149,7 +149,7 @@ namespace System.Reflection.Metadata
             private int AddOffsets(int value, int delta)
             {
                 int result = unchecked(value + delta);
-                if (result < 0 || result > int.MaxValue)
+                if (result < 0)
                 {
                     Throw.SequencePointValueOutOfRange();
                 }


### PR DESCRIPTION
Found by a coverity scan
cc: @nguerrera, @tmat