### PR TITLE
Add missing members to Path

### DIFF
--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -773,11 +773,13 @@ namespace System.IO
     {
         public static readonly char AltDirectorySeparatorChar;
         public static readonly char DirectorySeparatorChar;
+        public static readonly char[] InvalidPathChars;
         public static readonly char PathSeparator;
         public static readonly char VolumeSeparatorChar;
         public static string ChangeExtension(string path, string extension) { return default(string); }
         public static string Combine(string path1, string path2) { return default(string); }
         public static string Combine(string path1, string path2, string path3) { return default(string); }
+        public static string Combine(string path1, string path2, string path3, string path4) { return default(string); }
         public static string Combine(params string[] paths) { return default(string); }
         public static string GetDirectoryName(string path) { return default(string); }
         public static string GetExtension(string path) { return default(string); }

--- a/src/System.Runtime.Extensions/src/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.cs
@@ -18,6 +18,9 @@ namespace System.IO
         // as the alternate separator on Windows, so same definition is used for both.
         public static readonly char AltDirectorySeparatorChar = '/';
 
+        [Obsolete("Please use GetInvalidPathChars or GetInvalidFileNameChars instead.")]
+        public static readonly char[] InvalidPathChars = GetInvalidPathChars();
+
         // Changes the extension of a file path. The path parameter
         // specifies a file path, and the extension parameter
         // specifies a file extension (with a leading period, such as
@@ -214,6 +217,20 @@ namespace System.IO
             return CombineNoChecks(path1, path2, path3);
         }
 
+        public static string Combine(string path1, string path2, string path3, string path4)
+        {
+            if (path1 == null || path2 == null || path3 == null || path4 == null)
+                throw new ArgumentNullException((path1 == null) ? "path1" : (path2 == null) ? "path2" : (path3 == null) ? "path3" : "path4");
+            Contract.EndContractBlock();
+
+            PathInternal.CheckInvalidPathChars(path1);
+            PathInternal.CheckInvalidPathChars(path2);
+            PathInternal.CheckInvalidPathChars(path3);
+            PathInternal.CheckInvalidPathChars(path4);
+
+            return CombineNoChecks(path1, path2, path3, path4);
+        }
+
         public static string Combine(params string[] paths)
         {
             if (paths == null)
@@ -341,6 +358,63 @@ namespace System.IO
                   .Append(path2)
                   .Append(DirectorySeparatorChar)
                   .Append(path3);
+                return StringBuilderCache.GetStringAndRelease(sb);
+            }
+        }
+
+        private static string CombineNoChecks(string path1, string path2, string path3, string path4)
+        {
+            if (path1.Length == 0)
+                return CombineNoChecks(path2, path3, path4);
+            if (path2.Length == 0)
+                return CombineNoChecks(path1, path3, path4);
+            if (path3.Length == 0)
+                return CombineNoChecks(path1, path2, path4);
+            if (path4.Length == 0)
+                return CombineNoChecks(path1, path2, path3);
+
+            if (IsPathRooted(path4))
+                return path4;
+            if (IsPathRooted(path3))
+                return CombineNoChecks(path3, path4);
+            if (IsPathRooted(path2))
+                return CombineNoChecks(path2, path3, path4);
+
+            bool hasSep1 = PathInternal.IsDirectoryOrVolumeSeparator(path1[path1.Length - 1]);
+            bool hasSep2 = PathInternal.IsDirectoryOrVolumeSeparator(path2[path2.Length - 1]);
+            bool hasSep3 = PathInternal.IsDirectoryOrVolumeSeparator(path3[path3.Length - 1]);
+
+            if (hasSep1 && hasSep2 && hasSep3)
+            {
+                // Use string.Concat overload that takes four strings
+                return path1 + path2 + path3 + path4;
+            }
+            else
+            {
+                // string.Concat only has string-based overloads up to four arguments; after that requires allocating
+                // a params string[].  Instead, try to use a cached StringBuilder.
+                StringBuilder sb = StringBuilderCache.Acquire(path1.Length + path2.Length + path3.Length + path4.Length + 3);
+
+                sb.Append(path1);
+                if (!hasSep1)
+                {
+                    sb.Append(DirectorySeparatorChar);
+                }
+
+                sb.Append(path2);
+                if (!hasSep2)
+                {
+                    sb.Append(DirectorySeparatorChar);
+                }
+
+                sb.Append(path3);
+                if (!hasSep3)
+                {
+                    sb.Append(DirectorySeparatorChar);
+                }
+
+                sb.Append(path4);
+
                 return StringBuilderCache.GetStringAndRelease(sb);
             }
         }

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -30,6 +30,7 @@
     <Compile Include="System\EnvironmentTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="System\Environment.MachineName.cs" />
     <Compile Include="System\IO\Path.Combine.cs" />
+    <Compile Include="System\IO\PathTests.netstandard1.7.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />
     <Compile Include="System\IO\PathTests.cs" />
     <Compile Include="System\Net\WebUtility.cs" />

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    public static class PathCombineTests
+    public static partial class PathTests
     {
         private static readonly char s_separator = Path.DirectorySeparatorChar;
 
@@ -104,8 +104,9 @@ namespace System.IO.Tests
                     Assert.Equal(expected, Path.Combine(paths[0], paths[1], paths[2]));
                     break;
 
-                default:
-                    // Nothing to do: everything else is pushed into an array
+                case 4:
+                    // Combine(string, string, string, string)
+                    Assert.Equal(expected, Path.Combine(paths[0], paths[1], paths[2], paths[3]));
                     break;
             }
         }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    public static class PathTests
+    public static partial class PathTests
     {
         [Theory]
         [InlineData(null, null, null)]

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.netstandard1.7.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.netstandard1.7.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public static partial class PathTests
+    {
+        [Fact]
+        public static void InvalidPathChars_MatchesGetInvalidPathChars()
+        {
+            Assert.NotNull(Path.InvalidPathChars);
+            Assert.Equal(Path.GetInvalidPathChars(), Path.InvalidPathChars);
+            Assert.Same(Path.InvalidPathChars, Path.InvalidPathChars);
+        }
+    }
+}


### PR DESCRIPTION
Path is missing the Combine(string, string, string, string) overload and the obsolete InvalidPathChars field.

cc: @JeremyKuhne, @danmosemsft, @ianhays 