### PR TITLE
Initial IsolatedStorage tests

### DIFF
--- a/src/System.IO.IsolatedStorage/System.IO.IsolatedStorage.sln
+++ b/src/System.IO.IsolatedStorage/System.IO.IsolatedStorage.sln
@@ -12,39 +12,75 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{0610303E-B70C-468D-B4AA-4E91573254E7}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4779DC08-FCB3-4678-9470-2E6076F924D1}"
-	ProjectSection(SolutionItems) = preProject
-		src\project.json = src\project.json
-		src\System.IO.IsolatedStorage.builds = src\System.IO.IsolatedStorage.builds
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.IsolatedStorage", "src\System.IO.IsolatedStorage.csproj", "{FAF5D1E4-BA43-4663-8429-C069066D75CB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.IsolatedStorage", "ref\System.IO.IsolatedStorage.csproj", "{27225772-FE8B-49D7-8E58-29242D536130}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{8751BC6B-FD4E-40E0-A5F8-63F92D987719}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.IsolatedStorage.Tests", "tests\System.IO.IsolatedStorage.Tests.csproj", "{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		net463_Debug|Any CPU = net463_Debug|Any CPU
+		net463_Release|Any CPU = net463_Release|Any CPU
 		uap101_Debug|Any CPU = uap101_Debug|Any CPU
 		uap101_Release|Any CPU = uap101_Release|Any CPU
+		Unix_Debug|Any CPU = Unix_Debug|Any CPU
+		Unix_Release|Any CPU = Unix_Release|Any CPU
 		Windows_Debug|Any CPU = Windows_Debug|Any CPU
 		Windows_Release|Any CPU = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.net463_Debug|Any CPU.ActiveCfg = net463_Debug|Any CPU
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.net463_Debug|Any CPU.Build.0 = net463_Debug|Any CPU
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.net463_Release|Any CPU.ActiveCfg = net463_Release|Any CPU
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.net463_Release|Any CPU.Build.0 = net463_Release|Any CPU
 		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.uap101_Debug|Any CPU.ActiveCfg = uap101_Debug|Any CPU
 		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.uap101_Debug|Any CPU.Build.0 = uap101_Debug|Any CPU
 		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.uap101_Release|Any CPU.ActiveCfg = uap101_Release|Any CPU
 		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.uap101_Release|Any CPU.Build.0 = uap101_Release|Any CPU
-		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Unix_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Unix_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Unix_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Unix_Release|Any CPU.Build.0 = Release|Any CPU
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAF5D1E4-BA43-4663-8429-C069066D75CB}.Windows_Release|Any CPU.Build.0 = Release|Any CPU
+		{27225772-FE8B-49D7-8E58-29242D536130}.net463_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{27225772-FE8B-49D7-8E58-29242D536130}.net463_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{27225772-FE8B-49D7-8E58-29242D536130}.net463_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27225772-FE8B-49D7-8E58-29242D536130}.net463_Release|Any CPU.Build.0 = Release|Any CPU
 		{27225772-FE8B-49D7-8E58-29242D536130}.uap101_Debug|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{27225772-FE8B-49D7-8E58-29242D536130}.uap101_Debug|Any CPU.Build.0 = Windows_Release|Any CPU
 		{27225772-FE8B-49D7-8E58-29242D536130}.uap101_Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27225772-FE8B-49D7-8E58-29242D536130}.uap101_Release|Any CPU.Build.0 = Release|Any CPU
