### PR TITLE
Fixing issue with typing of Quote nodes after runtime rewrite

### DIFF
--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
@@ -98,7 +98,7 @@ namespace System.Runtime.CompilerServices
                 {
                     return node;
                 }
-                return Expression.Block(node.Variables, b);
+                return node.Rewrite(node.Variables, b);
             }
 
             protected override CatchBlock VisitCatchBlock(CatchBlock node)

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -206,6 +206,7 @@
     <Compile Include="Unary\UnaryIsFalseNullableTests.cs" />
     <Compile Include="Unary\UnaryIsFalseTests.cs" />
     <Compile Include="Unary\UnaryIsTrueNullableTests.cs" />
+    <Compile Include="Unary\UnaryQuoteTests.cs" />
     <Compile Include="Unary\UnaryUnboxTests.cs" />
     <Compile Include="Unary\UnaryIsTrueTests.cs" />
     <Compile Include="Unary\UnaryOnesComplementNullableTests.cs" />

--- a/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Xunit;
+
+using static System.Linq.Expressions.Expression;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class UnaryQuoteTests
+    {
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void QuotePreservesTypingOfBlock(bool useInterpreter)
+        {
+            var x = Parameter(typeof(int));
+
+            var f1 =
+                Lambda<Func<int, Type>>(
+                    Call(
+                        typeof(UnaryQuoteTests).GetMethod(nameof(Quote1)),
+                        Lambda(
+                            Block(typeof(void), x)
+                        )
+                    ),
+                    x
+                );
+
+            Assert.Equal(typeof(void), f1.Compile(useInterpreter)(42));
+
+            var s = Parameter(typeof(string));
+
+            var f2 =
+                Lambda<Func<string, Type>>(
+                    Call(
+                        typeof(UnaryQuoteTests).GetMethod(nameof(Quote2)),
+                        Lambda(
+                            Block(typeof(object), s)
+                        )
+                    ),
+                    s
+                );
+
+            Assert.Equal(typeof(object), f2.Compile(useInterpreter)("bar"));
+        }
+
+        public static Type Quote1(Expression<Action> e) => e.Body.Type;
+        public static Type Quote2(Expression<Func<object>> e) => e.Body.Type;
+    }
+}


### PR DESCRIPTION
This fixes issue #11590 and fixes some of the inconsistencies between the interpreter's and compiler's quotation mechanism (more of that happens in https://github.com/dotnet/corefx/pull/11314).