### PR TITLE
Remove Contract.Requires from immutable collections tests

### DIFF
--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
 
@@ -350,8 +349,8 @@ namespace System.Collections.Immutable.Tests
 
         private IImmutableDictionary<TKey, TValue> AddTestHelper<TKey, TValue>(IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) where TKey : IComparable<TKey>
         {
-            Contract.Requires(map != null);
-            Contract.Requires(key != null);
+            Assert.NotNull(map);
+            Assert.NotNull(key);
 
             IImmutableDictionary<TKey, TValue> addedMap = map.Add(key, value);
             Assert.NotSame(map, addedMap);
@@ -367,7 +366,7 @@ namespace System.Collections.Immutable.Tests
 
         protected void AddAscendingTestHelper(IImmutableDictionary<int, GenericParameterHelper> map)
         {
-            Contract.Requires(map != null);
+            Assert.NotNull(map);
 
             for (int i = 0; i < 10; i++)
             {
@@ -397,7 +396,7 @@ namespace System.Collections.Immutable.Tests
 
         protected void AddRemoveRandomDataTestHelper(IImmutableDictionary<double, GenericParameterHelper> map)
         {
-            Contract.Requires(map != null);
+            Assert.NotNull(map);
 
             double[] inputs = GenerateDummyFillData();
             for (int i = 0; i < inputs.Length; i++)
@@ -422,7 +421,7 @@ namespace System.Collections.Immutable.Tests
 
         protected void AddRemoveEnumerableTestHelper(IImmutableDictionary<int, int> empty)
         {
-            Contract.Requires(empty != null);
+            Assert.NotNull(empty);
 
             Assert.Same(empty, empty.RemoveRange(Enumerable.Empty<int>()));
             Assert.Same(empty, empty.AddRange(Enumerable.Empty<KeyValuePair<int, int>>()));
@@ -437,9 +436,9 @@ namespace System.Collections.Immutable.Tests
 
         protected void AddExistingKeySameValueTestHelper<TKey, TValue>(IImmutableDictionary<TKey, TValue> map, TKey key, TValue value1, TValue value2)
         {
-            Contract.Requires(map != null);
-            Contract.Requires(key != null);
-            Contract.Requires(GetValueComparer(map).Equals(value1, value2));
+            Assert.NotNull(map);
+            Assert.NotNull(key);
+            Assert.True(GetValueComparer(map).Equals(value1, value2));
 
             map = map.Add(key, value1);
             Assert.Same(map, map.Add(key, value2));
@@ -461,9 +460,9 @@ namespace System.Collections.Immutable.Tests
         /// </remarks>
         protected void AddExistingKeyDifferentValueTestHelper<TKey, TValue>(IImmutableDictionary<TKey, TValue> map, TKey key, TValue value1, TValue value2)
         {
-            Contract.Requires(map != null);
-            Contract.Requires(key != null);
-            Contract.Requires(!GetValueComparer(map).Equals(value1, value2));
+            Assert.NotNull(map);
+            Assert.NotNull(key);
+            Assert.False(GetValueComparer(map).Equals(value1, value2));
 
             var map1 = map.Add(key, value1);
             var map2 = map.Add(key, value2);

--- a/src/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
 
@@ -206,7 +205,7 @@ namespace System.Collections.Immutable.Tests
         /// <param name="comparer">The comparer used to obtain the empty set, if any.</param>
         private void EmptyTestHelper<T>(IImmutableSet<T> emptySet, T value, IEqualityComparer<T> comparer)
         {
-            Contract.Requires(emptySet != null);
+            Assert.NotNull(emptySet);
 
             this.EmptyTestHelper(emptySet);
             Assert.Same(emptySet, emptySet.ToImmutableHashSet(comparer));

--- a/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
 
@@ -14,7 +13,7 @@ namespace System.Collections.Immutable.Tests
     {
         private void EnqueueDequeueTestHelper<T>(params T[] items)
         {
-            Contract.Requires(items != null);
+            Assert.NotNull(items);
 
             var queue = ImmutableQueue<T>.Empty;
             int i = 0;

--- a/src/System.Collections.Immutable/tests/ImmutableSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSetTest.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
 using SetTriad = System.Tuple<System.Collections.Generic.IEnumerable<int>, System.Collections.Generic.IEnumerable<int>, bool>;
@@ -226,7 +225,8 @@ namespace System.Collections.Immutable.Tests
 
         internal static List<T> ToListNonGeneric<T>(System.Collections.IEnumerable sequence)
         {
-            Contract.Requires(sequence != null);
+            Assert.NotNull(sequence);
+
             var list = new List<T>();
             var enumerator = sequence.GetEnumerator();
             while (enumerator.MoveNext())
@@ -268,9 +268,9 @@ namespace System.Collections.Immutable.Tests
 
         protected void CustomSortTestHelper<T>(IImmutableSet<T> emptySet, bool matchOrder, T[] injectedValues, T[] expectedValues)
         {
-            Contract.Requires(emptySet != null);
-            Contract.Requires(injectedValues != null);
-            Contract.Requires(expectedValues != null);
+            Assert.NotNull(emptySet);
+            Assert.NotNull(injectedValues);
+            Assert.NotNull(expectedValues);
 
             var set = emptySet;
             foreach (T value in injectedValues)
@@ -296,7 +296,7 @@ namespace System.Collections.Immutable.Tests
         /// <param name="emptySet">The empty set.</param>
         protected void EmptyTestHelper<T>(IImmutableSet<T> emptySet)
         {
-            Contract.Requires(emptySet != null);
+            Assert.NotNull(emptySet);
 
             Assert.Equal(0, emptySet.Count); //, "Empty set should have a Count of 0");
             Assert.Equal(0, emptySet.Count()); //, "Enumeration of an empty set yielded elements.");
@@ -398,8 +398,8 @@ namespace System.Collections.Immutable.Tests
 
         private void RemoveTestHelper<T>(IImmutableSet<T> set, params T[] values)
         {
-            Contract.Requires(set != null);
-            Contract.Requires(values != null);
+            Assert.NotNull(set);
+            Assert.NotNull(values);
 
             Assert.Same(set, set.Except(Enumerable.Empty<T>()));
 
@@ -442,8 +442,8 @@ namespace System.Collections.Immutable.Tests
 
         private void AddRemoveLoadTestHelper<T>(IImmutableSet<T> set, T[] data)
         {
-            Contract.Requires(set != null);
-            Contract.Requires(data != null);
+            Assert.NotNull(set);
+            Assert.NotNull(data);
 
             foreach (T value in data)
             {
@@ -514,8 +514,8 @@ namespace System.Collections.Immutable.Tests
 
         private void ExceptTestHelper<T>(IImmutableSet<T> set, params T[] valuesToRemove)
         {
-            Contract.Requires(set != null);
-            Contract.Requires(valuesToRemove != null);
+            Assert.NotNull(set);
+            Assert.NotNull(valuesToRemove);
 
             var expectedSet = new HashSet<T>(set);
             expectedSet.ExceptWith(valuesToRemove);
@@ -528,8 +528,8 @@ namespace System.Collections.Immutable.Tests
 
         private void SymmetricExceptTestHelper<T>(IImmutableSet<T> set, params T[] otherCollection)
         {
-            Contract.Requires(set != null);
-            Contract.Requires(otherCollection != null);
+            Assert.NotNull(set);
+            Assert.NotNull(otherCollection);
 
             var expectedSet = new HashSet<T>(set);
             expectedSet.SymmetricExceptWith(otherCollection);
@@ -542,8 +542,8 @@ namespace System.Collections.Immutable.Tests
 
         private void IntersectTestHelper<T>(IImmutableSet<T> set, params T[] values)
         {
-            Contract.Requires(set != null);
-            Contract.Requires(values != null);
+            Assert.NotNull(set);
+            Assert.NotNull(values);
 
             Assert.True(set.Intersect(Enumerable.Empty<T>()).Count == 0);
 
@@ -558,8 +558,8 @@ namespace System.Collections.Immutable.Tests
 
         private void UnionTestHelper<T>(IImmutableSet<T> set, params T[] values)
         {
-            Contract.Requires(set != null);
-            Contract.Requires(values != null);
+            Assert.NotNull(set);
+            Assert.NotNull(values);
 
             var expected = new HashSet<T>(set);
             expected.UnionWith(values);
@@ -572,8 +572,8 @@ namespace System.Collections.Immutable.Tests
 
         private void AddTestHelper<T>(IImmutableSet<T> set, params T[] values)
         {
-            Contract.Requires(set != null);
-            Contract.Requires(values != null);
+            Assert.NotNull(set);
+            Assert.NotNull(values);
 
             Assert.Same(set, set.Union(Enumerable.Empty<T>()));
 

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
 
@@ -410,7 +409,7 @@ namespace System.Collections.Immutable.Tests
         /// <param name="comparer">The comparer used to obtain the empty set, if any.</param>
         private void EmptyTestHelper<T>(IImmutableSet<T> emptySet, T value, IComparer<T> comparer)
         {
-            Contract.Requires(emptySet != null);
+            Assert.NotNull(emptySet);
 
             this.EmptyTestHelper(emptySet);
             Assert.Same(emptySet, emptySet.ToImmutableSortedSet(comparer));

--- a/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
 
@@ -27,7 +26,7 @@ namespace System.Collections.Immutable.Tests
 
         private ImmutableStack<T> InitStackHelper<T>(params T[] values)
         {
-            Contract.Requires(values != null);
+            Assert.NotNull(values);
 
             var result = ImmutableStack<T>.Empty;
             foreach (var value in values)
@@ -52,8 +51,8 @@ namespace System.Collections.Immutable.Tests
 
         private void PopTestHelper<T>(params T[] values)
         {
-            Contract.Requires(values != null);
-            Contract.Requires(values.Length > 0);
+            Assert.NotNull(values);
+            Assert.InRange(values.Length, 1, int.MaxValue);
 
             var full = this.InitStackHelper(values);
             var currentStack = full;
@@ -74,8 +73,8 @@ namespace System.Collections.Immutable.Tests
 
         private void PeekTestHelper<T>(params T[] values)
         {
-            Contract.Requires(values != null);
-            Contract.Requires(values.Length > 0);
+            Assert.NotNull(values);
+            Assert.InRange(values.Length, 1, int.MaxValue);
 
             var current = this.InitStackHelper(values);
             for (int i = values.Length - 1; i >= 0; i--)

--- a/src/System.Collections.Immutable/tests/ImmutableTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableTestBase.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -102,9 +101,7 @@ namespace System.Collections.Immutable.Tests
         /// <returns>An array of doubles.</returns>
         protected double[] GenerateDummyFillData(int length = 1000)
         {
-            Contract.Requires(length >= 0);
-            Contract.Ensures(Contract.Result<double[]>() != null);
-            Contract.Ensures(Contract.Result<double[]>().Length == length);
+            Assert.InRange(length, 0, int.MaxValue);
 
             int seed = unchecked((int)DateTime.Now.Ticks);
 
@@ -123,6 +120,9 @@ namespace System.Collections.Immutable.Tests
                 while (!ensureUniqueness.Add(input));
                 inputs[i] = input;
             }
+
+            Assert.NotNull(inputs);
+            Assert.Equal(length, inputs.Length);
 
             return inputs;
         }
@@ -187,7 +187,7 @@ namespace System.Collections.Immutable.Tests
 
             internal DeferredToString(Func<string> generator)
             {
-                Contract.Requires(generator != null);
+                Debug.Assert(generator != null);
                 _generator = generator;
             }
 

--- a/src/System.Collections.Immutable/tests/project.json
+++ b/src/System.Collections.Immutable/tests/project.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24510-01",
-    "System.Diagnostics.Contracts": "4.3.0-beta-24510-01",
     "System.Linq.Expressions": "4.3.0-beta-24510-01",
     "System.ObjectModel": "4.3.0-beta-24510-01",
     "System.Reflection.Emit": "4.3.0-beta-24510-01",


### PR DESCRIPTION
Without the contract rewriter, Contract.Requires is a nop.  https://github.com/dotnet/corefx/pull/11600 removed most of its usage from corefx, but it's still used in a bunch of places throughout the immutable collections tests.  This changes those to be either xunit asserts or Debug.Asserts, depending on usage.

Fixes https://github.com/dotnet/corefx/issues/11596
cc: @benaadams 