### PR TITLE
Cleanup and improve test coverage for Concat tests

### DIFF
--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -4,68 +4,46 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Linq.Tests
 {
     public class ConcatTests : EnumerableTests
     {
-        [Fact]
-        public void SameResultsRepeatCallsIntQuery()
+        [Theory]
+        [InlineData(new int[] { 2, 3, 2, 4, 5 }, new int[] { 1, 9, 4 })]
+        public void SameResultsWithQueryAndRepeatCalls(IEnumerable<int> first, IEnumerable<int> second)
         {
-            var q1 = from x1 in new int?[] { 2, 3, null, 2, null, 4, 5 }
-                     select x1;
-            var q2 = from x2 in new int?[] { 1, 9, null, 4 }
-                     select x2;
-
-            Assert.Equal(q1.Concat(q2), q1.Concat(q2));
+            // workaround: xUnit type inference doesn't work if the input type is not T (like IEnumerable<T>)
+            SameResultsWithQueryAndRepeatCallsWorker(first, second);
         }
 
-        [Fact]
-        public void SameResultsRepeatCallsStringQuery()
+        [Theory]
+        [InlineData(new[] { "AAA", "", "q", "C", "#", "!@#$%^", "0987654321", "Calling Twice" }, new[] { "!@#$%^", "C", "AAA", "", "Calling Twice", "SoS" })]
+        public void SameResultsWithQueryAndRepeatCalls(IEnumerable<string> first, IEnumerable<string> second)
         {
-            var q1 = from x1 in new[] { "AAA", String.Empty, "q", "C", "#", "!@#$%^", "0987654321", "Calling Twice" }
-                     select x1;
-            var q2 = from x2 in new[] { "!@#$%^", "C", "AAA", "", "Calling Twice", "SoS" }
-                     select x2;
-
-            Assert.Equal(q1.Concat(q2), q1.Concat(q2));
+            // workaround: xUnit type inference doesn't work if the input type is not T (like IEnumerable<T>)
+            SameResultsWithQueryAndRepeatCallsWorker(first, second);
         }
 
-        [Fact]
-        public void BothEmpty()
+        private static void SameResultsWithQueryAndRepeatCallsWorker<T>(IEnumerable<T> first, IEnumerable<T> second)
         {
-            int[] first = { };
-            int[] second = { };
-            Assert.Empty(first.Concat(second));
+            first = from item in first select item;
+            second = from item in second select item;
+
+            VerifyEqualsWorker(first.Concat(second), first.Concat(second));
+            VerifyEqualsWorker(second.Concat(first), second.Concat(first));
         }
 
-        [Fact]
-        public void EmptyAndNonEmpty()
+        [Theory]
+        [InlineData(new int[] { }, new int[] { }, new int[] { })] // Both inputs are empty
+        [InlineData(new int[] { }, new int[] { 2, 6, 4, 6, 2 }, new int[] { 2, 6, 4, 6, 2 })] // One is empty
+        [InlineData(new int[] { 2, 3, 5, 9 }, new int[] { 8, 10 }, new int[] { 2, 3, 5, 9, 8, 10 })] // Neither side is empty
+        public void PossiblyEmptyInputs(IEnumerable<int> first, IEnumerable<int> second, IEnumerable<int> expected)
         {
-            int[] first = { };
-            int[] second = { 2, 6, 4, 6, 2 };
-
-            Assert.Equal(second, first.Concat(second));
-        }
-
-        [Fact]
-        public void NonEmptyAndEmpty()
-        {
-            int[] first = { 2, 6, 4, 6, 2 };
-            int[] second = { };
-
-            Assert.Equal(first, first.Concat(second));
-        }
-
-        [Fact]
-        public void NonEmptyAndNonEmpty()
-        {
-            int?[] first = { 2, null, 3, 5, 9 };
-            int?[] second = { null, 8, 10 };
-            int?[] expected = { 2, null, 3, 5, 9, null, 8, 10 };
-
-            Assert.Equal(expected, first.Concat(second));
+            VerifyEqualsWorker(expected, first.Concat(second));
+            VerifyEqualsWorker(expected.Skip(first.Count()).Concat(expected.Take(first.Count())), second.Concat(first)); // Swap the inputs around
         }
 
         [Fact]
@@ -89,90 +67,65 @@ namespace System.Linq.Tests
             Assert.Throws<ArgumentNullException>("second", () => Enumerable.Range(0, 0).Concat(null));
         }
 
-        [Fact]
-        public void TwoEnumerableSources()
+        [Theory]
+        [MemberData(nameof(ArraySourcesData))]
+        [MemberData(nameof(ArraySelectSourcesData))]
+        [MemberData(nameof(EnumerableSourcesData))]
+        [MemberData(nameof(NonCollectionSourcesData))]
+        [MemberData(nameof(ListSourcesData))]
+        [MemberData(nameof(ConcatOfConcatsData))]
+        [MemberData(nameof(ConcatWithSelfData))]
+        public void VerifyEquals(IEnumerable<int> expected, IEnumerable<int> actual)
         {
-            VerifyEquals(
-                Enumerable.Range(0, 7),
-                Enumerable.Range(0, 3).Concat(Enumerable.Range(3, 4)));
+            // workaround: xUnit type inference doesn't work if the input type is not T (like IEnumerable<T>)
+            VerifyEqualsWorker(expected, actual);
         }
 
-        [Fact]
-        public void TwoArraySources()
+        private static void VerifyEqualsWorker<T>(IEnumerable<T> expected, IEnumerable<T> actual)
         {
-            VerifyEquals(
-                Enumerable.Range(0, 7),
-                Enumerable.Range(0, 3).ToArray().Concat(Enumerable.Range(3, 4).ToArray()));
+            // All of these transforms should take an enumerable and produce
+            // another enumerable with the same contents.
+            var transforms = new List<Func<IEnumerable<T>, IEnumerable<T>>>
+            {
+                e => e,
+                e => e.ToArray(),
+                e => e.ToList(),
+                e => e.Select(i => i),
+                e => e.Select(i => i).ToArray(),
+                e => e.Where(i => true),
+                e => e.Concat(Enumerable.Empty<T>()),
+                e => ForceNotCollection(e)
+            };
+            
+            // We run the transforms N^2 times, by testing all transforms
+            // of expected against all transforms of actual.
+            foreach (var outTransform in transforms)
+            {
+                foreach (var inTransform in transforms)
+                {
+                    IEnumerable<T> sameExpected = outTransform(expected);
+                    IEnumerable<T> sameActual = inTransform(actual);
+
+                    Assert.Equal(sameExpected, sameActual);
+                    Assert.Equal(sameExpected.Count(), sameActual.Count());
+                }
+            }
         }
 
-        [Fact]
-        public void TwoArraySelectSources()
-        {
-            VerifyEquals(
-                Enumerable.Range(0, 7),
-                Enumerable.Range(0, 3).ToArray().Select(i => i).Concat(Enumerable.Range(3, 4).ToArray().Select(i => i)));
-        }
+        public static IEnumerable<object[]> ArraySourcesData() => GenerateSourcesData(e => e.ToArray());
 
-        [Fact]
-        public void TwoNonCollectionSources()
-        {
-            VerifyEquals(
-                Enumerable.Range(0, 7),
-                NumberRangeGuaranteedNotCollectionType(0, 3).Concat(NumberRangeGuaranteedNotCollectionType(3, 4).ToArray().Select(i => i)));
-        }
+        public static IEnumerable<object[]> ArraySelectSourcesData() => GenerateSourcesData(e => e.Select(i => i).ToArray());
 
-        [Fact]
-        public void ThreeEnumerableSources()
-        {
-            VerifyEquals(
-                Enumerable.Range(0, 12),
-                Enumerable.Range(0, 3).Concat(Enumerable.Range(3, 4)).Concat(Enumerable.Range(7, 5)));
-        }
+        public static IEnumerable<object[]> EnumerableSourcesData() => GenerateSourcesData(e => e);
 
-        [Fact]
-        public void FourEnumerableSources()
-        {
-            VerifyEquals(
-                Enumerable.Range(0, 18),
-                Enumerable.Range(0, 3).Concat(Enumerable.Range(3, 4)).Concat(Enumerable.Range(7, 5)).Concat(Enumerable.Range(12, 6)));
-        }
+        public static IEnumerable<object[]> NonCollectionSourcesData() => GenerateSourcesData(e => ForceNotCollection(e));
 
-        [Fact]
-        public void FiveEnumerableSources()
-        {
-            VerifyEquals(
-                Enumerable.Range(0, 25),
-                Enumerable.Range(0, 3).Concat(Enumerable.Range(3, 4)).Concat(Enumerable.Range(7, 5)).Concat(Enumerable.Range(12, 6)).Concat(Enumerable.Range(18, 7)));
-        }
+        public static IEnumerable<object[]> ListSourcesData() => GenerateSourcesData(e => e.ToList());
 
-        [Fact]
-        public void FiveNonCollectionSources()
+        public static IEnumerable<object[]> ConcatOfConcatsData()
         {
-            VerifyEquals(
-                Enumerable.Range(0, 25),
-                NumberRangeGuaranteedNotCollectionType(0, 3)
-                .Concat(NumberRangeGuaranteedNotCollectionType(3, 4))
-                .Concat(NumberRangeGuaranteedNotCollectionType(7, 5))
-                .Concat(NumberRangeGuaranteedNotCollectionType(12, 6))
-                .Concat(NumberRangeGuaranteedNotCollectionType(18, 7)));
-        }
-
-        [Fact]
-        public void FiveListSources()
-        {
-            VerifyEquals(
-                Enumerable.Range(0, 25),
-                Enumerable.Range(0, 3).ToList()
-                          .Concat(Enumerable.Range(3, 4).ToList())
-                          .Concat(Enumerable.Range(7, 5).ToList())
-                          .Concat(Enumerable.Range(12, 6).ToList())
-                          .Concat(Enumerable.Range(18, 7).ToList()));
-        }
-
-        [Fact]
-        public void ConcatOfConcats()
-        {
-            VerifyEquals(
+            yield return new object[]
+            {
                 Enumerable.Range(0, 20),
                 Enumerable.Concat(
                     Enumerable.Concat(
@@ -180,51 +133,53 @@ namespace System.Linq.Tests
                         Enumerable.Range(4, 6)),
                     Enumerable.Concat(
                         Enumerable.Range(10, 3),
-                        Enumerable.Range(13, 7))));
+                        Enumerable.Range(13, 7)))
+            };
         }
 
