### PR TITLE
Fix some broken ZipFile unicode tests

### DIFF
--- a/src/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -137,13 +137,13 @@ namespace System.IO.Compression.Tests
             await IsZipSameAsDirAsync(archiveFile, directory, mode, false, false);
         }
 
-        public static async Task IsZipSameAsDirAsync(String archiveFile, String directory, ZipArchiveMode mode, bool dontRequireExplicit, bool dontCheckTimes)
+        public static async Task IsZipSameAsDirAsync(String archiveFile, String directory, ZipArchiveMode mode, bool requireExplicit, bool checkTimes)
         {
             var s = await StreamHelpers.CreateTempCopyStream(archiveFile);
-            IsZipSameAsDir(s, directory, mode, dontRequireExplicit, dontCheckTimes);
+            IsZipSameAsDir(s, directory, mode, requireExplicit, checkTimes);
         }
 
-        public static void IsZipSameAsDir(Stream archiveFile, String directory, ZipArchiveMode mode, Boolean dontRequireExplicit, Boolean dontCheckTimes)
+        public static void IsZipSameAsDir(Stream archiveFile, String directory, ZipArchiveMode mode, bool requireExplicit, bool checkTimes)
         {
             int count = 0;
 
@@ -175,7 +175,7 @@ namespace System.IO.Compression.Tests
                             Assert.Equal(file.CRC, crc);
                         }
 
-                        if (!dontCheckTimes)
+                        if (checkTimes)
                         {
                             const int zipTimestampResolution = 2; // Zip follows the FAT timestamp resolution of two seconds for file records
                             DateTime lower = file.LastModifiedDate.AddSeconds(-zipTimestampResolution);
@@ -197,12 +197,12 @@ namespace System.IO.Compression.Tests
                                 f => f.IsFile &&
                                      (f.FullName.StartsWith(entryName, StringComparison.OrdinalIgnoreCase) ||
                                       f.FullName.StartsWith(entryNameOtherSlash, StringComparison.OrdinalIgnoreCase)));
-                            if (!dontRequireExplicit || isEmtpy)
+                            if (requireExplicit || isEmtpy)
                             {
                                 Assert.Contains("emptydir", entryName);
                             }
 
-                            if ((dontRequireExplicit && !isEmtpy) || entryName.Contains("emptydir"))
+                            if ((!requireExplicit && !isEmtpy) || entryName.Contains("emptydir"))
                                 count--; //discount this entry
                         }
                         else

