### PR TITLE
Remove some more dead code across a few libs

### DIFF
--- a/src/Common/src/System/Net/Security/Unix/SafeFreeNegoCredentials.cs
+++ b/src/Common/src/System/Net/Security/Unix/SafeFreeNegoCredentials.cs
@@ -59,10 +59,7 @@ namespace System.Net.Security
                 domain = domain.Trim();
             }
 
-            if (username != null)
-            {
-                username = username.Trim();
-            }
+            username = username.Trim();
 
             if ((username.IndexOf(At) < 0) && !string.IsNullOrEmpty(domain))
             {

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -708,10 +708,10 @@ namespace System.Diagnostics
             /// </summary>
             public TransformSpec(string transformSpec, int startIdx, int endIdx, TransformSpec next = null)
             {
+                Debug.Assert(transformSpec != null && startIdx < endIdx);
 #if DEBUG
                 string spec = transformSpec.Substring(startIdx, endIdx - startIdx);
 #endif
-                Debug.Assert(transformSpec != null && startIdx < endIdx);
                 Next = next;
 
                 // Pick off the Var=

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/PatternMatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/PatternMatcher.cs
@@ -227,7 +227,6 @@ namespace System.IO
                 if (nameOffset < name.Length)
                 {
                     nameChar = name[nameOffset];
-                    length = 1;
                     nameOffset++;
                 }
                 else

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
@@ -425,6 +425,7 @@ namespace System.IO
                 }
 
                 // Add subdirs to _searchList. Exempt ReparsePoints as appropriate
+                Debug.Assert(_searchList != null, "_searchList should not be null");
                 int initialCount = _searchList.Count;
                 do
                 {
@@ -439,7 +440,6 @@ namespace System.IO
                         // Setup search data for the sub directory and push it into the list
                         PathPair searchDataSubDir = new PathPair(tempUserPath, tempFullPath);
 
-                        Debug.Assert(_searchList != null, "_searchList should not be null");
                         _searchList.Add(searchDataSubDir);
                     }
                 } while (Interop.mincore.FindNextFile(hnd, ref data));

--- a/src/System.IO/src/System/IO/BinaryReader.cs
+++ b/src/System.IO/src/System/IO/BinaryReader.cs
@@ -510,10 +510,8 @@ namespace System.IO
                 Debug.Assert(charsRead < 2, "InternalReadOneChar - assuming we only got 0 or 1 char, not 2!");
                 //                Console.WriteLine("That became: " + charsRead + " characters.");
             }
-            if (charsRead == 0)
-            {
-                return -1;
-            }
+
+            Debug.Assert(charsRead != 0);
 
             return _singleChar[0];
         }

--- a/src/System.IO/src/System/IO/StringReader.cs
+++ b/src/System.IO/src/System/IO/StringReader.cs
@@ -23,7 +23,7 @@ namespace System.IO
             }
 
             _s = s;
-            _length = s == null ? 0 : s.Length;
+            _length = s.Length;
         }
 
 

--- a/src/System.Text.Encoding.CodePages/src/System/Text/SBCSCodePageEncoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/SBCSCodePageEncoding.cs
@@ -852,7 +852,8 @@ namespace System.Text
             byte[] byteBuffer = new byte[1];
             char* charEnd = chars + charCount;
 
-            DecoderFallbackBufferHelper fallbackHelper = new DecoderFallbackBufferHelper(decoder.FallbackBuffer);
+            DecoderFallbackBufferHelper fallbackHelper = new DecoderFallbackBufferHelper(
+                decoder != null ? decoder.FallbackBuffer : DecoderFallback.CreateFallbackBuffer());
 
             // Not quite so fast loop
             while (bytes < byteEnd)

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchBlock.cs
@@ -654,7 +654,7 @@ namespace System.Threading.Tasks.Dataflow
                 {
                     etwLog.TaskLaunchedForMessageHandling(
                         _owningBatch, _nonGreedyState.TaskForInputProcessing, DataflowEtwProvider.TaskLaunchedReason.ProcessingInputMessages,
-                        _messages.Count + (_nonGreedyState != null ? _nonGreedyState.PostponedMessages.Count : 0));
+                        _messages.Count + _nonGreedyState.PostponedMessages.Count);
                 }
 #endif
 

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XLinq.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XLinq.cs
@@ -559,16 +559,8 @@ namespace System.Xml.Linq
             FlushElement();
             _element = e;
             Write(e.content);
-            bool contentWritten = _element == null;
             FlushElement();
-            if (contentWritten)
-            {
-                _writer.WriteFullEndElement();
-            }
-            else
-            {
-                _writer.WriteEndElement();
-            }
+            _writer.WriteEndElement();
             _resolver.PopScope();
         }
 


### PR DESCRIPTION
Found by a coverity scan

I'm still working through the results of a scan, but this is the last of the changes from the batch I've reviewed thus far. There were ~540 issues reported across corefx, of which I've done an initial triage through ~340.  Of those:
- 193 were false positives, i.e. the tool was wrong, e.g. it looked at the IL of a called method and determined that it returned null and thus the call site was going to blow up with a null reference exception, but the called method was from a reference assembly, where every method has a dummy implementation
- 36 weren't immediately obvious and will require some more investigation, which for some issues may be worthwhile (e.g. race conditions) and which for others I won't bother with (e.g. dead code)
- 56 were valid warnings but intentional, e.g. concerns around how the legacy SyncArrayList type uses locking, exceptions from auto-generated methods in our always-throw unix implementations, etc.
- 58 were bugs, and I've submitted PRs to fix [all of these](https://github.com/dotnet/corefx/pulls?utf8=%E2%9C%93&q=is%3Apr%20coverity), this PR being the last of them.  Most of these were minor, though, e.g. irrelevant asserts, dead code, etc.  Still, there were a few worthwhile issues caught and fixed.

I still plan to go through and triage the remaining ~200 warnings.