### PR TITLE
Improve CustomAttributeBuilder tests

### DIFF
--- a/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor1.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor1.cs
@@ -9,16 +9,6 @@ namespace System.Reflection.Emit.Tests
 {
     public class CustomAttributeBuilderCtor1
     {
-        [Theory]
-        [InlineData(new Type[] { typeof(string) }, new object[] { "TestString" })]
-        [InlineData(new Type[0], new object[0])]
-        [InlineData(new Type[] { typeof(string), typeof(bool) }, new object[] { "TestString", true })]
-        public void ConstructorInfo_ObjectArray(Type[] paramTypes, object[] paramValues)
-        {
-            ConstructorInfo constructor = typeof(ObsoleteAttribute).GetConstructor(paramTypes);
-            CustomAttributeBuilder attribute = new CustomAttributeBuilder(constructor, paramValues);
-        }
-
         [Fact]
         public void ConstructorInfo_ObjectArray_StaticCtor_ThrowsArgumentException()
         {

--- a/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor2.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor2.cs
@@ -15,91 +15,6 @@ namespace System.Reflection.Emit.Tests
         private const string GetStringField = "GetString";
         private const string GetIntField = "GetInt";
 
-        public static IEnumerable<object[]> TestData()
-        {
-            string stringValue1 = "TestString1";
-            string stringValue2 = "TestString2";
-            int intValue1 = 10;
-            int intValue2 = 20;
-
-            yield return new object[]
-            {
-                new Type[] { typeof(string), typeof(int) },
-                new object[] { stringValue1, intValue1 },
-                new string[] { IntField },
-                new object[] { intValue2 },
-                new object[] { intValue2, null, stringValue1, intValue1 }
-            };
-
-            yield return new object[]
-            {
-                new Type[] { typeof(string), typeof(int) },
-                new object[] { stringValue1, intValue1 },
-                new string[0],
-                new object[0],
-                new object[] { 0, null, stringValue1, intValue1 }
-            };
-
-            yield return new object[]
-            {
-                new Type[0],
-                new object[0],
-                new string[0],
-                new object[0],
-                new object[] { 0, null, null, 0 }
-            };
-
-            yield return new object[]
-            {
-                new Type[0],
-                new object[0],
-                new string[] { IntField },
-                new object[] { intValue1 },
-                new object[] { intValue1, null, null, 0 }
-            };
-
-            yield return new object[]
-            {
-                new Type[0],
-                new object[0],
-                new string[] { IntField, StringField },
-                new object[] { intValue1, stringValue1 },
-                new object[] { intValue1, stringValue1, null, 0 }
-            };
-
-            yield return new object[]
-            {
-                new Type[] { typeof(string), typeof(int) },
-                new object[] { stringValue1, intValue1 },
-                new string[] { IntField, StringField },
-                new object[] { intValue2, stringValue2 },
-                new object[] { intValue2, stringValue2, stringValue1, intValue1 }
-            };
-
-            yield return new object[]
-            {
-                new Type[0],
-                new object[0],
-                new string[] { GetStringField },
-                new object[] { stringValue1 },
-                new object[] { 0, null, stringValue1, 0 }
-            };
-        }
-
-        [Theory]
-        [MemberData(nameof(TestData))]
-        public void Ctor(Type[] ctorParams, object[] constructorArgs, string[] namedFieldNames, object[] fieldValues, object[] expected)
-        {
-            Type attribute = typeof(CustomAttributeBuilderTest);
-            ConstructorInfo constructor = attribute.GetConstructor(ctorParams);
-            FieldInfo[] namedField = Helpers.GetFields(namedFieldNames);
-
-            CustomAttributeBuilder cab = new CustomAttributeBuilder(constructor, constructorArgs, namedField, fieldValues);
-
-            FieldInfo[] verifyFields = Helpers.GetFields(IntField, StringField, GetStringField, GetIntField);
-            VerifyCustomAttribute(cab, attribute, verifyFields, expected);
-        }
-
         [Theory]
         [InlineData(new string[] { IntField }, new object[0], "namedFields, fieldValues")]
         [InlineData(new string[] { IntField }, new object[] { "TestString", 10 }, "namedFields, fieldValues")]
@@ -107,7 +22,7 @@ namespace System.Reflection.Emit.Tests
         [InlineData(new string[] { StringField }, new object[] { 10 }, null)]
         public void NamedFieldAndFieldValuesDifferentLengths_ThrowsArgumentException(string[] fieldNames, object[] fieldValues, string paramName)
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             FieldInfo[] namedFields = Helpers.GetFields(fieldNames);
 
             Assert.Throws<ArgumentException>(paramName, () => new CustomAttributeBuilder(constructor, new object[0], namedFields, fieldValues));
@@ -134,7 +49,7 @@ namespace System.Reflection.Emit.Tests
         [InlineData(new Type[] { typeof(string), typeof(int) }, new object[] { 10, "TestString" })]
         public void ConstructorArgsDontMatchConstructor_ThrowsArgumentException(Type[] ctorParams, object[] constructorArgs)
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(ctorParams);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(ctorParams);
 
             Assert.Throws<ArgumentException>(null, () => new CustomAttributeBuilder(constructor, constructorArgs, new FieldInfo[0], new object[0]));
         }
@@ -148,56 +63,36 @@ namespace System.Reflection.Emit.Tests
         [Fact]
         public void NullConstructorArgs_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("constructorArgs", () => new CustomAttributeBuilder(constructor, null, new FieldInfo[0], new object[0]));
         }
 
         [Fact]
         public void NullNamedFields_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("namedFields", () => new CustomAttributeBuilder(constructor, new object[0], (FieldInfo[])null, new object[0]));
         }
 
         [Fact]
         public void NullFieldValues_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("fieldValues", () => new CustomAttributeBuilder(constructor, new object[0], new FieldInfo[0], null));
         }
 
         [Fact]
         public void NullObjectInFieldValues_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("fieldValues[0]", () => new CustomAttributeBuilder(constructor, new object[0], Helpers.GetFields(IntField, StringField), new object[] { null, 10 }));
         }
 
         [Fact]
         public void NullObjectInNamedFields_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("namedFields[0]", () => new CustomAttributeBuilder(constructor, new object[0], Helpers.GetFields(null, IntField), new object[] { "TestString", 10 }));
