### PR TITLE
Add Windows GetFolderPath implementation

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -61,6 +61,7 @@ internal static partial class Interop
         internal const string ServiceMgmt_L1 = "api-ms-win-service-management-l1-1-0.dll";
         internal const string ServiceMgmt_L2 = "api-ms-win-service-management-l2-1-0.dll";
         internal const string ServiceWinSvc = "api-ms-win-service-winsvc-l1-1-0.dll";
+        internal const string ShellFolders = "api-ms-win-shell-shellfolders-l1-1-0.dll";
         internal const string Sspi = "sspicli.dll";
         internal const string String_L1 = "api-ms-win-core-string-l1-1-0.dll";
         internal const string Synch = "api-ms-win-core-synch-l1-1-0.dll";

--- a/src/Common/src/Interop/Windows/mincore/Interop.SHGetKnownFolderPath.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.SHGetKnownFolderPath.cs
@@ -1,0 +1,320 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        internal const int COR_E_PLATFORMNOTSUPPORTED = unchecked((int)0x80131539);
+
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/bb762188.aspx
+        [DllImport(Libraries.ShellFolders, CharSet = CharSet.Unicode, SetLastError = false, BestFitMapping = false, ExactSpelling = true)]
+        internal static extern int SHGetKnownFolderPath(
+            [MarshalAs(UnmanagedType.LPStruct)] Guid rfid,
+            uint dwFlags,
+            IntPtr hToken,
+            out string ppszPath);
+
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/dd378457.aspx
+        internal static class KnownFolders
+        {
+            /// <summary>
+            /// (CSIDL_ADMINTOOLS) Per user Administrative Tools
+            /// "%APPDATA%\Microsoft\Windows\Start Menu\Programs\Administrative Tools"
+            /// </summary>
+            internal const string AdminTools = "{724EF170-A42D-4FEF-9F26-B60E846FBA4F}";
+
+            /// <summary>
+            /// (CSIDL_CDBURN_AREA) Temporary Burn folder
+            /// "%LOCALAPPDATA%\Microsoft\Windows\Burn\Burn"
+            /// </summary>
+            internal const string CDBurning = "{9E52AB10-F80D-49DF-ACB8-4330F5687855}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_ADMINTOOLS) Common Administrative Tools
+            /// "%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs\Administrative Tools"
+            /// </summary>
+            internal const string CommonAdminTools = "{D0384E7D-BAC3-4797-8F14-CBA229B392B5}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_OEM_LINKS) OEM Links folder
+            /// "%ALLUSERSPROFILE%\OEM Links"
+            /// </summary>
+            internal const string CommonOEMLinks = "{C1BAE2D0-10DF-4334-BEDD-7AA20B227A9D}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_PROGRAMS) Common Programs folder
+            /// "%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs"
+            /// </summary>
+            internal const string CommonPrograms = "{0139D44E-6AFE-49F2-8690-3DAFCAE6FFB8}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_STARTMENU) Common Start Menu folder
+            /// "%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu"
+            /// </summary>
+            internal const string CommonStartMenu = "{A4115719-D62E-491D-AA7C-E74B8BE3B067}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_STARTUP, CSIDL_COMMON_ALTSTARTUP) Common Startup folder
+            /// "%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs\StartUp"
+            /// </summary>
+            internal const string CommonStartup = "{82A5EA35-D9CD-47C5-9629-E15D2F714E6E}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_TEMPLATES) Common Templates folder
+            /// "%ALLUSERSPROFILE%\Microsoft\Windows\Templates"
+            /// </summary>
+            internal const string CommonTemplates = "{B94237E7-57AC-4347-9151-B08C6C32D1F7}";
+
+            /// <summary>
+            /// (CSIDL_DRIVES) Computer virtual folder
+            /// </summary>
+            internal const string ComputerFolder = "{0AC0837C-BBF8-452A-850D-79D08E667CA7}";
+
+            /// <summary>
+            /// (CSIDL_CONNECTIONS) Network Conections virtual folder
+            /// </summary>
+            internal const string ConnectionsFolder = "{6F0CD92B-2E97-45D1-88FF-B0D186B8DEDD}";
+
+            /// <summary>
+            /// (CSIDL_CONTROLS) Control Panel virtual folder
+            /// </summary>
+            internal const string ControlPanelFolder = "{82A74AEB-AEB4-465C-A014-D097EE346D63}";
+
+            /// <summary>
+            /// (CSIDL_COOKIES) Cookies folder
+            /// "%APPDATA%\Microsoft\Windows\Cookies"
+            /// </summary>
+            internal const string Cookies = "{2B0F765D-C0E9-4171-908E-08A611B84FF6}";
+
+            /// <summary>
+            /// (CSIDL_DESKTOP, CSIDL_DESKTOPDIRECTORY) Desktop folder
+            /// "%USERPROFILE%\Desktop"
+            /// </summary>
+            internal const string Desktop = "{B4BFCC3A-DB2C-424C-B029-7FE99A87C641}";
+
+            /// <summary>
+            /// (CSIDL_MYDOCUMENTS, CSIDL_PERSONAL) Documents (My Documents) folder
+            /// "%USERPROFILE%\Documents"
+            /// </summary>
+            internal const string Documents = "{FDD39AD0-238F-46AF-ADB4-6C85480369C7}";
+
+            /// <summary>
+            /// (CSIDL_FAVORITES, CSIDL_COMMON_FAVORITES) Favorites folder
+            /// "%USERPROFILE%\Favorites"
+            /// </summary>
+            internal const string Favorites = "{1777F761-68AD-4D8A-87BD-30B759FA33DD}";
+
+            /// <summary>
+            /// (CSIDL_FONTS) Fonts folder
+            /// "%windir%\Fonts"
+            /// </summary>
+            internal const string Fonts = "{FD228CB7-AE11-4AE3-864C-16F3910AB8FE}";
+
+            /// <summary>
+            /// (CSIDL_HISTORY) History folder
+            /// "%LOCALAPPDATA%\Microsoft\Windows\History"
+            /// </summary>
+            internal const string History = "{D9DC8A3B-B784-432E-A781-5A1130A75963}";
+
+            /// <summary>
+            /// (CSIDL_INTERNET_CACHE) Temporary Internet Files folder
+            /// "%LOCALAPPDATA%\Microsoft\Windows\Temporary Internet Files"
+            /// </summary>
+            internal const string InternetCache = "{352481E8-33BE-4251-BA85-6007CAEDCF9D}";
+
+            /// <summary>
+            /// (CSIDL_INTERNET) The Internet virtual folder
+            /// </summary>
+            internal const string InternetFolder = "{4D9F7874-4E0C-4904-967B-40B0D20C3E4B}";
+
+            /// <summary>
+            /// (CSIDL_LOCAL_APPDATA) Local folder
+            /// "%LOCALAPPDATA%" ("%USERPROFILE%\AppData\Local")
+            /// </summary>
+            internal const string LocalAppData = "{F1B32785-6FBA-4FCF-9D55-7B8E7F157091}";
+
+            /// <summary>
+            /// (CSIDL_RESOURCES_LOCALIZED) Fixed localized resources folder
+            /// "%windir%\resources\0409" (per active codepage)
+            /// </summary>
+            internal const string LocalizedResourcesDir = "{2A00375E-224C-49DE-B8D1-440DF7EF3DDC}";
+
+            /// <summary>
+            /// (CSIDL_MYMUSIC) Music folder
+            /// "%USERPROFILE%\Music"
+            /// </summary>
+            internal const string Music = "{4BD8D571-6D19-48D3-BE97-422220080E43}";
+
+            /// <summary>
+            /// (CSIDL_NETHOOD) Network shortcuts folder "%APPDATA%\Microsoft\Windows\Network Shortcuts"
+            /// </summary>
+            internal const string NetHood = "{C5ABBF53-E17F-4121-8900-86626FC2C973}";
+
+            /// <summary>
+            /// (CSIDL_NETWORK, CSIDL_COMPUTERSNEARME) Network virtual folder
+            /// </summary>
+            internal const string NetworkFolder = "{D20BEEC4-5CA8-4905-AE3B-BF251EA09B53}";
+
+            /// <summary>
+            /// (CSIDL_MYPICTURES) Pictures folder "%USERPROFILE%\Pictures"
+            /// </summary>
+            internal const string Pictures = "{33E28130-4E1E-4676-835A-98395C3BC3BB}";
+
+            /// <summary>
+            /// (CSIDL_PRINTERS) Printers virtual folder
+            /// </summary>
+            internal const string PrintersFolder = "{76FC4E2D-D6AD-4519-A663-37BD56068185}";
+
+            /// <summary>
+            /// (CSIDL_PRINTHOOD) Printer Shortcuts folder
+            /// "%APPDATA%\Microsoft\Windows\Printer Shortcuts"
+            /// </summary>
+            internal const string PrintHood = "{9274BD8D-CFD1-41C3-B35E-B13F55A758F4}";
+
+            /// <summary>
+            /// (CSIDL_PROFILE) The root users profile folder "%USERPROFILE%"
+            /// ("%SystemDrive%\Users\%USERNAME%")
+            /// </summary>
+            internal const string Profile = "{5E6C858F-0E22-4760-9AFE-EA3317B67173}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_APPDATA) ProgramData folder
+            /// "%ALLUSERSPROFILE%" ("%ProgramData%", "%SystemDrive%\ProgramData")
+            /// </summary>
+            internal const string ProgramData = "{62AB5D82-FDC1-4DC3-A9DD-070D1D495D97}";
+
+            /// <summary>
+            /// (CSIDL_PROGRAM_FILES) Program Files folder for the current process architecture
+            /// "%ProgramFiles%" ("%SystemDrive%\Program Files")
+            /// </summary>
+            internal const string ProgramFiles = "{905e63b6-c1bf-494e-b29c-65b732d3d21a}";
+
+            /// <summary>
+            /// (CSIDL_PROGRAM_FILESX86) 32 bit Program Files folder (available to both 32/64 bit processes)
+            /// </summary>
+            internal const string ProgramFilesX86 = "{7C5A40EF-A0FB-4BFC-874A-C0F2E0B9FA8E}";
+
+            /// <summary>
+            /// (CSIDL_PROGRAM_FILES_COMMON) Common Program Files folder for the current process architecture
+            /// "%ProgramFiles%\Common Files"
+            /// </summary>
+            internal const string ProgramFilesCommon = "{F7F1ED05-9F6D-47A2-AAAE-29D317C6F066}";
+
+            /// <summary>
+            /// (CSIDL_PROGRAM_FILES_COMMONX86) Common 32 bit Program Files folder (available to both 32/64 bit processes)
+            /// </summary>
+            internal const string ProgramFilesCommonX86 = "{DE974D24-D9C6-4D3E-BF91-F4455120B917}";
+
+            /// <summary>
+            /// (CSIDL_PROGRAMS) Start menu Programs folder
+            /// "%APPDATA%\Microsoft\Windows\Start Menu\Programs"
+            /// </summary>
+            internal const string Programs = "{A77F5D77-2E2B-44C3-A6A2-ABA601054A51}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_DESKTOPDIRECTORY) Public Desktop folder
+            /// "%PUBLIC%\Desktop"
+            /// </summary>
+            internal const string PublicDesktop = "{C4AA340D-F20F-4863-AFEF-F87EF2E6BA25}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_DOCUMENTS) Public Documents folder
+            /// "%PUBLIC%\Documents"
+            /// </summary>
+            internal const string PublicDocuments = "{ED4824AF-DCE4-45A8-81E2-FC7965083634}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_MUSIC) Public Music folder
+            /// "%PUBLIC%\Music"
+            /// </summary>
+            internal const string PublicMusic = "{3214FAB5-9757-4298-BB61-92A9DEAA44FF}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_PICTURES) Public Pictures folder
+            /// "%PUBLIC%\Pictures"
+            /// </summary>
+            internal const string PublicPictures = "{B6EBFB86-6907-413C-9AF7-4FC2ABF07CC5}";
+
+            /// <summary>
+            /// (CSIDL_COMMON_VIDEO) Public Videos folder
+            /// "%PUBLIC%\Videos"
+            /// </summary>
+            internal const string PublicVideos = "{2400183A-6185-49FB-A2D8-4A392A602BA3}";
+
+            /// <summary>
+            /// (CSIDL_RECENT) Recent Items folder
+            /// "%APPDATA%\Microsoft\Windows\Recent"
+            /// </summary>
+            internal const string Recent = "{AE50C081-EBD2-438A-8655-8A092E34987A}";
+
+            /// <summary>
+            /// (CSIDL_BITBUCKET) Recycle Bin virtual folder
+            /// </summary>
+            internal const string RecycleBinFolder = "{B7534046-3ECB-4C18-BE4E-64CD4CB7D6AC}";
+
+            /// <summary>
+            /// (CSIDL_RESOURCES) Resources fixed folder
+            /// "%windir%\Resources"
+            /// </summary>
+            internal const string ResourceDir = "{8AD10C31-2ADB-4296-A8F7-E4701232C972}";
+
+            /// <summary>
+            /// (CSIDL_APPDATA) Roaming user application data folder
+            /// "%APPDATA%" ("%USERPROFILE%\AppData\Roaming")
+            /// </summary>
+            internal const string RoamingAppData = "{3EB685DB-65F9-4CF6-A03A-E3EF65729F3D}";
+
+            /// <summary>
+            /// (CSIDL_SENDTO) SendTo folder
+            /// "%APPDATA%\Microsoft\Windows\SendTo"
+            /// </summary>
+            internal const string SendTo = "{8983036C-27C0-404B-8F08-102D10DCFD74}";
+
+            /// <summary>
+            /// (CSIDL_STARTMENU) Start Menu folder
+            /// "%APPDATA%\Microsoft\Windows\Start Menu"
+            /// </summary>
+            internal const string StartMenu = "{625B53C3-AB48-4EC1-BA1F-A1EF4146FC19}";
+
+            /// <summary>
+            /// (CSIDL_STARTUP, CSIDL_ALTSTARTUP) Startup folder
+            /// "%APPDATA%\Microsoft\Windows\Start Menu\Programs\StartUp"
+            /// </summary>
+            internal const string Startup = "{B97D20BB-F46A-4C97-BA10-5E3608430854}";
+
+            /// <summary>
+            /// (CSIDL_SYSTEM) System32 folder
+            /// "%windir%\system32"
+            /// </summary>
+            internal const string System = "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}";
+
+            /// <summary>
+            /// (CSIDL_SYSTEMX86) X86 System32 folder
+            /// "%windir%\system32" or "%windir%\syswow64"
+            /// </summary>
+            internal const string SystemX86 = "{D65231B0-B2F1-4857-A4CE-A8E7C6EA7D27}";
+
+            /// <summary>
+            /// (CSIDL_TEMPLATES) Templates folder
+            /// "%APPDATA%\Microsoft\Windows\Templates"
+            /// </summary>
+            internal const string Templates = "{A63293E8-664E-48DB-A079-DF759E0509F7}";
+
+            /// <summary>
+            /// (CSIDL_MYVIDEO) Videos folder
+            /// "%USERPROFILE%\Videos"
+            /// </summary>
+            internal const string Videos = "{18989B1D-99B5-455B-841C-AB7C74E4DDFC}";
+
+            /// <summary>
+            /// (CSIDL_WINDOWS) Windows folder "%windir%"
+            /// </summary>
+            internal const string Windows = "{F38BF404-1D43-42F2-9305-67DE0B28FC23}";
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -141,6 +141,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SetCurrentDirectory.cs">
       <Link>Common\Interop\Windows\mincore\Interop.SetCurrentDirectory.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SHGetKnownFolderPath.cs">
+      <Link>Common\Interop\Windows\mincore\Interop.SHGetKnownFolderPath.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SYSTEM_INFO.cs">
       <Link>Common\Interop\Windows\mincore\Interop.SYSTEM_INFO.cs</Link>
     </Compile>

--- a/src/System.Runtime.Extensions/src/System/Environment.SpecialFolderOption.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.SpecialFolderOption.cs
@@ -19,8 +19,15 @@ namespace System
         // used on all platforms.
         private static class SpecialFolderOptionValues
         {
-            internal const int CSIDL_FLAG_CREATE = 0x8000; // force folder creation in SHGetFolderPath
-            internal const int CSIDL_FLAG_DONT_VERIFY = 0x4000; // return an unverified folder path
+            /// <summary>
+            /// Force folder creation in SHGetFolderPath. Equivalent of KF_FLAG_CREATE (0x00008000).
+            /// </summary>
+            internal const int CSIDL_FLAG_CREATE = 0x8000;
+
+            /// <summary>
+            /// Return an unverified folder path. Equivalent of KF_FLAG_DONT_VERIFY (0x00004000).
+            /// </summary>
+            internal const int CSIDL_FLAG_DONT_VERIFY = 0x4000;
         }
     }
 }