+		{27225772-FE8B-49D7-8E58-29242D536130}.Unix_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{27225772-FE8B-49D7-8E58-29242D536130}.Unix_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{27225772-FE8B-49D7-8E58-29242D536130}.Unix_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27225772-FE8B-49D7-8E58-29242D536130}.Unix_Release|Any CPU.Build.0 = Release|Any CPU
 		{27225772-FE8B-49D7-8E58-29242D536130}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{27225772-FE8B-49D7-8E58-29242D536130}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{27225772-FE8B-49D7-8E58-29242D536130}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{27225772-FE8B-49D7-8E58-29242D536130}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.net463_Debug|Any CPU.ActiveCfg = net463_Debug|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.net463_Debug|Any CPU.Build.0 = net463_Debug|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.net463_Release|Any CPU.ActiveCfg = net463_Release|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.net463_Release|Any CPU.Build.0 = net463_Release|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.uap101_Debug|Any CPU.ActiveCfg = uap101_Debug|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.uap101_Debug|Any CPU.Build.0 = uap101_Debug|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.uap101_Release|Any CPU.ActiveCfg = uap101_Release|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.uap101_Release|Any CPU.Build.0 = uap101_Release|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Unix_Release|Any CPU.Build.0 = Unix_Release|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -52,5 +88,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{FAF5D1E4-BA43-4663-8429-C069066D75CB} = {4779DC08-FCB3-4678-9470-2E6076F924D1}
 		{27225772-FE8B-49D7-8E58-29242D536130} = {0610303E-B70C-468D-B4AA-4E91573254E7}
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91} = {8751BC6B-FD4E-40E0-A5F8-63F92D987719}
 	EndGlobalSection
 EndGlobal

--- a/src/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'=='' and '$(TargetGroup)' == ''"></Configuration>
+    <Configuration Condition="'$(Configuration)'=='' and '$(TargetGroup)' == ''">
+    </Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -45,6 +46,13 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+    <None Include="System.IO.IsolatedStorage.builds" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="ApiCompatBaseline.txt" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
+++ b/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
@@ -139,10 +139,10 @@ namespace System.IO.IsolatedStorage
                     bw.Write(publicKey);
                     bw.Write(name.Version.Major);
                     bw.Write(name.Name);
-                }
 
-                ms.Position = 0;
-                return GetStrongHashSuitableForObjectName(ms);
+                    ms.Position = 0;
+                    return GetStrongHashSuitableForObjectName(ms);
+                }
             }
         }
 
@@ -153,10 +153,10 @@ namespace System.IO.IsolatedStorage
                 using (BinaryWriter b = new BinaryWriter(ms))
                 {
                     b.Write(name.ToUpperInvariant());
-                }
 
-                ms.Position = 0;
-                return GetStrongHashSuitableForObjectName(ms);
+                    ms.Position = 0;
+                    return GetStrongHashSuitableForObjectName(ms);
+                }
             }
         }
 

--- a/src/System.IO.IsolatedStorage/tests/Resources/Strings.resx
+++ b/src/System.IO.IsolatedStorage/tests/Resources/Strings.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="IsolatedStorage_Init" xml:space="preserve">
+    <value>Initialization failed.</value>
+  </data>
+</root>

