### PR TITLE
Add missing APIs to System.IO.FileSystem

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.LockFile.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.LockFile.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        internal static extern bool LockFile(SafeFileHandle handle, int offsetLow, int offsetHigh, int countLow, int countHigh);
+
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        internal static extern bool UnlockFile(SafeFileHandle handle, int offsetLow, int offsetHigh, int countLow, int countHigh);
+    }
+}

--- a/src/Common/src/Interop/Windows/mincore/Interop.ReplaceFile.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.ReplaceFile.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreFile_L2, EntryPoint = "ReplaceFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        private static extern bool ReplaceFilePrivate(
+            string replacedFileName, string replacementFileName, string backupFileName,
+            int dwReplaceFlags, IntPtr lpExclude, IntPtr lpReserved);
+
+        internal static bool ReplaceFile(
+            string replacedFileName, string replacementFileName, string backupFileName,
+            int dwReplaceFlags, IntPtr lpExclude, IntPtr lpReserved)
+        {
+            replacedFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(replacedFileName);
+            replacementFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(replacementFileName);
+            if (backupFileName != null)
+            {
+                backupFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(backupFileName);
+            }
+
+            return ReplaceFilePrivate(
+                replacedFileName, replacementFileName, backupFileName,
+                dwReplaceFlags, lpExclude, lpReserved);
+        }
+
+        internal const int REPLACEFILE_WRITE_THROUGH = 0x1;
+        internal const int REPLACEFILE_IGNORE_MERGE_ERRORS = 0x2;
+    }
+}

--- a/src/Common/src/Interop/Windows/mincore/WinRT/Interop.LockFile.cs
+++ b/src/Common/src/Interop/Windows/mincore/WinRT/Interop.LockFile.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        internal static bool LockFile(SafeFileHandle handle, int offsetLow, int offsetHigh, int countLow, int countHigh)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        internal static bool UnlockFile(SafeFileHandle handle, int offsetLow, int offsetHigh, int countLow, int countHigh)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
+++ b/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
@@ -107,6 +107,8 @@ namespace System.IO
         public static System.IO.FileStream Create(string path, int bufferSize, System.IO.FileOptions options) { return default(System.IO.FileStream); }
         public static System.IO.StreamWriter CreateText(string path) { return default(System.IO.StreamWriter); }
         public static void Delete(string path) { }
+        public static void Decrypt(string path) { }
+        public static void Encrypt(string path) { }
         public static bool Exists(string path) { return default(bool); }
         public static System.IO.FileAttributes GetAttributes(string path) { return default(System.IO.FileAttributes); }
         public static System.DateTime GetCreationTime(string path) { return default(System.DateTime); }
@@ -129,6 +131,8 @@ namespace System.IO
         public static string ReadAllText(string path, System.Text.Encoding encoding) { return default(string); }
         public static System.Collections.Generic.IEnumerable<string> ReadLines(string path) { return default(System.Collections.Generic.IEnumerable<string>); }
         public static System.Collections.Generic.IEnumerable<string> ReadLines(string path, System.Text.Encoding encoding) { return default(System.Collections.Generic.IEnumerable<string>); }
+        public static void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName) { }
+        public static void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors) { }
         public static void SetAttributes(string path, System.IO.FileAttributes fileAttributes) { }
         public static void SetCreationTime(string path, System.DateTime creationTime) { }
         public static void SetCreationTimeUtc(string path, System.DateTime creationTimeUtc) { }
@@ -137,7 +141,9 @@ namespace System.IO
         public static void SetLastWriteTime(string path, System.DateTime lastWriteTime) { }
         public static void SetLastWriteTimeUtc(string path, System.DateTime lastWriteTimeUtc) { }
         public static void WriteAllBytes(string path, byte[] bytes) { }
+        public static void WriteAllLines(string path, string[] contents) { }
         public static void WriteAllLines(string path, System.Collections.Generic.IEnumerable<string> contents) { }
+        public static void WriteAllLines(string path, string[] contents, System.Text.Encoding encoding) { }
         public static void WriteAllLines(string path, System.Collections.Generic.IEnumerable<string> contents, System.Text.Encoding encoding) { }
         public static void WriteAllText(string path, string contents) { }
         public static void WriteAllText(string path, string contents, System.Text.Encoding encoding) { }
