### PR TITLE
Fixing ExpressionStringBuilder for Power and Convert[Checked]

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
@@ -251,7 +251,7 @@ namespace System.Linq.Expressions
                     case ExpressionType.OrAssign:              op = IsBool(node) ? "||=" : "|="; break;
                     case ExpressionType.ExclusiveOr:           op = "^";                         break;
                     case ExpressionType.ExclusiveOrAssign:     op = "^=";                        break;
-                    case ExpressionType.Power:                 op = "^";                         break;
+                    case ExpressionType.Power:                 op = "**";                        break; // This was changed in CoreFx from ^ to **
                     case ExpressionType.PowerAssign:           op = "**=";                       break;
                     case ExpressionType.Coalesce:              op = "??";                        break;
                     default:
@@ -634,6 +634,10 @@ namespace System.Linq.Expressions
                 case ExpressionType.TypeAs:              Out(" As ");
                                                          Out(node.Type.Name);
                                                          Out(')');               break;
+                case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked:      Out(", ");
+                                                         Out(node.Type.Name);
+                                                         Out(')');               break; // These were changed in CoreFx to add the type name
                 case ExpressionType.PostIncrementAssign: Out("++");              break;
                 case ExpressionType.PostDecrementAssign: Out("--");              break;
                 default:                                 Out(')');               break;

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryPowerTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryPowerTests.cs
@@ -355,7 +355,7 @@ namespace System.Linq.Expressions.Tests
         public static void ToStringTest()
         {
             var e = Expression.Power(Expression.Parameter(typeof(double), "a"), Expression.Parameter(typeof(double), "b"));
-            Assert.Equal("(a ^ b)", e.ToString()); // QUIRK: Same output as ExclusiveOr, see https://github.com/dotnet/corefx/issues/11415
+            Assert.Equal("(a ** b)", e.ToString());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Unary/UnaryConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryConvertTests.cs
@@ -108,10 +108,10 @@ namespace System.Linq.Expressions.Tests
             // NB: Unlike TypeAs, the output does not include the type we're converting to
 
             var e1 = Expression.Convert(Expression.Parameter(typeof(object), "o"), typeof(int));
-            Assert.Equal("Convert(o)", e1.ToString());
+            Assert.Equal("Convert(o, Int32)", e1.ToString());
 
             var e2 = Expression.ConvertChecked(Expression.Parameter(typeof(long), "x"), typeof(int));
-            Assert.Equal("ConvertChecked(x)", e2.ToString());
+            Assert.Equal("ConvertChecked(x, Int32)", e2.ToString());
         }
 
         private static IEnumerable<KeyValuePair<Expression, object>> ConvertBooleanToNumeric()


### PR DESCRIPTION
This fixes issue #11415. CC @VSadov.