### PR TITLE
Add Expression.Assign tests

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -510,9 +510,6 @@
   <data name="InvalidLvalue" xml:space="preserve">
     <value>Invalid lvalue for assignment: {0}.</value>
   </data>
-  <data name="InvalidMemberType" xml:space="preserve">
-    <value>Invalid member type: {0}.</value>
-  </data>
   <data name="UnknownLiftType" xml:space="preserve">
     <value>unknown lift type: '{0}'.</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -796,15 +796,10 @@ namespace System.Linq.Expressions.Compiler
             }
             else
             {
-                var prop = member as PropertyInfo;
-                if ((object)prop != null)
-                {
-                    EmitCall(objectType, prop.GetSetMethod(true));
-                }
-                else
-                {
-                    throw Error.InvalidMemberType(member);
-                }
+                // MemberExpression.Member can only be a FieldInfo or a PropertyInfo
+                Debug.Assert(member is PropertyInfo);
+                var prop = (PropertyInfo)member;
+                EmitCall(objectType, prop.GetSetMethod(true));
             }
 
             if (emitAs != CompilationFlags.EmitAsVoidType)
@@ -847,15 +842,10 @@ namespace System.Linq.Expressions.Compiler
             }
             else
             {
-                var prop = member as PropertyInfo;
-                if ((object)prop != null)
-                {
-                    EmitCall(objectType, prop.GetGetMethod(true));
-                }
-                else
-                {
-                    throw ContractUtils.Unreachable;
-                }
+                // MemberExpression.Member or MemberBinding.Member can only be a FieldInfo or a PropertyInfo
+                Debug.Assert(member is PropertyInfo);
+                var prop = (PropertyInfo)member;
+                EmitCall(objectType, prop.GetGetMethod(true));
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -1047,13 +1047,6 @@ namespace System.Linq.Expressions
             return new InvalidOperationException(Strings.InvalidLvalue(p0));
         }
         /// <summary>
-        /// InvalidOperationException with message like "Invalid member type: {0}."
-        /// </summary>
-        internal static Exception InvalidMemberType(object p0)
-        {
-            return new InvalidOperationException(Strings.InvalidMemberType(p0));
-        }
-        /// <summary>
         /// InvalidOperationException with message like "unknown lift type: '{0}'."
         /// </summary>
         internal static Exception UnknownLiftType(object p0)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -1236,14 +1236,6 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// A string like "Invalid member type: {0}."
-        /// </summary>
-        internal static string InvalidMemberType(object p0)
-        {
-            return SR.Format(SR.InvalidMemberType, p0);
-        }
-
-        /// <summary>
         /// A string like "unknown lift type: '{0}'."
         /// </summary>
         internal static string UnknownLiftType(object p0)

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -45,10 +45,8 @@ namespace System.Linq.Expressions.Tests
                 get { return _underlyingIndexerField1; }
                 set
                 {
-                    if (i == 1)
-                    {
-                        _underlyingIndexerField1 = value;
-                    }
+                    Assert.Equal(1, i);
+                    _underlyingIndexerField1 = value;
                 }
             }
 
@@ -58,10 +56,9 @@ namespace System.Linq.Expressions.Tests
                 get { return _underlyingIndexerField2; }
                 set
                 {
-                    if (i == 1 && j == 2)
-                    {
-                        _underlyingIndexerField2 = value;
-                    }
+                    Assert.Equal(1, i);
+                    Assert.Equal(2, j);
+                    _underlyingIndexerField2 = value;
                 }
             }
 
@@ -88,10 +85,8 @@ namespace System.Linq.Expressions.Tests
                 get { return _underlyingIndexerField; }
                 set
                 {
-                    if (i == 1)
-                    {
-                        _underlyingIndexerField = value;
-                    }
+                    Assert.Equal(1, i);
+                    _underlyingIndexerField = value;
                 }
             }
         }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -24,18 +25,75 @@ namespace System.Linq.Expressions.Tests
             public string WriteOnlyString { set { } }
             public static string WriteOnlyStaticString { set { } }
 
+            public BaseClass BaseClassProperty { get; set; }
+
             public int Int32Property { get; set; }
             public int Int32Field;
             public readonly int ReadonlyInt32Field;
             public int ReadonlyInt32Property { get { return 42; } }
-            public static int StaticInt32Property { get; set; }
+            public static int StaticInt32Property1 { get; set; }
             public static int StaticInt32Field;
             public static readonly int ReadonlyStaticInt32Field;
             public static int ReadonlyStaticInt32Property { get { return 321; } }
             public const int ConstantInt32 = 12;
             public int WriteOnlyInt32 { set { } }
             public static int WriteOnlyStaticInt32 { set { } }
