### PR TITLE
Fixing prerelease label in master after merge from dev/api

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PreReleaseLabel>beta-devapi</PreReleaseLabel>
+    <PreReleaseLabel>beta</PreReleaseLabel>
     <PackageDescriptionFile>$(ProjectDir)pkg/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(ProjectDir)pkg/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)pkg/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>


### PR DESCRIPTION
When merging dev/api, I forgot to change the prerelease label causing packages from master branch to contain the wrong prerelease label. With this change, packages from master will only have 'beta' as their label.

cc: @ericstj 

FYI: @weshaggard @stephentoub 