-        }
-
-        private static void VerifyCustomAttribute(CustomAttributeBuilder builder, Type attributeType, FieldInfo[] fieldNames, object[] fieldValues)
-        {
-            AssemblyName assemblyName = new AssemblyName("VerificationAssembly");
-            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
-            assembly.SetCustomAttribute(builder);
-
-            object[] customAttributes = assembly.GetCustomAttributes(attributeType).ToArray();
-            Assert.Equal(1, customAttributes.Length);
-
-            object customAttribute = customAttributes[0];
-            for (int i = 0; i < fieldNames.Length; ++i)
-            {
-                FieldInfo field = attributeType.GetField(fieldNames[i].Name);
-                object expected = field.GetValue(customAttribute);
-                object actual = fieldValues[i];
-
-                Assert.Equal(expected, actual);
-            }
         }
     }
 }

--- a/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor3.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor3.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -14,48 +13,6 @@ namespace System.Reflection.Emit.Tests
         private const string StringProperty = "TestString";
         private const string GetStringProperty = "GetOnlyString";
         private const string GetIntProperty = "GetOnlyInt32";
-
-        public static IEnumerable<object[]> TestData()
-        {
-            string stringValue1 = "TestString1";
-            int intValue1 = 10;
-
-            // DUPLICATE: 2 ctor, 0 properties, 0 fields
-            yield return new object[]
-            {
-                new Type[] { typeof(string), typeof(int) },
-                new object[] { stringValue1, intValue1 },
-                new string[0],
-                new object[0],
-                new object[] { 0, null, stringValue1, intValue1 }
-            };
-
-            // DUPLICATE: 0 ctor, 0 properties, 0 fields
-            yield return new object[]
-            {
-                new Type[0],
-                new object[0],
-                new string[0],
-                new object[0],
-                new object[] { 0, null, null, 0 }
-            };
-
-        }
-
-        [Theory]
-        [MemberData(nameof(TestData))]
-        public void Ctor(Type[] ctorParams, object[] constructorArgs, string[] namedPropertyNames, object[] propertyValues, object[] expected)
-        {
-            Type attribute = typeof(TestAttribute);
-
-            ConstructorInfo constructor = attribute.GetConstructor(ctorParams);
-            PropertyInfo[] namedProperties = Helpers.GetProperties(namedPropertyNames);
-
-            CustomAttributeBuilder cab = new CustomAttributeBuilder(constructor, constructorArgs, namedProperties, propertyValues);
-
-            PropertyInfo[] properties = Helpers.GetProperties(IntProperty, StringProperty, GetStringProperty, GetIntProperty);
-            VerifyCustomAttribute(cab, attribute, properties, expected);
-        }
 
         [Theory]
         [InlineData(new string[] { IntProperty }, new object[0], "namedProperties, propertyValues")]