@@ -157,6 +163,8 @@ namespace System.IO
         public System.IO.FileStream Create() { return default(System.IO.FileStream); }
         public System.IO.StreamWriter CreateText() { return default(System.IO.StreamWriter); }
         public override void Delete() { }
+        public void Decrypt() { }
+        public void Encrypt() { }
         public void MoveTo(string destFileName) { }
         public System.IO.FileStream Open(System.IO.FileMode mode) { return default(System.IO.FileStream); }
         public System.IO.FileStream Open(System.IO.FileMode mode, System.IO.FileAccess access) { return default(System.IO.FileStream); }
@@ -191,6 +199,7 @@ namespace System.IO
         public override bool CanRead { get { return default(bool); } }
         public override bool CanSeek { get { return default(bool); } }
         public override bool CanWrite { get { return default(bool); } }
+        public virtual System.IntPtr Handle { get { return default(System.IntPtr); } }
         public virtual bool IsAsync { get { return default(bool); } }
         public override long Length { get { return default(long); } }
         public string Name { get { return default(string); } }
@@ -205,6 +214,7 @@ namespace System.IO
         public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task<int>); }
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) { return default(IAsyncResult); }
         public override int EndRead(IAsyncResult asyncResult) { return default(int); }
+        public virtual void Lock(long position, long length) { }
         public override int ReadByte() { return default(int); }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { return default(long); }
         public override void SetLength(long value) { }
@@ -213,6 +223,7 @@ namespace System.IO
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) { return default(IAsyncResult); }
         public override void EndWrite(IAsyncResult asyncResult) { }
         public override void WriteByte(byte value) { }
+        public virtual void Unlock(long position, long length) { }
     }
     public abstract partial class FileSystemInfo
     {

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -212,6 +212,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SafeCreateFile.cs">
       <Link>Common\Interop\Windows\Interop.SafeCreateFile.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.ReplaceFile.cs">
+      <Link>Common\Interop\Windows\Interop.ReplaceFile.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Windows : Win32 only -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(EnableWinRT)' != 'true' and '$(TargetGroup)' != 'net46' and '$(TargetGroup)' != 'net463'">
@@ -238,6 +241,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.DeleteVolumeMountPoint.cs">
       <Link>Common\Interop\Windows\Interop.DeleteVolumeMountPoint.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.LockFile.cs">
+      <Link>Common\Interop\Windows\Interop.LockFile.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SetErrorMode.cs">
       <Link>Common\Interop\Windows\Interop.SetErrorMode.cs</Link>
     </Compile>
@@ -252,6 +258,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\WinRT\Interop.DeleteVolumeMountPoint.cs">
       <Link>Common\Interop\Windows\WinRT\Interop.DeleteVolumeMountPoint.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\WinRT\Interop.LockFile.cs">
+      <Link>Common\Interop\Windows\WinRT\Interop.LockFile.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\WinRT\Interop.SetErrorMode.cs">
       <Link>Common\Interop\Windows\WinRT\Interop.SetErrorMode.cs</Link>

--- a/src/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/System.IO.FileSystem/src/System/IO/File.cs
@@ -551,6 +551,11 @@ namespace System.IO
             return ReadLinesIterator.CreateIterator(path, encoding);
         }
 
+        public static void WriteAllLines(String path, String[] contents)
+        {
+            WriteAllLines(path, (IEnumerable<String>)contents);
+        }
+
         public static void WriteAllLines(String path, IEnumerable<String> contents)
         {
             if (path == null)
@@ -564,6 +569,11 @@ namespace System.IO
             Stream stream = FileStream.InternalCreate(path, useAsync: false);
 
             InternalWriteAllLines(new StreamWriter(stream, UTF8NoBOM), contents);
+        }
+
+        public static void WriteAllLines(String path, String[] contents, Encoding encoding)
+        {
+            WriteAllLines(path, (IEnumerable<String>)contents, encoding);
         }
 
         public static void WriteAllLines(String path, IEnumerable<String> contents, Encoding encoding)
@@ -666,6 +676,25 @@ namespace System.IO
             InternalWriteAllLines(new StreamWriter(stream, encoding), contents);
         }
 
