### PR TITLE
PLINQ - Union Combinatorial tests fix

### DIFF
--- a/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
@@ -1396,7 +1396,7 @@ namespace System.Linq.Parallel.Tests
                 }
                 Assert.Equal(DefaultStart + DefaultSize, seen);
             };
-            union(operation.Item, DefaultSource);
+            union(operation.Item, LabeledDefaultSource.AsOrdered().Item);
             union(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
@@ -1413,7 +1413,7 @@ namespace System.Linq.Parallel.Tests
                 Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
                 Assert.Equal(DefaultStart + DefaultSize, seen);
             };
-            union(operation.Item, DefaultSource);
+            union(operation.Item, LabeledDefaultSource.AsOrdered().Item);
             union(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 


### PR DESCRIPTION
@stephentoub 
Somehow ended up using a non-ordered collection for one half of the Union combinatorial tests, not quite sure how I started that.  
I'm assuming I missed it during testing because `/p:xunitoptions` only adds parameters now, not replaces them (since combinatorial is part of outerloop).