### PR TITLE
Specialize Enumerable.Concat when all items are ICollections.

### DIFF
--- a/src/System.Linq/src/System/Linq/Concatenate.cs
+++ b/src/System.Linq/src/System/Linq/Concatenate.cs
@@ -21,13 +21,13 @@ namespace System.Linq
                 throw Error.ArgumentNull(nameof(second));
             }
 
-            var firstCol = first as ICollection<TSource>;
-            if (firstCol != null)
+            var firstCollection = first as ICollection<TSource>;
+            if (firstCollection != null)
             {
-                var secondCol = second as ICollection<TSource>;
-                if (secondCol != null)
+                var secondCollection = second as ICollection<TSource>;
+                if (secondCollection != null)
                 {
-                    return new Concat2CollectionIterator<TSource>(firstCol, secondCol);
+                    return new Concat2CollectionIterator<TSource>(firstCollection, secondCollection);
                 }
             }
 
@@ -176,10 +176,10 @@ namespace System.Linq
 
             internal override ConcatIterator<TSource> Concat(IEnumerable<TSource> next)
             {
-                var nextCol = next as ICollection<TSource>;
-                if (nextCol != null)
+                var nextCollection = next as ICollection<TSource>;
+                if (nextCollection != null)
                 {
-                    return new ConcatNCollectionIterator<TSource>(this, nextCol, 2);
+                    return new ConcatNCollectionIterator<TSource>(this, nextCollection, 2);
                 }
                 return new ConcatNEnumerableIterator<TSource>(this, next, 2);
             }
@@ -279,10 +279,10 @@ namespace System.Linq
 
             internal override ConcatIterator<TSource> Concat(IEnumerable<TSource> next)
             {
-                var nextCol = next as ICollection<TSource>;
-                if (nextCol != null)
+                var nextCollection = next as ICollection<TSource>;
+                if (nextCollection != null)
                 {
-                    return new ConcatNCollectionIterator<TSource>(this, nextCol, _nextIndex + 1);
+                    return new ConcatNCollectionIterator<TSource>(this, nextCollection, _nextIndex + 1);
                 }
                 
                 // If we encounter a non-ICollection then getting .Count and performing .ToArray()

--- a/src/System.Linq/src/System/Linq/Concatenate.cs
+++ b/src/System.Linq/src/System/Linq/Concatenate.cs
@@ -142,8 +142,8 @@ namespace System.Linq
                     if (previousCollections != null)
                     {
                         // Since ConcatNCollectionIterator.GetEnumerable does not call into this method,
-                        // it is safe to call GetEnumerable on it here. It also makes things faster since
-                        // we know we'll only ever run the above typecast once per call of this method.
+                        // it is safe to call GetEnumerable on it here. It also makes things faster, since
+                        // the above type-cast will only ever be run once per call of this method.
                         return previousCollections.GetEnumerable(index);
                     }
 
@@ -205,7 +205,6 @@ namespace System.Linq
 
             public override TSource[] ToArray()
             {
-                // TODO: Once #11525 is merged, we must add tests ensuring this throws on overflow.
                 int firstCount = _first.Count; // Cache an interface method call
                 int totalCount = checked(firstCount + _second.Count);
 

--- a/src/System.Linq/src/System/Linq/Concatenate.cs
+++ b/src/System.Linq/src/System/Linq/Concatenate.cs
@@ -281,6 +281,14 @@ namespace System.Linq
                 var nextCollection = next as ICollection<TSource>;
                 if (nextCollection != null)
                 {
+                    if (_nextIndex == int.MaxValue - 2)
+                    {
+                        // In the unlikely case of this many concatenations, if we produced a ConcatNCollectionIterator
+                        // with int.MaxValue then state would overflow before it matched it's index.
+                        // So we use the naïve approach of just having a left and right sequence.
+                        return new Concat2EnumerableIterator<TSource>(this, next);
+                    }
+
                     return new ConcatNCollectionIterator<TSource>(this, nextCollection, _nextIndex + 1);
                 }
                 

--- a/src/System.Linq/src/System/Linq/Concatenate.cs
+++ b/src/System.Linq/src/System/Linq/Concatenate.cs
@@ -21,6 +21,16 @@ namespace System.Linq
                 throw Error.ArgumentNull(nameof(second));
             }
 
+            var firstCol = first as ICollection<TSource>;
+            if (firstCol != null)
+            {
+                var secondCol = second as ICollection<TSource>;
+                if (secondCol != null)
+                {
+                    return new Concat2CollectionIterator<TSource>(firstCol, secondCol);
+                }
+            }
+
             var concatFirst = first as ConcatIterator<TSource>;
             return concatFirst != null ?
                 concatFirst.Concat(second) :
@@ -126,10 +136,256 @@ namespace System.Linq
                         continue;
                     }
 
