### PR TITLE
Make Package.Open default fileaccess Read only

### DIFF
--- a/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
@@ -1171,12 +1171,12 @@ namespace System.IO.Packaging
         #region Private Members
 
         // Default values for the Package.Open method overloads
-        private static readonly FileMode s_defaultFileMode = FileMode.OpenOrCreate;
-        private static readonly FileAccess s_defaultFileAccess = FileAccess.ReadWrite;
-        private static readonly FileShare s_defaultFileShare = FileShare.None;
+        private const FileMode s_defaultFileMode = FileMode.OpenOrCreate;
+        private const FileAccess s_defaultFileAccess = FileAccess.ReadWrite;
+        private const FileShare s_defaultFileShare = FileShare.None;
 
-        private static readonly FileMode s_defaultStreamMode = FileMode.Open;
-        private static readonly FileAccess s_defaultStreamAccess = FileAccess.Read;
+        private const FileMode s_defaultStreamMode = FileMode.Open;
+        private const FileAccess s_defaultStreamAccess = FileAccess.Read;
 
         private FileAccess _openFileAccess;
         private FileMode _openFileMode;

--- a/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
@@ -146,7 +146,7 @@ namespace System.IO.Packaging
         /// <exception cref="IOException">If package to be created should have readwrite/write access and underlying stream is read only</exception>
         public static Package Open(Stream stream)
         {
-            return Open(stream, s_defaultStreamMode);
+            return Open(stream, s_defaultStreamMode, s_defaultStreamAccess);
         }
 
         /// <summary>
@@ -1176,6 +1176,7 @@ namespace System.IO.Packaging
         private static readonly FileShare s_defaultFileShare = FileShare.None;
 
         private static readonly FileMode s_defaultStreamMode = FileMode.Open;
+        private static readonly FileAccess s_defaultStreamAccess = FileAccess.Read;
 
         private FileAccess _openFileAccess;
         private FileMode _openFileMode;

--- a/src/System.IO.Packaging/tests/Tests.cs
+++ b/src/System.IO.Packaging/tests/Tests.cs
@@ -1949,6 +1949,17 @@ namespace System.IO.Packaging.Tests
         }
 
         [Fact]
+        public void PackageOpenStream_VerifyDefaultAccess()
+        {
+            var docName = "plain.docx";
+            using (Package package = Package.Open(File.OpenRead(docName)))
+            {
+                var partCount = package.GetParts().Count();
+                Assert.Equal(10, partCount);
+            }
+        }
+
+        [Fact]
         public void T011_PackageOpen()
         {
             var docName = "plain.docx";


### PR DESCRIPTION
brings the behavior of Package.Open(Stream) in line with deskop

resolves https://github.com/dotnet/corefx/issues/9932

@stephentoub @EricWhiteDev @svick 