### PR TITLE
fix break in layout\dir.proj

### DIFF
--- a/layout/dir.proj
+++ b/layout/dir.proj
@@ -17,30 +17,32 @@
       <RID>win7-x64</RID>
       <AdditionalBinaryPath>
         $(PackagesDir)/runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.1.0-$(CoreClrExpectedPrerelease)/runtimes/win7-x64/lib/netstandard1.0;
-        $(PackagesDir)/runtime.win7.System.Private.Uri\4.0.3-$(CoreFxExpectedPrerelease)\runtimes\win\lib\netstandard1.0;
-        $(PackagesDir)/System.Private.DataContractSerialization\4.1.2-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
-        $(PackagesDir)/System.Private.Xml\4.0.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
-        $(PackagesDir)/System.Private.Xml.Linq\4.0.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
+        $(PackagesDir)/runtime.win7.System.Private.Uri\4.3.0-$(CoreFxExpectedPrerelease)\runtimes\win\lib\netstandard1.0;
+        $(PackagesDir)/System.Private.DataContractSerialization\4.3.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
+        $(PackagesDir)/System.Private.Xml\4.3.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
+        $(PackagesDir)/System.Private.Xml.Linq\4.3.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
       </AdditionalBinaryPath>
     </TargetFrameworkMonikers>
+  <!--
     <TargetFrameworkMonikers Include="uap10.0">
       <RID>win10-x64-aot</RID>
       <AdditionalBinaryPath>
-        $(PackagesDir)/Microsoft.TargetingPack.Private.NETNative/1.0.1-beta-24415-00/lib/netcore50;
-        $(PackagesDir)/runtime.win7.System.Private.Uri\4.0.3-$(CoreFxExpectedPrerelease)\runtimes\aot\lib\netcore50;
-        $(PackagesDir)/System.Private.DataContractSerialization\4.1.2-$(CoreFxExpectedPrerelease)\runtimes\aot\lib\netcore50;
-        $(PackagesDir)/System.Private.Xml\4.0.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
-        $(PackagesDir)/System.Private.Xml.Linq\4.0.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
+        $(PackagesDir)/Microsoft.TargetingPack.Private.NETNative/1.0.1-beta-24512-00/lib/netcore50;
+        $(PackagesDir)/runtime.win7.System.Private.Uri\4.3.0-$(CoreFxExpectedPrerelease)\runtimes\aot\lib\netcore50;
+        $(PackagesDir)/System.Private.DataContractSerialization\4.3.0-$(CoreFxExpectedPrerelease)\runtimes\aot\lib\netcore50;
+        $(PackagesDir)/System.Private.Xml\4.3.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
+        $(PackagesDir)/System.Private.Xml.Linq\4.3.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
       </AdditionalBinaryPath>
     </TargetFrameworkMonikers>
+  -->
     <TargetFrameworkMonikers Include="uap10.1">
       <RID>win10-x64-aot</RID>
       <AdditionalBinaryPath>
-        $(PackagesDir)/Microsoft.TargetingPack.Private.NETNative/1.1.0-beta-24410-00/lib/uap10.1;
-        $(PackagesDir)/runtime.win7.System.Private.Uri\4.0.3-$(CoreFxExpectedPrerelease)\runtimes\aot\lib\netcore50;
-        $(PackagesDir)/System.Private.DataContractSerialization\4.1.2-$(CoreFxExpectedPrerelease)\runtimes\aot\lib\netcore50;
-        $(PackagesDir)/System.Private.Xml\4.0.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
-        $(PackagesDir)/System.Private.Xml.Linq\4.0.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
+        $(PackagesDir)/Microsoft.TargetingPack.Private.NETNative/1.1.0-beta-24512-00/lib/uap10.1;
+        $(PackagesDir)/runtime.win7.System.Private.Uri\4.3.0-$(CoreFxExpectedPrerelease)\runtimes\aot\lib\netcore50;
+        $(PackagesDir)/System.Private.DataContractSerialization\4.3.0-$(CoreFxExpectedPrerelease)\runtimes\aot\lib\netcore50;
+        $(PackagesDir)/System.Private.Xml\4.3.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
+        $(PackagesDir)/System.Private.Xml.Linq\4.3.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;
       </AdditionalBinaryPath>
     </TargetFrameworkMonikers>
   </ItemGroup>


### PR DESCRIPTION
layout\dir.proj is not part of the build - it is used to generate a folder of reference and implementation assemblies in bin\layout that can be indexed into apicatalog. It is not currently building because of package version changes upstream.

Fix this by updating the package versions as appropriate. The 1.0.1 .NET native package no longer builds, so commenting this out per Wes.

cc: @weshaggard 