### PR TITLE
Pick up newer version of microsoft.xunit.runner.uwp

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -15,7 +15,7 @@
 
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
-    <AppXRunnerVersion>1.0.3-prerelease-00614-01</AppXRunnerVersion>
+    <AppXRunnerVersion>1.0.3-prerelease-00807-03</AppXRunnerVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -99,7 +99,7 @@
         "System.Text.Encoding.CodePages": "4.0.1",
         "System.Xml.XmlSerializer": "4.0.11",
         "System.Console": "4.3.0-beta-24507-02",
-        "microsoft.xunit.runner.uwp": "1.0.3-prerelease-00614-01",
+        "microsoft.xunit.runner.uwp": "1.0.3-prerelease-00807-03",
         "Microsoft.DotNet.TestILC": {
           "version": "1.4.24208-prerelease",
           "include": "contentFiles"


### PR DESCRIPTION
@davidsh  this is what I was talking about.  

@crummel 
I'm not totally sure how this works currently as I don't always get it copied into my test execution folder, can you comment how these support files get copied in with the test?  