+        public static void Replace(String sourceFileName, String destinationFileName, String destinationBackupFileName)
+        {
+            Replace(sourceFileName, destinationFileName, destinationBackupFileName, ignoreMetadataErrors: false);
+        }
+
+        public static void Replace(String sourceFileName, String destinationFileName, String destinationBackupFileName, bool ignoreMetadataErrors)
+        {
+            if (sourceFileName == null)
+                throw new ArgumentNullException(nameof(sourceFileName));
+            if (destinationFileName == null)
+                throw new ArgumentNullException(nameof(destinationFileName));
+
+            FileSystem.Current.ReplaceFile(
+                Path.GetFullPath(sourceFileName), 
+                Path.GetFullPath(destinationFileName),
+                destinationBackupFileName != null ? Path.GetFullPath(destinationBackupFileName) : null,
+                ignoreMetadataErrors);
+        }
+
         // Moves a specified file to a new location and potentially a new file name.
         // This method does work across volumes.
         //
@@ -696,6 +725,32 @@ namespace System.IO
             }
 
             FileSystem.Current.MoveFile(fullSourceFileName, fullDestFileName);
+        }
+
+        public static void Encrypt(String path)
+        {
+            if (path == null)
+                throw new ArgumentNullException(nameof(path));
+
+            // TODO: Not supported on Unix or in WinRt, and the EncryptFile API isn't currently
+            // available in OneCore.  For now, we just throw PNSE everywhere.  When the API is
+            // available, we can put this into the FileSystem abstraction and implement it
+            // properly for Win32.
+
+            throw new PlatformNotSupportedException();
+        }
+
+        public static void Decrypt(String path)
+        {
+            if (path == null)
+                throw new ArgumentNullException(nameof(path));
+
+            // TODO: Not supported on Unix or in WinRt, and the EncryptFile API isn't currently
+            // available in OneCore.  For now, we just throw PNSE everywhere.  When the API is
+            // available, we can put this into the FileSystem abstraction and implement it
+            // properly for Win32.
+
+            throw new PlatformNotSupportedException();
         }
 
         private static volatile Encoding _UTF8NoBOM;

--- a/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
@@ -296,5 +296,16 @@ namespace System.IO
         {
             return DisplayPath;
         }
+
+        public void Decrypt()
+        {
+            File.Decrypt(FullPath);
+        }
+
+        public void Encrypt()
+        {
+            File.Encrypt(FullPath);
+        }
+
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.cs
@@ -129,11 +129,33 @@ namespace System.IO
         public virtual bool IsAsync { get { return this._innerStream.IsAsync; } }
         public string Name { get { return this._innerStream.Name; } }
         public virtual Microsoft.Win32.SafeHandles.SafeFileHandle SafeFileHandle { get { return this._innerStream.SafeFileHandle; } }
+        public virtual IntPtr Handle { get { return SafeFileHandle.DangerousGetHandle(); } }
 
         public virtual void Flush(bool flushToDisk)
         {
             this._innerStream.Flush(flushToDisk);
         }
