### PR TITLE
Use ArrayPool in FileStream.CopyToAsync

### DIFF
--- a/src/System.IO.FileSystem/src/netcore50/project.json
+++ b/src/System.IO.FileSystem/src/netcore50/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
+    "System.Buffers": "4.0.0",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.IO.FileSystem/src/project.json
+++ b/src/System.IO.FileSystem/src/project.json
@@ -3,6 +3,7 @@
     "netstandard1.3": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Buffers": "4.0.0",
         "System.Collections": "4.0.10",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.IO.FileSystem/src/win/project.json
+++ b/src/System.IO.FileSystem/src/win/project.json
@@ -3,6 +3,7 @@
     "netstandard1.3": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Buffers": "4.0.0",
         "System.Collections": "4.0.10",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",


### PR DESCRIPTION
Rather than allocating a new buffer in CopyToAsync, take one from the shared array pool.  This drastically reduces the memory allocation from a FileStream.CopyToAsync operation, and helps to improve throughput as a result.  In one microbenchmark that repeatedly copied an 80K file with CopyToAsync's default args (80K was chosen as that's the default buffer size used), throughput increased by 20% and gen0 GCs decreased by 100x.

cc: @JeremyKuhne, @ianhays, @weshaggard, @jkotas, @davidfowl 