--- a/src/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -153,7 +153,8 @@ namespace System.IO.Compression.Tests
                 Assert.All<FileData>(files, (file) => {
                     count++;
                     String entryName = file.FullName;
-                    if (file.IsFolder) entryName += Path.DirectorySeparatorChar;
+                    if (file.IsFolder)
+                        entryName += Path.DirectorySeparatorChar;
                     ZipArchiveEntry entry = archive.GetEntry(entryName);
                     if (entry == null)
                     {
@@ -251,6 +252,13 @@ namespace System.IO.Compression.Tests
 
             ItemEqual(actualList, expectedList, true);
             ItemEqual(actualFolders, expectedList, false);
+        }
+
+        public static void DirFileNamesEqual(string actual, string expected)
+        {
+            IEnumerable<string> actualEntries = Directory.EnumerateFileSystemEntries(actual, "*", SearchOption.AllDirectories);
+            IEnumerable<string> expectedEntries = Directory.EnumerateFileSystemEntries(expected, "*", SearchOption.AllDirectories);
+            Assert.True(Enumerable.SequenceEqual(expectedEntries.Select(i => Path.GetFileName(i)), actualEntries.Select(i => Path.GetFileName(i))));
         }
 
         private static void ItemEqual(String[] actualList, List<FileData> expectedList, Boolean isFile)

--- a/src/System.IO.Compression.ZipFile/System.IO.Compression.ZipFile.sln
+++ b/src/System.IO.Compression.ZipFile/System.IO.Compression.ZipFile.sln
@@ -1,28 +1,73 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22609.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Compression.ZipFile", "src\System.IO.Compression.ZipFile.csproj", "{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Compression.ZipFile", "src\System.IO.Compression.ZipFile.csproj", "{D5FF747F-7A0B-9003-885A-FE9A63E755E5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Compression.ZipFile.Tests", "tests\System.IO.Compression.ZipFile.Tests.csproj", "{ED453083-A80F-480C-AD25-5B8618E8A303}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{23EC0B36-E211-4825-8636-8BB5A52BAC5A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{1562AFFA-2EB8-4650-AF30-655C038FC045}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{9F7AB953-32ED-44FC-98FD-2DE78A567EB9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Compression.ZipFile", "ref\System.IO.Compression.ZipFile.csproj", "{62E1C77D-E8C7-46F5-9499-8AC302F533A6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Compression.ZipFile.Tests", "tests\System.IO.Compression.ZipFile.Tests.csproj", "{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		net46_Debug|Any CPU = net46_Debug|Any CPU
+		net46_Release|Any CPU = net46_Release|Any CPU
+		netcore50_Debug|Any CPU = netcore50_Debug|Any CPU
+		netcore50_Release|Any CPU = netcore50_Release|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.Debug|Any CPU.Build.0 = Release|Any CPU
-		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A8CF61F0-56EA-4B5F-9375-0723DF4250C0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{ED453083-A80F-480C-AD25-5B8618E8A303}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{ED453083-A80F-480C-AD25-5B8618E8A303}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{ED453083-A80F-480C-AD25-5B8618E8A303}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{ED453083-A80F-480C-AD25-5B8618E8A303}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.netcore50_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.netcore50_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.netcore50_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.netcore50_Release|Any CPU.Build.0 = Release|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.net46_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.net46_Release|Any CPU.Build.0 = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.netcore50_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.netcore50_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.netcore50_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.netcore50_Release|Any CPU.Build.0 = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.net46_Release|Any CPU.Build.0 = Release|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.netcore50_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.netcore50_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.netcore50_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.netcore50_Release|Any CPU.Build.0 = Release|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5} = {23EC0B36-E211-4825-8636-8BB5A52BAC5A}
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6} = {1562AFFA-2EB8-4650-AF30-655C038FC045}
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08} = {9F7AB953-32ED-44FC-98FD-2DE78A567EB9}
 	EndGlobalSection
 EndGlobal

--- a/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
+++ b/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <UseECMAKey Condition="'$(UseECMAKey)' == ''">true</UseECMAKey>
     <AssemblyName>System.IO.Compression.ZipFile</AssemblyName>
-    <ProjectGuid>{A8CF61F0-56EA-4b5f-9375-0723DF4250C0}</ProjectGuid>
+    <ProjectGuid>{D5FF747F-7A0B-9003-885A-FE9A63E755E5}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -51,7 +51,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.1-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.4-prerelease\content\**\*.*" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -51,7 +51,9 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.4-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.4-prerelease\content\**\*.*">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </SupplementalTestData>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
-    <ProjectGuid>{ED453083-A80F-480C-AD25-5B8618E8A303}</ProjectGuid>
+    <ProjectGuid>{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.Compression.ZipFile.Tests</AssemblyName>
     <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -21,7 +21,7 @@ namespace System.IO.Compression.Tests
             string noBaseDir = GetTestFilePath();
             ZipFile.CreateFromDirectory(folderName, noBaseDir);
 
-            await IsZipSameAsDirAsync(noBaseDir, folderName, ZipArchiveMode.Read, true, true);
+            await IsZipSameAsDirAsync(noBaseDir, folderName, ZipArchiveMode.Read, requireExplicit: false, checkTimes: false);
         }
 
         [Fact]
@@ -122,7 +122,7 @@ namespace System.IO.Compression.Tests
                         archive.CreateEntryFromFile(sourceFilePath, entryName, CompressionLevel.Fastest);
                     Assert.NotNull(e);
                 }
-                await IsZipSameAsDirAsync(testArchive.Path, zmodified("addFile"), ZipArchiveMode.Read, true, true);
+                await IsZipSameAsDirAsync(testArchive.Path, zmodified("addFile"), ZipArchiveMode.Read, requireExplicit: false, checkTimes: false);
             }
         }
 

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,94 +17,93 @@ namespace System.IO.Compression.Tests
         [Fact]
         public async Task CreateFromDirectoryNormal()
         {
-            await TestCreateDirectory(zfolder("normal"), true);
-        }
-
-        [Fact]
-        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Jenkins fails with unicode characters [JENKINS-12610]
-        public async Task CreateFromDirectoryUnicodel()
-        {
-            await TestCreateDirectory(zfolder("unicode"), true);
-        }
-
-        private async Task TestCreateDirectory(string folderName, Boolean testWithBaseDir)
-        {
+            string folderName = zfolder("normal");
             string noBaseDir = GetTestFilePath();
             ZipFile.CreateFromDirectory(folderName, noBaseDir);
 
             await IsZipSameAsDirAsync(noBaseDir, folderName, ZipArchiveMode.Read, true, true);
-
-            if (testWithBaseDir)
-            {
-                string withBaseDir = GetTestFilePath();
-                ZipFile.CreateFromDirectory(folderName, withBaseDir, CompressionLevel.Optimal, true);
-                SameExceptForBaseDir(noBaseDir, withBaseDir, folderName);
-            }
         }
 
-        private static void SameExceptForBaseDir(string zipNoBaseDir, string zipBaseDir, string baseDir)
+        [Fact]
+        public void CreateFromDirectory_IncludeBaseDirectory()
         {
-            //b has the base dir
-            using (ZipArchive a = ZipFile.Open(zipNoBaseDir, ZipArchiveMode.Read),
-                              b = ZipFile.Open(zipBaseDir, ZipArchiveMode.Read))
+            string folderName = zfolder("normal");
+            string withBaseDir = GetTestFilePath();
+            ZipFile.CreateFromDirectory(folderName, withBaseDir, CompressionLevel.Optimal, true);
+
+            IEnumerable<string> expected = Directory.EnumerateFiles(zfolder("normal"), "*", SearchOption.AllDirectories);
+            using (ZipArchive actual_withbasedir = ZipFile.Open(withBaseDir, ZipArchiveMode.Read))
             {
-                var aCount = a.Entries.Count;
-                var bCount = b.Entries.Count;
-                Assert.Equal(aCount, bCount);
-
-                int bIdx = 0;
-                foreach (ZipArchiveEntry aEntry in a.Entries)
+                foreach (ZipArchiveEntry actualEntry in actual_withbasedir.Entries)
                 {
-                    ZipArchiveEntry bEntry = b.Entries[bIdx++];
-
-                    Assert.Equal(Path.GetFileName(baseDir) + "/" + aEntry.FullName, bEntry.FullName);
-                    Assert.Equal(aEntry.Name, bEntry.Name);
-                    Assert.Equal(aEntry.Length, bEntry.Length);
-                    Assert.Equal(aEntry.CompressedLength, bEntry.CompressedLength);
-                    using (Stream aStream = aEntry.Open(), bStream = bEntry.Open())
+                    string expectedFile = expected.Single(i => Path.GetFileName(i).Equals(actualEntry.Name));
+                    Assert.True(actualEntry.FullName.StartsWith("normal"));
+                    Assert.Equal(new FileInfo(expectedFile).Length, actualEntry.Length);
+                    using (Stream expectedStream = File.OpenRead(expectedFile))
+                    using (Stream actualStream = actualEntry.Open())
                     {
-                        StreamsEqual(aStream, bStream);
+                        StreamsEqual(expectedStream, actualStream);
                     }
                 }
             }
         }
 
         [Fact]
-        public void ExtractToDirectoryNormal()
+        public void CreateFromDirectoryUnicode()
         {
-            TestExtract(zfile("normal.zip"), zfolder("normal"));
-            TestExtract(zfile("empty.zip"), zfolder("empty"));
-            TestExtract(zfile("explicitdir1.zip"), zfolder("explicitdir"));
-            TestExtract(zfile("explicitdir2.zip"), zfolder("explicitdir"));
-            TestExtract(zfile("appended.zip"), zfolder("small"));
-            TestExtract(zfile("prepended.zip"), zfolder("small"));
-            TestExtract(zfile("noexplicitdir.zip"), zfolder("explicitdir"));
+            string folderName = zfolder("unicode");
+            string noBaseDir = GetTestFilePath();
+            ZipFile.CreateFromDirectory(folderName, noBaseDir);
+
+            using (ZipArchive archive = ZipFile.OpenRead(noBaseDir))
+            {
+                IEnumerable<string> actual = archive.Entries.Select(entry => entry.Name);
+                IEnumerable<string> expected = Directory.EnumerateFileSystemEntries(zfolder("unicode"), "*", SearchOption.AllDirectories).ToList();
+                Assert.True(Enumerable.SequenceEqual(expected.Select(i => Path.GetFileName(i)), actual.Select(i => i)));
+            }
         }
 
-        [Fact]
-        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Jenkins fails with unicode characters [JENKINS-12610]
-        public void ExtractToDirectoryUnicode()
+        [Theory]
+        [InlineData("normal.zip", "normal")]
+        [InlineData("empty.zip", "empty")]
+        [InlineData("explicitdir1.zip", "explicitdir")]
+        [InlineData("explicitdir2.zip", "explicitdir")]
+        [InlineData("appended.zip", "small")]
+        [InlineData("prepended.zip", "small")]
+        [InlineData("noexplicitdir.zip", "explicitdir")]
+        public void ExtractToDirectoryNormal(string file, string folder)
         {
-            TestExtract(zfile("unicode.zip"), zfolder("unicode"));
-        }
-
-        private void TestExtract(string zipFileName, string folderName)
-        {
+            string zipFileName = zfile(file);
+            string folderName = zfolder(folder);
             using (var tempFolder = new TempDirectory(GetTestFilePath()))
             {
                 ZipFile.ExtractToDirectory(zipFileName, tempFolder.Path);
                 DirsEqual(tempFolder.Path, folderName);
-
-                Assert.Throws<ArgumentNullException>(() => ZipFile.ExtractToDirectory(null, tempFolder.Path));
             }
         }
 
-        #region "Extension Methods"
+        [Fact]
+        public void ExtractToDirectoryNull()
+        {
+            Assert.Throws<ArgumentNullException>("sourceArchiveFileName", () => ZipFile.ExtractToDirectory(null, GetTestFilePath()));
+        }
+
+        [Fact]
+        public void ExtractToDirectoryUnicode()
+        {
+            string zipFileName = zfile("unicode.zip");
+            string folderName = zfolder("unicode");
+            using (var tempFolder = new TempDirectory(GetTestFilePath()))
+            {
+                ZipFile.ExtractToDirectory(zipFileName, tempFolder.Path);
+                DirFileNamesEqual(tempFolder.Path, folderName);
+            }
+        }
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task CreateEntryFromFileTest(bool withCompressionLevel)
+        public async Task CreateEntryFromFileExtension(bool withCompressionLevel)
         {
             //add file
             using (TempFile testArchive = CreateTempCopyFile(zfile("normal.zip"), GetTestFilePath()))
@@ -126,7 +127,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
-        public void ExtractToFileTest()
+        public void ExtractToFileExtension()
         {
             using (ZipArchive archive = ZipFile.Open(zfile("normal.zip"), ZipArchiveMode.Read))
             {
@@ -160,7 +161,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
-        public void ExtractToDirectoryTest()
+        public void ExtractToDirectoryExtension()
         {
             using (ZipArchive archive = ZipFile.Open(zfile("normal.zip"), ZipArchiveMode.Read))
             {
@@ -174,15 +175,13 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
-        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Jenkins fails with unicode characters [JENKINS-12610]
-        public void ExtractToDirectoryTest_Unicode()
+        public void ExtractToDirectoryExtension_Unicode()
         {
             using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))
             {
                 string tempFolder = GetTestFilePath();
                 archive.ExtractToDirectory(tempFolder);
-
-                DirsEqual(tempFolder, zfolder("unicode"));
+                DirFileNamesEqual(tempFolder, zfolder("unicode"));
             }
         }
 
@@ -224,7 +223,5 @@ namespace System.IO.Compression.Tests
                 }
             }
         }
-
-        #endregion
     }
 }

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -7,7 +7,7 @@
     "System.Diagnostics.Debug": "4.3.0-beta-24509-01",
     "System.IO": "4.3.0-beta-24509-01",
     "System.IO.Compression": "4.3.0-beta-24509-01",
