### PR TITLE
Skip failing tests on netcoreapp1.0 in dev/api.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -90,7 +90,7 @@
       Verify it at a static version rather than referencing the build-info.
     -->
     <StaticDependency Include="Microsoft.xunit.netcore.extensions;Microsoft.DotNet.BuildTools.TestSuite">
-      <Version>1.0.0-prerelease-00731-01</Version>
+      <Version>1.0.0-prerelease-00807-03</Version>
     </StaticDependency>
 
     <DependencyBuildInfo Include="@(StaticDependency)">

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -16,7 +16,7 @@
     "Microsoft.DotNet.xunit.performance.analysis.cli": "1.0.0-alpha-build0039",
     "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0039",
     "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0039",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "xunit.console.netcore": "1.0.3-prerelease-00607-01"
   },
   "frameworks": {

--- a/src/Common/tests/project.json
+++ b/src/Common/tests/project.json
@@ -25,8 +25,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/Microsoft.CSharp/tests/project.json
+++ b/src/Microsoft.CSharp/tests/project.json
@@ -24,8 +24,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Microsoft.VisualBasic/tests/project.json
+++ b/src/Microsoft.VisualBasic/tests/project.json
@@ -26,8 +26,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Microsoft.Win32.Primitives/tests/project.json
+++ b/src/Microsoft.Win32.Primitives/tests/project.json
@@ -10,8 +10,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Microsoft.Win32.Registry/tests/project.json
+++ b/src/Microsoft.Win32.Registry/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.AppContext/tests/project.json
+++ b/src/System.AppContext/tests/project.json
@@ -10,8 +10,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Buffers/tests/project.json
+++ b/src/System.Buffers/tests/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Collections.Concurrent/tests/project.json
+++ b/src/System.Collections.Concurrent/tests/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Collections.Immutable/tests/project.json
+++ b/src/System.Collections.Immutable/tests/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Collections.NonGeneric/tests/Performance/project.json
+++ b/src/System.Collections.NonGeneric/tests/Performance/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.KeysTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.KeysTests.cs
@@ -45,6 +45,7 @@ namespace System.Collections.Specialized.Tests
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {
@@ -63,6 +64,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexEqualToArrayCount_ThrowsArgumentException(int count)
         {
@@ -75,6 +77,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NotEnoughSpaceInOffsettedArray_ThrowsArgumentException(int count)
         {
@@ -87,6 +90,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowsAnyArgumentException(int count)
         {

--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.ValuesTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.ValuesTests.cs
@@ -45,6 +45,7 @@ namespace System.Collections.Specialized.Tests
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {
@@ -63,6 +64,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexEqualToArrayCount_ThrowsArgumentException(int count)
         {
@@ -75,6 +77,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NotEnoughSpaceInOffsettedArray_ThrowsArgumentException(int count)
         {
@@ -87,6 +90,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowsAnyArgumentException(int count)
         {

--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
@@ -37,6 +37,7 @@ namespace System.Collections.Specialized.Tests
         protected override object CreateTValue(int seed) => CreateTKey(seed);
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {

--- a/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.IDictionary.Tests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.IDictionary.Tests.cs
@@ -46,6 +46,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {

--- a/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Keys.Tests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Keys.Tests.cs
@@ -47,6 +47,7 @@ namespace System.Collections.Specialized.Tests
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexEqualToArrayCount_ThrowsArgumentException(int count)
         {
@@ -59,6 +60,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NotEnoughSpaceInOffsettedArray_ThrowsArgumentException(int count)
         {
@@ -71,6 +73,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowsAnyArgumentException(int count)
         {
@@ -87,6 +90,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {

--- a/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Values.Tests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Values.Tests.cs
@@ -47,6 +47,7 @@ namespace System.Collections.Specialized.Tests
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexEqualToArrayCount_ThrowsArgumentException(int count)
         {
@@ -59,6 +60,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NotEnoughSpaceInOffsettedArray_ThrowsArgumentException(int count)
         {
@@ -71,6 +73,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowsAnyArgumentException(int count)
         {
@@ -87,6 +90,7 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.builds
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <!-- Disabling netcoreapp1.0 test run from CI since there are a lot of failures. Issue tracking is: https://github.com/dotnet/corefx/issues/11364
-    <Project Include="System.Collections.Specialized.Tests.csproj"/>
-    -->
+    <Project Include="System.Collections.Specialized.Tests.csproj" />
     <Project Include="System.Collections.Specialized.Tests.csproj">
       <TargetGroup>netstandard1.7</TargetGroup>
       <TestTFMs>netcoreapp1.1</TestTFMs>

--- a/src/System.Collections.Specialized/tests/project.json
+++ b/src/System.Collections.Specialized/tests/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Collections/tests/Performance/project.json
+++ b/src/System.Collections/tests/Performance/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.ComponentModel.Annotations/tests/project.json
+++ b/src/System.ComponentModel.Annotations/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.4": {}

--- a/src/System.ComponentModel.EventBasedAsync/tests/project.json
+++ b/src/System.ComponentModel.EventBasedAsync/tests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.ComponentModel.Primitives/tests/project.json
+++ b/src/System.ComponentModel.Primitives/tests/project.json
@@ -10,8 +10,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.ComponentModel.TypeConverter/tests/Performance/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/Performance/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.ComponentModel/tests/project.json
+++ b/src/System.ComponentModel/tests/project.json
@@ -9,8 +9,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Composition.Convention/tests/project.json
+++ b/src/System.Composition.Convention/tests/project.json
@@ -8,8 +8,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Composition/tests/project.json
+++ b/src/System.Composition/tests/project.json
@@ -8,8 +8,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Console/tests/Performance/project.json
+++ b/src/System.Console/tests/Performance/project.json
@@ -19,8 +19,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -19,8 +19,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Data.Common/tests/project.json
+++ b/src/System.Data.Common/tests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Data.SqlClient/tests/ManualTests/project.json
+++ b/src/System.Data.SqlClient/tests/ManualTests/project.json
@@ -52,8 +52,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.Contracts/tests/project.json
+++ b/src/System.Diagnostics.Contracts/tests/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -9,8 +9,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.Process/tests/Performance/project.json
+++ b/src/System.Diagnostics.Process/tests/Performance/project.json
@@ -27,8 +27,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Diagnostics.Process/tests/project.json
+++ b/src/System.Diagnostics.Process/tests/project.json
@@ -27,8 +27,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.Tools/tests/project.json
+++ b/src/System.Diagnostics.Tools/tests/project.json
@@ -9,8 +9,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.TraceSource/tests/project.json
+++ b/src/System.Diagnostics.TraceSource/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Diagnostics.Tracing/tests/project.json
+++ b/src/System.Diagnostics.Tracing/tests/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Drawing.Primitives/tests/project.json
+++ b/src/System.Drawing.Primitives/tests/project.json
@@ -10,8 +10,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Dynamic.Runtime/tests/project.json
+++ b/src/System.Dynamic.Runtime/tests/project.json
@@ -22,8 +22,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Globalization.Calendars/tests/project.json
+++ b/src/System.Globalization.Calendars/tests/project.json
@@ -10,8 +10,8 @@
     "System.Text.RegularExpressions": "4.3.0-beta-devapi-24512-01",
     "System.Threading.Tasks": "4.3.0-beta-devapi-24512-01",
     "System.Text.Encoding": "4.3.0-beta-devapi-24512-01",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Globalization.Extensions/tests/project.json
+++ b/src/System.Globalization.Extensions/tests/project.json
@@ -12,8 +12,8 @@
     "System.Runtime.Extensions": "4.3.0-beta-devapi-24512-01",
     "System.Text.RegularExpressions": "4.3.0-beta-devapi-24512-01",
     "System.Threading.Tasks": "4.3.0-beta-devapi-24512-01",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Globalization/tests/Performance/project.json
+++ b/src/System.Globalization/tests/Performance/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039",
     "Microsoft.NETCore.Platforms": "4.3.0-beta-devapi-24512-01",
     "System.Diagnostics.Process": "4.3.0-beta-devapi-24512-01",

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039",
     "Microsoft.NETCore.Platforms": "4.3.0-beta-devapi-24512-01",
     "System.Diagnostics.Process": "4.3.0-beta-devapi-24512-01",

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -23,8 +23,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.Compression/tests/Performance/project.json
+++ b/src/System.IO.Compression/tests/Performance/project.json
@@ -21,8 +21,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -21,8 +21,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.IO.FileSystem.AccessControl/tests/project.json
+++ b/src/System.IO.FileSystem.AccessControl/tests/project.json
@@ -22,8 +22,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.FileSystem.DriveInfo/tests/project.json
+++ b/src/System.IO.FileSystem.DriveInfo/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.FileSystem.Primitives/tests/project.json
+++ b/src/System.IO.FileSystem.Primitives/tests/project.json
@@ -9,8 +9,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.FileSystem.Watcher/tests/project.json
+++ b/src/System.IO.FileSystem.Watcher/tests/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.FileSystem/tests/Performance/project.json
+++ b/src/System.IO.FileSystem/tests/Performance/project.json
@@ -26,8 +26,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -28,8 +28,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.IO.MemoryMappedFiles/tests/Performance/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/Performance/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.IO.MemoryMappedFiles/tests/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.IO.Packaging/tests/project.json
+++ b/src/System.IO.Packaging/tests/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.Pipes.AccessControl/tests/project.json
+++ b/src/System.IO.Pipes.AccessControl/tests/project.json
@@ -27,8 +27,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.IO.Pipes/tests/Performance/project.json
+++ b/src/System.IO.Pipes/tests/Performance/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.IO.Pipes/tests/project.json
+++ b/src/System.IO.Pipes/tests/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.IO.UnmanagedMemoryStream/tests/project.json
+++ b/src/System.IO.UnmanagedMemoryStream/tests/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO/tests/project.json
+++ b/src/System.IO/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.5": {},

--- a/src/System.Json/tests/project.json
+++ b/src/System.Json/tests/project.json
@@ -22,8 +22,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Linq.Expressions/tests/project.json
+++ b/src/System.Linq.Expressions/tests/project.json
@@ -19,8 +19,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Linq.Parallel/tests/project.json
+++ b/src/System.Linq.Parallel/tests/project.json
@@ -19,8 +19,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Linq.Queryable/tests/project.json
+++ b/src/System.Linq.Queryable/tests/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Linq/tests/Performance/project.json
+++ b/src/System.Linq/tests/Performance/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -24,8 +24,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Http/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/unix/project.json
@@ -24,8 +24,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Http/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/win/project.json
@@ -25,8 +25,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Http/tests/UnitTests/project.json
+++ b/src/System.Net.Http/tests/UnitTests/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NameResolution/tests/FunctionalTests/project.json
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NameResolution/tests/PalTests/project.json
+++ b/src/System.Net.NameResolution/tests/PalTests/project.json
@@ -32,8 +32,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NameResolution/tests/UnitTests/project.json
+++ b/src/System.Net.NameResolution/tests/UnitTests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NetworkInformation/tests/UnitTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/UnitTests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Ping/tests/FunctionalTests/project.json
+++ b/src/System.Net.Ping/tests/FunctionalTests/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Primitives/tests/FunctionalTests/project.json
+++ b/src/System.Net.Primitives/tests/FunctionalTests/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Primitives/tests/PalTests/project.json
+++ b/src/System.Net.Primitives/tests/PalTests/project.json
@@ -23,8 +23,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Primitives/tests/PerformanceTests/project.json
+++ b/src/System.Net.Primitives/tests/PerformanceTests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Net.Primitives/tests/UnitTests/project.json
+++ b/src/System.Net.Primitives/tests/UnitTests/project.json
@@ -24,8 +24,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Requests/tests/project.json
+++ b/src/System.Net.Requests/tests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -25,8 +25,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -21,8 +21,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Security/tests/UnitTests/project.json
+++ b/src/System.Net.Security/tests/UnitTests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Sockets/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets/tests/FunctionalTests/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Sockets/tests/PerformanceTests/project.json
+++ b/src/System.Net.Sockets/tests/PerformanceTests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.WebHeaderCollection/tests/project.json
+++ b/src/System.Net.WebHeaderCollection/tests/project.json
@@ -6,8 +6,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.WebSockets.Client/tests/project.json
+++ b/src/System.Net.WebSockets.Client/tests/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.WebSockets/tests/project.json
+++ b/src/System.Net.WebSockets/tests/project.json
@@ -10,8 +10,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Numerics.Vectors/tests/Performance/project.json
+++ b/src/System.Numerics.Vectors/tests/Performance/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Numerics.Vectors/tests/project.json
+++ b/src/System.Numerics.Vectors/tests/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.ObjectModel/tests/project.json
+++ b/src/System.ObjectModel/tests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Uri/tests/ExtendedFunctionalTests/project.json
+++ b/src/System.Private.Uri/tests/ExtendedFunctionalTests/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Private.Uri/tests/FunctionalTests/project.json
+++ b/src/System.Private.Uri/tests/FunctionalTests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Uri/tests/UnitTests/project.json
+++ b/src/System.Private.Uri/tests/UnitTests/project.json
@@ -8,8 +8,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/Properties/project.json
+++ b/src/System.Private.Xml.Linq/tests/Properties/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/SDMSample/project.json
+++ b/src/System.Private.Xml.Linq/tests/SDMSample/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/Streaming/project.json
+++ b/src/System.Private.Xml.Linq/tests/Streaming/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/TreeManipulation/project.json
+++ b/src/System.Private.Xml.Linq/tests/TreeManipulation/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/XDocument.Common/project.json
+++ b/src/System.Private.Xml.Linq/tests/XDocument.Common/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/project.json
+++ b/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/XPath/XDocument/project.json
+++ b/src/System.Private.Xml.Linq/tests/XPath/XDocument/project.json
@@ -23,8 +23,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/axes/project.json
+++ b/src/System.Private.Xml.Linq/tests/axes/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/events/project.json
+++ b/src/System.Private.Xml.Linq/tests/events/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/misc/project.json
+++ b/src/System.Private.Xml.Linq/tests/misc/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/project.json
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/project.json
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/Readers/CharCheckingReader/project.json
+++ b/src/System.Private.Xml/tests/Readers/CharCheckingReader/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/Readers/CustomReader/project.json
+++ b/src/System.Private.Xml/tests/Readers/CustomReader/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/Readers/FactoryReader/project.json
+++ b/src/System.Private.Xml/tests/Readers/FactoryReader/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/Readers/NameTable/project.json
+++ b/src/System.Private.Xml/tests/Readers/NameTable/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/Readers/ReaderSettings/project.json
+++ b/src/System.Private.Xml/tests/Readers/ReaderSettings/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/Readers/SubtreeReader/project.json
+++ b/src/System.Private.Xml/tests/Readers/SubtreeReader/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/Readers/WrappedReader/project.json
+++ b/src/System.Private.Xml/tests/Readers/WrappedReader/project.json
@@ -10,8 +10,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/Writers/RwFactory/project.json
+++ b/src/System.Private.Xml/tests/Writers/RwFactory/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/project.json
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XPath/XPathDocument/project.json
+++ b/src/System.Private.Xml/tests/XPath/XPathDocument/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XPath/XmlDocument/project.json
+++ b/src/System.Private.Xml/tests/XPath/XmlDocument/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlConvert/project.json
+++ b/src/System.Private.Xml/tests/XmlConvert/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlDocument/Performance/project.json
+++ b/src/System.Private.Xml/tests/XmlDocument/Performance/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Private.Xml/tests/XmlDocument/project.json
+++ b/src/System.Private.Xml/tests/XmlDocument/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlReader/ReadContentAs/project.json
+++ b/src/System.Private.Xml/tests/XmlReader/ReadContentAs/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlReader/Tests/project.json
+++ b/src/System.Private.Xml/tests/XmlReader/Tests/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlReader/XmlResolver/project.json
+++ b/src/System.Private.Xml/tests/XmlReader/XmlResolver/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlReaderLib/project.json
+++ b/src/System.Private.Xml/tests/XmlReaderLib/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/project.json
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/project.json
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlSerializer/Performance/ContractReferences/project.json
+++ b/src/System.Private.Xml/tests/XmlSerializer/Performance/ContractReferences/project.json
@@ -21,8 +21,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
   },
   "frameworks": {

--- a/src/System.Private.Xml/tests/XmlSerializer/Performance/project.json
+++ b/src/System.Private.Xml/tests/XmlSerializer/Performance/project.json
@@ -23,8 +23,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlSerializer/project.json
+++ b/src/System.Private.Xml/tests/XmlSerializer/project.json
@@ -28,8 +28,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Private.Xml/tests/XmlWriter/project.json
+++ b/src/System.Private.Xml/tests/XmlWriter/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/project.json
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/project.json
@@ -22,8 +22,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/project.json
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/project.json
@@ -21,8 +21,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/project.json
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/project.json
@@ -21,8 +21,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Private.Xml/tests/Xslt/XsltScenarios/project.json
+++ b/src/System.Private.Xml/tests/Xslt/XsltScenarios/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Context/tests/project.json
+++ b/src/System.Reflection.Context/tests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.DispatchProxy/tests/project.json
+++ b/src/System.Reflection.DispatchProxy/tests/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Emit.ILGeneration/tests/project.json
+++ b/src/System.Reflection.Emit.ILGeneration/tests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Emit.Lightweight/tests/project.json
+++ b/src/System.Reflection.Emit.Lightweight/tests/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Emit/tests/project.json
+++ b/src/System.Reflection.Emit/tests/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Extensions/tests/project.json
+++ b/src/System.Reflection.Extensions/tests/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Metadata/tests/project.json
+++ b/src/System.Reflection.Metadata/tests/project.json
@@ -26,8 +26,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.TypeExtensions/tests/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Reflection/tests/CoreCLR/project.json
+++ b/src/System.Reflection/tests/CoreCLR/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Reflection/tests/project.json
+++ b/src/System.Reflection/tests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Resources.Reader/tests/project.json
+++ b/src/System.Resources.Reader/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Resources.ResourceManager/tests/project.json
+++ b/src/System.Resources.ResourceManager/tests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Resources.Writer/tests/project.json
+++ b/src/System.Resources.Writer/tests/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/project.json
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/project.json
@@ -6,8 +6,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Extensions/tests/Performance/project.json
+++ b/src/System.Runtime.Extensions/tests/Performance/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -26,8 +26,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Runtime.Handles/tests/project.json
+++ b/src/System.Runtime.Handles/tests/project.json
@@ -10,8 +10,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.InteropServices/tests/project.json
+++ b/src/System.Runtime.InteropServices/tests/project.json
@@ -9,8 +9,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Loader/tests/DefaultContext/project.json
+++ b/src/System.Runtime.Loader/tests/DefaultContext/project.json
@@ -19,8 +19,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Runtime.Loader/tests/RefEmitLoadContext/project.json
+++ b/src/System.Runtime.Loader/tests/RefEmitLoadContext/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Runtime.Loader/tests/project.json
+++ b/src/System.Runtime.Loader/tests/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Runtime.Numerics/tests/project.json
+++ b/src/System.Runtime.Numerics/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Serialization.Formatters/tests/project.json
+++ b/src/System.Runtime.Serialization.Formatters/tests/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Runtime.Serialization.Json/tests/Performance/ContractReferences/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/ContractReferences/project.json
@@ -27,8 +27,8 @@
       "exclude": "compile"
     },
     "Newtonsoft.Json": "8.0.4-beta1",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Json/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/project.json
@@ -26,8 +26,8 @@
       "exclude": "compile"
     },
     "Newtonsoft.Json": "8.0.4-beta1",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Json/tests/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/project.json
@@ -24,8 +24,8 @@
       "exclude": "compile"
     },
     "Newtonsoft.Json": "8.0.4-beta1",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/ContractReferences/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/ContractReferences/project.json
@@ -26,8 +26,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
@@ -26,8 +26,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -24,8 +24,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Runtime/tests/Performance/project.json
+++ b/src/System.Runtime/tests/Performance/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Runtime/tests/project.json
+++ b/src/System.Runtime/tests/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Security.AccessControl/tests/project.json
+++ b/src/System.Security.AccessControl/tests/project.json
@@ -31,8 +31,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Security.Claims/tests/project.json
+++ b/src/System.Security.Claims/tests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.Cryptography.Algorithms/tests/project.json
+++ b/src/System.Security.Cryptography.Algorithms/tests/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.6": {},

--- a/src/System.Security.Cryptography.Cng/tests/project.json
+++ b/src/System.Security.Cryptography.Cng/tests/project.json
@@ -22,8 +22,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.6": {},

--- a/src/System.Security.Cryptography.Csp/tests/project.json
+++ b/src/System.Security.Cryptography.Csp/tests/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.Cryptography.Encoding/tests/project.json
+++ b/src/System.Security.Cryptography.Encoding/tests/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039",
     "System.Xml.XmlSerializer": "4.3.0-beta-devapi-24512-01"
   },

--- a/src/System.Security.Cryptography.OpenSsl/tests/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/tests/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.6": {},

--- a/src/System.Security.Cryptography.Pkcs/tests/project.json
+++ b/src/System.Security.Cryptography.Pkcs/tests/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.Cryptography.Primitives/tests/project.json
+++ b/src/System.Security.Cryptography.Primitives/tests/project.json
@@ -10,8 +10,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.Cryptography.ProtectedData/tests/project.json
+++ b/src/System.Security.Cryptography.ProtectedData/tests/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.json
@@ -19,8 +19,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.4": {}

--- a/src/System.Security.Permissions/tests/project.json
+++ b/src/System.Security.Permissions/tests/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Security.Principal.Windows/tests/project.json
+++ b/src/System.Security.Principal.Windows/tests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.SecureString/tests/project.json
+++ b/src/System.Security.SecureString/tests/project.json
@@ -6,8 +6,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.4": {}

--- a/src/System.Text.Encoding.CodePages/tests/project.json
+++ b/src/System.Text.Encoding.CodePages/tests/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Text.Encoding.Extensions/tests/project.json
+++ b/src/System.Text.Encoding.Extensions/tests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Text.Encoding/tests/Performance/project.json
+++ b/src/System.Text.Encoding/tests/Performance/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Text.Encoding/tests/project.json
+++ b/src/System.Text.Encoding/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Text.Encodings.Web/tests/project.json
+++ b/src/System.Text.Encodings.Web/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Text.RegularExpressions/tests/project.json
+++ b/src/System.Text.RegularExpressions/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Threading.AccessControl/tests/project.json
+++ b/src/System.Threading.AccessControl/tests/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading.Overlapped/tests/project.json
+++ b/src/System.Threading.Overlapped/tests/project.json
@@ -9,8 +9,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading.Tasks.Dataflow/tests/project.json
+++ b/src/System.Threading.Tasks.Dataflow/tests/project.json
@@ -22,8 +22,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading.Tasks.Extensions/tests/project.json
+++ b/src/System.Threading.Tasks.Extensions/tests/project.json
@@ -10,8 +10,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading.Tasks.Parallel/tests/project.json
+++ b/src/System.Threading.Tasks.Parallel/tests/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Threading.Tasks/tests/project.json
+++ b/src/System.Threading.Tasks/tests/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Threading.Timer/tests/project.json
+++ b/src/System.Threading.Timer/tests/project.json
@@ -12,8 +12,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading/tests/Performance/project.json
+++ b/src/System.Threading/tests/Performance/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Threading/tests/project.json
+++ b/src/System.Threading/tests/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
   },
   "frameworks": {

--- a/src/System.Transactions/tests/project.json
+++ b/src/System.Transactions/tests/project.json
@@ -19,8 +19,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.ValueTuple/tests/project.json
+++ b/src/System.ValueTuple/tests/project.json
@@ -13,8 +13,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}


### PR DESCRIPTION
These tests are skipped here because netcoreapp1.0 is using the outdated implementation for netstandard1.3 from packages, we are doing a live build only for netstandard1.7 in this branch.

fixes #11364 
cc @joperezr @danmosemsft  