--- a/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor3.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor3.cs
@@ -18,28 +18,9 @@ namespace System.Reflection.Emit.Tests
         public static IEnumerable<object[]> TestData()
         {
             string stringValue1 = "TestString1";
-            string stringValue2 = "TestString2";
             int intValue1 = 10;
-            int intValue2 = 20;
 
-            yield return new object[]
-            {
-                new Type[] { typeof(string), typeof(int) },
-                new object[] { stringValue1, intValue1 },
-                new string[] { IntProperty, StringProperty },
-                new object[] { intValue2, stringValue2 },
-                new object[] { intValue2, stringValue2, stringValue1, intValue1 }
-            };
-
-            yield return new object[]
-            {
-                new Type[] { typeof(string), typeof(int) },
-                new object[] { stringValue1, intValue1 },
-                new string[] { IntProperty },
-                new object[] { intValue2 },
-                new object[] { intValue2, null, stringValue1, intValue1 }
-            };
-
+            // DUPLICATE: 2 ctor, 0 properties, 0 fields
             yield return new object[]
             {
                 new Type[] { typeof(string), typeof(int) },
@@ -49,6 +30,7 @@ namespace System.Reflection.Emit.Tests
                 new object[] { 0, null, stringValue1, intValue1 }
             };
 
+            // DUPLICATE: 0 ctor, 0 properties, 0 fields
             yield return new object[]
             {
                 new Type[0],
@@ -58,39 +40,13 @@ namespace System.Reflection.Emit.Tests
                 new object[] { 0, null, null, 0 }
             };
 
-            yield return new object[]
-            {
-                new Type[0],
-                new object[0],
-                new string[] { IntProperty },
-                new object[] {intValue1 },
-                new object[] { intValue1, null, null, 0 }
-            };
-
-            yield return new object[]
-            {
-                new Type[0],
-                new object[0],
-                new string[] { IntProperty, StringProperty },
-                new object[] {intValue1, stringValue1 },
-                new object[] { intValue1, stringValue1, null, 0 }
-            };
-
-            yield return new object[]
-            {
-                new Type[] { typeof(string), typeof(int), typeof(string), typeof(int) },
-                new object[] { stringValue1, intValue1, stringValue1, intValue1 },
-                new string[] { IntProperty, StringProperty },
-                new object[] { intValue2, stringValue2 },
-                new object[] { intValue2, stringValue2, stringValue1, intValue1 }
-            };
         }
 
         [Theory]
         [MemberData(nameof(TestData))]
         public void Ctor(Type[] ctorParams, object[] constructorArgs, string[] namedPropertyNames, object[] propertyValues, object[] expected)
         {
-            Type attribute = typeof(CustomAttributeBuilderTest);
+            Type attribute = typeof(TestAttribute);
 
             ConstructorInfo constructor = attribute.GetConstructor(ctorParams);
             PropertyInfo[] namedProperties = Helpers.GetProperties(namedPropertyNames);
@@ -110,7 +66,7 @@ namespace System.Reflection.Emit.Tests
         [InlineData(new string[] { IntProperty }, new object[] { "TestString" }, null)]
         public void NamedPropertyAndPropertyValuesDifferentLengths_ThrowsArgumentException(string[] propertyNames, object[] propertyValues, string paramName)
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             PropertyInfo[] namedProperties = Helpers.GetProperties(propertyNames);
 
             Assert.Throws<ArgumentException>(paramName, () => new CustomAttributeBuilder(constructor, new object[0], namedProperties, propertyValues));
@@ -137,7 +93,7 @@ namespace System.Reflection.Emit.Tests
         [InlineData(new Type[] { typeof(string), typeof(int) }, new object[] { 10, "TestString" })]
         public void ConstructorArgsDontMatchConstructor_ThrowsArgumentException(Type[] ctorParams, object[] constructorArgs)
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(ctorParams);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(ctorParams);
 
             Assert.Throws<ArgumentException>(null, () => new CustomAttributeBuilder(constructor, constructorArgs, new PropertyInfo[0], new object[0]));
         }
@@ -151,35 +107,35 @@ namespace System.Reflection.Emit.Tests
         [Fact]
         public void NullConstructorArgs_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("constructorArgs", () => new CustomAttributeBuilder(constructor, null, new PropertyInfo[0], new object[0]));
         }
 
         [Fact]
         public void NullNamedProperties_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("namedProperties", () => new CustomAttributeBuilder(constructor, new object[0], (PropertyInfo[])null, new object[0]));
         }
 
         [Fact]
         public void NullPropertyValues_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("propertyValues", () => new CustomAttributeBuilder(constructor, new object[0], new PropertyInfo[0], null));
         }
 
         [Fact]
         public void NullObjectInPropertyValues_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("propertyValues[0]", () => new CustomAttributeBuilder(constructor, new object[0], Helpers.GetProperties(IntProperty, StringProperty), new object[] { null, 10 }));
         }
 
         [Fact]
         public void NullObjectInNamedProperties_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("namedProperties[0]", () => new CustomAttributeBuilder(constructor, new object[0], Helpers.GetProperties(null, IntProperty), new object[] { "TestString", 10 }));
         }
 