-    "System.IO.Compression.TestData": "1.0.1-prerelease",
+    "System.IO.Compression.TestData": "1.0.4-prerelease",
     "System.IO.FileSystem": "4.3.0-beta-24509-01",
     "System.IO.FileSystem.Primitives": "4.3.0-beta-24509-01",
     "System.Linq": "4.3.0-beta-24509-01",

--- a/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -68,7 +68,7 @@ namespace System.IO.Compression.Tests
                 var testStream = new WrappedStream(s, false, true, seekable, null);
                 await CreateFromDir(zfolder(folder), testStream, ZipArchiveMode.Create);
 
-                IsZipSameAsDir(s, zfolder(folder), ZipArchiveMode.Read, false, false);
+                IsZipSameAsDir(s, zfolder(folder), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
             }
         }
 
@@ -84,7 +84,7 @@ namespace System.IO.Compression.Tests
                 var testStream = new WrappedStream(s, false, true, seekable, null);
                 await CreateFromDir(zfolder(folder), testStream, ZipArchiveMode.Create);
 
-                IsZipSameAsDir(s, zfolder(folder), ZipArchiveMode.Read, false, false);
+                IsZipSameAsDir(s, zfolder(folder), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
             }
         }
     }

--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -201,14 +201,14 @@ namespace System.IO.Compression.Tests
         }
 
         [Theory]