-        [Fact]
-        public void ConcatWithSelf()
+        public static IEnumerable<object[]> ConcatWithSelfData()
         {
             IEnumerable<int> source = Enumerable.Repeat(1, 4).Concat(Enumerable.Repeat(1, 5));
             source = source.Concat(source);
-            VerifyEquals(Enumerable.Repeat(1, 18), source);
+
+            yield return new object[] { Enumerable.Repeat(1, 18), source };
         }
 
-        private void VerifyEquals(IEnumerable<int> expected, IEnumerable<int> actual)
+        private static IEnumerable<object[]> GenerateSourcesData(Func<IEnumerable<int>, IEnumerable<int>> concatTransform)
         {
-            Assert.Equal(expected, actual);
-            Assert.Equal(expected, actual.ToArray());
-            Assert.Equal(expected, actual.ToList());
-            Assert.Equal(expected, actual.Select(i => i).ToArray());
-            Assert.Equal(expected, actual.Where(i => true).ToArray());
-            Assert.Equal(expected, actual.OrderBy(i => i));
-            Assert.Equal(expected, Enumerable.Empty<int>().Concat(actual));
-            Assert.Equal(expected.Count(), actual.Count());
-        }
-
-        [Fact]
-        public void ManyEmptyConcats()
-        {
-            IEnumerable<int> source = Enumerable.Empty<int>();
-            for (int i = 0; i < 256; i++)
+            for (int i = 2; i <= 6; i++)
             {
-                source = source.Concat(Enumerable.Empty<int>());
+                var expected = Enumerable.Range(0, i * 3);
+                var actual = Enumerable.Empty<int>();
+                for (int j = 0; j < i; j++)
+                {
+                    actual = concatTransform(actual.Concat(Enumerable.Range(j * 3, 3)));
+                }
+
+                yield return new object[] { expected, actual };
             }
-            Assert.Equal(0, source.Count());
-            Assert.Equal(Enumerable.Empty<int>(), source);
         }
 
