### PR TITLE
Disable failing WindowsSearchPatternInvalid test

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -250,6 +250,7 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, @".." + Path.DirectorySeparatorChar));
         }
 
+        [ActiveIssue(11584)]
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public void WindowsSearchPatternInvalid()


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/11584