-                    Debug.Assert(current._previousConcat is Concat2EnumerableIterator<TSource>);
+                    ConcatIterator<TSource> prev2 = current._previousConcat;
+                    Debug.Assert(prev2 is Concat2EnumerableIterator<TSource> || prev2 is Concat2CollectionIterator<TSource>);
                     Debug.Assert(index == 0 || index == 1);
-                    return current._previousConcat.GetEnumerable(index);
+                    return prev2.GetEnumerable(index);
                 }
+            }
+        }
+
+        private sealed class Concat2CollectionIterator<TSource> : ConcatCollectionIterator<TSource>
+        {
+            private readonly ICollection<TSource> _first;
+            private readonly ICollection<TSource> _second;
+
+            internal Concat2CollectionIterator(ICollection<TSource> first, ICollection<TSource> second)
+            {
+                Debug.Assert(first != null && second != null);
+                _first = first;
+                _second = second;
+            }
+
+            internal override int Count => checked(_first.Count + _second.Count);
+
+            public override Iterator<TSource> Clone()
+            {
+                return new Concat2CollectionIterator<TSource>(_first, _second);
+            }
+
+            internal override ConcatIterator<TSource> Concat(IEnumerable<TSource> next)
+            {
+                var nextCol = next as ICollection<TSource>;
+                if (nextCol != null)
+                {
+                    return new ConcatNCollectionIterator<TSource>(this, nextCol, 2);
+                }
+                return new ConcatNEnumerableIterator<TSource>(this, next, 2);
+            }
+
+            internal override void CopyToUntil(TSource[] array, int lastIndex)
+            {
+                Debug.Assert(array != null && array.Length != 0);
+                Debug.Assert(lastIndex >= 0 && lastIndex < array.Length);
+
+                int totalCount = lastIndex + 1;
+                Debug.Assert(totalCount >= Count);
+
+                int firstCount = _first.Count;
+                int secondCount = _second.Count;
+
+                _second.CopyTo(array, totalCount - secondCount);
+                _first.CopyTo(array, totalCount - secondCount - firstCount);
+            }
+
+            internal override IEnumerable<TSource> GetEnumerable(int index)
+            {
+                switch (index)
+                {
+                    case 0: return _first;
+                    case 1: return _second;
+                    default: return null;
+                }
+            }
+
+            public override TSource[] ToArray()
+            {
+                int firstCount = _first.Count;
+                int secondCount = _second.Count;
+                int totalCount = firstCount + secondCount;
+
+                if (totalCount == 0)
+                {
+                    return Array.Empty<TSource>();
+                }
+
+                var result = new TSource[totalCount];
+
+                _first.CopyTo(result, 0);
+                _second.CopyTo(result, firstCount);
+
+                return result;
+            }
+
+            public override List<TSource> ToList()
+            {
+                int firstCount = _first.Count;
+                int secondCount = _second.Count;
+                var result = new List<TSource>(firstCount + secondCount);
+                
+                if (firstCount != 0)
+                {
+                    result.AddRange(_first);
+                }
+                if (secondCount != 0)
+                {
+                    result.AddRange(_second);
+                }
+
+                return result;
+            }
+        }
+
+        private sealed class ConcatNCollectionIterator<TSource> : ConcatCollectionIterator<TSource>
+        {
+            private readonly ConcatCollectionIterator<TSource> _previous;
+            private readonly ICollection<TSource> _next;
+            private readonly int _nextIndex;
+
+            internal ConcatNCollectionIterator(ConcatCollectionIterator<TSource> previous, ICollection<TSource> next, int nextIndex)
+            {
+                Debug.Assert(previous != null);
+                Debug.Assert(next != null);
+                Debug.Assert(nextIndex >= 2);
+
+                _previous = previous;
+                _next = next;
+                _nextIndex = nextIndex;
+            }
+
+            internal override int Count
+            {
+                get
+                {
+                    // Walk the linked list of Concat{2,N}CollectionIterators and call .Count
+                    // on each of the collections.
+                    // Note that we start from the last collection and make our way to the first,
+                    // but the cumulative count will be the same either way.
+                    // Though tempting, it is unwise to use recursion here since we could end up
+                    // with a stack overflow.
+                    
+                    int totalCount = _next.Count;
+                    ConcatCollectionIterator<TSource> previous = _previous;
+
+                    while (true)
+                    {
+                        var previousN = previous as ConcatNCollectionIterator<TSource>;
+                        if (previousN != null)
+                        {
+                            checked
+                            {
+                                totalCount += previousN._next.Count;
+                            }
+                            previous = previousN._previous;
+                            continue;
+                        }
+
+                        Debug.Assert(previous is Concat2CollectionIterator<TSource>);
+                        return checked(totalCount + previous.Count);
+                    }
+                }
+            }
+
+            public override Iterator<TSource> Clone()
+            {
+                return new ConcatNCollectionIterator<TSource>(_previous, _next, _nextIndex);
+            }
+
+            internal override ConcatIterator<TSource> Concat(IEnumerable<TSource> next)
+            {
+                var nextCol = next as ICollection<TSource>;
+                if (nextCol != null)
+                {
+                    return new ConcatNCollectionIterator<TSource>(this, nextCol, _nextIndex + 1);
+                }
+                return new ConcatNEnumerableIterator<TSource>(this, next, _nextIndex + 1);
+            }
+
+            internal override void CopyToUntil(TSource[] array, int lastIndex)
+            {
+                Debug.Assert(array != null && array.Length != 0);
+                Debug.Assert(lastIndex >= 0 && lastIndex < array.Length);
+
+                int totalCount = lastIndex + 1;
+                Debug.Assert(totalCount >= Count);
+
+                // Copy the items from this collection, which is the last
+                // one that was concatenated
+                int copied = _next.Count;
+                _next.CopyTo(array, totalCount - copied);
+
+                ConcatCollectionIterator<TSource> previous = _previous;
+
+                while (true)
+                {
+                    var previousN = previous as ConcatNCollectionIterator<TSource>;
+                    if (previousN != null)
+                    {
+                        checked
+                        {
+                            copied += previousN._next.Count;
+                        }
+                        previousN._next.CopyTo(array, totalCount - copied);
+                        previous = previousN._previous;
+                        continue;
+                    }
+
+                    // We've reached the first 2 collections that were concatenated
+                    Debug.Assert(previous is Concat2CollectionIterator<TSource>);
+                    Debug.Assert(previous.Count == Count - copied);
+
+                    // We just called CopyTo *starting from* totalCount - copied, so this will copy all of
+                    // the previous elements *until* totalCount - copied - 1. 
+                    previous.CopyToUntil(array, totalCount - copied - 1);
+                    break;
+                }
+            }
+
+            internal override IEnumerable<TSource> GetEnumerable(int index)
+            {
+                if (index > _nextIndex)
+                {
+                    return null;
+                }
+
+                ConcatNCollectionIterator<TSource> current = this;
+                while (true)
+                {
+                    if (index == current._nextIndex)
+                    {
+                        return current._next;
+                    }
+
+                    var previousN = current._previous as ConcatNCollectionIterator<TSource>;
+                    if (previousN != null)
+                    {
+                        current = previousN;
+                        continue;
+                    }
+
+                    ConcatCollectionIterator<TSource> previous2 = current._previous;
+                    Debug.Assert(previous2 is Concat2CollectionIterator<TSource>);
+                    Debug.Assert(index == 0 || index == 1);
+                    return previous2.GetEnumerable(index);
+                }
+            }
+
+            public override TSource[] ToArray()
+            {
+                int totalCount = Count;
+                if (totalCount == 0)
+                {
+                    return Array.Empty<TSource>();
+                }
+
+                var result = new TSource[totalCount];
+                CopyToUntil(result, result.Length - 1);
+                return result;
+            }
+
+            public override List<TSource> ToList()
+            {
+                return PopulateList(new List<TSource>(Count));
             }
         }
 
