### PR TITLE
Add missing token property to System.Security.Principal.WindowsIdentity

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1801,7 +1801,7 @@
       "BaselineVersion": "4.0.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
-        "4.0.1.0": "4.3.0"
+        "4.1.0.0": "4.3.0"
       }
     },
     "System.Security.SecureString": {

--- a/src/System.Security.Principal.Windows/dir.props
+++ b/src/System.Security.Principal.Windows/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>
 

--- a/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
+++ b/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
@@ -205,6 +205,7 @@ namespace System.Security.Principal
         public virtual bool IsSystem { get { return default(bool); } }
         public override string Name { get { return default(string); } }
         public System.Security.Principal.SecurityIdentifier Owner { get { return default(System.Security.Principal.SecurityIdentifier); } }
+        public virtual IntPtr Token { get { return default(System.IntPtr); } }
         public System.Security.Principal.SecurityIdentifier User { get { return default(System.Security.Principal.SecurityIdentifier); } }
         public override System.Security.Claims.ClaimsIdentity Clone() { return default(System.Security.Claims.ClaimsIdentity); }
         public void Dispose() { }

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -556,6 +556,14 @@ namespace System.Security.Principal
             }
         }
 
+        public virtual IntPtr Token
+        {
+            get
+            {
+                return _safeTokenHandle.DangerousGetHandle();
+            }
+        }
+
         //
         // Public methods.
         //

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -63,13 +63,8 @@ public class WindowsIdentityTests
     [Fact]
     public static void GetTokenHandle()
     {
-        IntPtr logonToken = WindowsIdentity.GetCurrent().Token;
-        WindowsIdentity winId = new WindowsIdentity(logonToken);
-
-        Assert.NotNull(winId);
-        Assert.Equal(winId.Token, logonToken);
-
-        CheckDispose(winId);
+        WindowsIdentity id = WindowsIdentity.GetCurrent();
+        Assert.Equal(id.AccessToken.DangerousGetHandle(), id.Token);
     }
 
     private static void CheckDispose(WindowsIdentity identity, bool anonymous = false)

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -60,6 +60,18 @@ public class WindowsIdentityTests
         CheckDispose(cloneWinId);        
     }
 
+    [Fact]
+    public static void GetTokenHandle()
+    {
+        IntPtr logonToken = WindowsIdentity.GetCurrent().Token;
+        WindowsIdentity winId = new WindowsIdentity(logonToken);
+
+        Assert.NotNull(winId);
+        Assert.Equal(winId.Token, logonToken);
+
+        CheckDispose(winId);
+    }
+
     private static void CheckDispose(WindowsIdentity identity, bool anonymous = false)
     {
         Assert.False(identity.AccessToken.IsClosed);


### PR DESCRIPTION
- Cherry-picks commit from #11461 to add the Token property
- Then adds a commit that updates the project version, adds Token to the ref assembly, and fixes the previously added test (the actual token handle of the newly constructed identity is going to be different from the one from which it was constructed)

cc: @maddin2016, @bartonjs, @ericstj, @joperezr 