### PR TITLE
Pick up async fixes for microsoft.xunit.runner.uwp

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -15,7 +15,7 @@
 
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
-    <AppXRunnerVersion>1.0.3-prerelease-00807-03</AppXRunnerVersion>
+    <AppXRunnerVersion>1.0.3-prerelease-00808-02</AppXRunnerVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -99,7 +99,7 @@
         "System.Text.Encoding.CodePages": "4.0.1",
         "System.Xml.XmlSerializer": "4.0.11",
         "System.Console": "4.3.0-beta-24507-02",
-        "microsoft.xunit.runner.uwp": "1.0.3-prerelease-00807-03",
+        "microsoft.xunit.runner.uwp": "1.0.3-prerelease-00808-02",
         "Microsoft.DotNet.TestILC": {
           "version": "1.4.24208-prerelease",
           "include": "contentFiles"


### PR DESCRIPTION
See: https://github.com/dotnet/buildtools/pull/1025

These fixes are needed to run async test methods for UWP