### PR TITLE
Add DSACryptoServiceProvider to Csp assembly

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1870,7 +1870,8 @@
       "BaselineVersion": "4.0.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
-        "4.0.1.0": "4.3.0"
+        "4.0.1.0": "4.3.0",
+        "4.1.0.0": "4.3.0"
       }
     },
     "System.Security.Cryptography.Encoding": {

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAFactory.cs
@@ -8,6 +8,7 @@ namespace System.Security.Cryptography.Dsa.Tests
     {
         DSA Create();
         DSA Create(int keySize);
+        bool SupportsFips186_3 { get; }
     }
 
     public static partial class DSAFactory
@@ -20,6 +21,18 @@ namespace System.Security.Cryptography.Dsa.Tests
         public static DSA Create(int keySize)
         {
             return s_provider.Create(keySize);
+        }
+
+        /// <summary>
+        /// If false, 186-2 is assumed which implies key size of 1024 or less and only SHA-1
+        /// If true, 186-3 includes support for keysizes >1024 and SHA-2 algorithms
+        /// </summary>
+        public static bool SupportsFips186_3
+        {
+            get
+            {
+                return s_provider.SupportsFips186_3;
+            }
         }
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAImportExport.cs
@@ -65,6 +65,26 @@ namespace System.Security.Cryptography.Dsa.Tests
             }
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void ImportRoundTrip(bool includePrivate)
+        {
+            DSAParameters imported = DSATestData.GetDSA1024Params();
+
+            using (DSA dsa = DSAFactory.Create())
+            {
+                dsa.ImportParameters(imported);
+                DSAParameters exported = dsa.ExportParameters(includePrivate);
+                using (DSA dsa2 = DSAFactory.Create())
+                {
+                    dsa2.ImportParameters(exported);
+                    DSAParameters exported2 = dsa2.ExportParameters(includePrivate);
+                    AssertKeyEquals(ref exported, ref exported2);
+                }
+            }
+        }
+
         internal static void AssertKeyEquals(ref DSAParameters expected, ref DSAParameters actual)
         {
             Assert.Equal(expected.G, actual.G);

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -41,7 +41,7 @@ namespace System.Security.Cryptography.Dsa.Tests
             SignAndVerify(DSATestData.HelloBytes, "SHA1", DSATestData.GetDSA1024Params(), 40);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsFips186_3))]
         public static void SignAndVerifyDataExplicit2048()
         {
             SignAndVerify(DSATestData.HelloBytes, "SHA256", DSATestData.GetDSA2048Params(), 64);
@@ -106,6 +106,14 @@ namespace System.Security.Cryptography.Dsa.Tests
                 Assert.Equal(expectedSignatureLength, signature.Length);
                 bool signatureMatched = dsa.VerifyData(data, signature, new HashAlgorithmName(hashAlgorithmName));
                 Assert.True(signatureMatched);
+            }
+        }
+
+        static internal bool SupportsFips186_3
+        {
+            get
+            {
+                return DSAFactory.SupportsFips186_3;
             }
         }
     }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.cpp
@@ -126,7 +126,10 @@ extern "C" int32_t CryptoNative_GetDsaParameters(
     *q = dsa->q; *qLength = BN_num_bytes(*q);
     *g = dsa->g; *gLength = BN_num_bytes(*g);
     *y = dsa->pub_key; *yLength = BN_num_bytes(*y);
-    *x = dsa->priv_key; *xLength = BN_num_bytes(*x);
+
+    // dsa->priv_key is optional
+    *x = dsa->priv_key;
+    *xLength = (*x == nullptr) ? 0 : BN_num_bytes(*x);
 
     return 1;
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
@@ -17,6 +17,14 @@ namespace System.Security.Cryptography.Dsa.Tests
             dsa.KeySize = keySize;
             return dsa;
         }
+
+        public bool SupportsFips186_3
+        {
+            get
+            {
+                return true;
+            }
+        }
     }
 
     public partial class DSAFactory

--- a/src/System.Security.Cryptography.Cng/tests/DSACngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/DSACngProvider.cs
@@ -15,6 +15,14 @@ namespace System.Security.Cryptography.Dsa.Tests
         {
             return new DSACng(keySize);
         }
+
+        public bool SupportsFips186_3
+        {
+            get
+            {
+                return true;
+            }
+        }
     }
 
     public partial class DSAFactory

--- a/src/System.Security.Cryptography.Csp/dir.props
+++ b/src/System.Security.Cryptography.Csp/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>
 

--- a/src/System.Security.Cryptography.Csp/pkg/System.Security.Cryptography.Csp.pkgproj
+++ b/src/System.Security.Cryptography.Csp/pkg/System.Security.Cryptography.Csp.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Csp.csproj">
-      <SupportedFramework>net46;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Csp.builds" />
     <NotSupportedOnTargetFramework Include="netcore50">

--- a/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.cs
+++ b/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.cs
@@ -5,7 +5,6 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System.Security.Cryptography
 {
     public sealed partial class CspKeyContainerInfo
@@ -50,6 +49,34 @@ namespace System.Security.Cryptography
         UseNonExportableKey = 4,
         UseUserProtectedKey = 32,
     }