+
+        public virtual void Lock(long position, long length)
+        {
+            if (position < 0 || length < 0)
+            {
+                throw new ArgumentOutOfRangeException(position < 0 ? nameof(position) : nameof(length), SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            _innerStream.Lock(position, length);
+        }
+
+        public virtual void Unlock(long position, long length)
+        {
+            if (position < 0 || length < 0)
+            {
+                throw new ArgumentOutOfRangeException(position < 0 ? nameof(position) : nameof(length), SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            _innerStream.Unlock(position, length);
+        }
+
         #endregion
 
         #region Stream members

--- a/src/System.IO.FileSystem/src/System/IO/FileStreamBase.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStreamBase.cs
@@ -28,5 +28,7 @@ namespace System.IO
         internal abstract bool IsClosed { get; }
 
         public abstract void Flush(bool flushToDisk);
+        public abstract void Lock(long position, long length);
+        public abstract void Unlock(long position, long length);
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.cs
@@ -18,6 +18,7 @@ namespace System.IO
 
         // File
         public abstract void CopyFile(string sourceFullPath, string destFullPath, bool overwrite);
+        public abstract void ReplaceFile(string sourceFullPath, string destFullPath, string destBackupFullPath, bool ignoreMetadataErrors);
         public abstract void DeleteFile(string fullPath);
         public abstract bool FileExists(string fullPath);
         public abstract FileStreamBase Open(string fullPath, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options, FileStream parent);

--- a/src/System.IO.FileSystem/src/System/IO/MultiplexingWin32WinRTFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/MultiplexingWin32WinRTFileSystem.cs
@@ -28,6 +28,11 @@ namespace System.IO
             Select(sourceFullPath, destFullPath).CopyFile(sourceFullPath, destFullPath, overwrite);
         }
 
+        public override void ReplaceFile(string sourceFullPath, string destFullPath, string destBackupFullPath, bool ignoreMetadataErrors)
+        {
+            Select(sourceFullPath, destFullPath, destBackupFullPath).ReplaceFile(sourceFullPath, destFullPath, destBackupFullPath, ignoreMetadataErrors);
+        }
+
         public override void CreateDirectory(string fullPath)
         {
             Select(fullPath, isCreate: true).CreateDirectory(fullPath);
@@ -147,6 +152,14 @@ namespace System.IO
         private FileSystem Select(string sourceFullPath, string destFullPath)
         {
             return (ShouldUseWinRT(sourceFullPath, isCreate: false) || ShouldUseWinRT(destFullPath, isCreate: true)) ? _winRTFileSystem : _win32FileSystem;
+        }
+
+        private FileSystem Select(string sourceFullPath, string destFullPath, string destFullBackupPath)
+        {
+            return 
+                (ShouldUseWinRT(sourceFullPath, isCreate: false) || ShouldUseWinRT(destFullPath, isCreate: true) || ShouldUseWinRT(destFullBackupPath, isCreate: true)) ?
+                _winRTFileSystem :
+                _win32FileSystem;
         }
 
         public override string[] GetLogicalDrives()

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -1196,6 +1196,24 @@ namespace System.IO
             }
         }
 
+        /// <summary>Prevents other processes from reading from or writing to the FileStream.</summary>
+        /// <param name="position">The beginning of the range to lock.</param>
+        /// <param name="length">The range to be locked.</param>
+        public override void Lock(long position, long length)
+        {
+            // TODO #5964: Implement this with fcntl and F_SETLK in System.Native
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <summary>Allows access by other processes to all or part of a file that was previously locked.</summary>
+        /// <param name="position">The beginning of the range to unlock.</param>
+        /// <param name="length">The range to be unlocked.</param>
+        public override void Unlock(long position, long length)
+        {
+            // TODO #5964: Implement this with fcntl and F_SETLK in System.Native
+            throw new PlatformNotSupportedException();
+        }
+
         /// <summary>Sets the current position of this stream to the given value.</summary>
         /// <param name="offset">The point relative to origin from which to begin seeking. </param>
         /// <param name="origin">

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -39,6 +39,21 @@ namespace System.IO
             }
         }
 
+        public override void ReplaceFile(string sourceFullPath, string destFullPath, string destBackupFullPath, bool ignoreMetadataErrors)
+        {
+            // Copy the destination file to a backup.
+            if (destBackupFullPath != null)
+            {
+                CopyFile(destFullPath, destBackupFullPath, overwrite: true);
+            }
+
+            // Then copy the contents of the source file to the destination file.
+            CopyFile(sourceFullPath, destFullPath, overwrite: true);
+
+            // Finally, delete the source file.
+            DeleteFile(sourceFullPath);
+        }
+
         public override void MoveFile(string sourceFullPath, string destFullPath)
         {
             // The desired behavior for Move(source, dest) is to not overwrite the destination file

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
@@ -1781,5 +1781,41 @@ namespace System.IO
 
             return completedTask;
         }
+
+        public override void Lock(long position, long length)
+        {
+            if (_handle.IsClosed)
+            {
+                throw Error.GetFileNotOpen();
+            }
+
+            int positionLow = unchecked((int)(position));
+            int positionHigh = unchecked((int)(position >> 32));
+            int lengthLow = unchecked((int)(length));
+            int lengthHigh = unchecked((int)(length >> 32));
+
+            if (!Interop.mincore.LockFile(_handle, positionLow, positionHigh, lengthLow, lengthHigh))
+            {
+                throw Win32Marshal.GetExceptionForLastWin32Error();
+            }
+        }
+
+        public override void Unlock(long position, long length)
+        {
+            if (_handle.IsClosed)
+            {
+                throw Error.GetFileNotOpen();
+            }
+
+            int positionLow = unchecked((int)(position));
+            int positionHigh = unchecked((int)(position >> 32));
+            int lengthLow = unchecked((int)(length));
+            int lengthHigh = unchecked((int)(length >> 32));
+
+            if (!Interop.mincore.UnlockFile(_handle, positionLow, positionHigh, lengthLow, lengthHigh))
+            {
+                throw Win32Marshal.GetExceptionForLastWin32Error();
+            }
+        }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -45,6 +45,20 @@ namespace System.IO
             }
         }
 
