### PR TITLE
Make AsyncBuilderAttribute public

### DIFF
--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="System\Runtime\CompilerServices\AsyncBuilderAttribute.cs" />
+    <Compile Include="System\Runtime\CompilerServices\AsyncMethodBuilderAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\AsyncValueTaskMethodBuilder.cs" />
     <Compile Include="System\Runtime\CompilerServices\ConfiguredValueTaskAwaitable.cs" />
     <Compile Include="System\Runtime\CompilerServices\ValueTaskAwaiter.cs" />

--- a/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncBuilderAttribute.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncBuilderAttribute.cs
@@ -5,14 +5,20 @@
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
-    /// Indicates the async method builder that should be used by the C# compiler to build
-    /// the attributed type when used as the return type of an async method.
+    /// Indicates the async method builder that should be used by a language compiler to
+    /// build the attributed type when used as the return type of an async method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
-    internal sealed class AsyncBuilderAttribute : Attribute
+    public sealed class AsyncBuilderAttribute : Attribute
     {
         /// <summary>Initializes the <see cref="AsyncBuilderAttribute"/>.</summary>
-        /// <param name="builderType">The associated builder type.</param>
-        public AsyncBuilderAttribute(Type builderType) { }
+        /// <param name="builderType">The <see cref="Type"/> of the associated builder.</param>
+        public AsyncBuilderAttribute(Type builderType)
+        {
+            BuilderType = builderType;
+        }
+
+        /// <summary>Gets the <see cref="Type"/> of the associated builder.</summary>
+        public Type BuilderType { get; }
     }
 }

--- a/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs
@@ -5,15 +5,15 @@
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
-    /// Indicates the async method builder that should be used by a language compiler to
+    /// Indicates the type of the async method builder that should be used by a language compiler to
     /// build the attributed type when used as the return type of an async method.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
-    public sealed class AsyncBuilderAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Delegate | AttributeTargets.Enum, Inherited = false, AllowMultiple = false)]
+    public sealed class AsyncMethodBuilderAttribute : Attribute
     {
-        /// <summary>Initializes the <see cref="AsyncBuilderAttribute"/>.</summary>
+        /// <summary>Initializes the <see cref="AsyncMethodBuilderAttribute"/>.</summary>
         /// <param name="builderType">The <see cref="Type"/> of the associated builder.</param>
-        public AsyncBuilderAttribute(Type builderType)
+        public AsyncMethodBuilderAttribute(Type builderType)
         {
             BuilderType = builderType;
         }

--- a/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
@@ -48,7 +48,7 @@ namespace System.Threading.Tasks
     /// a <see cref="Task"/>-returning method completes synchronously and successfully.
     /// </para>
     /// </remarks>
-    [AsyncBuilder(typeof(AsyncValueTaskMethodBuilder<>))]
+    [AsyncMethodBuilder(typeof(AsyncValueTaskMethodBuilder<>))]
     [StructLayout(LayoutKind.Auto)]
     public struct ValueTask<TResult> : IEquatable<ValueTask<TResult>>
     {

--- a/src/System.Threading.Tasks.Extensions/tests/AsyncMethodBuilderAttributeTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/AsyncMethodBuilderAttributeTests.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.CompilerServices.Tests
+{
+    public class AsyncMethodBuilderAttributeTests
+    {
+        [Theory]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(AsyncValueTaskMethodBuilder<>))]
+        [InlineData(typeof(AsyncValueTaskMethodBuilder<int>))]
+        [InlineData(typeof(AsyncValueTaskMethodBuilder<string>))]
+        public void Ctor_BuilderType_Roundtrip(Type builderType)
+        {
+            var amba = new AsyncMethodBuilderAttribute(builderType);
+            Assert.Same(builderType, amba.BuilderType);
+        }
+
+        // No tests for the following, other than verifying that they successfully compile
+
+        [AsyncMethodBuilder(typeof(string))]
+        class MyClass { }
+
+        [AsyncMethodBuilder(typeof(string))]
+        struct MyStruct { }
+
+        [AsyncMethodBuilder(typeof(string))]
+        interface MyInterface { }
+
+        [AsyncMethodBuilder(typeof(string))]
+        enum MyEnum { }
+
+        [AsyncMethodBuilder(typeof(string))]
+        delegate void MyDelegate();
+    }
+}

