### PR TITLE
Adding various tests for LambdaCompiler

### DIFF
--- a/src/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -10,6 +10,18 @@ namespace System.Linq.Expressions.Tests
 {
     public static class CallTests
     {
+        private interface IBar
+        {
+            int Bar();
+        }
+
+        private struct S : IBar
+        {
+            public int X;
+
+            public int Bar() => X;
+        }
+
         private struct Mutable
         {
             private int x;
@@ -223,6 +235,17 @@ namespace System.Linq.Expressions.Tests
 
             var m = new Mutable() { X = 41 };
             Assert.Equal(42, lambda(m));
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public static void CallInterface(bool useInterpreter)
+        {
+            var p = Expression.Parameter(typeof(S));
+            var body = Expression.Call(p, typeof(IBar).GetMethod("Bar"));
+            var lambda = Expression.Lambda<Func<S, int>>(body, p).Compile(useInterpreter);
+
+            Assert.Equal(42, lambda(new S() { X = 42 }));
         }
 
         private static Expression s_valid => Expression.Constant(5);

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -483,6 +484,175 @@ namespace System.Linq.Expressions.Tests
             lambda = (Expression<Func<int>>)Expression.Lambda(typeof(Func<int>), Expression.Constant(3), Enumerable.Empty<ParameterExpression>());
             lambda = lambda.Update(Expression.Constant(4), lambda.Parameters);
             Assert.False(lambda.TailCall);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void CurriedFunctions(bool useInterpreter)
+        {
+            Expression<Func<int, Func<int>>> f1 = x => () => x;
+            var d1 = f1.Compile(useInterpreter);
+            var c1 = d1(42);
+            Assert.Equal(42, c1());
+            Assert.Equal(42, c1());
+
+            Expression<Func<int, Func<int, int>>> f2 = x => y => x - y;
+            var d2 = f2.Compile(useInterpreter);
+            var c2 = d2(42);
+            Assert.Equal(41, c2(1));
+            Assert.Equal(40, c2(2));
+
+            Expression<Func<int, Func<int, Func<int, int>>>> f3 = x => y => z => x * y - z;
+            var d3 = f3.Compile(useInterpreter);
+            var c3 = d3(2);
+            var c31 = c3(21);
+            Assert.Equal(41, c31(1));
+            Assert.Equal(40, c31(2));
+            var c32 = c3(22);
+            Assert.Equal(41, c32(3));
+            Assert.Equal(40, c32(4));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void CurriedFunctionsReadWrite(bool useInterpreter)
+        {
+            // Generate code like:
+            //
+            // val => () =>
+            // {
+            //     sum = 0;
+            //
+            //     val = 1;
+            //     sum += val;
+            //     ...
+            //     val = n;
+            //     sum += val;
+            //
+            //     return sum;
+            // }
+            //
+            // This introduces repeated reads and writes for a hoisted local, which may be subject
+            // to optimizations for closure storage access.
+            //
+            for (var i = 0; i < 10; i++)
+            {
+                var val = Expression.Parameter(typeof(int));
+                var sum = Expression.Parameter(typeof(int));
+
+                var addExprs = new List<Expression>();
+
+                for (var j = 1; j <= i; j++)
+                {
+                    addExprs.Add(Expression.Assign(val, Expression.Constant(j)));
+                    addExprs.Add(Expression.AddAssign(sum, val));
+                }
+
+                var adds = Expression.Block(addExprs);
+                var body = Expression.Block(new[] { sum }, Expression.Assign(sum, Expression.Constant(0)), adds, sum);
+
+                var e = Expression.Lambda<Func<int, Func<int>>>(Expression.Lambda<Func<int>>(body), val);
+                var f = e.Compile(useInterpreter);
+
+                Assert.Equal(i * (i + 1) / 2, f(i)());
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void CurriedFunctionsUsingRef(bool useInterpreter)
+        {
+            Expression<Func<int, Func<int>>> f1 = x => () => x * Add(ref x, 1);
+            var d1 = f1.Compile(useInterpreter);
+            Assert.Equal(3 * 4, d1(3)());
+
+            Expression<Func<int, Func<int>>> f2 = x => () => x * Add(ref x, 1) * Add(ref x, 2);
+            var d2 = f2.Compile(useInterpreter);
+            Assert.Equal(3 * 4 * 6, d2(3)());
+
+            Expression<Func<int, Func<int>>> f3 = x => () => x * Add(ref x, 1) * Add(ref x, 2) * x;
+            var d3 = f3.Compile(useInterpreter);
+            Assert.Equal(3 * 4 * 6 * 6, d3(3)());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void CurriedFunctionsReadWriteThroughRef(bool useInterpreter)
+        {
+            // Generate code like:
+            //
+            // val => () =>
+            // {
+            //     sum = 0;
+            //
+            //     val = 1;
+            //     Add(ref sum, val);
+            //     ...
+            //     val = n;
+            //     Add(ref sum, val);
+            //
+            //     return sum;
+            // }
+            //
+            // This introduces repeated reads and writes for a hoisted local, which may be subject
+            // to optimizations for closure storage access.
+            //
+
+            var add = typeof(LambdaTests).GetMethod(nameof(LambdaTests.Add), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+            for (var i = 0; i < 10; i++)
+            {
+                var val = Expression.Parameter(typeof(int));
+                var sum = Expression.Parameter(typeof(int));
+
+                var addExprs = new List<Expression>();
+
+                for (var j = 1; j <= i; j++)
+                {
+                    addExprs.Add(Expression.Assign(val, Expression.Constant(j)));
+                    addExprs.Add(Expression.Call(add, sum, val));
+                }
+
+                var adds = Expression.Block(addExprs);
+                var body = Expression.Block(new[] { sum }, Expression.Assign(sum, Expression.Constant(0)), adds, sum);
+
+                var e = Expression.Lambda<Func<int, Func<int>>>(Expression.Lambda<Func<int>>(body), val);
+                var f = e.Compile(useInterpreter);
+
+                Assert.Equal(i * (i + 1) / 2, f(i)());
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void CurriedFunctionsVariableCaptureSemantics(bool useInterpreter)
+        {
+            var x = Expression.Parameter(typeof(int));
+            var f = Expression.Parameter(typeof(Func<int>));
+
+            var e =
+                Expression.Lambda<Func<Func<int>>>(
+                    Expression.Block(
+                        new[] { f, x },
+                        Expression.Assign(x, Expression.Constant(-1)),
+                        Expression.Assign(
+                            f,
+                            Expression.Lambda<Func<int>>(
+                                Expression.MultiplyAssign(x, Expression.Constant(2))
+                            )
+                        ),
+                        Expression.Assign(x, Expression.Constant(20)),
+                        Expression.AddAssign(x, Expression.Constant(1)),
+                        f
+                    )
+                );
+
+            var d = e.Compile(useInterpreter);
+
+            var i = d();
+
+            Assert.Equal(42, i());
+            Assert.Equal(84, i());
+        }
+
+        private static int Add(ref int var, int val)
+        {
+            return var += val;
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Unary/UnaryConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryConvertTests.cs
@@ -31,6 +31,15 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertDelegatesTest(bool useInterpreter)
+        {
+            foreach (var e in ConvertDelegates())
+            {
+                VerifyUnaryConvert(e, useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void ConvertUnboxingInvalidCastTest(bool useInterpreter)
         {
             foreach (var e in ConvertUnboxingInvalidCast())
@@ -316,6 +325,30 @@ namespace System.Linq.Expressions.Tests
                     yield return factory(Expression.Constant(DayOfWeek.Monday, typeof(Enum)), typeof(DayOfWeek?));
                     yield return factory(Expression.Constant(null, typeof(Enum)), typeof(DayOfWeek?));
                 }
+            }
+        }
+
+        private static IEnumerable<Expression> ConvertDelegates()
+        {
+            var factories = new Func<Expression, Type, Expression>[] { Expression.Convert, Expression.ConvertChecked };
+
+            foreach (var factory in factories)
+            {
+                yield return factory(Expression.Constant((Action)(() => { })), typeof(Action));
+
+                yield return factory(Expression.Constant((Action<int>)(x => { })), typeof(Action<int>));
+                yield return factory(Expression.Constant((Action<int, object>)((x, o) => { })), typeof(Action<int, object>));
+                yield return factory(Expression.Constant((Action<int, object>)((x, o) => { })), typeof(Action<int, string>)); // contravariant
+                yield return factory(Expression.Constant((Action<object, int>)((o, x) => { })), typeof(Action<string, int>)); // contravariant
+
+                yield return factory(Expression.Constant((Func<int>)(() => 42)), typeof(Func<int>));
+                yield return factory(Expression.Constant((Func<string>)(() => "bar")), typeof(Func<string>));
+                yield return factory(Expression.Constant((Func<string>)(() => "bar")), typeof(Func<object>)); // covariant
+                yield return factory(Expression.Constant((Func<int, string>)(x => "bar")), typeof(Func<int, object>)); // covariant
+
+                yield return factory(Expression.Constant((Func<object, string>)(o => "bar")), typeof(Func<string, object>)); // contravariant and covariant
+                yield return factory(Expression.Constant((Func<object, int, string>)((o, x) => "bar")), typeof(Func<string, int, object>)); // contravariant and covariant
+                yield return factory(Expression.Constant((Func<int, object, string>)((x, o) => "bar")), typeof(Func<int, string, object>)); // contravariant and covariant
             }
         }
 

--- a/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -120,7 +121,52 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(6, argument);
         }
 
-        public delegate T ByRefReadFunc<T>(ref T arg);
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public void CanUseAsLambdaByRefParameter_String(bool useInterpreter)
+        {
+            var param = Expression.Parameter(typeof(string).MakeByRefType());
+            var f = Expression.Lambda<ByRefFunc<string>>(
+                Expression.Assign(param, Expression.Call(param, typeof(string).GetMethod(nameof(string.ToUpper), Type.EmptyTypes))),
+                param
+                ).Compile(useInterpreter);
+            string argument = "bar";
+            f(ref argument);
+            Assert.Equal("BAR", argument);
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public void CanUseAsLambdaByRefParameter_Char(bool useInterpreter)
+        {
+            var param = Expression.Parameter(typeof(char).MakeByRefType());
+            var f = Expression.Lambda<ByRefFunc<char>>(
+                Expression.Assign(param, Expression.Call(typeof(char).GetMethod(nameof(char.ToUpper), new[] { typeof(char) }), param)),
+                param
+                ).Compile(useInterpreter);
+            char argument = 'a';
+            f(ref argument);
+            Assert.Equal('A', argument);
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public void CanUseAsLambdaByRefParameter_Bool(bool useInterpreter)
+        {
+            var param = Expression.Parameter(typeof(bool).MakeByRefType());
+            var f = Expression.Lambda<ByRefFunc<bool>>(
+                Expression.ExclusiveOrAssign(param, Expression.Constant(true)),
+                param
+                ).Compile(useInterpreter);
+
+            bool b1 = false;
+            f(ref b1);
+            Assert.Equal(false ^ true, b1);
+
+            bool b2 = true;
+            f(ref b2);
+            Assert.Equal(true ^ true, b2);
+        }
 
         [Theory]
         [ClassData(typeof(CompilationTypes))]
@@ -163,6 +209,8 @@ namespace System.Linq.Expressions.Tests
             AssertCanReadFromRefParameter<DateTime?>(null, useInterpreter);
             AssertCanReadFromRefParameter<DateTime?>(new DateTime(1983, 2, 11), useInterpreter);
         }
+
+        public delegate T ByRefReadFunc<T>(ref T arg);
 
         private void AssertCanReadFromRefParameter<T>(T value, bool useInterpreter)
         {
@@ -253,5 +301,46 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("type", () => Expression.Parameter(typeof(int*)));
             Assert.Throws<ArgumentException>("type", () => Expression.Parameter(typeof(int*), "pointer"));
         }
+
+        [Theory]
+        [MemberData(nameof(ReadAndWriteRefCases))]
+        public void ReadAndWriteRefParameters(bool useInterpreter, object value, object increment, object result)
+        {
+            var type = value.GetType();
+
+            var method = typeof(ParameterTests).GetMethod(nameof(AssertReadAndWriteRefParameters), BindingFlags.NonPublic | BindingFlags.Static);
+
+            method.MakeGenericMethod(type).Invoke(null, new object[] { useInterpreter, value, increment, result });
+        }
+
+        private static void AssertReadAndWriteRefParameters<T>(bool useInterpreter, T value, T increment, T result)
+        {
+            var param = Expression.Parameter(typeof(T).MakeByRefType());
+            var addOneInPlace = Expression.Lambda<ByRefFunc<T>>(
+                Expression.AddAssign(param, Expression.Constant(increment, typeof(T))),
+                param
+                ).Compile(useInterpreter);
+            T argument = value;
+            addOneInPlace(ref argument);
+            Assert.Equal(result, argument);
+        }
+
+        public static IEnumerable<object[]> ReadAndWriteRefCases()
+        {
+            foreach (var useInterpreter in new[] { true, false })
+            {
+                yield return new object[] { useInterpreter, (short)41, (short)1, (short)42 };
+                yield return new object[] { useInterpreter, (ushort)41, (ushort)1, (ushort)42 };
+                yield return new object[] { useInterpreter, 41, 1, 42 };
+                yield return new object[] { useInterpreter, 41U, 1U, 42U };
+                yield return new object[] { useInterpreter, 41L, 1L, 42L };
+                yield return new object[] { useInterpreter, 41UL, 1UL, 42UL };
+                yield return new object[] { useInterpreter, 41.0F, 1.0F, Apply((x, y) => x + y, 41.0F, 1.0F) };
+                yield return new object[] { useInterpreter, 41.0D, 1.0D, Apply((x, y) => x + y, 41.0D, 1.0D) };
+                yield return new object[] { useInterpreter, TimeSpan.FromSeconds(41), TimeSpan.FromSeconds(1), Apply((x, y) => x + y, TimeSpan.FromSeconds(41), TimeSpan.FromSeconds(1)) };
+            }
+        }
+
+        private static T Apply<T>(Func<T, T, T> f, T x, T y) => f(x, y);
     }
 }


### PR DESCRIPTION
Adds a bunch of tests for `LambdaCompiler` mostly focusing on:

* `ILGen` for some cases of calls
* `ILGen` for `decimal` types in various ranges, using different `System.Decimal` constructors
* `ILGen` involving `ldtoken` for `MethodInfo` objects, and calls to runtime helpers for generics
* Treatment of live constants including hitting the caching heuristic in `VariableBinder`
* Various cases for generated closures, including accessing `HoistedLocals` and cached boxes
* `ILGen` for switch tables for `string`
* `ILGen` for various `ref` cases for primitives, leading to `ldind` and `stind` instructions
* Type system checks for conversion of delegate types with co- and contra-variant type parameters

This addresses part of issue #11409 with more to follow in separate PRs. It brings code coverage for `System.Linq.Expressions` over 85%.