+        public override void ReplaceFile(string sourceFullPath, string destFullPath, string destBackupFullPath, bool ignoreMetadataErrors)
+        {
+            int flags = Interop.mincore.REPLACEFILE_WRITE_THROUGH;
+            if (ignoreMetadataErrors)
+            {
+                flags |= Interop.mincore.REPLACEFILE_IGNORE_MERGE_ERRORS;
+            }
+
+            if (!Interop.mincore.ReplaceFile(destFullPath, sourceFullPath, destBackupFullPath, flags, IntPtr.Zero, IntPtr.Zero))
+            {
+                throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
+            }
+        }
+
         [System.Security.SecuritySafeCritical]
         public override void CreateDirectory(string fullPath)
         {

--- a/src/System.IO.FileSystem/src/System/IO/WinRTFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/WinRTFileStream.cs
@@ -61,6 +61,16 @@ namespace System.IO
                 _innerStream.Flush();
             }
         }
+
+        public override void Lock(long position, long length)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public override void Unlock(long position, long length)
+        {
+            throw new PlatformNotSupportedException();
+        }
         #endregion
 
         #region Stream members

--- a/src/System.IO.FileSystem/src/System/IO/WinRTFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/WinRTFileSystem.cs
@@ -96,6 +96,27 @@ namespace System.IO
             await file.CopyAsync(destFolder, destFileName, overwrite ? NameCollisionOption.ReplaceExisting : NameCollisionOption.FailIfExists).TranslateWinRTTask(sourceFullPath);
         }
 
+        public override void ReplaceFile(string sourceFullPath, string destFullPath, string destBackupFullPath, bool ignoreMetadataErrors)
+        {
+            EnsureBackgroundThread();
+            SynchronousResultOf(ReplaceFileAsync(sourceFullPath, destFullPath, destBackupFullPath, ignoreMetadataErrors));
+        }
+
+        private async Task ReplaceFileAsync(string sourceFullPath, string destFullPath, string destBackupFullPath, bool ignoreMetadataErrors)
+        {
+            // Copy the destination file to a backup.
+            if (destBackupFullPath != null)
+            {
+                await CopyFileAsync(destFullPath, destBackupFullPath, overwrite: true).ConfigureAwait(false);
+            }
+
+            // Then copy the contents of the source file to the destination file.
+            await CopyFileAsync(sourceFullPath, destFullPath, overwrite: true).ConfigureAwait(false);
+
+            // Finally, delete the source file.
+            await DeleteFileAsync(sourceFullPath).ConfigureAwait(false);
+        }
+
         public override void CreateDirectory(string fullPath)
         {
             EnsureBackgroundThread();

--- a/src/System.IO.FileSystem/tests/File/Append.cs
+++ b/src/System.IO.FileSystem/tests/File/Append.cs
@@ -61,7 +61,7 @@ namespace System.IO.Tests
         }
     }
 