-        [InlineData("extradata/extraDataLHandCDentryAndArchiveComments.zip", "verysmall", false)]
-        [InlineData("extradata/extraDataThenZip64.zip", "verysmall", false)]
-        [InlineData("extradata/zip64ThenExtraData.zip", "verysmall", false)]
-        [InlineData("dataDescriptor.zip", "normalWithoutBinary", true)]
-        [InlineData("filenameTimeAndSizesDifferentInLH.zip", "verysmall", true)]
-        public static async Task StrangeFiles(string zipFile, string zipFolder, bool dontRequireExplicit)
+        [InlineData("extradata/extraDataLHandCDentryAndArchiveComments.zip", "verysmall", true)]
+        [InlineData("extradata/extraDataThenZip64.zip", "verysmall", true)]
+        [InlineData("extradata/zip64ThenExtraData.zip", "verysmall", true)]
+        [InlineData("dataDescriptor.zip", "normalWithoutBinary", false)]
+        [InlineData("filenameTimeAndSizesDifferentInLH.zip", "verysmall", false)]
+        public static async Task StrangeFiles(string zipFile, string zipFolder, bool requireExplicit)
         {
-            IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(strange(zipFile)), zfolder(zipFolder), ZipArchiveMode.Update, dontRequireExplicit, dontCheckTimes: false);
+            IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(strange(zipFile)), zfolder(zipFolder), ZipArchiveMode.Update, requireExplicit, checkTimes: true);
         }
 
         /// <summary>

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ManualAndCompatibilityTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ManualAndCompatibilityTests.cs
@@ -10,26 +10,26 @@ namespace System.IO.Compression.Tests
     public class zip_ManualAndCompatabilityTests : ZipFileTestBase
     {
         [Theory]
-        [InlineData("7zip.zip", "normal", false, false)]
-        [InlineData("deflate64.zip", "normal", false, false)]
-        [InlineData("windows.zip", "normalWithoutEmptyDir", true, false)]
-        [InlineData("dotnetzipstreaming.zip", "normal", true, true)]
-        [InlineData("sharpziplib.zip", "normalWithoutEmptyDir", true, true)]
-        [InlineData("xceedstreaming.zip", "normal", true, true)]
-        public static async Task CompatibilityTests(string zipFile, string zipFolder, bool dontRequireExplicit, bool dontCheckTimes)
+        [InlineData("7zip.zip", "normal", true, true)]
+        [InlineData("deflate64.zip", "normal", true, true)]
+        [InlineData("windows.zip", "normalWithoutEmptyDir", false, true)]
+        [InlineData("dotnetzipstreaming.zip", "normal", false, false)]
+        [InlineData("sharpziplib.zip", "normalWithoutEmptyDir", false, false)]
+        [InlineData("xceedstreaming.zip", "normal", false, false)]
+        public static async Task CompatibilityTests(string zipFile, string zipFolder, bool requireExplicit, bool checkTimes)
         {
-            IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(compat(zipFile)), zfolder(zipFolder), ZipArchiveMode.Update, dontRequireExplicit, dontCheckTimes);
+            IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(compat(zipFile)), zfolder(zipFolder), ZipArchiveMode.Update, requireExplicit, checkTimes);
         }
 
         [Theory]
