### PR TITLE
Downgrade projectk-tfs package to release/1.0.0

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -3,14 +3,13 @@
   <PropertyGroup>
     <CoreFxCurrentRef>980912e90011208423360eba83fe37ad46a1cc91</CoreFxCurrentRef>
     <CoreClrCurrentRef>980912e90011208423360eba83fe37ad46a1cc91</CoreClrCurrentRef>
-    <ExternalCurrentRef>980912e90011208423360eba83fe37ad46a1cc91</ExternalCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
     <CoreFxExpectedPrerelease>preview1-24508-08</CoreFxExpectedPrerelease>
     <CoreClrExpectedPrerelease>preview1-24510-01</CoreClrExpectedPrerelease>
-    <ExternalExpectedPrerelease>beta-24509-00</ExternalExpectedPrerelease>
+    <ExternalExpectedPrerelease>rc3-24214-00</ExternalExpectedPrerelease>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->
@@ -34,11 +33,6 @@
       <BuildInfoPath>$(BaseDotNetBuildInfo)coreclr/$(DependencyBranch)</BuildInfoPath>
       <CurrentRef>$(CoreClrCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
-    <RemoteDependencyBuildInfo Include="External">
-      <!-- ProjectK-TFS dependency remains on master: there aren't release/1.1.0 builds from TFS. -->
-      <BuildInfoPath>$(BaseDotNetBuildInfo)projectk-tfs/master</BuildInfoPath>
-      <CurrentRef>$(ExternalCurrentRef)</CurrentRef>
-    </RemoteDependencyBuildInfo>
 
     <DependencyBuildInfo Include="@(RemoteDependencyBuildInfo)">
       <RawVersionsBaseUrl>https://raw.githubusercontent.com/dotnet/versions</RawVersionsBaseUrl>
@@ -53,11 +47,6 @@
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>CoreClrExpectedPrerelease</ElementName>
       <BuildInfoName>CoreClr</BuildInfoName>
-    </XmlUpdateStep>
-    <XmlUpdateStep Include="External">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>ExternalExpectedPrerelease</ElementName>
-      <BuildInfoName>External</BuildInfoName>
     </XmlUpdateStep>
   </ItemGroup>
 

--- a/pkg/ExternalPackages/project.json
+++ b/pkg/ExternalPackages/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Private.Intellisense": "1.0.0-beta-24509-00"
+    "Microsoft.Private.Intellisense": "1.0.0-rc3-24214-00"
   },
   "frameworks": {
     "netstandard1.0": {}


### PR DESCRIPTION
Downgrades `Microsoft.Private.Intellisense` to the version at release/1.0.0. I then removed the release/1.0.0 buildinfo dependency because it conflicts with coreclr. (Some packages were built in projectk-tfs 1.0.0 RTM and are now built in coreclr. E.g. `Microsoft.NETCore.TestHost`)

@weshaggard @ericstj @gkhanna79 