--- a/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor4.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor4.cs
@@ -23,32 +23,9 @@ namespace System.Reflection.Emit.Tests
         public static IEnumerable<object[]> TestData()
         {
             string stringValue1 = "TestString1";
-            string stringValue2 = "TestString2";
             int intValue1 = 10;
-            int intValue2 = 20;
-
-            yield return new object[]
-            {
-                new Type[] { typeof(string), typeof(int) },
-                new object[] { stringValue1, intValue1 },
-                new string[] { IntProperty, StringProperty },
-                new object[] { intValue2, stringValue2 },
-                new string[] { IntField, StringField },
-                new object[] { intValue2, stringValue2 },
-                new object[] { intValue2, stringValue2, stringValue1, intValue1 }
-            };
-
-            yield return new object[]
-            {
-                new Type[] { typeof(string), typeof(int) },
-                new object[] { stringValue1, intValue1 },
-                new string[] { StringProperty },
-                new object[] { stringValue2 },
-                new string[] { IntField },
-                new object[] { intValue2 },
-                new object[] { intValue2, stringValue2, stringValue1, intValue1 }
-            };
-
+            
+            // DUPLICATE: 2 ctor, 0 properties, 0 fields
             yield return new object[]
             {
                 new Type[] { typeof(string), typeof(int) },
@@ -60,6 +37,7 @@ namespace System.Reflection.Emit.Tests
                 new object[] { 0, null, stringValue1, intValue1 }
             };
 
+            // DUPLICATE: 0 ctor, 0 properties, 0 fields
             yield return new object[]
             {
                 new Type[0],
@@ -70,32 +48,6 @@ namespace System.Reflection.Emit.Tests
                 new object[0],
                 new object[] { 0, null, null, 0 }
             };
-
-            yield return new object[]
-            {
-                new Type[0],
-                new object[0],
-                new string[] { IntProperty, StringProperty },
-                new object[] { intValue1, stringValue1 },
-                new string[] { IntField },
-                new object[] { intValue2 },
-                new object[] { intValue2, stringValue1, null, 0 }
-            };
-        }
-
-        [Theory]
-        [MemberData(nameof(TestData))]
-        public void Ctor(Type[] ctorParams, object[] constructorArgs, string[] namedPropertyNames, object[] propertyValues, string[] namedFieldNames, object[] fieldValues, object[] expected)
-        {
-            Type attribute = typeof(CustomAttributeBuilderTest);
-            ConstructorInfo constructor = attribute.GetConstructor(ctorParams);
-            FieldInfo[] namedFields = Helpers.GetFields(namedFieldNames);
-            PropertyInfo[] namedProperties = Helpers.GetProperties(namedPropertyNames);
-
-            CustomAttributeBuilder cab = new CustomAttributeBuilder(constructor, constructorArgs, namedProperties, propertyValues, namedFields, fieldValues);
-
-            FieldInfo[] fields = Helpers.GetFields(IntField, StringField, GetStringField, GetIntField);
-            VerifyCustomAttribute(cab, attribute, fields, expected);
         }
 
         [Theory]
@@ -107,7 +59,7 @@ namespace System.Reflection.Emit.Tests
         [InlineData(new string[] { IntProperty }, new object[] { "TestString" }, null)]
         public void NamedPropertyAndPropertyValuesDifferentLengths_ThrowsArgumentException(string[] propertyNames, object[] propertyValues, string paramName)
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             PropertyInfo[] namedProperties = Helpers.GetProperties(propertyNames);
 
             Assert.Throws<ArgumentException>(paramName, () => new CustomAttributeBuilder(constructor, new object[0], namedProperties, propertyValues, new FieldInfo[0], new object[0]));
@@ -134,7 +86,7 @@ namespace System.Reflection.Emit.Tests
         [InlineData(new Type[] { typeof(string), typeof(int) }, new object[] { 10, "TestString" })]
         public void ConstructorArgsDontMatchConstructor_ThrowsArgumentException(Type[] ctorParams, object[] constructorArgs)
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(ctorParams);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(ctorParams);
 
             Assert.Throws<ArgumentException>(null, () => new CustomAttributeBuilder(constructor, constructorArgs, new PropertyInfo[0], new object[0], new FieldInfo[0], new object[0]));
         }
@@ -148,85 +100,64 @@ namespace System.Reflection.Emit.Tests
         [Fact]
         public void NullConstructorArgs_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("constructorArgs", () => new CustomAttributeBuilder(constructor, null, new PropertyInfo[0], new object[0], new FieldInfo[0], new object[0]));
         }
 
         [Fact]
         public void NullNamedProperties_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("namedProperties", () => new CustomAttributeBuilder(constructor, new object[0], (PropertyInfo[])null, new object[0], new FieldInfo[0], new object[0]));
         }
 
         [Fact]
         public void NullPropertyValues_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("propertyValues", () => new CustomAttributeBuilder(constructor, new object[0], new PropertyInfo[0], null, new FieldInfo[0], new object[0]));
         }
 
         [Fact]
         public void NullObjectInPropertyValues_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("propertyValues[0]", () => new CustomAttributeBuilder(constructor, new object[0], Helpers.GetProperties(IntProperty, StringProperty), new object[] { null, 10 }, new FieldInfo[0], new object[0]));
         }
 
         [Fact]
         public void NullObjectInNamedProperties_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("namedProperties[0]", () => new CustomAttributeBuilder(constructor, new object[0], Helpers.GetProperties(null, IntProperty), new object[] { "TestString", 10 }, new FieldInfo[0], new object[0]));
         }
 
         [Fact]
         public void NullNamedFields_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("namedFields", () => new CustomAttributeBuilder(constructor, new object[0], new PropertyInfo[0], new object[0], (FieldInfo[])null, new object[0]));
         }
 
         [Fact]
         public void NullFieldValues_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("fieldValues", () => new CustomAttributeBuilder(constructor, new object[0], new PropertyInfo[0], new object[0], new FieldInfo[0], null));
         }
 
         [Fact]
         public void NullObjectInFieldValues_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("fieldValues[0]", () => new CustomAttributeBuilder(constructor, new object[0], new PropertyInfo[0], new object[0], Helpers.GetFields(IntField, StringField), new object[] { null, 10 }));
         }
 
         [Fact]
         public void NullObjectInNamedFields_ThrowsArgumentNullException()
         {
-            ConstructorInfo constructor = typeof(CustomAttributeBuilderTest).GetConstructor(new Type[0]);
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(new Type[0]);
             Assert.Throws<ArgumentNullException>("namedFields[0]", () => new CustomAttributeBuilder(constructor, new object[0], new PropertyInfo[0], new object[0], Helpers.GetFields(null, IntField), new object[] { "TestString", 10 }));
-        }
-
-        private void VerifyCustomAttribute(CustomAttributeBuilder builder, Type attributeType, FieldInfo[] namedFields, object[] fieldValues)
-        {
-            AssemblyName assemblyName = new AssemblyName("VerificationAssembly");
-            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
-
-            assembly.SetCustomAttribute(builder);
-
-            object[] customAttributes = assembly.GetCustomAttributes(attributeType).ToArray();
-            Assert.Equal(1, customAttributes.Length);
-
-            object customAttribute = customAttributes[0];
-            for (int i = 0; i < namedFields.Length; ++i)
-            {
-                FieldInfo field = attributeType.GetField(namedFields[i].Name);
-                object expected = field.GetValue(customAttribute);
-                object actual = fieldValues[i];
-
-                Assert.Equal(expected, actual);
-            }
         }
     }
 }

