### PR TITLE
Remove stale comment comparing .NET Native and coreclr behaviour in ComponentModel.Annotations tests

### DIFF
--- a/src/System.ComponentModel.Annotations/tests/CustomValidationAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/CustomValidationAttributeTests.cs
@@ -38,11 +38,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             yield return new TestCase(GetAttribute(nameof(CustomValidator.CorrectValidationMethodOneArg)), new TestClass("AnyString"));
             yield return new TestCase(GetAttribute(nameof(CustomValidator.CorrectValidationMethodTwoArgs)), "AnyString");
 
-            // This Assert produces different results on Core CLR versus .Net Native. In CustomValidationAttribute.TryConvertValue()
-            // we call Convert.ChangeType(instanceOfAClass, typeof(string), ...). On K this throws InvalidCastException because
-            // the class does not implement IConvertible. On N this just returns the result of ToString() on the class and does not throw.
-            // As of 7/9/14 no plans to change this.
-            // yield return new Test(GetAttribute(nameof(CustomValidator.CorrectValidationMethodOneArgStronglyTyped)), new TestClass("AnyString"));
+            yield return new TestCase(GetAttribute(nameof(CustomValidator.CorrectValidationMethodOneArgStronglyTyped)), new TestClass("AnyString"));
             yield return new TestCase(GetAttribute(nameof(CustomValidator.CorrectValidationMethodTwoArgsStronglyTyped)), "AnyString");
 
             yield return new TestCase(GetAttribute(nameof(CustomValidator.CorrectValidationMethodOneArgNullable)), new TestStruct());


### PR DESCRIPTION
This is no longer the case - the implementations of the
Convert.ChangeType are the same in corert and coreclr

Fixes dotnet/corert#1805

/cc @stephentoub