@@ -186,29 +442,17 @@ namespace System.Linq
                 return false;
             }
 
-            public TSource[] ToArray()
+            public virtual TSource[] ToArray()
             {
                 return EnumerableHelpers.ToArray(this);
             }
 
-            public List<TSource> ToList()
+            public virtual List<TSource> ToList()
             {
-                var list = new List<TSource>();
-                for (int i = 0; ; i++)
-                {
-                    IEnumerable<TSource> source = GetEnumerable(i);
-                    if (source == null)
-                    {
-                        break;
-                    }
-
-                    list.AddRange(source);
-                }
-
-                return list;
+                return PopulateList(new List<TSource>());
             }
 
-            public int GetCount(bool onlyIfCheap)
+            public virtual int GetCount(bool onlyIfCheap)
             {
                 if (onlyIfCheap)
                 {
@@ -232,6 +476,31 @@ namespace System.Linq
 
                 return count;
             }
+
+            protected List<TSource> PopulateList(List<TSource> list)
+            {
+                for (int i = 0; ; i++)
+                {
+                    IEnumerable<TSource> source = GetEnumerable(i);
+                    if (source == null)
+                    {
+                        break;
+                    }
+
+                    list.AddRange(source);
+                }
+
+                return list;
+            }
+        }
+
+        private abstract class ConcatCollectionIterator<TSource> : ConcatIterator<TSource>
+        {
+            internal abstract int Count { get; }
+
+            internal abstract void CopyToUntil(TSource[] array, int lastIndex);
+
+            public override int GetCount(bool onlyIfCheap) => Count; // Should always be cheap
         }
     }
 }

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -206,6 +206,16 @@ namespace System.Linq.Tests
             Assert.Throws<OverflowException>(() => supposedlyLargeCollection.Concat(tinyCollection).Count());
             Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(supposedlyLargeCollection).Count());
             Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(tinyCollection).Concat(supposedlyLargeCollection).Count());
