### PR TITLE
Replace % inside loop of Random ctor

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Random.cs
+++ b/src/System.Runtime.Extensions/src/System/Random.cs
@@ -56,7 +56,7 @@ namespace System
 
         public Random(int Seed)
         {
-            int ii;
+            int ii = 0;
             int mj, mk;
 
             //Initialize our Seed array.
@@ -66,7 +66,7 @@ namespace System
             mk = 1;
             for (int i = 1; i < 55; i++)
             {  //Apparently the range [1..55] is special (Knuth) and so we're wasting the 0'th position.
-                ii = (21 * i) % 55;
+                if ((ii += 21) >= 55) ii -= 55;
                 SeedArray[ii] = mk;
                 mk = mj - mk;
                 if (mk < 0) mk += MBIG;

--- a/src/System.Runtime.Extensions/src/System/Random.cs
+++ b/src/System.Runtime.Extensions/src/System/Random.cs
@@ -76,7 +76,9 @@ namespace System
             {
                 for (int i = 1; i < 56; i++)
                 {
-                    SeedArray[i] -= SeedArray[1 + (i + 30) % 55];
+                    int n = i + 30;
+                    if (n >= 55) n -= 55;
+                    SeedArray[i] -= SeedArray[1 + n];
                     if (SeedArray[i] < 0) SeedArray[i] += MBIG;
                 }
             }


### PR DESCRIPTION
This fixes/implements #11568

A quick local instantiation loop/benchmark thingy seems to show this about twice as fast as before in x86. 

In x64 it does seem to be about the same performance, maybe I'm doing something wrong. x64 assembly shows it did not do a idiv with the existing code, but optimized it away to shifts. The new version generates far fewer instruction, but includes a branch now, maybe that's why it still about the same performance.

Assembly before (x86):
```
            for (int i = 1; i < 55; i++)
010F2F4E  mov         ebx,edi  
010F2F50  mov         eax,dword ptr [ebp-18h]  
010F2F53  mov         esi,dword ptr [eax+4]  
            {  //Apparently the range [1..55] is special (Knuth) and so we're wasting the 0'th position.
                ii = (21 * i) % 55;
010F2F56  imul        eax,ebx,15h  
010F2F59  mov         ecx,37h  
010F2F5E  cdq  
010F2F5F  idiv        eax,ecx  
                SeedArray[ii] = mk;
010F2F61  cmp         edx,dword ptr [esi+4]  
010F2F64  jae         010F3018  
010F2F6A  mov         dword ptr [esi+edx*4+8],edi  
```

Assembly after (x86):
```
            for (int i = 1; i < 55; i++)
010F312C  mov         ebx,edx  
010F312E  mov         eax,dword ptr [ebp-14h]  
010F3131  mov         esi,dword ptr [eax+4]  
            {  //Apparently the range [1..55] is special (Knuth) and so we're wasting the 0'th position.
                if ((ii += 21) >= 55) ii -= 55;
010F3134  add         edi,15h  
010F3137  cmp         edi,37h  
010F313A  jl          010F313F  
                if ((ii += 21) >= 55) ii -= 55;
010F313C  add         edi,0FFFFFFC9h  
                SeedArray[ii] = mk;
010F313F  cmp         edi,dword ptr [esi+4]  
010F3142  jae         010F31F0  
010F3148  mov         dword ptr [esi+edi*4+8],edx  
```

Assembly before (x64):
```
            for (int i = 1; i < 55; i++)
00007FFC9D2C0696  mov         r11d,1  
            {  //Apparently the range [1..55] is special (Knuth) and so we're wasting the 0'th position.
                ii = (21 * i) % 55;
00007FFC9D2C069C  imul        edi,r11d,15h  
00007FFC9D2C06A0  mov         eax,94F2095h  
00007FFC9D2C06A5  imul        edi  
00007FFC9D2C06A7  mov         eax,edx  
00007FFC9D2C06A9  sar         eax,1  
00007FFC9D2C06AB  mov         edx,eax  
00007FFC9D2C06AD  shr         edx,1Fh  
00007FFC9D2C06B0  add         eax,edx  
00007FFC9D2C06B2  imul        eax,eax,37h  
00007FFC9D2C06B5  mov         edx,edi  
00007FFC9D2C06B7  sub         edx,eax  
00007FFC9D2C06B9  mov         eax,edx  
                SeedArray[ii] = mk;
00007FFC9D2C06BB  mov         rdx,r8  
00007FFC9D2C06BE  cmp         eax,r9d  
00007FFC9D2C06C1  jae         00007FFC9D2C0790  
00007FFC9D2C06C7  movsxd      rdi,eax  
00007FFC9D2C06CA  mov         dword ptr [rdx+rdi*4+10h],r10d  
```

Assembly after(x64):
```
            for (int i = 1; i < 55; i++)
00007FFC9D2C0B66  mov         r9d,1  
            {  //Apparently the range [1..55] is special (Knuth) and so we're wasting the 0'th position.
                if ((ii += 21) >= 55) ii -= 55;
00007FFC9D2C0B6C  add         ebx,15h  
00007FFC9D2C0B6F  cmp         ebx,37h  
00007FFC9D2C0B72  jl          00007FFC9D2C0B77  
                if ((ii += 21) >= 55) ii -= 55;
00007FFC9D2C0B74  add         ebx,0FFFFFFC9h  
                SeedArray[ii] = mk;
00007FFC9D2C0B77  mov         r10,rcx  
00007FFC9D2C0B7A  cmp         ebx,r8d  
00007FFC9D2C0B7D  jae         00007FFC9D2C0C4C  
00007FFC9D2C0B83  movsxd      r11,ebx  
00007FFC9D2C0B86  mov         dword ptr [r10+r11*4+10h],edx  
```