--- a/src/System.Threading.Tasks.Extensions/tests/System.Threading.Tasks.Extensions.Tests.csproj
+++ b/src/System.Threading.Tasks.Extensions/tests/System.Threading.Tasks.Extensions.Tests.csproj
@@ -13,6 +13,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="AsyncMethodBuilderAttributeTests.cs" />
     <Compile Include="AsyncValueTaskMethodBuilderTests.cs" />
     <Compile Include="ValueTaskTests.cs" />
   </ItemGroup>

--- a/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
@@ -318,14 +318,14 @@ namespace System.Threading.Tasks.Tests
         [InlineData(typeof(ValueTask<>))]
         [InlineData(typeof(ValueTask<int>))]
         [InlineData(typeof(ValueTask<string>))]
-        public void AsyncBuilderAttribute_ValueTaskAttributed(Type valueTaskType)
+        public void AsyncMethodBuilderAttribute_ValueTaskAttributed(Type valueTaskType)
         {
-            CustomAttributeData cad = valueTaskType.GetTypeInfo().CustomAttributes.Single(attr => attr.AttributeType == typeof(AsyncBuilderAttribute));
+            CustomAttributeData cad = valueTaskType.GetTypeInfo().CustomAttributes.Single(attr => attr.AttributeType == typeof(AsyncMethodBuilderAttribute));
             Type builderTypeCtorArg = (Type)cad.ConstructorArguments[0].Value;
             Assert.Equal(typeof(AsyncValueTaskMethodBuilder<>), builderTypeCtorArg);
 
-            AsyncBuilderAttribute aba = valueTaskType.GetTypeInfo().GetCustomAttribute<AsyncBuilderAttribute>();
-            Assert.Equal(builderTypeCtorArg, aba.BuilderType);
+            AsyncMethodBuilderAttribute amba = valueTaskType.GetTypeInfo().GetCustomAttribute<AsyncMethodBuilderAttribute>();
+            Assert.Equal(builderTypeCtorArg, amba.BuilderType);
         }
 
         private sealed class TrackingSynchronizationContext : SynchronizationContext

--- a/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
@@ -320,10 +320,12 @@ namespace System.Threading.Tasks.Tests
         [InlineData(typeof(ValueTask<string>))]
         public void AsyncBuilderAttribute_ValueTaskAttributed(Type valueTaskType)
         {
-            CustomAttributeData aba = valueTaskType.GetTypeInfo().CustomAttributes.Single(
-                attr => attr.AttributeType.FullName == "System.Runtime.CompilerServices.AsyncBuilderAttribute");
-            Assert.True(aba.AttributeType.GetTypeInfo().IsNotPublic);
-            Assert.Equal(typeof(AsyncValueTaskMethodBuilder<>), aba.ConstructorArguments[0].Value);
+            CustomAttributeData cad = valueTaskType.GetTypeInfo().CustomAttributes.Single(attr => attr.AttributeType == typeof(AsyncBuilderAttribute));
+            Type builderTypeCtorArg = (Type)cad.ConstructorArguments[0].Value;
+            Assert.Equal(typeof(AsyncValueTaskMethodBuilder<>), builderTypeCtorArg);
+
+            AsyncBuilderAttribute aba = valueTaskType.GetTypeInfo().GetCustomAttribute<AsyncBuilderAttribute>();
+            Assert.Equal(builderTypeCtorArg, aba.BuilderType);
         }
 
         private sealed class TrackingSynchronizationContext : SynchronizationContext


### PR DESCRIPTION
Per a C# 7 language design change, the AsyncBuilderAttribute needs to be public.  And once it's public, it needs to conform better to framework design guidelines, which means it needs a public getter for the ctor's required argument.

cc: @ljw1004, @madstorgersen, @weshaggard, @terrajobst 