+
+            // This applies to ToArray() and ToList() as well, which try to preallocate the exact size
+            // needed if all inputs are ICollections.
+            Assert.Throws<OverflowException>(() => supposedlyLargeCollection.Concat(tinyCollection).ToArray());
+            Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(supposedlyLargeCollection).ToArray());
+            Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(tinyCollection).Concat(supposedlyLargeCollection).ToArray());
+
+            Assert.Throws<OverflowException>(() => supposedlyLargeCollection.Concat(tinyCollection).ToList());
+            Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(supposedlyLargeCollection).ToList());
+            Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(tinyCollection).Concat(supposedlyLargeCollection).ToList());
         }
     }
 }

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -217,5 +217,141 @@ namespace System.Linq.Tests
             Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(supposedlyLargeCollection).ToList());
             Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(tinyCollection).Concat(supposedlyLargeCollection).ToList());
         }
+
+        [Fact]
+        [OuterLoop("This test tries to catch stack overflows and can take a long time.")]
+        public void CountOfConcatCollectionChainShouldBeResilientToStackOverflow()
+        {
+            // Currently, .Concat chains of 3+ ICollections are represented as a
+            // singly-linked list of iterators, each holding 1 collection. When
+            // we call Count() on the last iterator, it needs to sum up the count
+            // of its collection, plus the count of all the previous collections.
+            
+            // It is tempting to use recursion to solve this problem, by simply
+            // returning [this collection].Count + [previous iterator].Count(),
+            // since it is so much simpler than the iterative solution.
+            // However, this can lead to a stack overflow for long chains of
+            // .Concats. This is a test to guard against that.
+
+            // Something big enough to cause a SO when this many method calls
+            // are made, but not too large.
+            const int NumberOfConcats = 30000;
+
+            // For perf reasons (this test can take a long time to run)
+            // we use a for-loop manually rather than .Repeat and .Aggregate
+            IEnumerable<int> concatChain = Array.Empty<int>(); // note: all items in this chain must implement ICollection<T>
+            for (int i = 0; i < NumberOfConcats; i++)
+            {
+                concatChain = concatChain.Concat(Array.Empty<int>());
+            }
+
+            Assert.Equal(0, concatChain.Count()); // should not throw a StackOverflowException
+            // ToArray needs the count as well, and the process of copying all of the collections
+            // to the array should also not be recursive.
+            Assert.Equal(new int[] { }, concatChain.ToArray()); 
+            Assert.Equal(new List<int> { }, concatChain.ToList()); // ToList also gets the count beforehand
+        }
+
+        [Fact]
+        [OuterLoop("This test tries to catch stack overflows and can take a long time.")]
+        public void CountOfConcatEnumerableChainShouldBeResilientToStackOverflow()
+        {
+            // Concat chains where one or more of the inputs is not an ICollection
+            // (so we cannot figure out the total count w/o iterating through some
+            // of the enumerables) are represented much the same, as singly-linked lists.
+            // However, the underlying iterator type/implementation of Count()
+            // will be different (it treats all of the concatenated enumerables as lazy),
+            // so we have to make sure that implementation isn't recursive either.
+
+            const int NumberOfConcats = 30000;
+
+            // Start with a non-ICollection seed, which means all subsequent
+            // Concats will be treated as lazy enumerables.
+            IEnumerable<int> concatChain = ForceNotCollection(Array.Empty<int>());
+
+            // Then, concatenate a bunch of ICollections to it.
+            // Since Count() is optimized for when its input is an ICollection,
+            // this will reduce the time it takes to run the test, which otherwise
+            // would take quite long.
+            for (int i = 0; i < NumberOfConcats; i++)
+            {
+                concatChain = concatChain.Concat(Array.Empty<int>());
+            }
+
+            Assert.Equal(0, concatChain.Count());
+            // ToArray/ToList do not attempt to preallocate a result of the correct
+            // size- if there's just 1 lazy enumerable in the chain, it's impossible
+            // to get the count to preallocate without iterating through that, and then
+            // when the data is being copied you'd need to iterate through it again
+            // (not ideal). So we do not need to worry about those methods having a
+            // stack overflow through getting the Count() of the iterator.
+        }
+
+        [Fact]
+        [OuterLoop("This test tries to catch stack overflows and can take a long time.")]
+        public void GettingFirstEnumerableShouldBeResilientToStackOverflow()
+        {
+            // When MoveNext() is first called on a chain of 3+ Concats, we have to
+            // walk all the way to the tail of the linked list to reach the first
+            // concatee. Likewise as before, make sure this isn't accomplished with
+            // a recursive implementation.
+
+            const int NumberOfConcats = 30000;
+
+            // Start with a lazy seed.
+            // The seed holds 1 item, so during the first MoveNext we won't have to
+            // backtrack through the linked list 30000 times. This is for test perf.
+            IEnumerable<int> concatChain = ForceNotCollection(new int[] { 0xf00 });
+
+            for (int i = 0; i < NumberOfConcats; i++)
+            {
+                concatChain = concatChain.Concat(Array.Empty<int>());
+            }
+
+            using (IEnumerator<int> en = concatChain.GetEnumerator())
+            {
+                Assert.True(en.MoveNext()); // should not SO
+                Assert.Equal(0xf00, en.Current);
+            }
+        }
+
+        [Fact]
+        [OuterLoop("This test tries to catch stack overflows and can take a long time.")]
+        public void GetEnumerableOfConcatCollectionChainFollowedByEnumerableNodeShouldBeResilientToStackOverflow()
+        {
+            // Since concatenating even 1 lazy enumerable ruins the ability for ToArray/ToList
+            // optimizations, if one is Concat'd to a collection-based iterator then we will
+            // fall back to treating all subsequent concatenations as lazy.
+            // Since it is possible for an enumerable iterator to be preceded by a collection
+            // iterator, but not the other way around, an assumption is made. If an enumerable
+            // iterator encounters a collection iterator during GetEnumerable(), it calls into
+            // the collection iterator's GetEnumerable() under the assumption that the callee
+            // will never call into another enumerable iterator's GetEnumerable(). This is
+            // because collection iterators can only be preceded by other collection iterators.
+            
+            // Violation of this assumption means that the GetEnumerable() implementations could
+            // become mutually recursive, which may lead to stack overflow for enumerable iterators
+            // preceded by a long chain of collection iterators.
+
+            const int NumberOfConcats = 30000;
+
+            // This time, start with an ICollection seed. We want the subsequent Concats in
+            // the loop to produce collection iterators.
+            IEnumerable<int> concatChain = new int[] { 0xf00 };
+
+            for (int i = 0; i < NumberOfConcats - 1; i++)
+            {
+                concatChain = concatChain.Concat(Array.Empty<int>());
+            }
+
+            // Finally, link an enumerable iterator at the head of the list.
+            concatChain = concatChain.Concat(ForceNotCollection(Array.Empty<int>()));
+            
+            using (IEnumerator<int> en = concatChain.GetEnumerator())
+            {
+                Assert.True(en.MoveNext());
+                Assert.Equal(0xf00, en.Current);
+            }
+        }
     }
 }