--- a/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
@@ -208,14 +208,185 @@ namespace System
 
         private static string GetFolderPathCore(SpecialFolder folder, SpecialFolderOption option)
         {
+            // We're using SHGetKnownFolderPath instead of SHGetFolderPath as SHGetFolderPath is
+            // capped at MAX_PATH.
+            //
+            // Because we validate both of the input enums we shouldn't have to care about CSIDL and flag
+            // definitions we haven't mapped. If we remove or loosen the checks we'd have to account
+            // for mapping here (this includes tweaking as SHGetFolderPath would do).
+            //
+            // The only SpecialFolderOption defines we have are equivalent to KnownFolderFlags.
+
+            string folderGuid;
+
             switch (folder)
             {
+                case SpecialFolder.ApplicationData:
+                    folderGuid = Interop.mincore.KnownFolders.RoamingAppData;
+                    break;
+                case SpecialFolder.CommonApplicationData:
+                    folderGuid = Interop.mincore.KnownFolders.ProgramData;
+                    break;
+                case SpecialFolder.LocalApplicationData:
+                    folderGuid = Interop.mincore.KnownFolders.LocalAppData;
+                    break;
+                case SpecialFolder.Cookies:
+                    folderGuid = Interop.mincore.KnownFolders.Cookies;
+                    break;
+                case SpecialFolder.Desktop:
+                    folderGuid = Interop.mincore.KnownFolders.Desktop;
+                    break;
+                case SpecialFolder.Favorites:
+                    folderGuid = Interop.mincore.KnownFolders.Favorites;
+                    break;
+                case SpecialFolder.History:
+                    folderGuid = Interop.mincore.KnownFolders.History;
+                    break;
+                case SpecialFolder.InternetCache:
+                    folderGuid = Interop.mincore.KnownFolders.InternetCache;
+                    break;
+                case SpecialFolder.Programs:
+                    folderGuid = Interop.mincore.KnownFolders.Programs;
+                    break;
+                case SpecialFolder.MyComputer:
+                    folderGuid = Interop.mincore.KnownFolders.ComputerFolder;
+                    break;
+                case SpecialFolder.MyMusic:
+                    folderGuid = Interop.mincore.KnownFolders.Music;
+                    break;
+                case SpecialFolder.MyPictures:
+                    folderGuid = Interop.mincore.KnownFolders.Pictures;
+                    break;
+                case SpecialFolder.MyVideos:
+                    folderGuid = Interop.mincore.KnownFolders.Videos;
+                    break;
+                case SpecialFolder.Recent:
+                    folderGuid = Interop.mincore.KnownFolders.Recent;
+                    break;
+                case SpecialFolder.SendTo:
+                    folderGuid = Interop.mincore.KnownFolders.SendTo;
+                    break;
+                case SpecialFolder.StartMenu:
+                    folderGuid = Interop.mincore.KnownFolders.StartMenu;
+                    break;
+                case SpecialFolder.Startup:
+                    folderGuid = Interop.mincore.KnownFolders.Startup;
+                    break;
                 case SpecialFolder.System:
-                    return SystemDirectory;
+                    folderGuid = Interop.mincore.KnownFolders.System;
+                    break;
+                case SpecialFolder.Templates:
+                    folderGuid = Interop.mincore.KnownFolders.Templates;
+                    break;
+                case SpecialFolder.DesktopDirectory:
+                    folderGuid = Interop.mincore.KnownFolders.Desktop;
+                    break;
+                case SpecialFolder.Personal:
+                    // Same as Personal
+                    // case SpecialFolder.MyDocuments:
+                    folderGuid = Interop.mincore.KnownFolders.Documents;
+                    break;
+                case SpecialFolder.ProgramFiles:
+                    folderGuid = Interop.mincore.KnownFolders.ProgramFiles;
+                    break;
+                case SpecialFolder.CommonProgramFiles:
+                    folderGuid = Interop.mincore.KnownFolders.ProgramFilesCommon;
+                    break;
+                case SpecialFolder.AdminTools:
+                    folderGuid = Interop.mincore.KnownFolders.AdminTools;
+                    break;
+                case SpecialFolder.CDBurning:
+                    folderGuid = Interop.mincore.KnownFolders.CDBurning;
+                    break;
+                case SpecialFolder.CommonAdminTools:
+                    folderGuid = Interop.mincore.KnownFolders.CommonAdminTools;
+                    break;
+                case SpecialFolder.CommonDocuments:
+                    folderGuid = Interop.mincore.KnownFolders.PublicDocuments;
+                    break;
+                case SpecialFolder.CommonMusic:
+                    folderGuid = Interop.mincore.KnownFolders.PublicMusic;
+                    break;
+                case SpecialFolder.CommonOemLinks:
+                    folderGuid = Interop.mincore.KnownFolders.CommonOEMLinks;
+                    break;
+                case SpecialFolder.CommonPictures:
+                    folderGuid = Interop.mincore.KnownFolders.PublicPictures;
+                    break;
+                case SpecialFolder.CommonStartMenu:
+                    folderGuid = Interop.mincore.KnownFolders.CommonStartMenu;
+                    break;
+                case SpecialFolder.CommonPrograms:
+                    folderGuid = Interop.mincore.KnownFolders.CommonPrograms;
+                    break;
+                case SpecialFolder.CommonStartup:
+                    folderGuid = Interop.mincore.KnownFolders.CommonStartup;
+                    break;
+                case SpecialFolder.CommonDesktopDirectory:
+                    folderGuid = Interop.mincore.KnownFolders.PublicDesktop;
+                    break;
+                case SpecialFolder.CommonTemplates:
+                    folderGuid = Interop.mincore.KnownFolders.CommonTemplates;
+                    break;
+                case SpecialFolder.CommonVideos:
+                    folderGuid = Interop.mincore.KnownFolders.PublicVideos;
+                    break;
+                case SpecialFolder.Fonts:
+                    folderGuid = Interop.mincore.KnownFolders.Fonts;
+                    break;
+                case SpecialFolder.NetworkShortcuts:
+                    folderGuid = Interop.mincore.KnownFolders.NetHood;
+                    break;
+                case SpecialFolder.PrinterShortcuts:
+                    folderGuid = Interop.mincore.KnownFolders.PrintersFolder;
+                    break;
+                case SpecialFolder.UserProfile:
+                    folderGuid = Interop.mincore.KnownFolders.Profile;
+                    break;
+                case SpecialFolder.CommonProgramFilesX86:
+                    folderGuid = Interop.mincore.KnownFolders.ProgramFilesCommonX86;
+                    break;
+                case SpecialFolder.ProgramFilesX86:
+                    folderGuid = Interop.mincore.KnownFolders.ProgramFilesX86;
+                    break;
+                case SpecialFolder.Resources:
+                    folderGuid = Interop.mincore.KnownFolders.ResourceDir;
+                    break;
+                case SpecialFolder.LocalizedResources:
+                    folderGuid = Interop.mincore.KnownFolders.LocalizedResourcesDir;
+                    break;
+                case SpecialFolder.SystemX86:
+                    folderGuid = Interop.mincore.KnownFolders.SystemX86;
+                    break;
+                case SpecialFolder.Windows:
+                    folderGuid = Interop.mincore.KnownFolders.Windows;
+                    break;
                 default:
-                    // TODO: SHGetFolderPath is not available in the approved API list
                     return string.Empty;
             }
+
+            return GetKnownFolderPath(folderGuid, option);
+        }
+
+        private static string GetKnownFolderPath(string folderGuid, SpecialFolderOption option)
+        {
+            Guid folderId = new Guid(folderGuid);
+
+            string path;
+            int hr = Interop.mincore.SHGetKnownFolderPath(folderId, (uint)option, IntPtr.Zero, out path);
+            if (hr != 0) // Not S_OK
+            {
+                if (hr == Interop.mincore.COR_E_PLATFORMNOTSUPPORTED)
+                {
+                    throw new PlatformNotSupportedException();
+                }
+                else
+                {
+                    return string.Empty;
+                }
+            }
+
+            return path;
         }
 
         private static bool Is64BitOperatingSystemWhen32BitProcess