-        [Fact]
-        public void ManyNonEmptyConcats()
+        [Theory]
+        [MemberData(nameof(ManyConcatsData))]
+        public void ManyConcats(IEnumerable<int> toConcat, int times, IEnumerable<int> expected)
         {
+            Debug.Assert(times >= 0);
+
             IEnumerable<int> source = Enumerable.Empty<int>();
-            for (int i = 0; i < 256; i++)
+            for (int i = 0; i < times; i++)
             {
-                source = source.Concat(Enumerable.Repeat(i, 1));
+                source = source.Concat(toConcat);
             }
-            Assert.Equal(256, source.Count());
-            Assert.Equal(Enumerable.Range(0, 256), source);
+
+            Assert.Equal(toConcat.Count() * times, source.Count());
+            VerifyEqualsWorker(expected, source);
+        }
+
+        public static IEnumerable<object[]> ManyConcatsData()
+        {
+            yield return new object[] { Enumerable.Empty<int>(), 256, Enumerable.Empty<int>() };
+            yield return new object[] { Enumerable.Repeat(6, 1), 256, Enumerable.Repeat(6, 256) };
         }
     }
 }

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -201,6 +201,7 @@ namespace System.Linq.Tests
             // We need to use checked arithmetic summing up the collections' counts.
             Assert.Throws<OverflowException>(() => supposedlyLargeCollection.Concat(tinyCollection).Count());
             Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(supposedlyLargeCollection).Count());
