### PR TITLE
Targeting System.Runtime.Serialization.Primitives to uap10.1

### DIFF
--- a/src/System.Runtime.Serialization.Primitives/pkg/System.Runtime.Serialization.Primitives.pkgproj
+++ b/src/System.Runtime.Serialization.Primitives/pkg/System.Runtime.Serialization.Primitives.pkgproj
@@ -9,7 +9,7 @@
       <SupportedFramework>net46;netcore50;netcoreapp1.0</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Runtime.Serialization.Primitives.csproj">
-      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;uap10.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Serialization.Primitives.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Runtime.Serialization.Primitives/ref/System.Runtime.Serialization.Primitives.csproj
+++ b/src/System.Runtime.Serialization.Primitives/ref/System.Runtime.Serialization.Primitives.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.7;uap10.1</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.Serialization.Primitives.cs" />

--- a/src/System.Runtime.Serialization.Primitives/src/System.Runtime.Serialization.Primitives.builds
+++ b/src/System.Runtime.Serialization.Primitives/src/System.Runtime.Serialization.Primitives.builds
@@ -13,10 +13,14 @@
       <TargetGroup>net463</TargetGroup>
     </Project>
     <!-- System.Runtime.Serialization.Primitives needs to be build for netcore50 because it needs to have the reflection block enabled
-    By default, all assemblies that are built for netcore50 or netcore50aot have the reflection block enabled. -->
+    By default, all assemblies that are built for netcore50 or netcore50aot or uap101* have the reflection block enabled. -->
     <Project Include="System.Runtime.Serialization.Primitives.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+    <Project Include="System.Runtime.Serialization.Primitives.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>uap101aot</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Runtime.Serialization.Primitives/src/System.Runtime.Serialization.Primitives.csproj
+++ b/src/System.Runtime.Serialization.Primitives/src/System.Runtime.Serialization.Primitives.csproj
@@ -13,6 +13,7 @@
     <ProjectGuid>{CDF0ACB5-1361-4E48-8ECB-22E8022F5F01}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46' Or '$(TargetGroup)'=='net463'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <PackageTargetFramework Condition="'$(TargetGroup)'==''">netstandard1.7;uap10.1</PackageTargetFramework>    
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -40,14 +41,10 @@
     <Compile Include="System\Runtime\Serialization\SerializationException.cs" />
     <Compile Include="System\Runtime\Serialization\StreamingContext.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'==''">
+  <ItemGroup Condition="'$(TargetGroup)'=='' Or '$(TargetGroup)'=='uap101aot'">
     <Compile Include="System\Runtime\Serialization\InvalidDataContractException.Serialization.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'==''">
-    <!-- ToDo: Remove this dependency once System.Runtime is published. -->
-    <ProjectReference Include="..\..\System.Runtime\pkg\System.Runtime.pkgproj">
-      <Name>System.Runtime</Name>
-    </ProjectReference>
+  <ItemGroup Condition="'$(TargetGroup)'=='' Or '$(TargetGroup)'=='uap101aot'">
     <Compile Include="System.Runtime.Serialization.Primitives.TypeForwards.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='net46' Or '$(TargetGroup)'=='net463'">

--- a/src/System.Runtime.Serialization.Primitives/src/project.json
+++ b/src/System.Runtime.Serialization.Primitives/src/project.json
@@ -38,6 +38,12 @@
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
-    }
+    },
+    "uap10.1": {
+      "dependencies": {
+        "System.Runtime": "4.3.0-beta-devapi-24509-01",
+        "System.Resources.ResourceManager": "4.0.0",
+      }
+    } 
   }
 }


### PR DESCRIPTION
Now that System.Runtime targets uap10.1, we can port S.R.Serialization.Primitives too.
I also included the clean up of the /ToDo in csproj. 
The only interesting thing is the RD.XML, which has directives about now-forwarded types. I'll tackle with what to do with the rd.xml later.

fixes #11554, and prerequisite for fixing .net native toolchain issue about duplicate SerializationException type.

@stephentoub @joperezr 
/cc @dotnet/corert-contrib 