--- a/src/System.Runtime.Extensions/tests/Performance/project.json
+++ b/src/System.Runtime.Extensions/tests/Performance/project.json
@@ -6,6 +6,7 @@
     "System.IO.FileSystem": "4.3.0-beta-devapi-24503-01",
     "System.Linq.Expressions": "4.3.0-beta-devapi-24503-01",
     "System.ObjectModel": "4.3.0-beta-devapi-24503-01",
+    "System.Reflection": "4.3.0-beta-devapi-24503-01",
     "System.Reflection.TypeExtensions": "4.3.0-beta-devapi-24503-01",
     "System.Runtime": "4.3.0-beta-devapi-24503-01",
     "System.Runtime.Extensions": "4.3.0-beta-devapi-24503-01",

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -246,6 +246,65 @@ namespace System.Tests
             }
         }
 
+        [Theory]
+        [InlineData(SpecialFolder.ApplicationData)]
+        [InlineData(SpecialFolder.CommonApplicationData)]
+        [InlineData(SpecialFolder.LocalApplicationData)]
+        [InlineData(SpecialFolder.Cookies)]
+        [InlineData(SpecialFolder.Desktop)]
+        [InlineData(SpecialFolder.Favorites)]
+        [InlineData(SpecialFolder.History)]
+        [InlineData(SpecialFolder.InternetCache)]
+        [InlineData(SpecialFolder.Programs)]
+        [InlineData(SpecialFolder.MyComputer)]
+        [InlineData(SpecialFolder.MyMusic)]
+        [InlineData(SpecialFolder.MyPictures)]
+        [InlineData(SpecialFolder.MyVideos)]
+        [InlineData(SpecialFolder.Recent)]
+        [InlineData(SpecialFolder.SendTo)]
+        [InlineData(SpecialFolder.StartMenu)]
+        [InlineData(SpecialFolder.Startup)]
+        [InlineData(SpecialFolder.System)]
+        [InlineData(SpecialFolder.Templates)]
+        [InlineData(SpecialFolder.DesktopDirectory)]
+        [InlineData(SpecialFolder.Personal)]
+        [InlineData(SpecialFolder.ProgramFiles)]
+        [InlineData(SpecialFolder.CommonProgramFiles)]
+        [InlineData(SpecialFolder.AdminTools)]
+        [InlineData(SpecialFolder.CDBurning)]
+        [InlineData(SpecialFolder.CommonAdminTools)]
+        [InlineData(SpecialFolder.CommonDocuments)]
+        [InlineData(SpecialFolder.CommonMusic)]
+        [InlineData(SpecialFolder.CommonOemLinks)]
+        [InlineData(SpecialFolder.CommonPictures)]
+        [InlineData(SpecialFolder.CommonStartMenu)]
+        [InlineData(SpecialFolder.CommonPrograms)]
+        [InlineData(SpecialFolder.CommonStartup)]
+        [InlineData(SpecialFolder.CommonDesktopDirectory)]
+        [InlineData(SpecialFolder.CommonTemplates)]
+        [InlineData(SpecialFolder.CommonVideos)]
+        [InlineData(SpecialFolder.Fonts)]
+        [InlineData(SpecialFolder.NetworkShortcuts)]
+        [InlineData(SpecialFolder.PrinterShortcuts)]
+        [InlineData(SpecialFolder.UserProfile)]
+        [InlineData(SpecialFolder.CommonProgramFilesX86)]
+        [InlineData(SpecialFolder.ProgramFilesX86)]
+        [InlineData(SpecialFolder.Resources)]
+        [InlineData(SpecialFolder.LocalizedResources)]
+        [InlineData(SpecialFolder.SystemX86)]
+        [InlineData(SpecialFolder.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
+        public unsafe void GetFolderPath_Windows(SpecialFolder folder)
+        {
+            string knownFolder = Environment.GetFolderPath(folder);
+            Assert.NotEmpty(knownFolder);
+
+            char* buffer = stackalloc char[260];
+            SHGetFolderPathW(IntPtr.Zero, (int)folder, IntPtr.Zero, 0, buffer);
+            string folderPath = new string(buffer);
+            Assert.Equal(folderPath, knownFolder);
+        }
+
         [Fact]
         [PlatformSpecific(Xunit.PlatformID.AnyUnix)]
         public void GetLogicalDrives_Unix_AtLeastOneIsRoot()
@@ -278,5 +337,13 @@ namespace System.Tests
 
         [DllImport("api-ms-win-core-file-l1-1-0.dll", SetLastError = true)]
         internal static extern int GetLogicalDrives();
+
+        [DllImport("api-ms-win-shell-shellfolders-l1-1-0.dll", SetLastError = false, BestFitMapping = false, ExactSpelling = true)]
+        internal unsafe static extern int SHGetFolderPathW(
+            IntPtr hwndOwner,
+            int nFolder,
+            IntPtr hToken,
+            uint dwFlags,
+            char* pszPath);
     }
 }

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/project.json
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/project.json
@@ -7,6 +7,7 @@
     "System.Threading.Thread": "4.3.0-beta-devapi-24503-01"
   },
   "frameworks": {
+    ".NETCoreApp,Version=v1.0": {},
     "netstandard1.3": {}
   }
 }

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -9,6 +9,7 @@
     "System.IO": "4.3.0-beta-devapi-24503-01",
     "System.Linq.Expressions": "4.3.0-beta-devapi-24503-01",
     "System.ObjectModel": "4.3.0-beta-devapi-24503-01",
+    "System.Reflection": "4.3.0-beta-devapi-24503-01",
     "System.Reflection.TypeExtensions": "4.3.0-beta-devapi-24503-01",
     "System.Runtime": "4.3.0-beta-devapi-24503-01",
     "System.Runtime.Extensions": "4.3.0-beta-devapi-24503-01",
@@ -28,6 +29,7 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {
+    ".NETCoreApp,Version=v1.0": {},
     "netstandard1.5": {},
     "netstandard1.7": {}
   },


### PR DESCRIPTION
Add Environment.GetFolderPath() implementation for Windows.
Using SHGetKnownFolderPath as it isn't blocked at MAX_PATH.
Tweak the .json files to reduce warnings.

This needs an updated build tools- https://github.com/dotnet/buildtools/pull/1022.
I've validated with the relevant build tool change manually.

@weshaggard, @danmosemsft, @ericstj, @danmosemsft 

Also note that I need to make a similar change to NetFX/desktop to allow for long paths.