### PR DESCRIPTION
If all of the inputs to `Enumerable.Concat` are ICollections, (which is common, at least in code I've written) then we can optimize much better if it is called `ToArray` or `Count` on. This change introduces 2 new iterators for Concat, `Concat2CollectionIterator` and `ConcatNCollectionIterator`, and renames the existing ones to `Concat{2,N}EnumerableIterator`.

The main difference with these iterators is:

- It has a better implementation for `ToArray`. Previously we just called `EnumerableHelpers.ToArray` if a `Concat` iterator was returned `ToArray` on. However, if we know that all of the enumerables are ICollections, we can sum their counts to allocate an array of exactly the right size, and then call `CopyTo` on each of them to fill the array. (This is a bit tricky in `ConcatNCollectionIterator` since we hold a reference to the most recently `Concat`'d collection, so we have to `CopyTo` the collections in reverse order.)

- We no longer pessimize `GetCount(true)`, since we assuming that accessing the `Count` property of the collections will be cheap (at least, cheaper than manually enumerating them), and we just sum the count of all of them.

Any input that implements `ICollection` will use these iterators. However, as soon as we see a non-ICollection, we fallback to using a regular `ConcatNIterator`.

## Benchmarks

Results/test are [here](https://gist.github.com/jamesqo/0164d1d8229a010e07d225d2d4d8af34).

Quite amazingly, there is a 5x reduction in gen0 collections and 40x speedup with the new implementation, at least for length 100 collections. Even for length 3 ones, it's still 4x faster and the # of collections go from 89 => 15 (presumably since we're no longer allocating enumerators).

/cc: @JonHanna, @stephentoub, @VSadov 