+
+            private int _underlyingIndexerField1;
+            public int this[int i]
+            {
+                get { return _underlyingIndexerField1; }
+                set
+                {
+                    if (i == 1)
+                    {
+                        _underlyingIndexerField1 = value;
+                    }
+                }
+            }
+
+            private int _underlyingIndexerField2;
+            public int this[int i, int j]
+            {
+                get { return _underlyingIndexerField2; }
+                set
+                {
+                    if (i == 1 && j == 2)
+                    {
+                        _underlyingIndexerField2 = value;
+                    }
+                }
+            }
+
+            public static int StaticInt32Property2 { get; set; }
+
 #pragma warning restore 649
+        }
+
+        private class ReadOnlyIndexer
+        {
+            public int this[int i] { get { return 0; } }
+        }
+
+        private class WriteOnlyIndexer
+        {
+            public int this[int i] { set { } }
+        }
+
+        private struct StructWithPropertiesAndFields
+        {
+            private int _underlyingIndexerField;
+            public int this[int i]
+            {
+                get { return _underlyingIndexerField; }
+                set
+                {
+                    if (i == 1)
+                    {
+                        _underlyingIndexerField = value;
+                    }
+                }
+            }
         }
 
         private static IEnumerable<object[]> ReadOnlyExpressions()
@@ -54,6 +112,8 @@ namespace System.Linq.Expressions.Tests
             yield return new object[] { Expression.Default(typeof(int)) };
             yield return new object[] { Expression.Default(typeof(string)) };
             yield return new object[] { Expression.Default(typeof(DateTime)) };
+            yield return new object[] { Expression.Constant(1) };
+            yield return new object[] { Expression.Property(Expression.Constant(new ReadOnlyIndexer()), "Item", new Expression[] { Expression.Constant(1) }) };
         }
 
         private static IEnumerable<object> WriteOnlyExpressions()
@@ -63,19 +123,34 @@ namespace System.Linq.Expressions.Tests
             yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.WriteOnlyString)) };
             yield return new object[] { Expression.Property(null, typeof(PropertyAndFields), nameof(PropertyAndFields.WriteOnlyStaticInt32)) };
             yield return new object[] { Expression.Property(null, typeof(PropertyAndFields), nameof(PropertyAndFields.WriteOnlyStaticString)) };
+            yield return new object[] { Expression.Property(Expression.Constant(new WriteOnlyIndexer()), "Item", new Expression[] { Expression.Constant(1) }) };
         }
 
         private static IEnumerable<object> MemberAssignments()
         {
             Expression obj = Expression.Constant(new PropertyAndFields());
             yield return new object[] { Expression.Field(null, typeof(PropertyAndFields), nameof(PropertyAndFields.StaticInt32Field)), 1 };
-            yield return new object[] { Expression.Property(null, typeof(PropertyAndFields), nameof(PropertyAndFields.StaticInt32Property)), 2 };
+            yield return new object[] { Expression.Property(null, typeof(PropertyAndFields), nameof(PropertyAndFields.StaticInt32Property1)), 2 };
             yield return new object[] { Expression.Field(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.Int32Field)), 3 };
             yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.Int32Property)), 4 };
             yield return new object[] { Expression.Field(null, typeof(PropertyAndFields), nameof(PropertyAndFields.StaticStringField)), "a" };
             yield return new object[] { Expression.Property(null, typeof(PropertyAndFields), nameof(PropertyAndFields.StaticStringProperty)), "b" };
             yield return new object[] { Expression.Field(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.StringField)), "c" };
             yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.StringProperty)), "d" };
+
+            yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.BaseClassProperty)), new BaseClass() };
+            yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.BaseClassProperty)), new SubClass() };
+
+            // IndexExpression for indexed property
+            PropertyInfo simpleIndexer = typeof(PropertyAndFields).GetProperties().First(prop => prop.GetIndexParameters().Length == 1);
+            yield return new object[] { Expression.Property(obj, simpleIndexer, new Expression[] { Expression.Constant(1) }), 5 };
+
+            PropertyInfo advancedIndexer = typeof(PropertyAndFields).GetProperties().First(prop => prop.GetIndexParameters().Length == 2);
+            yield return new object[] { Expression.Property(obj, simpleIndexer, new Expression[] { Expression.Constant(1), Expression.Constant(2) }), 5 };
+
+            // IndexExpression for non-indexed property
+            yield return new object[] { Expression.Property(null, typeof(PropertyAndFields).GetProperty(nameof(PropertyAndFields.StaticInt32Property2)), new Expression[0]), 6 };
+            yield return new object[] { Expression.Property(obj, nameof(PropertyAndFields.Int32Property), new Expression[0]), 7 };
         }
 
         [Fact]
