### PR TITLE
Enable Windows 10 outerloop testing in PRs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -207,7 +207,7 @@ def osShortName = ['Windows 10': 'win10',
 // Define outerloop testing for OSes that can build and run.  Run locally on each machine.
 // **************************
 [true, false].each { isPR ->
-    ['Windows 7', 'Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2', 'Fedora23', 'Debian8.4', 'OSX'].each { osName ->
+    ['Windows 10', 'Windows 7', 'Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2', 'Fedora23', 'Debian8.4', 'OSX'].each { osName ->
         ['Debug', 'Release'].each { configurationGroup ->
 
             def newJobName = "outerloop_${osShortName[osName]}_${configurationGroup.toLowerCase()}"


### PR DESCRIPTION
It looks like this was disabled in https://github.com/dotnet/corefx/pull/10178, citing https://github.com/dotnet/corefx/issues/10177 to bring it back.  That issues is now closed as fixed, so hopefully this works now.

cc: @ellismg, @Priya91, @mmitche 