--- a/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor4.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilder/CustomAttributeBuilderCtor4.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -19,36 +18,6 @@ namespace System.Reflection.Emit.Tests
         private const string StringProperty = "TestString";
         private const string GetStringProperty = "GetOnlyString";
         private const string GetIntProperty = "GetOnlyInt32";
-
-        public static IEnumerable<object[]> TestData()
-        {
-            string stringValue1 = "TestString1";
-            int intValue1 = 10;
-            
-            // DUPLICATE: 2 ctor, 0 properties, 0 fields
-            yield return new object[]
-            {
-                new Type[] { typeof(string), typeof(int) },
-                new object[] { stringValue1, intValue1 },
-                new string[0],
-                new object[0],
-                new string[0],
-                new object[0],
-                new object[] { 0, null, stringValue1, intValue1 }
-            };
-
-            // DUPLICATE: 0 ctor, 0 properties, 0 fields
-            yield return new object[]
-            {
-                new Type[0],
-                new object[0],
-                new string[0],
-                new object[0],
-                new string[0],
-                new object[0],
-                new object[] { 0, null, null, 0 }
-            };
-        }
 
         [Theory]
         [InlineData(new string[] { IntProperty }, new object[0], "namedProperties, propertyValues")]

--- a/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilderTests.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilderTests.cs
@@ -1,0 +1,261 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Reflection.Emit.Tests
+{
+    public class CustomAttributeBuilderTests
+    {
+        public static IEnumerable<object[]> Ctor_Basic_TestData()
+        {
+            yield return new object[] { new Type[] { typeof(string) }, new object[] { "TestString" } };
+            yield return new object[] { new Type[0], new object[0] };
+            yield return new object[] { new Type[] { typeof(string), typeof(bool) }, new object[] { "TestString", true } };
+        }
+        
+        [Theory]
+        [MemberData(nameof(Ctor_Basic_TestData))]
+        public static void Ctor_Basic(Type[] typeArguments, object[] constructorArguments)
+        {
+            ConstructorInfo constructor = typeof(ObsoleteAttribute).GetConstructor(typeArguments);
+            Action<CustomAttributeBuilder> verify = attr => Assert.NotNull(attr);
+            Ctor(constructor, constructorArguments, new PropertyInfo[0], new object[0], new FieldInfo[0], new object[0], verify);
+        }
+
+        public static IEnumerable<object[]> Ctor_Advanced_TestData()
+        {
+            string stringValue1 = "TestString1";
+            string stringValue2 = "TestString2";
+            int intValue1 = 10;
+            int intValue2 = 20;
+
+            // 2 ctor, 0 properties, 1 fields
+            yield return new object[]
+            {
+                new Type[] { typeof(string), typeof(int) },
+                new object[] { stringValue1, intValue1 },
+                new string[0], new object[0],
+                new object[] { intValue2, null, stringValue1, intValue1 },
+                new string[] { nameof(TestAttribute.TestInt) }, new object[] { intValue2 },
+                new object[] { intValue2, null, stringValue1, intValue1 }
+            };
+
+            // 2 ctor, 0 properties, 0 fields
+            yield return new object[]
+            {
+                new Type[] { typeof(string), typeof(int) }, new object[] { stringValue1, intValue1 },
+                new string[0], new object[0],
+                new object[] { 0, null, stringValue1, intValue1 },
+                new string[0], new object[0],
+                new object[] { 0, null, stringValue1, intValue1 }
+            };
+
+            // 0 ctor, 0 properties, 0 fields
+            yield return new object[]
+            {
+                new Type[0], new object[0],
+                new string[0], new object[0],
+                new object[] { 0, null, null, 0 },
+                new string[0], new object[0],
+                new object[] { 0, null, null, 0 }
+            };
+
+            // 0 ctor, 0 properties, 1 field
+            yield return new object[]
+            {
+                new Type[0], new object[0],
+                new string[0], new object[0],
+                new object[] { intValue1, null, null, 0 },
+                new string[] { nameof(TestAttribute.TestInt) }, new object[] { intValue1 },
+                new object[] { intValue1, null, null, 0 }
+            };
+
+            // 0 ctor, 0 properties, 2 fields
+            yield return new object[]
+            {
+                new Type[0], new object[0],
+                new string[0], new object[0],
+                new object[] { intValue1, stringValue1, null, 0 },
+                new string[] { nameof(TestAttribute.TestInt), nameof(TestAttribute.TestStringField) }, new object[] { intValue1, stringValue1 },
+                new object[] { intValue1, stringValue1, null, 0 }
+            };
+            
+            // 2 ctor, 0 properties, 2 fields
+            yield return new object[]
+            {
+                new Type[] { typeof(string), typeof(int) }, new object[] { stringValue1, intValue1 },
+                new string[0], new object[0],
+                new object[] { intValue2, stringValue2, stringValue1, intValue1 },
+                new string[] { nameof(TestAttribute.TestInt), nameof(TestAttribute.TestStringField) }, new object[] { intValue2, stringValue2 },
+                new object[] { intValue2, stringValue2, stringValue1, intValue1 }
+            };
+
+            // 0 ctor, 0 properties,1 field
+            yield return new object[]
+            {
+                new Type[0], new object[0],
+                new string[0], new object[0],
+                new object[] { 0, stringValue1, null, 0 },
+                new string[] { nameof(TestAttribute.TestStringField) }, new object[] { stringValue1 },
+                new object[] { 0, stringValue1, null, 0 }
+            };
+
+            // 2 ctor, 2 properties, 0 fields
+            yield return new object[]
+            {
+                new Type[] { typeof(string), typeof(int) }, new object[] { stringValue1, intValue1 },
+                new string[] { nameof(TestAttribute.TestInt32), nameof(TestAttribute.TestString) }, new object[] { intValue2, stringValue2 },
+                new object[] { intValue2, stringValue2, stringValue1, intValue1 },
+                new object[0], new object[0],
+                new object[] { intValue2, stringValue2, stringValue1, intValue1 }
+            };
+
+            // 2 ctor, 1 property, 0 fields
+            yield return new object[]
+            {
+                new Type[] { typeof(string), typeof(int) }, new object[] { stringValue1, intValue1 },
+                new string[] { nameof(TestAttribute.TestInt32) }, new object[] { intValue2 },
+                new object[] { intValue2, null, stringValue1, intValue1 },
+                new object[0], new object[0],
+                new object[] { intValue2, null, stringValue1, intValue1 }
+            };
+
+            // 0 ctor, 1 property, 0 fields
+            yield return new object[]
+            {
+                new Type[0], new object[0],
+                new string[] { nameof(TestAttribute.TestInt32) }, new object[] { intValue2 },
+                new object[] { intValue2, null, null, 0 },
+                new object[0], new object[0],
+                new object[] { intValue2, null, null, 0 }
+            };
+
+            // 0 ctor, 2 properties, 0 fields
+            yield return new object[]
+            {
+                new Type[0], new object[0],
+                new string[] { nameof(TestAttribute.TestInt32), nameof(TestAttribute.TestString) }, new object[] { intValue2, stringValue2 },
+                new object[] { intValue2, stringValue2, null, 0 },
+                new object[0], new object[0],
+                new object[] { intValue2, stringValue2, null, 0 }
+            };
+
+            // 4 ctor, 0 fields, 2 properties
+            yield return new object[]
+            {
+                new Type[] { typeof(string), typeof(int), typeof(string), typeof(int) }, new object[] { stringValue1, intValue1, stringValue1, intValue1 },
+                new string[] { nameof(TestAttribute.TestInt32), nameof(TestAttribute.TestString) }, new object[] { intValue2, stringValue2 },
+                new object[] { intValue2, stringValue2, stringValue1, intValue1 },
+                new string[0], new object[0],
+                new object[] { intValue2, stringValue2, stringValue1, intValue1 }
+            };
+
+            // 2 ctor, 2 property, 2 field
+            yield return new object[]
+            {
+                new Type[] { typeof(string), typeof(int) }, new object[] { stringValue1, intValue1 },
+                new string[] { nameof(TestAttribute.TestInt32), nameof(TestAttribute.TestString) }, new object[] { intValue2, stringValue2 },
+                new object[] { intValue2, stringValue2, stringValue1, intValue1 },
+                new string[] { nameof(TestAttribute.TestInt), nameof(TestAttribute.TestStringField) }, new object[] { intValue2, stringValue2 },
+                new object[] { intValue2, stringValue2, stringValue1, intValue1 }
+            };
+
+            // 2 ctor, 1 property, 1 field
+            yield return new object[]
+            {
+                new Type[] { typeof(string), typeof(int) }, new object[] { stringValue1, intValue1 },
+                new string[] { nameof(TestAttribute.TestString) }, new object[] { stringValue2 },
+                new object[] { intValue2, stringValue2, stringValue1, intValue1 },
+                new string[] { nameof(TestAttribute.TestInt) }, new object[] { intValue2 },
+                new object[] { intValue2, stringValue2, stringValue1, intValue1 }
+            };
+
+            // 0 ctor, 2 property, 1 field
+            yield return new object[]
+            {
+                new Type[0], new object[0],
+                new string[] { nameof(TestAttribute.TestInt32), nameof(TestAttribute.TestString) }, new object[] { intValue1, stringValue1 },
+                new object[] { intValue2, stringValue1, null, 0 },
+                new string[] { nameof(TestAttribute.TestInt) }, new object[] { intValue2 },
+                new object[] { intValue2, stringValue1, null, 0 }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(Ctor_Advanced_TestData))]
+        public static void Ctor(Type[] ctorTypes, object[] ctorArgs,
+                                string[] propertyNames, object[] propertyValues,
+                                object[] expectedPropertyValues,
+                                string[] fieldNames, object[] fieldValues,
+                                object[] expectedFieldValues)
+        {
+            ConstructorInfo constructor = typeof(TestAttribute).GetConstructor(ctorTypes);
+            PropertyInfo[] namedProperties = Helpers.GetProperties(propertyNames);
+            FieldInfo[] namedFields = Helpers.GetFields(fieldNames);
+            
+            Action<CustomAttributeBuilder> verify = attr =>
+            {
+                VerifyCustomAttributeBuilder(attr, TestAttribute.AllProperties, expectedPropertyValues, TestAttribute.AllFields, expectedFieldValues);
+            };
+
+            Ctor(constructor, ctorArgs, namedProperties, propertyValues, namedFields, fieldValues, verify);
+        }
+
+        public static void Ctor(ConstructorInfo constructor, object[] constructorArgs,
+                                PropertyInfo[] namedProperties, object[] propertyValues,
+                                FieldInfo[] namedFields, object[] fieldValues,
+                                Action<CustomAttributeBuilder> verify)
+        {
+            if (namedProperties.Length == 0)
+            {
+                if (namedFields.Length == 0)
+                {
+                    // Use CustomAttributeBuilder(ConstructorInfo, object[])
+                    CustomAttributeBuilder attribute1 = new CustomAttributeBuilder(constructor, constructorArgs);
+                    verify(attribute1);
+                }
+                // Use CustomAttributeBuilder(ConstructorInfo, object[], FieldInfo[], object[])
+                CustomAttributeBuilder attribute2 = new CustomAttributeBuilder(constructor, constructorArgs, namedFields, fieldValues);
+                verify(attribute2);
+            }
+            if (namedFields.Length == 0)
+            {
+                // Use CustomAttributeBuilder(ConstructorInfo, object[], PropertyInfo[], object[])
+                CustomAttributeBuilder attribute3 = new CustomAttributeBuilder(constructor, constructorArgs, namedProperties, propertyValues);
+                verify(attribute3);
+            }
+            // Use CustomAttributeBuilder(ConstructorInfo, object[], PropertyInfo[], object[], FieldInfo[], object[])
+            CustomAttributeBuilder attribute4 = new CustomAttributeBuilder(constructor, constructorArgs, namedProperties, propertyValues, namedFields, fieldValues);
+            verify(attribute4);
+        }
+        
+        private static void VerifyCustomAttributeBuilder(CustomAttributeBuilder builder,
+                                                        PropertyInfo[] propertyNames, object[] propertyValues,
+                                                        FieldInfo[] fieldNames, object[] fieldValues)
+        {
+            AssemblyName assemblyName = new AssemblyName("VerificationAssembly");
+            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            assembly.SetCustomAttribute(builder);
+
+            object[] customAttributes = assembly.GetCustomAttributes().ToArray();
+            Assert.Equal(1, customAttributes.Length);
+
+            object customAttribute = customAttributes[0];
+            for (int i = 0; i < fieldNames.Length; ++i)
+            {
+                FieldInfo field = typeof(TestAttribute).GetField(fieldNames[i].Name);
+                Assert.Equal(fieldValues[i], field.GetValue(customAttribute));
+            }
+
+            for (int i = 0; i < propertyNames.Length; ++i)
+            {
+                PropertyInfo property = typeof(TestAttribute).GetProperty(propertyNames[i].Name);
+                Assert.Equal(propertyValues[i], property.GetValue(customAttribute));
+            }
+        }
+    }
+}