--- a/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.builds
+++ b/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.builds
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.IO.IsolatedStorage.Tests.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TestTFMs>net463</TestTFMs>
+    </Project>
+    <Project Include="System.IO.IsolatedStorage.Tests.csproj">
+      <OSGroup>Unix</OSGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.7</TargetGroup>
+    </Project>
+    <Project Include="System.IO.IsolatedStorage.Tests.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.7</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TestTFM Condition="'$(TestTFM)' == ''">netcoreapp1.1</TestTFM>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <ProjectGuid>{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.IO.IsolatedStorage.Tests</AssemblyName>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
+    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <RuntimeTargetMonikers>.NETCoreApp,Version=v1.1</RuntimeTargetMonikers>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap101_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap101_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
+  <ItemGroup>
+    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
+      <Folder>netcoreapp1.1</Folder>
+    </TestNugetTargetMoniker>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\pkg\System.IO.IsolatedStorage.pkgproj">
+      <Project>{A0A1CB63-E053-420B-B15A-BA4496F56E2C}</Project>
+      <UndefineProperties>TargetGroup</UndefineProperties>
+      <Name>System.IO.IsolatedStorage</Name>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\src\System\IO\IsolatedStorage\Helper.cs">
+      <Link>Internals\Helper.cs</Link>
+    </Compile>
+    <Compile Include="..\src\System\IO\IsolatedStorage\Helper.Win32.Unix.cs">
+      <Link>Internals\Helper.Win32.Unix.cs</Link>
+    </Compile>
+    <Compile Include="System\IO\IsolatedStorage\HelperTests.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -1,0 +1,113 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.IsolatedStorage.Tests
+{
+    public class HelperTests
+    {
+        [Theory
+            InlineData(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00 }, @"aaaaaaaa")
+            InlineData(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, @"55555555")
+            InlineData(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, @"aaaaaaaaaaaaaaaa")
+            InlineData(new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 }, @"abcdeaaafghijaaa")
+            InlineData(
+                new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+                @"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            ]
+        public void ToBase32StringSuitableForDirName(byte[] buff, string expected)
+        {
+            // Validating that the legacy Path.ToBase32StringSuitableForDirName results match
+            // our copy of the code. Results should NOT change as IsolatedStorage depends
+            // on this for creating a stable hash based directory name.
+            Assert.Equal(expected, Helper.ToBase32StringSuitableForDirName(buff));
+        }
+
+        [Fact]
+        public void GetNormalizedStrongNameHash()
+        {
+            // Validating that we match the exact hash the desktop IsolatedStorage implementation would create.
+            Assert.Equal(@"10nbq10da2m1qfsisndjihnhqmilalwl", Helper.GetNormalizedStrongNameHash(GetAssemblyNameWithFullKey()));
+        }
+
+        [Fact]
+        public void GetNormalizedUrlHash()
+        {
+            // Validating that we match the exact hash the desktop IsolatedStorage implementation would create.
+            Uri uri = new Uri(@"file://C:/Users/jerem/Documents/Visual Studio 2015/Projects/LongPath/LongPath/bin/Debug/TestAssembly.EXE");
+            Assert.Equal(@"qgeirsoc3cznuklvq5xlalurh1m0unxl", Helper.GetNormalizedUriHash(uri));
+        }
+
+        private static AssemblyName GetAssemblyNameWithFullKey()
+        {
+            byte[] publicKey = new byte[]
+            {
+                0x00, 0x24, 0x00, 0x00, 0x04, 0x80, 0x00, 0x00, 0x94, 0x00, 0x00, 0x00, 0x06, 0x02, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00,
+                0x52, 0x53, 0x41, 0x31, 0x00, 0x04, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x37, 0x52, 0x6e, 0xdf, 0xc0, 0x62, 0x17, 0x9f,
+                0x9d, 0x24, 0xe5, 0x0d, 0x3f, 0x9b, 0xb1, 0x34, 0xe1, 0x7e, 0x14, 0x9e, 0xb5, 0x19, 0xcc, 0x2f, 0xd1, 0x9c, 0x39, 0x08,
+                0x46, 0xf4, 0x18, 0xba, 0x6b, 0x2b, 0xe1, 0xc2, 0xb7, 0xe9, 0x06, 0x59, 0x57, 0xed, 0xe1, 0x83, 0x9c, 0xc8, 0x66, 0x4f,
+                0xba, 0x3a, 0x05, 0x6b, 0x73, 0x98, 0x56, 0x0a, 0x34, 0x8e, 0x69, 0xf1, 0x4a, 0x69, 0x4f, 0x4f, 0xea, 0xc7, 0x3e, 0x27,
+                0xf6, 0x6f, 0xd5, 0x4c, 0xcb, 0xeb, 0xe3, 0xa7, 0x5f, 0x3c, 0x11, 0xd3, 0x82, 0xc7, 0xee, 0x1a, 0x5c, 0xf6, 0x37, 0x8c,
+                0xc9, 0x81, 0xbb, 0xb8, 0xa4, 0xab, 0xe6, 0x9d, 0x10, 0x96, 0x3a, 0xf8, 0xa0, 0xaa, 0x42, 0xb4, 0x45, 0xb1, 0x6c, 0xe3,
+                0x9b, 0xc5, 0xb0, 0x84, 0x29, 0x32, 0x20, 0xc8, 0xb9, 0x5b, 0x1d, 0x40, 0xec, 0xbe, 0x23, 0x2e, 0x6b, 0xdd, 0x5d, 0xc4
+            };
+
+            AssemblyName name = new AssemblyName();
+            name.Name = "TestAssembly";
+            name.Version = new Version(1, 0);
+            name.SetPublicKey(publicKey);
+
+            return name;
+
+            // C:\Users\jerem\AppData\Local\IsolatedStorage\10v31ho4.bo2\eeolfu22.f2w\Url.qgeirsoc3cznuklvq5xlalurh1m0unxl\AssemFiles\
+            // C:\Users\jerem\AppData\Local\IsolatedStorage\10v31ho4.bo2\eeolfu22.f2w\StrongName.10nbq10da2m1qfsisndjihnhqmilalwl\AssemFiles\
+        }
+
+        [Fact]
+        public void GetDefaultIdentityAndHash()
+        {
+            object identity = null;
+            string hash = null;
+            Helper.GetDefaultIdentityAndHash(ref identity, ref hash, '.');
+
+            Assert.NotNull(identity);
+            Assert.NotNull(hash);
+
+            // We lie about the identity type when creating the folder structure as we're emulating the Evidence types
+            // we don't have available in .NET Standard. We don't serialize the actual identity object, so the desktop
+            // implementation will work with locations built off the hash.
+            if (identity.GetType() == typeof(Uri))
+            {
+                Assert.StartsWith(@"Url.", hash);
+            }
+            else
+            {
+                Assert.IsType<AssemblyName>(identity);
+                Assert.StartsWith(@"StrongName.", hash);
+            }
+        }
+
+        /*
+         * Need to implement Environment.
+        [Theory
+            InlineData(IsolatedStorageScope.Assembly)
+            InlineData(IsolatedStorageScope.Assembly | IsolatedStorageScope.Roaming)
+            // Need to implement ACLing to test this one
+            // InlineData(IsolatedStorageScope.Machine)
+            ]
+        */
+        public void GetDataDirectory(IsolatedStorageScope scope)
+        {
+            string path = Helper.GetDataDirectory(scope);
+            Assert.Equal("IsolatedStorage", Path.GetDirectoryName(path));
+        }
+    }
+}