+            Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(tinyCollection).Concat(supposedlyLargeCollection).Count());
         }
     }
 }

--- a/src/System.Linq/tests/EnumerableTests.cs
+++ b/src/System.Linq/tests/EnumerableTests.cs
@@ -232,5 +232,41 @@ namespace System.Linq.Tests
             public string name { get; set; }
             public int?[] total { get; set; }
         }
+
+        protected class DelegateBasedCollection<T> : ICollection<T>
+        {
+            public Func<int> CountWorker { get; set; }
+            public Func<bool> IsReadOnlyWorker { get; set; }
+            public Action<T> AddWorker { get; set; }
+            public Action ClearWorker { get; set; }
+            public Func<T, bool> ContainsWorker { get; set; }
+            public Func<T, bool> RemoveWorker { get; set; }
+            public Action<T[], int> CopyToWorker { get; set; }
+            public Func<IEnumerator<T>> GetEnumeratorWorker { get; set; }
+            public Func<IEnumerator> NonGenericGetEnumeratorWorker { get; set; }
+
+            public DelegateBasedCollection()
+            {
+                CountWorker = () => 0;
+                IsReadOnlyWorker = () => false;
+                AddWorker = item => { };
+                ClearWorker = () => { };
+                ContainsWorker = item => false;
+                RemoveWorker = item => false;
+                CopyToWorker = (array, arrayIndex) => { };
+                GetEnumeratorWorker = () => Enumerable.Empty<T>().GetEnumerator();
+                NonGenericGetEnumeratorWorker = () => GetEnumeratorWorker();
+            }
+
+            public int Count => CountWorker();
+            public bool IsReadOnly => IsReadOnlyWorker();
+            public void Add(T item) => AddWorker(item);
+            public void Clear() => ClearWorker();
+            public bool Contains(T item) => ContainsWorker(item);
+            public bool Remove(T item) => RemoveWorker(item);
+            public void CopyTo(T[] array, int arrayIndex) => CopyToWorker(array, arrayIndex);
+            public IEnumerator<T> GetEnumerator() => GetEnumeratorWorker();
+            IEnumerator IEnumerable.GetEnumerator() => NonGenericGetEnumeratorWorker();
+        }
     }
 }


### PR DESCRIPTION
These changes convert most of the `Concat` tests to use `[Theory]` and improve test coverage, since the asserts are more centralized in one place. I added tests for the relevant codepaths mentioned in #11492; the case where we concat two collections, then append an enumerable is handled indirectly by `ChainedCollectionConcatData`, since an `Enumerable.Empty<T>().Concat(x.ToList())` gets passed to the theory and that is eventually compared to `.Concat(ForceNotCollection(Array.Empty<T>()))`.

Separated out from #11492 since I felt the PR was already a little long.

cc @stephentoub 