--- a/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilderTests.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilderTests.cs
@@ -10,23 +10,7 @@ namespace System.Reflection.Emit.Tests
 {
     public class CustomAttributeBuilderTests
     {
-        public static IEnumerable<object[]> Ctor_Basic_TestData()
-        {
-            yield return new object[] { new Type[] { typeof(string) }, new object[] { "TestString" } };
-            yield return new object[] { new Type[0], new object[0] };
-            yield return new object[] { new Type[] { typeof(string), typeof(bool) }, new object[] { "TestString", true } };
-        }
-        
-        [Theory]
-        [MemberData(nameof(Ctor_Basic_TestData))]
-        public static void Ctor_Basic(Type[] typeArguments, object[] constructorArguments)
-        {
-            ConstructorInfo constructor = typeof(ObsoleteAttribute).GetConstructor(typeArguments);
-            Action<CustomAttributeBuilder> verify = attr => Assert.NotNull(attr);
-            Ctor(constructor, constructorArguments, new PropertyInfo[0], new object[0], new FieldInfo[0], new object[0], verify);
-        }
-
-        public static IEnumerable<object[]> Ctor_Advanced_TestData()
+        public static IEnumerable<object[]> Ctor_TestData()
         {
             string stringValue1 = "TestString1";
             string stringValue2 = "TestString2";
@@ -186,8 +170,8 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Ctor_Advanced_TestData))]
-        public static void Ctor(Type[] ctorTypes, object[] ctorArgs,
+        [MemberData(nameof(Ctor_TestData))]
+        public static void Ctor(Type[] ctorTypes, object[] constructorArgs,
                                 string[] propertyNames, object[] propertyValues,
                                 object[] expectedPropertyValues,
                                 string[] fieldNames, object[] fieldValues,
@@ -201,15 +185,7 @@ namespace System.Reflection.Emit.Tests
             {
                 VerifyCustomAttributeBuilder(attr, TestAttribute.AllProperties, expectedPropertyValues, TestAttribute.AllFields, expectedFieldValues);
             };
-
-            Ctor(constructor, ctorArgs, namedProperties, propertyValues, namedFields, fieldValues, verify);
-        }
-
-        public static void Ctor(ConstructorInfo constructor, object[] constructorArgs,
-                                PropertyInfo[] namedProperties, object[] propertyValues,
-                                FieldInfo[] namedFields, object[] fieldValues,
-                                Action<CustomAttributeBuilder> verify)
-        {
+            
             if (namedProperties.Length == 0)
             {
                 if (namedFields.Length == 0)

--- a/src/System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj
+++ b/src/System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="SignatureHelper\SignatureHelperGetPropertySigHelper.cs" />
     <Compile Include="SignatureHelper\SignatureHelperGetSignature.cs" />
     <Compile Include="SignatureHelper\SignatureHelperToString.cs" />
+    <Compile Include="CustomAttributeBuilderTests.cs" />
     <Compile Include="Utilities.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Reflection.Emit.ILGeneration/tests/Utilities.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/Utilities.cs
@@ -10,7 +10,7 @@ namespace System.Reflection.Emit.Tests
         internal TestConstructor(bool b) { }
     }
 
-    public class CustomAttributeBuilderTest : Attribute
+    public class TestAttribute : Attribute
     {
         public string TestString
         {
@@ -39,21 +39,24 @@ namespace System.Reflection.Emit.Tests
         public string GetString;
         public int GetInt;
 
-        public CustomAttributeBuilderTest() { }
+        public TestAttribute() { }
 
-        public CustomAttributeBuilderTest(string getOnlyString, int getOnlyInt32)
+        public TestAttribute(string getOnlyString, int getOnlyInt32)
         {
             GetString = getOnlyString;
             GetInt = getOnlyInt32;
         }
 
-        public CustomAttributeBuilderTest(string testString, int testInt32, string getOnlyString, int getOnlyInt32)
+        public TestAttribute(string testString, int testInt32, string getOnlyString, int getOnlyInt32)
         {
             TestStringField = testString;
             TestInt = testInt32;
             GetString = getOnlyString;
             GetInt = getOnlyInt32;
         }
+
+        public static FieldInfo[] AllFields => Helpers.GetFields(nameof(TestInt), nameof(TestStringField), nameof(GetString), nameof(GetInt));
+        public static PropertyInfo[] AllProperties => Helpers.GetProperties(nameof(TestInt32), nameof(TestString), nameof(GetOnlyString), nameof(GetOnlyInt32));
     }
 
     public static class Helpers
@@ -65,7 +68,7 @@ namespace System.Reflection.Emit.Tests
             for (int i = 0; i < fieldNames.Length; i++)
             {
                 string name = fieldNames[i];
-                fields[i] = name == null ? null : typeof(CustomAttributeBuilderTest).GetField(name, Flags);
+                fields[i] = name == null ? null : typeof(TestAttribute).GetField(name, Flags);
             }
             return fields;
         }
@@ -77,7 +80,7 @@ namespace System.Reflection.Emit.Tests
             for (int i = 0; i < propertyNames.Length; i++)
             {
                 string name = propertyNames[i];
-                properties[i] = name == null ? null : typeof(CustomAttributeBuilderTest).GetProperty(name, Flags);
+                properties[i] = name == null ? null : typeof(TestAttribute).GetProperty(name, Flags);
             }
             return properties;
         }


### PR DESCRIPTION
- Consolidate test data (test all overloads when we can, and remove duplication)
- Make all tests actually test everything (as opposed to NotNull or weak assertions)

Fixes #1914
/cc @stephentoub @Priya91