### PR TITLE
Update package baseline for s.p.xml and s.p.xml.linq

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2425,8 +2425,12 @@
       }
     },
     "System.Json": {},
-    "System.Private.Xml": {},
-    "System.Private.Xml.Linq": {},
+    "System.Private.Xml": {
+        "BaselineVersion": "4.3.0"
+    },
+    "System.Private.Xml.Linq": {
+        "BaselineVersion": "4.3.0"
+    },
     "System.Security.Permissions": {
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.3.0"


### PR DESCRIPTION
Adding a baseline for two assemblies, so that they publish packages with the correct version.

Per @weshaggard 