-    public class File_AppendAllLines : File_ReadWriteAllLines
+    public class File_AppendAllLines : File_ReadWriteAllLines_Enumerable
     {
         protected override void Write(string path, string[] content)
         {

--- a/src/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
+++ b/src/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class EncryptDecrypt : FileSystemTest
+    {
+        [Fact]
+        public static void NullArg_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>("path", () => File.Encrypt(null));
+            Assert.Throws<ArgumentNullException>("path", () => File.Decrypt(null));
+        }
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [Fact]
+        public static void EncryptDecrypt_NotSupported()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => File.Encrypt("path"));
+            Assert.Throws<PlatformNotSupportedException>(() => File.Decrypt("path"));
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/File/ReadWriteAllLines.netstandard1.7.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadWriteAllLines.netstandard1.7.cs
@@ -10,13 +10,13 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    public class File_ReadWriteAllLines_Enumerable : FileSystemTest
+    public class File_ReadWriteAllLines_StringArray : FileSystemTest
     {
         #region Utilities
 
         protected virtual void Write(string path, string[] content)
         {
-            File.WriteAllLines(path, (IEnumerable<string>)content);
+            File.WriteAllLines(path, content);
         }
 
         protected virtual string[] Read(string path)
@@ -148,11 +148,11 @@ namespace System.IO.Tests
         #endregion
     }
 
-    public class File_ReadWriteAllLines_Enumerable_Encoded : File_ReadWriteAllLines_Enumerable
+    public class File_ReadWriteAllLines_StringArray_Encoded : File_ReadWriteAllLines_StringArray
     {
         protected override void Write(string path, string[] content)
         {
-            File.WriteAllLines(path, (IEnumerable<string>)content, new UTF8Encoding(false));
+            File.WriteAllLines(path, content, new UTF8Encoding(false));
         }
 
         protected override string[] Read(string path)
@@ -164,37 +164,8 @@ namespace System.IO.Tests
         public void NullEncoding()
         {
             string path = GetTestFilePath();
-            Assert.Throws<ArgumentNullException>(() => File.WriteAllLines(path, (IEnumerable<string>)new string[] { "Text" }, null));
+            Assert.Throws<ArgumentNullException>(() => File.WriteAllLines(path, new string[] { "Text" }, null));
             Assert.Throws<ArgumentNullException>(() => File.ReadAllLines(path, null));
-        }
-    }
-
-    public class File_ReadLines : File_ReadWriteAllLines_Enumerable
-    {
-        protected override string[] Read(string path)
-        {
-            return File.ReadLines(path).ToArray();
-        }
-    }
-
-    public class File_ReadLines_Encoded : File_ReadWriteAllLines_Enumerable
-    {
-        protected override void Write(string path, string[] content)
-        {
-            File.WriteAllLines(path, (IEnumerable<string>)content, new UTF8Encoding(false));
-        }
-
-        protected override string[] Read(string path)
-        {
-            return File.ReadLines(path, new UTF8Encoding(false)).ToArray();
-        }
-
-        [Fact]
-        public void NullEncoding()
-        {
-            string path = GetTestFilePath();
-            Assert.Throws<ArgumentNullException>(() => File.WriteAllLines(path, (IEnumerable<string>)new string[] { "Text" }, null));
-            Assert.Throws<ArgumentNullException>(() => File.ReadLines(path, null));
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/File/Replace.cs
+++ b/src/System.IO.FileSystem/tests/File/Replace.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class File_Replace_str_str_str : FileSystemTest
+    {
+        #region Utilities
+
+        public virtual void Replace(string source, string dest, string destBackup)
+        {
+            File.Replace(source, dest, destBackup);
+        }
+
+        public virtual void Replace(string source, string dest, string destBackup, bool ignoreMetadataErrors)
+        {
+            File.Replace(source, dest, destBackup, ignoreMetadataErrors);
+        }
+
+        #endregion
+
+        #region UniversalTests
+
+        [Fact]
+        public void NullFileName()
+        {
+            Assert.Throws<ArgumentNullException>("sourceFileName", () => File.Replace(null, "", ""));
+            Assert.Throws<ArgumentNullException>("destinationFileName", () => File.Replace("", null, ""));
+        }
+
+        [Fact]
+        public void NoBackup_FileCopiedAndDeleted()
+        {
+            string srcPath = GetTestFilePath();
+            string destPath = GetTestFilePath();
+
+            byte[] srcContents = new byte[] { 1, 2, 3, 4, 5 };
+            File.WriteAllBytes(srcPath, srcContents);
+
+            byte[] destContents = new byte[] { 6, 7, 8, 9, 10 };
+            File.WriteAllBytes(destPath, destContents);
+
+            Replace(srcPath, destPath, null);
+
+            Assert.False(File.Exists(srcPath));
+            Assert.Equal(srcContents, File.ReadAllBytes(destPath));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Backup_FileCopiedAndDeleted_DestCopied(bool ignoreMetadataErrors)
+        {
+            string srcPath = GetTestFilePath();
+            string destPath = GetTestFilePath();
+            string destBackupPath = GetTestFilePath();
+
+            byte[] srcContents = new byte[] { 1, 2, 3, 4, 5 };
+            File.WriteAllBytes(srcPath, srcContents);
+
+            byte[] destContents = new byte[] { 6, 7, 8, 9, 10 };
+            File.WriteAllBytes(destPath, destContents);
+
+            Replace(srcPath, destPath, destBackupPath, ignoreMetadataErrors);
+
+            Assert.False(File.Exists(srcPath));
+            Assert.Equal(srcContents, File.ReadAllBytes(destPath));
+            Assert.Equal(destContents, File.ReadAllBytes(destBackupPath));
+        }
+
+        [Fact]
+        public void NonExistentSourcePath()
+        {
+            Assert.Throws<FileNotFoundException>(() => Replace(GetTestFilePath(), GetTestFilePath(), null));
+        }
+
+        [Fact]
+        public void InvalidFileNames()
+        {
+            string testFile = GetTestFilePath();
+            string testFile2 = GetTestFilePath();
+            File.Create(testFile).Dispose();
+
+            Assert.Throws<ArgumentException>(() => Replace(testFile, "\0", null));
+            Assert.Throws<ArgumentException>(() => Replace(testFile, "*\0*", null));
+
+            Assert.Throws<ArgumentException>(() => Replace("*\0*", testFile, null));
+            Assert.Throws<ArgumentException>(() => Replace("\0", testFile, null));
+
+            Assert.Throws<ArgumentException>(() => Replace(testFile, testFile2, "\0"));
+            Assert.Throws<ArgumentException>(() => Replace(testFile, testFile2, "*\0*"));
+        }
+
+        #endregion
+    }
+
+    public class File_Replace_str_str_str_b : File_Replace_str_str_str
+    {
+        #region Utilities
+
+        public override void Replace(string source, string dest, string destBackup)
+        {
+            File.Replace(source, dest, destBackup, false);
+        }
+        
+        #endregion
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileStream/Handle.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Handle.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class FileStream_Handle : FileSystemTest
+    {
+        [Fact]
+        public void Handle_SameAsSafeFileHandle()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create))
+            {
+                Assert.Equal(fs.SafeFileHandle.DangerousGetHandle(), fs.Handle);
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileStream/LockUnlock.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/LockUnlock.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+using XunitPlatformID = Xunit.PlatformID;
+
+namespace System.IO.Tests
+{
+    public class FileStream_LockUnlock : FileSystemTest
+    {
+        [Fact]
+        public void InvalidArgs_Throws()
+        {
+            string path = GetTestFilePath();
+            File.WriteAllBytes(path, new byte[100]);
+
+            using (FileStream fs = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => fs.Lock(-1, 1));
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => fs.Lock(-1, -1));
+                Assert.Throws<ArgumentOutOfRangeException>("length", () => fs.Lock(0, -1));
+
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => fs.Unlock(-1, 1));
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => fs.Unlock(-1, -1));
+                Assert.Throws<ArgumentOutOfRangeException>("length", () => fs.Unlock(0, -1));
+            }
+        }
+
+        [ActiveIssue(5964, XunitPlatformID.AnyUnix)]
+        [Fact]
+        public void FileClosed_Throws()
+        {
+            string path = GetTestFilePath();
+            File.WriteAllBytes(path, new byte[100]);
+
+            FileStream fs = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            fs.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => fs.Lock(0, 1));
+        }
+
+        [ActiveIssue(5964, XunitPlatformID.AnyUnix)]
+        [Theory]
+        [InlineData(100, 0, 100)]
+        [InlineData(200, 0, 100)]
+        [InlineData(200, 50, 150)]
+        [InlineData(200, 100, 100)]
+        [InlineData(20, 2000, 1000)]
+        public void Lock_Unlock_Successful(long fileLength, long position, long length)
+        {
+            string path = GetTestFilePath();
+            File.WriteAllBytes(path, new byte[fileLength]);
+
+            using (FileStream fs = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                fs.Lock(position, length);
+                fs.Unlock(position, length);
+            }
+        }
+
+        [ActiveIssue(5964, XunitPlatformID.AnyUnix)]
+        [Theory]
+        [InlineData(10, 0, 2, 3, 5)]
+        public void NonOverlappingRegions_Success(long fileLength, long firstPosition, long firstLength, long secondPosition, long secondLength)
+        {
+            string path = GetTestFilePath();
+            File.WriteAllBytes(path, new byte[fileLength]);
+
+            using (FileStream fs1 = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (FileStream fs2 = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                // Lock and unlock the respective regions a few times
+                for (int i = 0; i < 2; i++)
+                {
+                    fs1.Lock(firstPosition, firstLength);
+                    fs2.Lock(secondPosition, secondLength);
+                    fs1.Unlock(firstPosition, firstLength);
+                    fs2.Unlock(secondPosition, secondLength);
+                }
+
+                // Then swap and do it again.
+                for (int i = 0; i < 2; i++)
+                {
+                    fs2.Lock(firstPosition, firstLength);
+                    fs1.Lock(secondPosition, secondLength);
+                    fs1.Unlock(secondPosition, secondLength);
+                    fs2.Unlock(firstPosition, firstLength);
+                }
+            }
+        }
+
+        [ActiveIssue(5964, XunitPlatformID.AnyUnix)]
+        [Theory]
+        [InlineData(10, 0, 10, 1, 2)]
+        [InlineData(10, 3, 5, 3, 5)]
+        [InlineData(10, 3, 5, 3, 4)]
+        [InlineData(10, 3, 5, 4, 5)]
+        [InlineData(10, 3, 5, 2, 6)]
+        [InlineData(10, 3, 5, 2, 4)]
+        [InlineData(10, 3, 5, 4, 6)]
+        public void OverlappingRegions_ThrowsException(long fileLength, long firstPosition, long firstLength, long secondPosition, long secondLength)
+        {
+            string path = GetTestFilePath();
+            File.WriteAllBytes(path, new byte[fileLength]);
+
+            using (FileStream fs1 = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (FileStream fs2 = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                fs1.Lock(firstPosition, firstLength);
+                Assert.Throws<IOException>(() => fs2.Lock(secondPosition, secondLength));
+                fs1.Unlock(firstPosition, firstLength);
+
+                fs2.Lock(secondPosition, secondLength);
+                fs2.Unlock(secondPosition, secondLength);
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="FileInfo\Open.cs" />
     <Compile Include="FileStream\FlushAsync.cs" />
     <Compile Include="FileStream\Pipes.cs" />
+    <Compile Include="FileStream\Handle.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="FileStream\SafeFileHandle.cs" />
     <Compile Include="FileStream\IsAsync.cs" />
     <Compile Include="FileStream\CanTimeout.cs" />
@@ -70,6 +71,7 @@
     <Compile Include="FileStream\ReadByte.cs" />
     <Compile Include="FileStream\SetLength.cs" />
     <Compile Include="FileStream\Length.cs" />
+    <Compile Include="FileStream\LockUnlock.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="FileStream\Position.cs" />
     <Compile Include="FileStream\Seek.cs" />
     <Compile Include="FileStream\ctor_sfh_fa_buffer_async.cs" />
@@ -85,10 +87,13 @@
     <Compile Include="FileStream\ctor_str_fm_fa.cs" />
     <Compile Include="FileStream\ctor_str_fm.cs" />
     <Compile Include="File\Append.cs" />
+    <Compile Include="File\EncryptDecrypt.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
+    <Compile Include="File\Replace.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="File\Create.cs" />
     <Compile Include="File\Delete.cs" />
     <Compile Include="File\GetSetAttributes.cs" />
     <Compile Include="File\Move.cs" />
+    <Compile Include="File\ReadWriteAllLines.netstandard1.7.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="File\ReadWriteAllText.cs" />
     <Compile Include="File\ReadWriteAllLines.cs" />
     <Compile Include="UnseekableFileStream.cs" />


### PR DESCRIPTION
Adds:
- File.WriteAllLines(string, string[])
- File.WriteAllLines(string, string[], Encoding)
- File.Replace(string, string, string)
- File.Replace(string, string, string, bool)
- File.Encrypt(string)
- File.Decrypt(string)
- FileInfo.Encrypt()
- FileInfo.Decrypt()
- FileStream.Handle
- FileStream.Lock(long, long)
- FileStream.Unlock(long, long)

Currently throws PlatformNotSupportedException from:
- Encrypt/Decrypt on all platforms.  These can be implemented on Win32, but the APIs needed are not currently exposed as allowed in buildtools.
- Lock/Unlock on Unix and WinRT.  These can be implemented on Unix; I just didn't in this commit.

Contributes to:
https://github.com/dotnet/corefx/issues/5964
https://github.com/dotnet/corefx/issues/9465
https://github.com/dotnet/corefx/issues/11128

cc: @JeremyKuhne, @ianhays, @danmosemsft, @ericstj