--- a/src/System.IO.IsolatedStorage/tests/project.json
+++ b/src/System.IO.IsolatedStorage/tests/project.json
@@ -1,0 +1,54 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "4.3.0-beta-devapi-24503-01",
+    "System.Collections": "4.3.0-beta-devapi-24503-01",
+    "System.Console": "4.3.0-beta-devapi-24503-01",
+    "System.Diagnostics.Debug": "4.3.0-beta-devapi-24503-01",
+    "System.Diagnostics.Process": "4.3.0-beta-devapi-24503-01",
+    "System.Globalization": "4.3.0-beta-devapi-24503-01",
+    "System.IO": "4.3.0-beta-devapi-24503-01",
+    "System.IO.FileSystem": "4.3.0-beta-devapi-24503-01",
+    "System.IO.FileSystem.Primitives": "4.3.0-beta-devapi-24503-01",
+    "System.IO.Pipes": "4.3.0-beta-devapi-24503-01",
+    "System.Linq": "4.3.0-beta-devapi-24503-01",
+    "System.Linq.Expressions": "4.3.0-beta-devapi-24503-01",
+    "System.ObjectModel": "4.3.0-beta-devapi-24503-01",
+    "System.Runtime": "4.3.0-beta-devapi-24503-01",
+    "System.Runtime.Extensions": "4.3.0-beta-devapi-24503-01",
+    "System.Runtime.Handles": "4.3.0-beta-devapi-24503-01",
+    "System.Runtime.InteropServices": "4.3.0-beta-devapi-24503-01",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.3.0-beta-devapi-24503-01",
+    "System.Text.Encoding": "4.3.0-beta-devapi-24503-01",
+    "System.Text.Encoding.Extensions": "4.3.0-beta-devapi-24503-01",
+    "System.Text.RegularExpressions": "4.3.0-beta-devapi-24503-01",
+    "System.Threading.Tasks": "4.3.0-beta-devapi-24503-01",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+  },
+  "frameworks": {
+    "netstandard1.7": {}
+  },
+  "supports": {
+    "coreFx.Test.netcoreapp1.1-ns17": {
+      "netstandard1.7": [
+        "win7-x86",
+        "win7-x64",
+        "win10-arm64",
+        "osx.10.10-x64",
+        "centos.7-x64",
+        "debian.8-x64",
+        "rhel.7-x64",
+        "ubuntu.14.04-x64",
+        "ubuntu.16.04-x64",
+        "fedora.23-x64",
+        "linux-x64",
+        "opensuse.13.2-x64"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Implements initial test project for IsolatedStorage.
Fixes a scoping problem with BinaryWriter usage.
Need GetFolderPathCore implemented in System.Enviroment for Win32 to write more tests.