-        [InlineData("excel.xlsx", "excel", true, true)]
-        [InlineData("powerpoint.pptx", "powerpoint", true, true)]
-        [InlineData("word.docx", "word", true, true)]
-        [InlineData("silverlight.xap", "silverlight", true, true)]
-        [InlineData("packaging.package", "packaging", true, true)]
-        public static async Task CompatibilityTestsMsFiles(string withTrailing, string withoutTrailing, bool dontRequireExplicit, bool dontCheckTimes)
+        [InlineData("excel.xlsx", "excel", false, false)]
+        [InlineData("powerpoint.pptx", "powerpoint", false, false)]
+        [InlineData("word.docx", "word", false, false)]
+        [InlineData("silverlight.xap", "silverlight", false, false)]
+        [InlineData("packaging.package", "packaging", false, false)]
+        public static async Task CompatibilityTestsMsFiles(string withTrailing, string withoutTrailing, bool requireExplicit, bool checkTimes)
         {
-            IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(compat(withTrailing)), compat(withoutTrailing), ZipArchiveMode.Update, dontRequireExplicit, dontCheckTimes);
+            IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(compat(withTrailing)), compat(withoutTrailing), ZipArchiveMode.Update, requireExplicit, checkTimes);
         }
 
         /// <summary>

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -38,7 +38,7 @@ namespace System.IO.Compression.Tests
             using (var stream = await StreamHelpers.CreateTempCopyStream(zfile(zipFile)))
             {
                 Stream wrapped = new WrappedStream(stream, true, false, false, null);
-                IsZipSameAsDir(wrapped, zfolder(zipFolder), ZipArchiveMode.Read, false, false);
+                IsZipSameAsDir(wrapped, zfolder(zipFolder), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
                 Assert.False(wrapped.CanRead, "Wrapped stream should be closed at this point"); //check that it was closed
             }
         }