@@ -144,33 +219,27 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
-        public void ThrowsOnLeftNull()
+        public void LeftNull_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("left", () => Expression.Assign(null, Expression.Constant("")));
         }
 
         [Fact]
-        public void ThrowsOnRightNull()
+        public void RightNull_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("right", () => Expression.Assign(Expression.Variable(typeof(int)), null));
         }
-
-        [Fact]
-        public void LeftMustBeWritable()
+        
+        [Theory]
+        [InlineData(typeof(int), "Hello", typeof(string))]
+        [InlineData(typeof(long), 1, typeof(int))]
+        [InlineData(typeof(int?), 1, typeof(int))]
+        [InlineData(typeof(SubClass), null, typeof(BaseClass))]
+        [InlineData(typeof(int), null, typeof(BaseClass))]
+        [InlineData(typeof(BaseClass), 1, typeof(int))]
+        public void MismatchTypes(Type variableType, object constantValue, Type constantType)
         {
-            Assert.Throws<ArgumentException>("left", () => Expression.Assign(Expression.Constant(0), Expression.Constant(1)));
-        }
-
-        [Fact]
-        public void MismatchTypes()
-        {
-            Assert.Throws<ArgumentException>(null, () => Expression.Assign(Expression.Variable(typeof(int)), Expression.Constant("Hello")));
-        }
-
-        [Fact]
-        public void AssignableButOnlyWithConversion()
-        {
-            Assert.Throws<ArgumentException>(null, () => Expression.Assign(Expression.Variable(typeof(long)), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Assign(Expression.Variable(variableType), Expression.Constant(constantValue, constantType)));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
@@ -187,17 +256,81 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("Hello", Expression.Lambda<Func<object>>(exp).Compile(useInterpreter)());
         }
 
-        [Theory, MemberData(nameof(ReadOnlyExpressions))]
-        public void AttemptToAssignToNonWritable(Expression readonlyExp)
+        [Theory]
+        [MemberData(nameof(ReadOnlyExpressions))]
+        public void LeftReadOnly_ThrowsArgumentException(Expression readonlyExp)
         {
             Assert.Throws<ArgumentException>("left", () => Expression.Assign(readonlyExp, Expression.Default(readonlyExp.Type)));
         }
 
-        [Theory, MemberData(nameof(WriteOnlyExpressions))]
-        public static void AttemptToAssignFromNonReadable(Expression writeOnlyExp)
+        [Theory]
+        [MemberData(nameof(WriteOnlyExpressions))]
+        public static void Right_WriteOnly_ThrowsArgumentException(Expression writeOnlyExp)
         {
             ParameterExpression variable = Expression.Variable(writeOnlyExp.Type);
             Assert.Throws<ArgumentException>("right", () => Expression.Assign(variable, writeOnlyExp));
+        }
+
+        [Theory]
+        [ClassData(typeof(InvalidTypes))]
+        public static void Left_InvalidType_ThrowsArgumentException(Type type)
+        {
+            Expression left = new FakeExpression(ExpressionType.Parameter, type);
+            Assert.Throws<ArgumentException>("left", () => Expression.Assign(left, Expression.Parameter(typeof(int))));
+        }
+
+        [Theory]
+        [ClassData(typeof(InvalidTypes))]
+        public static void Right_InvalidType_ThrowsArgumentException(Type type)
+        {
+            Expression right = new FakeExpression(ExpressionType.Parameter, type);
+            Assert.Throws<ArgumentException>("right", () => Expression.Assign(Expression.Variable(typeof(object)), right));
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public static void Left_ValueTypeContainsChildTryExpression_ThrowsNotSupportedExceptionOnCompilation(bool useInterpreter)
+        {
+            Expression tryExpression = Expression.TryFinally(
+                Expression.Constant(1),
+                Expression.Empty()
+            );
+            Expression index = Expression.Property(Expression.Constant(new StructWithPropertiesAndFields()), typeof(StructWithPropertiesAndFields).GetProperty("Item"), new Expression[] { tryExpression });
+
+            Expression<Func<bool>> func = Expression.Lambda<Func<bool>>(
+                Expression.Block(
+                    Expression.Assign(index, Expression.Constant(123)),
+                    Expression.Equal(index, Expression.Constant(123))
+                    )
+                );
+
+            if (useInterpreter)
+            {
+                Assert.True(func.Compile(useInterpreter)());
+            }
+            else
+            {
+                Assert.Throws<NotSupportedException>(() => func.Compile(useInterpreter));
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public static void Left_ReferenceTypeContainsChildTryExpression_Compiles(bool useInterpreter)
+        {
+            Expression tryExpression = Expression.TryFinally(
+                Expression.Constant(1),
+                Expression.Empty()
+            );
+            Expression index = Expression.Property(Expression.Constant(new PropertyAndFields()), typeof(PropertyAndFields).GetProperty("Item"), new Expression[] { tryExpression });
+
+            Func<bool> func = Expression.Lambda<Func<bool>>(
+                Expression.Block(
+                    Expression.Assign(index, Expression.Constant(123)),
+                    Expression.Equal(index, Expression.Constant(123))
+                    )
+                ).Compile(useInterpreter);
+            Assert.True(func());
         }
 
         [Fact]
@@ -206,5 +339,8 @@ namespace System.Linq.Expressions.Tests
             var e = Expression.Assign(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a = b)", e.ToString());
         }
+
+        class BaseClass { }
+        class SubClass : BaseClass { }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -146,7 +146,7 @@ namespace System.Linq.Expressions.Tests
             yield return new object[] { Expression.Property(obj, simpleIndexer, new Expression[] { Expression.Constant(1) }), 5 };
 
             PropertyInfo advancedIndexer = typeof(PropertyAndFields).GetProperties().First(prop => prop.GetIndexParameters().Length == 2);
-            yield return new object[] { Expression.Property(obj, simpleIndexer, new Expression[] { Expression.Constant(1), Expression.Constant(2) }), 5 };
+            yield return new object[] { Expression.Property(obj, advancedIndexer, new Expression[] { Expression.Constant(1), Expression.Constant(2) }), 5 };
 
             // IndexExpression for non-indexed property
             yield return new object[] { Expression.Property(null, typeof(PropertyAndFields).GetProperty(nameof(PropertyAndFields.StaticInt32Property2)), new Expression[0]), 6 };
@@ -322,7 +322,8 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(1),
                 Expression.Empty()
             );
-            Expression index = Expression.Property(Expression.Constant(new PropertyAndFields()), typeof(PropertyAndFields).GetProperty("Item"), new Expression[] { tryExpression });
+            PropertyInfo simpleIndexer = typeof(PropertyAndFields).GetProperties().First(prop => prop.GetIndexParameters().Length == 1);
+            Expression index = Expression.Property(Expression.Constant(new PropertyAndFields()), simpleIndexer, new Expression[] { tryExpression });
 
             Func<bool> func = Expression.Lambda<Func<bool>>(
                 Expression.Block(

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -287,6 +287,20 @@ namespace System.Linq.Expressions.Tests
         public void GenericMethod<T>() { }
         public static void StaticMethod() { }
     }
+    
+    public class InvalidTypes : IEnumerable<object[]>
+    {
+        private static readonly object[] GenericTypeDefinition = new object[] { typeof(GenericClass<>) };
+        private static readonly object[] ContainsGenericParameters = new object[] { typeof(GenericClass<>).MakeGenericType(typeof(GenericClass<>)) };
+
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return GenericTypeDefinition;
+            yield return ContainsGenericParameters;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
     public enum ByteEnum : byte { A = Byte.MaxValue }
     public enum SByteEnum : sbyte { A = SByte.MaxValue }
@@ -296,4 +310,19 @@ namespace System.Linq.Expressions.Tests
     public enum UInt32Enum : uint { A = UInt32.MaxValue }
     public enum Int64Enum : long { A = Int64.MaxValue }
     public enum UInt64Enum : ulong { A = UInt64.MaxValue }
+
+    public class FakeExpression : Expression
+    {
+        public FakeExpression(ExpressionType customNodeType, Type customType)
+        {
+            CustomNodeType = customNodeType;
+            CustomType = customType;
+        }
+
+        public ExpressionType CustomNodeType { get; set; }
+        public Type CustomType { get; set; }
+
+        public override ExpressionType NodeType => CustomNodeType;
+        public override Type Type => CustomType;
+    }
 }


### PR DESCRIPTION
- Also increases CC by ~1%, contributing to #1918
- Also removes some dead code

I've found a behaviour difference between the compiler and the interpreter (embedded try expressions in an index expression). I think this is by design, but let me know what you all thinl.

/cc @bartdesmet @vsadov @stephentoub