+    public sealed partial class DSACryptoServiceProvider : System.Security.Cryptography.DSA, System.Security.Cryptography.ICspAsymmetricAlgorithm
+    {
+        public DSACryptoServiceProvider() { }
+        public DSACryptoServiceProvider(int dwKeySize) { }
+        public DSACryptoServiceProvider(int dwKeySize, System.Security.Cryptography.CspParameters parameters) { }
+        public DSACryptoServiceProvider(System.Security.Cryptography.CspParameters parameters) { }
+        public System.Security.Cryptography.CspKeyContainerInfo CspKeyContainerInfo { get { return default(System.Security.Cryptography.CspKeyContainerInfo); } }
+        public override int KeySize { get { return default(int); } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
+        public bool PersistKeyInCsp { get { return default(bool); } set { } }
+        public bool PublicOnly { get { return default(bool); } }
+        public static bool UseMachineKeyStore { get { return default(bool); } set { } }
+        public override byte[] CreateSignature(byte[] rgbHash) { return default(byte[]); }
+        protected override void Dispose(bool disposing) { }
+        public byte[] ExportCspBlob(bool includePrivateParameters) { return default(byte[]); }
+        public override System.Security.Cryptography.DSAParameters ExportParameters(bool includePrivateParameters) { return default(System.Security.Cryptography.DSAParameters); }
+        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
+        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
+        public void ImportCspBlob(byte[] keyBlob) { }
+        public override void ImportParameters(System.Security.Cryptography.DSAParameters parameters) { }
+        public byte[] SignData(byte[] buffer) { return default(byte[]); }
+        public byte[] SignData(byte[] buffer, int offset, int count) { return default(byte[]); }
+        public byte[] SignData(System.IO.Stream inputStream) { return default(byte[]); }
+        public byte[] SignHash(byte[] rgbHash, string str) { return default(byte[]); }
+        public bool VerifyData(byte[] rgbData, byte[] rgbSignature) { return default(bool); }
+        public bool VerifyHash(byte[] rgbHash, string str, byte[] rgbSignature) { return default(bool); }
+        public override bool VerifySignature(byte[] rgbHash, byte[] rgbSignature) { return default(bool); }
+    }
     public partial interface ICspAsymmetricAlgorithm
     {
         System.Security.Cryptography.CspKeyContainerInfo CspKeyContainerInfo { get; }
@@ -69,6 +96,7 @@ namespace System.Security.Cryptography
         public RSACryptoServiceProvider(System.Security.Cryptography.CspParameters parameters) { }
         public System.Security.Cryptography.CspKeyContainerInfo CspKeyContainerInfo { get { return default(System.Security.Cryptography.CspKeyContainerInfo); } }
         public override int KeySize { get { return default(int); } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
         public bool PersistKeyInCsp { get { return default(bool); } set { } }
         public bool PublicOnly { get { return default(bool); } }
         public static bool UseMachineKeyStore { get { return default(bool); } set { } }
@@ -83,7 +111,6 @@ namespace System.Security.Cryptography
         protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
         public void ImportCspBlob(byte[] keyBlob) { }
         public override void ImportParameters(System.Security.Cryptography.RSAParameters parameters) { }
-        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
         public byte[] SignData(byte[] buffer, int offset, int count, object halg) { return default(byte[]); }
         public byte[] SignData(byte[] buffer, object halg) { return default(byte[]); }
         public byte[] SignData(System.IO.Stream inputStream, object halg) { return default(byte[]); }

--- a/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.Csp.cs" />

--- a/src/System.Security.Cryptography.Csp/ref/project.json
+++ b/src/System.Security.Cryptography.Csp/ref/project.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.0",
-    "System.IO": "4.0.0",
-    "System.Security.Cryptography.Algorithms": "4.2.0",
-    "System.Security.Cryptography.Primitives": "4.0.0"
+    "System.IO": "4.3.0-beta-devapi-24513-01",
+    "System.Runtime": "4.3.0-beta-devapi-24513-01",
+    "System.Security.Cryptography.Algorithms": "4.3.0-beta-devapi-24513-01",
+    "System.Security.Cryptography.Primitives": "4.3.0-beta-devapi-24513-01"
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "imports": [
-        "dotnet5.4"
+        "dotnet5.8"
       ]
     }
   }

--- a/src/System.Security.Cryptography.Csp/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Csp/src/Resources/Strings.resx
@@ -183,8 +183,14 @@
   <data name="Cryptography_InvalidCipherMode" xml:space="preserve">
     <value>Specified cipher mode is not valid for this algorithm.</value>
   </data>
+  <data name="Cryptography_InvalidDSASignatureSize" xml:space="preserve">
+    <value>Length of the DSA signature was not 40 bytes.</value>
+  </data>
   <data name="Cryptography_InvalidFeedbackSize" xml:space="preserve">
     <value>Specified feedback size is invalid.</value>
+  </data>
+  <data name="Cryptography_InvalidHashSize" xml:space="preserve">
+    <value>{0} algorithm hash size is {1} bytes.</value>
   </data>
   <data name="Cryptography_InvalidIVSize" xml:space="preserve">
     <value>Specified initialization vector (IV) does not match the block size for this algorithm.</value>

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.builds
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.builds
@@ -10,9 +10,8 @@
     </Project>
     <Project Include="System.Security.Cryptography.Csp.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TargetGroup>net46</TargetGroup>
+      <TargetGroup>net463</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -6,14 +6,14 @@
     <ProjectGuid>{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}</ProjectGuid>
     <AssemblyName>System.Security.Cryptography.Csp</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
-    <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
+    <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net463'">None</ResourcesSourceOutputDirectory>
     <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net463' AND '$(TargetsWindows)' == 'true'">
     <Compile Include="System\Security\Cryptography\CspProviderFlags.cs" />
     <Compile Include="System\Security\Cryptography\ICspAsymmetricAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\KeyNumber.cs" />
@@ -21,8 +21,10 @@
       <Link>Common\Interop\Windows\Crypt32\Interop.FindOidInfo.cs</Link>
     </Compile>
     <Compile Include="System\Security\Cryptography\CapiHelper.cs" />
+    <Compile Include="System\Security\Cryptography\CapiHelper.DSA.cs" />
     <Compile Include="System\Security\Cryptography\CspKeyContainerInfo.cs" />
     <Compile Include="System\Security\Cryptography\CspParameters.cs" />
+    <Compile Include="System\Security\Cryptography\DSACryptoServiceProvider.cs" />
     <Compile Include="System\Security\Cryptography\RSACryptoServiceProvider.cs" />
     <Compile Include="System\Security\Cryptography\SafeCryptoHandles.cs" />
     <Compile Include="System\Security\Cryptography\Utils.cs" />
@@ -43,7 +45,7 @@
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.DSA.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.DSA.cs
@@ -1,0 +1,398 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Cryptography;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Internal.NativeCrypto
+{
+    internal static partial class CapiHelper
+    {
+        // Provider type to use by default for DSS operations.
+        internal const int DefaultDssProviderType = (int)ProviderType.PROV_DSS_DH;
+
+        internal const int DSS_MAGIC = 0x31535344;          // Encoding of "DSS1"
+        internal const int DSS_PRIVATE_MAGIC = 0x32535344;  // Encoding of "DSS2"
+        internal const int DSS_PUB_MAGIC_VER3 = 0x33535344; // Encoding of "DSS3"
+        internal const int DSS_PRIV_MAGIC_VER3 = 0x34535344;// Encoding of "DSS4"
+
+        private const int DSS_Q_LEN = 20;
+
+        /// <summary>
+        /// Check to see if a better CSP than the one requested is available
+        /// DSS providers are supersets of each other in the following order:
+        ///    1. MS_ENH_DSS_DH_PROV
+        ///    2. MS_DEF_DSS_DH_PROV
+        ///
+        /// This will return the best provider which is a superset of wszProvider,
+        /// or NULL if there is no upgrade available on the machine.
+        /// </summary>
+        /// <param name="dwProvType">provider type</param>
+        /// <param name="wszProvider">provider name</param>
+        /// <returns>Returns upgrade CSP name</returns>
+        public static string UpgradeDSS(int dwProvType, string wszProvider)
+        {
+            string wszUpgrade = null;
+            if (string.Equals(wszProvider, MS_DEF_DSS_DH_PROV, StringComparison.Ordinal))
+            {
+                SafeProvHandle safeProvHandle;
+                // If this is the base DSS/DH provider, see if we can use the enhanced provider instead.
+                if (S_OK == AcquireCryptContext(out safeProvHandle,
+                    null,
+                    MS_ENH_DSS_DH_PROV,
+                    dwProvType,
+                    (uint)CryptAcquireContextFlags.CRYPT_VERIFYCONTEXT))
+                {
+                    wszUpgrade = MS_ENH_DSS_DH_PROV;
+                }
+                safeProvHandle.Dispose();
+            }
+            return wszUpgrade;
+        }
+
+        /// <summary>
+        /// Helper for DsaCryptoServiceProvider.ImportParameters()
+        /// </summary>
+        internal static byte[] ToKeyBlob(this DSAParameters dsaParameters)
+        {
+            const int NTE_BAD_DATA = unchecked((int)CryptKeyError.NTE_BAD_DATA);
+
+            // Validate the DSA structure first
+            // P and Q are required. Q is a 160 bit divisor of P-1.
+            if (dsaParameters.P == null || dsaParameters.P.Length == 0 || dsaParameters.Q == null || dsaParameters.Q.Length != DSS_Q_LEN)
+                throw NTE_BAD_DATA.ToCryptographicException();
+
+            // G is required. G is an element of Z_p
+            if (dsaParameters.G == null || dsaParameters.G.Length != dsaParameters.P.Length)
+                throw NTE_BAD_DATA.ToCryptographicException();
+
+            // If J is present, it should be less than the size of P: J = (P-1) / Q
+            // This is only a sanity check. Not doing it here is not really an issue as CAPI will fail.
+            if (dsaParameters.J != null && dsaParameters.J.Length >= dsaParameters.P.Length)
+                throw NTE_BAD_DATA.ToCryptographicException();
+
+            // Y is present for V3 DSA key blobs, Y = g^j mod P
+            if (dsaParameters.Y != null && dsaParameters.Y.Length != dsaParameters.P.Length)
+                throw NTE_BAD_DATA.ToCryptographicException();
+
+            // The seed is always a 20 byte array
+            if (dsaParameters.Seed != null && dsaParameters.Seed.Length != 20)
+                throw NTE_BAD_DATA.ToCryptographicException();
+
+            bool isPrivate = (dsaParameters.X != null && dsaParameters.X.Length > 0);
+
+            // The private key should be the same length as Q
+            if (isPrivate && dsaParameters.X.Length != DSS_Q_LEN)
+                throw NTE_BAD_DATA.ToCryptographicException();
+
+            uint bitLenP = (uint)dsaParameters.P.Length * 8;
+            uint bitLenJ = dsaParameters.J == null ? 0 : (uint)dsaParameters.J.Length * 8;
+
+            using (var ms = new MemoryStream())
+            using (var bw = new BinaryWriter(ms))
+            {
+                // Write out the BLOBHEADER
+                bool isV3;
+                WriteKeyBlobHeader(dsaParameters, bw, isPrivate, out isV3);
+
+                // Write out the DSA key
+                if (isV3)
+                {
+                    // We need to build a key blob (DSSPUBKEY_VER3 or DSSPRIVKEY_VER3) as follows:
+                    //  DWORD           magic
+                    //  DWORD           bitlenP
+                    //  DWORD           bitlenQ
+                    //  DWORD           bitlenJ
+                    //  DWORD           bitlenX (if private)
+                    //  DWORD           counter (DSSSEED)
+                    //  BYTE[20]        seed (DSSSEED)
+                    //  BYTE[lenP]      P
+                    //  BYTE[lenQ]      Q
+                    //  BYTE[lenP]      G
+                    //  BYTE[lenJ]      J (optional)
+                    //  BYTE[lenP]      Y
+                    //  BYTE[lenX]      X (if private)
+
+                    bw.Write((int)(isPrivate ? DSS_PRIV_MAGIC_VER3 : DSS_PUB_MAGIC_VER3));
+                    bw.Write((uint)(bitLenP));
+                    bw.Write((uint)(dsaParameters.Q.Length * 8));
+                    bw.Write((uint)(bitLenJ));
+
+                    if (isPrivate)
+                    {
+                        bw.Write((uint)dsaParameters.X.Length * 8);
+                    }
+
+                    WriteDSSSeed(dsaParameters, bw);
+
+                    bw.WriteReversed(dsaParameters.P);
+                    bw.WriteReversed(dsaParameters.Q);
+                    bw.WriteReversed(dsaParameters.G);
+
+                    if (bitLenJ != 0)
+                    {
+                        bw.WriteReversed(dsaParameters.J);
+                    }
+
+                    bw.WriteReversed(dsaParameters.Y);
+
+                    if (isPrivate)
+                    {
+                        bw.WriteReversed(dsaParameters.X);
+                    }
+                }
+                else
+                {
+                    // We need to build a key blob as follows:
+                    //  DWORD           magic (DSSPUBKEY)
+                    //  DWORD           bitlen (DSSPUBKEY)
+                    //  BYTE[len]       P
+                    //  BYTE[DSS_Q_LEN] Q
+                    //  BYTE[len]       G
+                    //  BYTE[20]        X (if private)
+                    //  BYTE[len]       Y (if public)
+                    //  DWORD           counter (DSSSEED)
+                    //  BYTE[20]        seed (DSSSEED)
+
+                    bw.Write((int)(isPrivate ? DSS_PRIVATE_MAGIC : DSS_MAGIC));
+                    bw.Write((uint)(bitLenP));
+                    bw.WriteReversed(dsaParameters.P);
+                    bw.WriteReversed(dsaParameters.Q);
+                    bw.WriteReversed(dsaParameters.G);
+
+                    if (isPrivate)
+                    {
+                        bw.WriteReversed(dsaParameters.X);
+                    }
+                    else
+                    {
+                        bw.WriteReversed(dsaParameters.Y);
+                    }
+
+                    WriteDSSSeed(dsaParameters, bw);
+                }
+
+                bw.Flush();
+                byte[] key = ms.ToArray();
+                return key;
+            }
+        }
+
+        /// <summary>
+        /// Helper for DSACryptoServiceProvider.ExportParameters()
+        /// </summary>
+        internal static DSAParameters ToDSAParameters(this byte[] cspBlob, bool includePrivateParameters, SafeKeyHandle safeKeyHandle)
+        {
+            try
+            {
+                using (var ms = new MemoryStream(cspBlob))
+                using (var br = new BinaryReader(ms))
+                {
+                    byte bVersion;
+                    ReadKeyBlobHeader(br, out bVersion);
+
+                    DSAParameters dsaParameters = new DSAParameters();
+
+                    if (bVersion > 2)
+                    {
+                        // We need to read a key blob (DSSPUBKEY_VER3 or DSSPRIVKEY_VER3) as follows:
+                        //  DWORD           magic
+                        //  DWORD           bitlenP
+                        //  DWORD           bitlenQ
+                        //  DWORD           bitlenJ
+                        //  DWORD           bitlenX (if private)
+                        //  DWORD           counter (DSSSEED)
+                        //  BYTE[20]        seed (DSSSEED)
+                        //  BYTE[lenP]      P
+                        //  BYTE[lenQ]      Q
+                        //  BYTE[lenP]      G
+                        //  BYTE[lenJ]      J (optional)
+                        //  BYTE[lenP]      Y
+                        //  BYTE[lenX]      X (if private)
+
+                        int magic = br.ReadInt32(); // Expected to be DSS_PUB_MAGIC_VER3 or DSS_PRIV_MAGIC_VER3
+                        int lenP = (br.ReadInt32() + 7) / 8;
+                        int lenQ = (br.ReadInt32() + 7) / 8;
+                        int lenJ = (br.ReadInt32() + 7) / 8;
+
+                        int lenX = 0;
+                        if (includePrivateParameters)
+                        {
+                            lenX = (br.ReadInt32() + 7) / 8;
+                        }
+
+                        ReadDSSSeed(dsaParameters, br, true);
+
+                        dsaParameters.P = br.ReadReversed(lenP);
+                        dsaParameters.Q = br.ReadReversed(lenQ);
+                        dsaParameters.G = br.ReadReversed(lenP);
+
+                        if (lenJ > 0)
+                        {
+                            dsaParameters.J = br.ReadReversed(lenJ);
+                        }
+
+                        dsaParameters.Y = br.ReadReversed(lenP);
+
+                        if (includePrivateParameters)
+                        {
+                            dsaParameters.X = br.ReadReversed(lenX);
+                        }
+                    }
+                    else
+                    {
+                        // We need to read a key blob as follows:
+                        //  DWORD           magic (DSSPUBKEY)
+                        //  DWORD           bitlen (DSSPUBKEY)
+                        //  BYTE[len]       P
+                        //  BYTE[DSS_Q_LEN] Q
+                        //  BYTE[len]       G
+                        //  BYTE[20]        X (if private)
+                        //  BYTE[len]       Y (if public)
+                        //  DWORD           counter (DSSSEED)
+                        //  BYTE[20]        seed (DSSSEED)
+
+                        int magic = br.ReadInt32();    // Expected to be DSS_MAGIC or DSS_PRIVATE_MAGIC
+                        int len = (br.ReadInt32() + 7) / 8;
+                        dsaParameters.P = br.ReadReversed(len);
+                        dsaParameters.Q = br.ReadReversed(DSS_Q_LEN);
+                        dsaParameters.G = br.ReadReversed(len);
+
+                        long keyLocation = 0;
+                        if (includePrivateParameters)
+                        {
+                            // Save the position of the stream for later access to Y.
+                            keyLocation = br.BaseStream.Position;
+                            dsaParameters.X = br.ReadReversed(20);
+                        }
+                        else
+                            dsaParameters.Y = br.ReadReversed(len);
+
+                        ReadDSSSeed(dsaParameters, br, false);
+
+                        if (includePrivateParameters)
+                        {
+                            // Since DSSPUBKEY key is used for both public and private keys, we got X
+                            // but not Y. To get Y, do another export and ask for public key blob.
+                            byte[] cspPublicBlob = ExportKeyBlob(false, safeKeyHandle);
+
+                            using (var msPublicBlob = new MemoryStream(cspPublicBlob))
+                            using (var brPublicBlob = new BinaryReader(msPublicBlob))
+                            {
+                                brPublicBlob.BaseStream.Position = keyLocation;
+                                dsaParameters.Y = brPublicBlob.ReadReversed(len);
+                            }
+                        }
+                    }
+
+                    return dsaParameters;
+                }
+            }
+            catch (EndOfStreamException)
+            {
+                // For compat reasons, we throw an E_FAIL CrytoException if CAPI returns a smaller blob than expected.
+                // For compat reasons, we ignore the extra bits if the CAPI returns a larger blob than expected.
+                throw E_FAIL.ToCryptographicException();
+            }
+        }
+
+        private static void ReadKeyBlobHeader(BinaryReader br, out byte bVersion)
+        {
+            // The format of BLOBHEADER (or PUBLICKEYSTRUC):
+            //  BYTE   bType
+            //  BYTE   bVersion
+            //  WORD   reserved
+            //  ALG_ID aiKeyAlg
+
+            byte bType = br.ReadByte();    // BLOBHEADER.bType: Expected to be 0x6 (PUBLICKEYBLOB) or 0x7 (PRIVATEKEYBLOB), though there's no check for backward compat reasons.
+            bVersion = br.ReadByte();      // BLOBHEADER.bVersion: Expected to be 0x2 or 0x3, though there's no check for backward compat reasons.
+            br.BaseStream.Position += sizeof(ushort); // BLOBHEADER.wReserved
+            int algId = br.ReadInt32();    // BLOBHEADER.aiKeyAlg
+            if (algId != CALG_DSS_SIGN)
+                throw new PlatformNotSupportedException();
+        }
+
+        private static void WriteKeyBlobHeader(DSAParameters dsaParameters, BinaryWriter bw, bool isPrivate, out bool isV3)
+        {
+            // Write out the BLOBHEADER (or PUBLICKEYSTRUC).
+            isV3 = false;
+
+            // If Y is present and this is a private key, 
+            // or Y and J are present and this is a public key, this should be a v3 blob.
+            byte version = BLOBHEADER_CURRENT_BVERSION;
+            if (((dsaParameters.Y != null) && isPrivate) ||
+                ((dsaParameters.Y != null) && (dsaParameters.J != null)))
+            {
+                Debug.Assert(dsaParameters.Y.Length > 0);
+                isV3 = true;
+                version = 0x3;
+            }
+            bw.Write((byte)(isPrivate ? PRIVATEKEYBLOB : PUBLICKEYBLOB));  // BLOBHEADER.bType
+            bw.Write((byte)version);                                       // BLOBHEADER.bVersion
+            bw.Write((ushort)0);                                           // BLOBHEADER.wReserved
+            bw.Write((int)CapiHelper.CALG_DSS_SIGN);                       // BLOBHEADER.aiKeyAlg
+        }
+
+        private static void ReadDSSSeed(DSAParameters dsaParameters, BinaryReader br, bool isV3)
+        {
+            bool hasSeed = false;
+            int counter = br.ReadInt32();
+
+            if (isV3)
+            {
+                hasSeed = (unchecked((uint)counter != 0xFFFFFFFF));
+            }
+            else
+            {
+                // This compares > 0 for backwards compatibility, and not just 0xFFFFFFFF
+                hasSeed = (counter > 0); // Does not include 0xFFFFFFFF which is signed value of -1
+            }
+
+            if (hasSeed)
+            {
+                dsaParameters.Counter = counter;
+                dsaParameters.Seed = br.ReadReversed(20);
+            }
+            else
+            {
+                dsaParameters.Counter = 0;
+                dsaParameters.Seed = null;
+                br.BaseStream.Position += 20; // Advance past seed[20]
+            }
+        }
+
+        private static void WriteDSSSeed(DSAParameters dsaParameters, BinaryWriter bw)
+        {
+            if (dsaParameters.Seed == null || dsaParameters.Seed.Length == 0)
+            {
+                bw.Write(0xFFFFFFFF); // counter
+
+                // seed[20] needs to be all 0xFF
+                for (int i = 0; i < 20; i += sizeof(uint))
+                {
+                    bw.Write(0xFFFFFFFF);
+                }
+            }
+            else
+            {
+                bw.Write((int)dsaParameters.Counter);
+                bw.WriteReversed(dsaParameters.Seed);
+            }
+        }
+
+        private static void ReverseDsaSignature(byte[] signature, int cbSignature)
+        {
+            // A DSA signature consists of two 20-byte components, each of which
+            // must be reversed in place.
+            if (cbSignature != 40)
+                throw new CryptographicException(SR.Cryptography_InvalidDSASignatureSize);
+
+            Array.Reverse(signature, 0, 20);
+            Array.Reverse(signature, 20, 20);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Cryptography;
+using Microsoft.Win32.SafeHandles;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.IO;
@@ -11,13 +12,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
-
-using Internal.Cryptography;
-using Microsoft.Win32.SafeHandles;
-
 using static Interop.Crypt32;
-
 using Libraries = Interop.Libraries;
 
 namespace Internal.NativeCrypto
@@ -27,35 +22,6 @@ namespace Internal.NativeCrypto
     /// </summary>
     internal static partial class CapiHelper
     {
-        /// <summary>
-        /// / Check to see if a better CSP than the one requested is available
-        /// DSS providers are supersets of each other in the following order:
-        ///    1. MS_ENH_DSS_DH_PROV
-        ///    2. MS_DEF_DSS_DH_PROV
-        ///
-        /// This will return the best provider which is a superset of wszProvider,
-        /// or NULL if there is no upgrade available on the machine.
-        /// </summary>
-        /// <param name="dwProvType">provider type</param>
-        /// <param name="wszProvider">provider name</param>
-        /// <returns>Returns upgrade CSP name</returns>
-        public static string UpgradeDSS(int dwProvType, string wszProvider)
-        {
-            string wszUpgrade = null;
-            if (string.Equals(wszProvider, MS_DEF_DSS_DH_PROV, StringComparison.Ordinal))
-            {
-                SafeProvHandle safeProvHandle;
-                // If this is the base DSS/DH provider, see if we can use the enhanced provider instead.
-                if (S_OK == AcquireCryptContext(out safeProvHandle, null, MS_ENH_DSS_DH_PROV, dwProvType,
-                                        (uint)CryptAcquireContextFlags.CRYPT_VERIFYCONTEXT))
-                {
-                    wszUpgrade = MS_ENH_DSS_DH_PROV;
-                }
-                safeProvHandle.Dispose();
-            }
-            return wszUpgrade;
-        }
-
         /// <summary>
         /// Check to see if a better CSP than the one requested is available
         /// RSA providers are supersets of each other in the following order:
@@ -627,7 +593,7 @@ namespace Internal.NativeCrypto
             if (userParameters == null)
             {
                 parameters = new CspParameters(keyType == CspAlgorithmType.Dss ?
-                                                (int)ProviderType.PROV_DSS_DH : DefaultRsaProviderType,
+                                                DefaultDssProviderType : DefaultRsaProviderType,
                                                 null, null, defaultFlags);
             }
             else
@@ -1273,8 +1239,8 @@ namespace Internal.NativeCrypto
                         break;
 
                     case CALG_DSS_SIGN:
-                        throw new PlatformNotSupportedException();
-
+                        ReverseDsaSignature(signature, cbSignature);
+                        break;
                     default:
                         throw new InvalidOperationException();
                 }
@@ -1295,7 +1261,9 @@ namespace Internal.NativeCrypto
                     break;
 
                 case CALG_DSS_SIGN:
-                    throw new PlatformNotSupportedException();
+                    signature = signature.CloneByteArray();
+                    ReverseDsaSignature(signature, signature.Length);
+                    break;
 
                 default:
                     throw new InvalidOperationException();

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.cs
@@ -1,0 +1,508 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.NativeCrypto;
+using System.Diagnostics;
+using System.IO;
+
+namespace System.Security.Cryptography
+{
+    public sealed class DSACryptoServiceProvider : DSA, ICspAsymmetricAlgorithm
+    {
+        private int _keySize;
+        private readonly CspParameters _parameters;
+        private readonly bool _randomKeyContainer;
+        private SafeKeyHandle _safeKeyHandle;
+        private SafeProvHandle _safeProvHandle;
+        private SHA1 _sha1;
+        private static volatile CspProviderFlags s_useMachineKeyStore = 0;
+
+        /// <summary>
+        /// Initializes a new instance of the DSACryptoServiceProvider class.
+        /// </summary>
+        public DSACryptoServiceProvider()
+            : this(
+                  new CspParameters(CapiHelper.DefaultDssProviderType,
+                      null,
+                      null,
+                      s_useMachineKeyStore))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the DSACryptoServiceProvider class with the specified key size.
+        /// </summary>
+        /// <param name="dwKeySize">The size of the key for the asymmetric algorithm in bits.</param>
+        public DSACryptoServiceProvider(int dwKeySize)
+            : this(dwKeySize,
+                  new CspParameters(CapiHelper.DefaultDssProviderType,
+                      null,
+                      null,
+                      s_useMachineKeyStore))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the DSACryptoServiceProvider class with the specified parameters
+        /// for the cryptographic service provider (CSP).
+        /// </summary>
+        /// <param name="parameters">The parameters for the CSP.</param>
+        public DSACryptoServiceProvider(CspParameters parameters)
+            : this(0, parameters)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the DSACryptoServiceProvider class with the specified key size and parameters
+        /// for the cryptographic service provider (CSP).
+        /// </summary>
+        /// <param name="dwKeySize">The size of the key for the cryptographic algorithm in bits.</param>
+        /// <param name="parameters">The parameters for the CSP.</param>
+        public DSACryptoServiceProvider(int dwKeySize, CspParameters parameters)
+        {
+            if (dwKeySize < 0)
+                throw new ArgumentOutOfRangeException(nameof(dwKeySize), SR.ArgumentOutOfRange_NeedNonNegNum);
+
+            _parameters = CapiHelper.SaveCspParameters(
+                CapiHelper.CspAlgorithmType.Dss,
+                parameters,
+                s_useMachineKeyStore,
+                out _randomKeyContainer);
+
+            _keySize = dwKeySize;
+            _sha1 = SHA1.Create();
+
+            // If this is not a random container we generate, create it eagerly 
+            // in the constructor so we can report any errors now.
+            if (!_randomKeyContainer)
+            {
+                // Force-read the SafeKeyHandle property, which will summon it into existence.
+                SafeKeyHandle localHandle = SafeKeyHandle;
+                Debug.Assert(localHandle != null);
+            }
+        }
+
+        private SafeProvHandle SafeProvHandle
+        {
+            get
+            {
+                if (_safeProvHandle == null)
+                {
+                    lock (_parameters)
+                    {
+                        if (_safeProvHandle == null)
+                        {
+                            SafeProvHandle hProv = CapiHelper.CreateProvHandle(_parameters, _randomKeyContainer);
+
+                            Debug.Assert(hProv != null);
+                            Debug.Assert(!hProv.IsInvalid);
+                            Debug.Assert(!hProv.IsClosed);
+
+                            _safeProvHandle = hProv;
+                        }
+                    }
+
+                    return _safeProvHandle;
+                }
+
+                return _safeProvHandle;
+            }
+            set
+            {
+                lock (_parameters)
+                {
+                    SafeProvHandle current = _safeProvHandle;
+
+                    if (ReferenceEquals(value, current))
+                    {
+                        return;
+                    }
+
+                    if (current != null)
+                    {
+                        SafeKeyHandle keyHandle = _safeKeyHandle;
+                        _safeKeyHandle = null;
+                        keyHandle?.Dispose();
+                        current.Dispose();
+                    }
+
+                    _safeProvHandle = value;
+                }
+            }
+        }
+
+        private SafeKeyHandle SafeKeyHandle
+        {
+            get
+            {
+                if (_safeKeyHandle == null)
+                {
+                    lock (_parameters)
+                    {
+                        if (_safeKeyHandle == null)
+                        {
+                            SafeKeyHandle hKey = CapiHelper.GetKeyPairHelper(
+                                CapiHelper.CspAlgorithmType.Dss,
+                                _parameters,
+                                _keySize,
+                                SafeProvHandle);
+
+                            Debug.Assert(hKey != null);
+                            Debug.Assert(!hKey.IsInvalid);
+                            Debug.Assert(!hKey.IsClosed);
+
+                            _safeKeyHandle = hKey;
+                        }
+                    }
+                }
+
+                return _safeKeyHandle;
+            }
+
+            set
+            {
+                lock (_parameters)
+                {
+                    SafeKeyHandle current = _safeKeyHandle;
+
+                    if (ReferenceEquals(value, current))
+                    {
+                        return;
+                    }
+
+                    _safeKeyHandle = value;
+                    current?.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets a CspKeyContainerInfo object that describes additional information about a cryptographic key pair.
+        /// </summary>
+        public CspKeyContainerInfo CspKeyContainerInfo
+        {
+            get
+            {
+                // Desktop compat: Read the SafeKeyHandle property to force the key to load,
+                // because it might throw here.
+                SafeKeyHandle localHandle = SafeKeyHandle;
+                Debug.Assert(localHandle != null);
+
+                return new CspKeyContainerInfo(_parameters, _randomKeyContainer);
+            }
+        }
+
+        public override int KeySize
+        {
+            get
+            {
+                byte[] keySize = CapiHelper.GetKeyParameter(SafeKeyHandle, Constants.CLR_KEYLEN);
+                _keySize = (keySize[0] | (keySize[1] << 8) | (keySize[2] << 16) | (keySize[3] << 24));
+                return _keySize;
+            }
+        }
+
+        public override KeySizes[] LegalKeySizes
+        {
+            get
+            {
+                return new[] { new KeySizes(512, 1024, 64) }; // per FIPS 186-2
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the key should be persisted in the cryptographic
+        /// service provider (CSP).
+        /// </summary>
+        public bool PersistKeyInCsp
+        {
+            get
+            {
+                return CapiHelper.GetPersistKeyInCsp(SafeProvHandle);
+            }
+            set
+            {
+                bool oldPersistKeyInCsp = this.PersistKeyInCsp;
+                if (value == oldPersistKeyInCsp)
+                {
+                    return; // Do nothing
+                }
+                CapiHelper.SetPersistKeyInCsp(SafeProvHandle, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether the DSACryptoServiceProvider object contains
+        /// only a public key.
+        /// </summary>
+        public bool PublicOnly
+        {
+            get
+            {
+                byte[] publicKey = CapiHelper.GetKeyParameter(SafeKeyHandle, Constants.CLR_PUBLICKEYONLY);
+                return (publicKey[0] == 1);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the key should be persisted in the computer's
+        /// key store instead of the user profile store.
+        /// </summary>
+        public static bool UseMachineKeyStore
+        {
+            get
+            {
+                return (s_useMachineKeyStore == CspProviderFlags.UseMachineKeyStore);
+            }
+            set
+            {
+                s_useMachineKeyStore = (value ? CspProviderFlags.UseMachineKeyStore : 0);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (_safeKeyHandle != null && !_safeKeyHandle.IsClosed)
+            {
+                _safeKeyHandle.Dispose();
+            }
+
+            if (_safeProvHandle != null && !_safeProvHandle.IsClosed)
+            {
+                _safeProvHandle.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Exports a blob containing the key information associated with an DSACryptoServiceProvider object.
+        /// </summary>
+        public byte[] ExportCspBlob(bool includePrivateParameters)
+        {
+            return CapiHelper.ExportKeyBlob(includePrivateParameters, SafeKeyHandle);
+        }
+
+        public override DSAParameters ExportParameters(bool includePrivateParameters)
+        {
+            byte[] cspBlob = ExportCspBlob(includePrivateParameters);
+            return cspBlob.ToDSAParameters(includePrivateParameters, SafeKeyHandle);
+        }
+
+        /// <summary>
+        /// This method helps Acquire the default CSP and avoids the need for static SafeProvHandle
+        /// in CapiHelper class
+        /// </summary>
+        private SafeProvHandle AcquireSafeProviderHandle()
+        {
+            SafeProvHandle safeProvHandle;
+            CapiHelper.AcquireCsp(new CspParameters(CapiHelper.DefaultDssProviderType), out safeProvHandle);
+            return safeProvHandle;
+        }
+
+        /// <summary>
+        /// Imports a blob that represents DSA key information.
+        /// </summary>
+        /// <param name="keyBlob">A byte array that represents a DSA key blob.</param>
+        public void ImportCspBlob(byte[] keyBlob)
+        {
+            SafeKeyHandle safeKeyHandle;
+
+            if (IsPublic(keyBlob))
+            {
+                SafeProvHandle safeProvHandleTemp = AcquireSafeProviderHandle();
+                CapiHelper.ImportKeyBlob(safeProvHandleTemp, (CspProviderFlags)0, keyBlob, out safeKeyHandle);
+
+                // The property set will take care of releasing any already-existing resources.
+                SafeProvHandle = safeProvHandleTemp;
+            }
+            else
+            {
+                CapiHelper.ImportKeyBlob(SafeProvHandle, _parameters.Flags, keyBlob, out safeKeyHandle);
+            }
+
+            // The property set will take care of releasing any already-existing resources.
+            SafeKeyHandle = safeKeyHandle;
+        }
+
+        public override void ImportParameters(DSAParameters parameters)
+        {
+            byte[] keyBlob = parameters.ToKeyBlob();
+            ImportCspBlob(keyBlob);
+        }
+
+        /// <summary>
+        /// Computes the hash value of the specified input stream and signs the resulting hash value.
+        /// </summary>
+        /// <param name="inputStream">The input data for which to compute the hash.</param>
+        /// <returns>The DSA signature for the specified data.</returns>
+        public byte[] SignData(Stream inputStream)
+        {
+            byte[] hashVal = _sha1.ComputeHash(inputStream);
+            return SignHash(hashVal, null);
+        }
+
+        /// <summary>
+        /// Computes the hash value of the specified input stream and signs the resulting hash value.
+        /// </summary>
+        /// <param name="buffer">The input data for which to compute the hash.</param>
+        /// <returns>The DSA signature for the specified data.</returns>
+        public byte[] SignData(byte[] buffer)
+        {
+            byte[] hashVal = _sha1.ComputeHash(buffer);
+            return SignHash(hashVal, null);
+        }
+
+        /// <summary>
+        /// Signs a byte array from the specified start point to the specified end point.
+        /// </summary>
+        /// <param name="buffer">The input data to sign.</param>
+        /// <param name="offset">The offset into the array from which to begin using data.</param>
+        /// <param name="count">The number of bytes in the array to use as data.</param>
+        /// <returns>The DSA signature for the specified data.</returns>
+        public byte[] SignData(byte[] buffer, int offset, int count)
+        {
+            byte[] hashVal = _sha1.ComputeHash(buffer, offset, count);
+            return SignHash(hashVal, null);
+        }
+
+        /// <summary>
+        /// Verifies the specified signature data by comparing it to the signature computed for the specified data.
+        /// </summary>
+        /// <param name="rgbData">The data that was signed.</param>
+        /// <param name="rgbSignature">The signature data to be verified.</param>
+        /// <returns>true if the signature verifies as valid; otherwise, false.</returns>
+        public bool VerifyData(byte[] rgbData, byte[] rgbSignature)
+        {
+            byte[] hashVal = _sha1.ComputeHash(rgbData);
+            return VerifyHash(hashVal, null, rgbSignature);
+        }
+
+        /// <summary>
+        /// Creates the DSA signature for the specified data.
+        /// </summary>
+        /// <param name="rgbHash">The data to be signed.</param>
+        /// <returns>The digital signature for the specified data.</returns>
+        override public byte[] CreateSignature(byte[] rgbHash)
+        {
+            return SignHash(rgbHash, null);
+        }
+
+        override public bool VerifySignature(byte[] rgbHash, byte[] rgbSignature)
+        {
+            return VerifyHash(rgbHash, null, rgbSignature);
+        }
+
+        protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
+        {
+            // we're sealed and the base should have checked this before calling us
+            Debug.Assert(data != null);
+            Debug.Assert(offset >= 0 && offset <= data.Length);
+            Debug.Assert(count >= 0 && count <= data.Length - offset);
+            Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
+
+            if (hashAlgorithm != HashAlgorithmName.SHA1)
+            {
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
+            }
+
+            return _sha1.ComputeHash(data, offset, count);
+        }
+
+        protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
+        {
+            // we're sealed and the base should have checked this before calling us
+            Debug.Assert(data != null);
+            Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
+
+            if (hashAlgorithm != HashAlgorithmName.SHA1)
+            {
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
+            }
+
+            return _sha1.ComputeHash(data);
+        }
+
+        /// <summary>
+        /// Computes the signature for the specified hash value by encrypting it with the private key.
+        /// </summary>
+        /// <param name="rgbHash">The hash value of the data to be signed.</param>
+        /// <param name="str">The name of the hash algorithm used to create the hash value of the data.</param>
+        /// <returns>The DSA signature for the specified hash value.</returns>
+        public byte[] SignHash(byte[] rgbHash, string str)
+        {
+            if (rgbHash == null)
+                throw new ArgumentNullException(nameof(rgbHash));
+            if (PublicOnly)
+                throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+
+            int calgHash = CapiHelper.NameOrOidToHashAlgId(str);
+
+            if (rgbHash.Length != _sha1.HashSize / 8)
+                throw new CryptographicException(string.Format(SR.Cryptography_InvalidHashSize, "SHA1", _sha1.HashSize / 8));
+
+            return CapiHelper.SignValue(
+                SafeProvHandle,
+                SafeKeyHandle,
+                _parameters.KeyNumber,
+                CapiHelper.CALG_DSS_SIGN,
+                calgHash,
+                rgbHash);
+        }
+
+        /// <summary>
+        /// Verifies the specified signature data by comparing it to the signature computed for the specified hash value.
+        /// </summary>
+        /// <param name="rgbHash">The hash value of the data to be signed.</param>
+        /// <param name="str">The name of the hash algorithm used to create the hash value of the data.</param>
+        /// <param name="rgbSignature">The signature data to be verified.</param>
+        /// <returns>true if the signature verifies as valid; otherwise, false.</returns>
+        public bool VerifyHash(byte[] rgbHash, string str, byte[] rgbSignature)
+        {
+            if (rgbHash == null)
+                throw new ArgumentNullException(nameof(rgbHash));
+            if (rgbSignature == null)
+                throw new ArgumentNullException(nameof(rgbSignature));
+
+            int calgHash = CapiHelper.NameOrOidToHashAlgId(str);
+
+            return CapiHelper.VerifySign(
+                SafeProvHandle,
+                SafeKeyHandle,
+                CapiHelper.CALG_DSS_SIGN,
+                calgHash,
+                rgbHash,
+                rgbSignature);
+        }
+
+        /// <summary>
+        /// Find whether a DSS key blob is public.
+        /// </summary>
+        private static bool IsPublic(byte[] keyBlob)
+        {
+            if (keyBlob == null)
+            {
+                throw new ArgumentNullException(nameof(keyBlob));
+            }
+
+            // The CAPI DSS public key representation consists of the following sequence:
+            //  - BLOBHEADER (the first byte is bType)
+            //  - DSSPUBKEY or DSSPUBKEY_VER3 (the first field is the magic field)
+
+            // The first byte should be PUBLICKEYBLOB
+            if (keyBlob[0] != CapiHelper.PUBLICKEYBLOB)
+            {
+                return false;
+            }
+
+            // Magic should be DSS_MAGIC or DSS_PUB_MAGIC_VER3
+            if ((keyBlob[11] != 0x31 && keyBlob[11] != 0x33) || keyBlob[10] != 0x53 || keyBlob[9] != 0x53 || keyBlob[8] != 0x44)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.cs
@@ -112,10 +112,10 @@ namespace System.Security.Cryptography
                         SafeKeyHandle keyHandle = _safeKeyHandle;
                         _safeKeyHandle = null;
                         keyHandle?.Dispose();
+                        current.Dispose();
                     }
 
                     _safeProvHandle = value;
-                    current?.Dispose();
                 }
             }
         }

--- a/src/System.Security.Cryptography.Csp/src/project.json
+++ b/src/System.Security.Cryptography.Csp/src/project.json
@@ -1,27 +1,29 @@
 {
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "imports": [
-        "dotnet5.4"
+        "dotnet5.8"
       ],
       "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1",
-        "System.Diagnostics.Contracts": "4.0.0",
-        "System.Diagnostics.Debug": "4.0.10",
-        "System.IO": "4.0.10",
-        "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.0.20",
-        "System.Runtime.Extensions": "4.0.10",
-        "System.Runtime.InteropServices": "4.0.20",
-        "System.Security.Cryptography.Algorithms": "4.2.0",
-        "System.Security.Cryptography.Encoding": "4.0.0",
-        "System.Text.Encoding": "4.0.10",
-        "System.Threading": "4.0.10"
+        "Microsoft.NETCore.Platforms": "4.3.0-beta-devapi-24513-01",
+        "System.Diagnostics.Contracts": "4.3.0-beta-devapi-24513-01",
+        "System.Diagnostics.Debug": "4.3.0-beta-devapi-24513-01",
+        "System.IO": "4.3.0-beta-devapi-24513-01",
+        "System.Reflection": "4.3.0-beta-devapi-24513-01",
+        "System.Resources.ResourceManager": "4.3.0-beta-devapi-24513-01",
+        "System.Runtime": "4.3.0-beta-devapi-24513-01",
+        "System.Runtime.Extensions": "4.3.0-beta-devapi-24513-01",
+        "System.Runtime.InteropServices": "4.3.0-beta-devapi-24513-01",
+        "System.Security.Cryptography.Algorithms": "4.3.0-beta-devapi-24513-01",
+        "System.Security.Cryptography.Encoding": "4.3.0-beta-devapi-24513-01",
+        "System.Text.Encoding": "4.3.0-beta-devapi-24513-01",
+        "System.Threading": "4.3.0-beta-devapi-24513-01",
+        "System.Threading.Tasks": "4.3.0-beta-devapi-24513-01"
       }
     },
-    "net46": {
+    "net463": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+        "Microsoft.TargetingPack.NETFramework.v4.6.2": "1.0.1"
       }
     }
   }

--- a/src/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
+++ b/src/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
@@ -4,29 +4,29 @@
 
 namespace System.Security.Cryptography.Dsa.Tests
 {
-    public class DSAOpenSslProvider : IDSAProvider
+    public class DSACryptoServiceProviderProvider : IDSAProvider
     {
         public DSA Create()
         {
-            return new DSAOpenSsl();
+            return new DSACryptoServiceProvider();
         }
 
         public DSA Create(int keySize)
         {
-            return new DSAOpenSsl(keySize);
+            return new DSACryptoServiceProvider(keySize);
         }
 
         public bool SupportsFips186_3
         {
             get
             {
-                return true;
+                return false;
             }
         }
     }
 
     public partial class DSAFactory
     {
-        private static readonly IDSAProvider s_provider = new DSAOpenSslProvider();
+        private static readonly IDSAProvider s_provider = new DSACryptoServiceProviderProvider();
     }
 }

--- a/src/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderTests.cs
+++ b/src/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderTests.cs
@@ -1,0 +1,246 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.Dsa.Tests;
+using Xunit;
+
+namespace System.Security.Cryptography.Csp.Tests
+{
+    public class DSACryptoServiceProviderTests
+    {
+        const int PROV_DSS_DH = 13;
+
+        [Fact]
+        public static void DefaultKeySize()
+        {
+            using (var dsa = new DSACryptoServiceProvider())
+            {
+                Assert.Equal(1024, dsa.KeySize);
+            }
+        }
+
+        [Fact]
+        public static void PublicOnly_DefaultKey()
+        {
+            using (var dsa = new DSACryptoServiceProvider())
+            {
+                // This will call the key into being, which should create a public/private pair,
+                // therefore it should not be public-only.
+                Assert.False(dsa.PublicOnly);
+            }
+        }
+
+        [Fact]
+        public static void PublicOnly_WithPrivateKey()
+        {
+            using (var dsa = new DSACryptoServiceProvider())
+            {
+                dsa.ImportParameters(DSATestData.GetDSA1024Params());
+
+                Assert.False(dsa.PublicOnly);
+            }
+        }
+
+        [Fact]
+        public static void CreateKey()
+        {
+            CspParameters cspParameters = new CspParameters(PROV_DSS_DH);
+
+            using (var dsa = new DSACryptoServiceProvider(cspParameters))
+            {
+                CspKeyContainerInfo containerInfo = dsa.CspKeyContainerInfo;
+                Assert.Equal(PROV_DSS_DH, containerInfo.ProviderType);
+            }
+        }
+
+        [Fact]
+        public static void CreateKey_RoundtripBlob()
+        {
+            const int KeySize = 512;
+
+            CspParameters cspParameters = new CspParameters(PROV_DSS_DH);
+            byte[] blob;
+
+            using (var dsa = new DSACryptoServiceProvider(KeySize, cspParameters))
+            {
+                CspKeyContainerInfo containerInfo = dsa.CspKeyContainerInfo;
+                Assert.Equal(PROV_DSS_DH, containerInfo.ProviderType);
+                Assert.Equal(KeySize, dsa.KeySize);
+
+                blob = dsa.ExportCspBlob(true);
+            }
+
+            using (var dsa = new DSACryptoServiceProvider())
+            {
+                dsa.ImportCspBlob(blob);
+
+                CspKeyContainerInfo containerInfo = dsa.CspKeyContainerInfo;
+
+                // The provider information is not persisted in the blob
+                Assert.Equal(PROV_DSS_DH, containerInfo.ProviderType);
+                Assert.Equal(KeySize, dsa.KeySize);
+            }
+        }
+
+        [Fact]
+        public static void DefaultKey_Parameters()
+        {
+            using (var dsa = new DSACryptoServiceProvider())
+            {
+                CspKeyContainerInfo keyContainerInfo = dsa.CspKeyContainerInfo;
+
+                Assert.NotNull(keyContainerInfo);
+                Assert.Equal(PROV_DSS_DH, keyContainerInfo.ProviderType);
+
+                // This shouldn't be localized, so it should be safe to test on all cultures
+                Assert.Equal("Microsoft Enhanced DSS and Diffie-Hellman Cryptographic Provider", keyContainerInfo.ProviderName);
+
+                Assert.Null(keyContainerInfo.KeyContainerName);
+                Assert.Equal(string.Empty, keyContainerInfo.UniqueKeyContainerName);
+
+                Assert.False(keyContainerInfo.HardwareDevice, "HardwareDevice");
+                Assert.False(keyContainerInfo.MachineKeyStore, "MachineKeyStore");
+                Assert.False(keyContainerInfo.Protected, "Protected");
+                Assert.False(keyContainerInfo.Removable, "Removable");
+
+                // Ephemeral keys don't successfully request the exportable bit.
+                Assert.ThrowsAny<CryptographicException>(() => keyContainerInfo.Exportable);
+
+                Assert.True(keyContainerInfo.RandomlyGenerated, "RandomlyGenerated");
+
+                Assert.Equal(KeyNumber.Signature, keyContainerInfo.KeyNumber);
+            }
+        }
+
+        [Fact]
+        public static void DefaultKey_NotPersisted()
+        {
+            using (var dsa = new DSACryptoServiceProvider())
+            {
+                Assert.False(dsa.PersistKeyInCsp);
+            }
+        }
+
+        [Fact]
+        public static void NamedKey_DefaultProvider()
+        {
+            const int KeySize = 1024;
+
+            CspParameters cspParameters = new CspParameters
+            {
+                ProviderType = PROV_DSS_DH,
+                KeyContainerName = Guid.NewGuid().ToString(),
+            };
+
+            using (new DsaKeyLifetime(cspParameters))
+            {
+                byte[] privateBlob;
+                string uniqueKeyContainerName;
+
+                using (var dsa = new DSACryptoServiceProvider(KeySize, cspParameters))
+                {
+                    Assert.True(dsa.PersistKeyInCsp, "dsa.PersistKeyInCsp");
+                    Assert.Equal(cspParameters.KeyContainerName, dsa.CspKeyContainerInfo.KeyContainerName);
+
+                    uniqueKeyContainerName = dsa.CspKeyContainerInfo.UniqueKeyContainerName;
+                    Assert.NotNull(uniqueKeyContainerName);
+                    Assert.NotEqual(string.Empty, uniqueKeyContainerName);
+
+                    privateBlob = dsa.ExportCspBlob(true);
+                    Assert.True(dsa.CspKeyContainerInfo.Exportable, "dsa.CspKeyContainerInfo.Exportable");
+                }
+
+                // Fail if the key didn't persist
+                cspParameters.Flags |= CspProviderFlags.UseExistingKey;
+
+                using (var dsa = new DSACryptoServiceProvider(cspParameters))
+                {
+                    Assert.True(dsa.PersistKeyInCsp);
+                    Assert.Equal(KeySize, dsa.KeySize);
+
+                    Assert.Equal(uniqueKeyContainerName, dsa.CspKeyContainerInfo.UniqueKeyContainerName);
+
+                    byte[] blob2 = dsa.ExportCspBlob(true);
+                    Assert.Equal(privateBlob, blob2);
+                }
+            }
+        }
+
+        [Fact]
+        public static void NonExportable_Ephemeral()
+        {
+            CspParameters cspParameters = new CspParameters
+            {
+                ProviderType = PROV_DSS_DH,
+                Flags = CspProviderFlags.UseNonExportableKey,
+            };
+
+            using (var dsa = new DSACryptoServiceProvider(cspParameters))
+            {
+                // Ephemeral keys don't successfully request the exportable bit.
+                Assert.ThrowsAny<CryptographicException>(() => dsa.CspKeyContainerInfo.Exportable);
+
+                Assert.Throws<CryptographicException>(() => dsa.ExportCspBlob(true));
+                Assert.Throws<CryptographicException>(() => dsa.ExportParameters(true));
+            }
+        }
+
+        [Fact]
+        public static void NonExportable_Persisted()
+        {
+            CspParameters cspParameters = new CspParameters
+            {
+                ProviderType = PROV_DSS_DH,
+                KeyContainerName = Guid.NewGuid().ToString(),
+                Flags = CspProviderFlags.UseNonExportableKey,
+            };
+
+            using (new DsaKeyLifetime(cspParameters))
+            {
+                using (var dsa = new DSACryptoServiceProvider(cspParameters))
+                {
+                    Assert.False(dsa.CspKeyContainerInfo.Exportable, "dsa.CspKeyContainerInfo.Exportable");
+
+                    Assert.Throws<CryptographicException>(() => dsa.ExportCspBlob(true));
+                    Assert.Throws<CryptographicException>(() => dsa.ExportParameters(true));
+                }
+            }
+        }
+
+        private sealed class DsaKeyLifetime : IDisposable
+        {
+            private readonly CspParameters _cspParameters;
+
+            internal DsaKeyLifetime(CspParameters cspParameters)
+            {
+                const CspProviderFlags CopyableFlags =
+                    CspProviderFlags.UseMachineKeyStore;
+
+                _cspParameters = new CspParameters(
+                    cspParameters.ProviderType,
+                    cspParameters.ProviderName,
+                    cspParameters.KeyContainerName)
+                {
+                    // If the test failed before creating the key, don't bother recreating it.
+                    Flags = (cspParameters.Flags & CopyableFlags) | CspProviderFlags.UseExistingKey,
+                };
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    using (var dsa = new DSACryptoServiceProvider(_cspParameters))
+                    {
+                        // Delete the key at the end of this using
+                        dsa.PersistKeyInCsp = false;
+                    }
+                }
+                catch (CryptographicException)
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.builds
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.builds
@@ -3,7 +3,11 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Security.Cryptography.Csp.Tests.csproj">
-        <TestTFMs>netcoreapp1.0;net46</TestTFMs>
+        <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.Csp.Tests.csproj">
+        <TargetGroup>netstandard1.7</TargetGroup>
+        <TestTFMs>netcoreapp1.1</TestTFMs>
         <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -10,7 +10,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Csp.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Csp.Tests</RootNamespace>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7' AND '$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
   </PropertyGroup>
     <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Debug|AnyCPU'" />
@@ -50,6 +51,25 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\IO\PositionValueStream.cs">
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+    <Compile Include="DSACryptoServiceProviderProvider.cs" />
+    <Compile Include="DSACryptoServiceProviderTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Security.Cryptography.Csp/tests/project.json
+++ b/src/System.Security.Cryptography.Csp/tests/project.json
@@ -7,6 +7,7 @@
     "System.Runtime": "4.3.0-beta-devapi-24513-01",
     "System.Runtime.Numerics": "4.3.0-beta-devapi-24513-01",
     "System.Security.Cryptography.Algorithms": "4.3.0-beta-devapi-24513-01",
+    "System.Text.Encoding": "4.3.0-beta-devapi-24513-01",
     "System.Text.Encoding.Extensions": "4.3.0-beta-devapi-24513-01",
     "System.Text.RegularExpressions": "4.3.0-beta-devapi-24513-01",
     "test-runtime": {
@@ -16,14 +17,31 @@
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
   },
-  "frameworks": {
-    "netstandard1.3": {}
+   "frameworks": {
+      "netstandard1.3": {},
+      "netstandard1.7": {}
   },
   "supports": {
     "coreFx.Test.netcoreapp1.0": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},
-    "coreFx.Test.net463": {}
+    "coreFx.Test.net463": {},
+    "coreFx.Test.netcoreapp1.1-ns17": {
+      "netstandard1.7": [
+        "win7-x86",
+        "win7-x64",
+        "win10-arm64",
+        "osx.10.10-x64",
+        "centos.7-x64",
+        "debian.8-x64",
+        "rhel.7-x64",
+        "ubuntu.14.04-x64",
+        "ubuntu.16.04-x64",
+        "fedora.23-x64",
+        "linux-x64",
+        "opensuse.13.2-x64"
+      ]
+    }
   }
 }


### PR DESCRIPTION
This is the last part of the work for adding DSA per issue #4813  

Note most of the code in CapiHelper.DSA.cs was ported from full desktop c++ code (not managed) using the same style as RSACryptoServiceProvider with loosely-coupled binary reads and writes with BinaryReader, etc. This is not like the code in Algorithms which uses more strongly-typed structs and and helper methods to read or write blobs.

@bartonjs please take a look.