--- a/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -21,7 +21,7 @@ namespace System.IO.Compression.Tests
         [InlineData("unicode.zip", "unicode")]
         public static async Task UpdateReadNormal(string zipFile, string zipFolder)
         {
-            IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(zfile(zipFile)), zfolder(zipFolder), ZipArchiveMode.Update, false, false);
+            IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(zfile(zipFile)), zfolder(zipFolder), ZipArchiveMode.Update, requireExplicit: true, checkTimes: true);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace System.IO.Compression.Tests
         {
             var zs = new LocalMemoryStream();
             await CreateFromDir(zfolder(zipFolder), zs, ZipArchiveMode.Update);
-            IsZipSameAsDir(zs.Clone(), zfolder(zipFolder), ZipArchiveMode.Read, false, false);
+            IsZipSameAsDir(zs.Clone(), zfolder(zipFolder), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
         }
 
         [Theory]
@@ -131,7 +131,7 @@ namespace System.IO.Compression.Tests
                 orig.Delete();
             }
 
-            IsZipSameAsDir(testArchive, zmodified("deleteMove"), ZipArchiveMode.Read, false, false);
+            IsZipSameAsDir(testArchive, zmodified("deleteMove"), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
 
         }
         [Fact]
@@ -155,7 +155,7 @@ namespace System.IO.Compression.Tests
                 e.LastWriteTime = file.LastModifiedDate;
             }
 
-            IsZipSameAsDir(testArchive, zmodified("append"), ZipArchiveMode.Read, false, false);
+            IsZipSameAsDir(testArchive, zmodified("append"), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
 
         }
         [Fact]
@@ -182,7 +182,7 @@ namespace System.IO.Compression.Tests
                 }
             }
 
-            IsZipSameAsDir(testArchive, zmodified("overwrite"), ZipArchiveMode.Read, false, false);
+            IsZipSameAsDir(testArchive, zmodified("overwrite"), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
         }
 
         [Fact]
@@ -196,7 +196,7 @@ namespace System.IO.Compression.Tests
                 await updateArchive(archive, zmodified(Path.Combine("addFile", "added.txt")), "added.txt");
             }
 
-            IsZipSameAsDir(testArchive, zmodified ("addFile"), ZipArchiveMode.Read, false, false);
+            IsZipSameAsDir(testArchive, zmodified ("addFile"), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
         }
 
         [Fact]
@@ -212,7 +212,7 @@ namespace System.IO.Compression.Tests
                 await updateArchive(archive, zmodified(Path.Combine("addFile", "added.txt")), "added.txt");
             }
 
-            IsZipSameAsDir(testArchive, zmodified("addFile"), ZipArchiveMode.Read, false, false);
+            IsZipSameAsDir(testArchive, zmodified("addFile"), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
         }
 
         [Fact]
@@ -228,7 +228,7 @@ namespace System.IO.Compression.Tests
                 var x = archive.Entries;
             }
 
-            IsZipSameAsDir(testArchive, zmodified("addFile"), ZipArchiveMode.Read, false, false);
+            IsZipSameAsDir(testArchive, zmodified("addFile"), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
         }
 
         private static async Task updateArchive(ZipArchive archive, String installFile, String entryName)


### PR DESCRIPTION
These tests rely on the use of the FileData class to verify zips are created/extracted with the correct files. However, FileData and the accompanying helper methods do not take unicode normalization into account, so unicode zip tests are failing on OSX. I modified these tests to verify based on the actual files being zipped/unzipped instead of using the expectations set in the FileData class.

resolves https://github.com/dotnet/corefx/issues/10397, https://github.com/dotnet/corefx/issues/9867

@stephentoub 