### PR TITLE
Remove unnecessarily Volatile.Reads in EnsureStoreOpened

### DIFF
--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -208,12 +208,12 @@ namespace System.Net
             X509Store store = isMachineStore ? s_myMachineCertStoreEx : s_myCertStoreEx;
 
             // TODO #3862 Investigate if this can be switched to either the static or Lazy<T> patterns.
-            if (Volatile.Read(ref store) == null)
+            if (store == null)
             {
                 lock (s_syncObject)
                 {
                     store = isMachineStore ? s_myMachineCertStoreEx : s_myCertStoreEx;
-                    if (Volatile.Read(ref store) == null)
+                    if (store == null)
                     {
                         // NOTE: that if this call fails we won't keep track and the next time we enter we will try to open the store again.
                         StoreLocation storeLocation = isMachineStore ? StoreLocation.LocalMachine : StoreLocation.CurrentUser;


### PR DESCRIPTION
The fields being read are already volatile, so the relevant read operations already have fences.  And these Volatile.Reads are on a local that's not shared with any other thread, making them unnecessary.

Found by a coverity scan
cc: @cipop, @davidsh, @bartonjs