### PR TITLE
Fix SqlClient stress test dependencies.

### DIFF
--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/project.json
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/project.json
@@ -40,8 +40,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00731-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00731-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
   "frameworks": {
     "netstandard1.3": {}


### PR DESCRIPTION
Two incompatible commits raced and broke the build:
https://github.com/dotnet/corefx/commit/d20732880dce6aec39a97c1dbe335c46a7cfdcd5
https://github.com/dotnet/corefx/commit/9447d75da2117e577e6a8549cb679e77207d5a26

I'll need to direct submit to unblock the build.
@mellinoe and @saurabh500 can one of you review?

/cc @weshaggard @stephentoub 