### PR TITLE
Add back missing System.Net.Security APIs

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1224,7 +1224,7 @@
       "BaselineVersion": "4.0.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
-        "4.0.1.0": "4.3.0"
+        "4.1.0.0": "4.3.0"
       }
     },
     "System.Net.Sockets": {

--- a/src/System.Net.Security/dir.props
+++ b/src/System.Net.Security/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>
 

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -46,6 +46,11 @@ namespace System.Net.Security
         public override int ReadTimeout { get { return default(int); } set { } }
         public virtual System.Security.Principal.IIdentity RemoteIdentity { get { return default(System.Security.Principal.IIdentity); } }
         public override int WriteTimeout { get { return default(int); } set { } }
+        public virtual void AuthenticateAsClient() { }
+        public virtual void AuthenticateAsClient(System.Net.NetworkCredential credential, string targetName) { }
+        public virtual void AuthenticateAsClient(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName) { }
+        public virtual void AuthenticateAsClient(System.Net.NetworkCredential credential, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { }
+        public virtual void AuthenticateAsClient(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync() { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(NetworkCredential credential, string targetName) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName) { return default(System.Threading.Tasks.Task); }
@@ -55,6 +60,17 @@ namespace System.Net.Security
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(NetworkCredential credential, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { return default(System.Threading.Tasks.Task); }
+        public System.IAsyncResult BeginAuthenticateAsClient(System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public System.IAsyncResult BeginAuthenticateAsClient(System.Net.NetworkCredential credential, string targetName, System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public System.IAsyncResult BeginAuthenticateAsClient(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName, System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public System.IAsyncResult BeginAuthenticateAsClient(System.Net.NetworkCredential credential, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public System.IAsyncResult BeginAuthenticateAsClient(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public System.IAsyncResult BeginAuthenticateAsServer(AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public System.IAsyncResult BeginAuthenticateAsServer(System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public IAsyncResult BeginAuthenticateAsServer(System.Net.NetworkCredential credential, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public IAsyncResult BeginAuthenticateAsServer(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public void EndAuthenticateAsClient(System.IAsyncResult asyncResult) { }
+        public void EndAuthenticateAsServer(System.IAsyncResult asyncResult) { }
         public override void Flush() { }
         public override int Read(byte[] buffer, int offset, int count) { return default(int); }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { return default(long); }

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -99,10 +99,20 @@ namespace System.Net.Security
         public virtual System.Security.Authentication.SslProtocols SslProtocol { get { return default(System.Security.Authentication.SslProtocols); } }
         public System.Net.TransportContext TransportContext { get { return default(System.Net.TransportContext); } }
         public override int WriteTimeout { get { return default(int); } set { } }
+        public virtual void AuthenticateAsClient(string targetHost) { }
+        public virtual void AuthenticateAsClient(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { }
+        public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate) { }
+        public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { return default(System.Threading.Tasks.Task); }
+        public virtual System.IAsyncResult BeginAuthenticateAsClient(string targetHost, System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public virtual System.IAsyncResult BeginAuthenticateAsClient(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation, System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public virtual System.IAsyncResult BeginAuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public virtual System.IAsyncResult BeginAuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation, System.AsyncCallback asyncCallback, object asyncState) { return default(System.IAsyncResult); }
+        public virtual void EndAuthenticateAsClient(IAsyncResult asyncResult) { }
+        public virtual void EndAuthenticateAsServer(IAsyncResult asyncResult) { }
         public override void Flush() { }
         public override int Read(byte[] buffer, int offset, int count) { return default(int); }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { return default(long); }

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/NegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/NegotiateStream.cs
@@ -48,28 +48,28 @@ namespace System.Net.Security
 #endif
         }
 
-        private IAsyncResult BeginAuthenticateAsClient(AsyncCallback asyncCallback, object asyncState)
+        public IAsyncResult BeginAuthenticateAsClient(AsyncCallback asyncCallback, object asyncState)
         {
             return BeginAuthenticateAsClient((NetworkCredential)CredentialCache.DefaultCredentials, null, string.Empty,
                                            ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification,
                                            asyncCallback, asyncState);
         }
 
-        private IAsyncResult BeginAuthenticateAsClient(NetworkCredential credential, string targetName, AsyncCallback asyncCallback, object asyncState)
+        public IAsyncResult BeginAuthenticateAsClient(NetworkCredential credential, string targetName, AsyncCallback asyncCallback, object asyncState)
         {
             return BeginAuthenticateAsClient(credential, null, targetName,
                                            ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification,
                                            asyncCallback, asyncState);
         }
 
-        private IAsyncResult BeginAuthenticateAsClient(NetworkCredential credential, ChannelBinding binding, string targetName, AsyncCallback asyncCallback, object asyncState)
+        public IAsyncResult BeginAuthenticateAsClient(NetworkCredential credential, ChannelBinding binding, string targetName, AsyncCallback asyncCallback, object asyncState)
         {
             return BeginAuthenticateAsClient(credential, binding, targetName,
                                              ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification,
                                              asyncCallback, asyncState);
         }
 
-        private IAsyncResult BeginAuthenticateAsClient(
+        public IAsyncResult BeginAuthenticateAsClient(
             NetworkCredential credential,
             string targetName,
             ProtectionLevel requiredProtectionLevel,
@@ -82,7 +82,7 @@ namespace System.Net.Security
                                              asyncCallback, asyncState);
         }
 
-        private IAsyncResult BeginAuthenticateAsClient(
+        public IAsyncResult BeginAuthenticateAsClient(
             NetworkCredential credential,
             ChannelBinding binding,
             string targetName,
@@ -106,7 +106,7 @@ namespace System.Net.Security
 #endif
         }
 
-        private void EndAuthenticateAsClient(IAsyncResult asyncResult)
+        public void EndAuthenticateAsClient(IAsyncResult asyncResult)
         {
 #if DEBUG
             using (GlobalLog.SetThreadKind(ThreadKinds.User))
@@ -118,17 +118,17 @@ namespace System.Net.Security
 #endif
         }
 
-        private IAsyncResult BeginAuthenticateAsServer(AsyncCallback asyncCallback, object asyncState)
+        public IAsyncResult BeginAuthenticateAsServer(AsyncCallback asyncCallback, object asyncState)
         {
             return BeginAuthenticateAsServer((NetworkCredential)CredentialCache.DefaultCredentials, null, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification, asyncCallback, asyncState);
         }
 
-        private IAsyncResult BeginAuthenticateAsServer(ExtendedProtectionPolicy policy, AsyncCallback asyncCallback, object asyncState)
+        public IAsyncResult BeginAuthenticateAsServer(ExtendedProtectionPolicy policy, AsyncCallback asyncCallback, object asyncState)
         {
             return BeginAuthenticateAsServer((NetworkCredential)CredentialCache.DefaultCredentials, policy, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification, asyncCallback, asyncState);
         }
 
-        private IAsyncResult BeginAuthenticateAsServer(
+        public IAsyncResult BeginAuthenticateAsServer(
             NetworkCredential credential,
             ProtectionLevel requiredProtectionLevel,
             TokenImpersonationLevel requiredImpersonationLevel,
@@ -138,7 +138,7 @@ namespace System.Net.Security
             return BeginAuthenticateAsServer(credential, null, requiredProtectionLevel, requiredImpersonationLevel, asyncCallback, asyncState);
         }
 
-        private IAsyncResult BeginAuthenticateAsServer(
+        public IAsyncResult BeginAuthenticateAsServer(
             NetworkCredential credential,
             ExtendedProtectionPolicy policy,
             ProtectionLevel requiredProtectionLevel,
@@ -161,13 +161,48 @@ namespace System.Net.Security
 #endif
         }
         //
-        private void EndAuthenticateAsServer(IAsyncResult asyncResult)
+        public void EndAuthenticateAsServer(IAsyncResult asyncResult)
         {
 #if DEBUG
             using (GlobalLog.SetThreadKind(ThreadKinds.User))
             {
 #endif
                 _negoState.EndProcessAuthentication(asyncResult);
+#if DEBUG
+            }
+#endif
+        }
+
+        public virtual void AuthenticateAsClient()
+        {
+            AuthenticateAsClient((NetworkCredential)CredentialCache.DefaultCredentials, null, string.Empty, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification);
+        }
+
+        public virtual void AuthenticateAsClient(NetworkCredential credential, string targetName)
+        {
+            AuthenticateAsClient(credential, null, targetName, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification);
+        }
+
+        public virtual void AuthenticateAsClient(NetworkCredential credential, ChannelBinding binding, string targetName)
+        {
+            AuthenticateAsClient(credential, binding, targetName, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification);
+        }
+
+        public virtual void AuthenticateAsClient(
+            NetworkCredential credential, string targetName, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel allowedImpersonationLevel)
+        {
+            AuthenticateAsClient(credential, null, targetName, requiredProtectionLevel, allowedImpersonationLevel);
+        }
+        
+        public virtual void AuthenticateAsClient(
+            NetworkCredential credential, ChannelBinding binding, string targetName, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel allowedImpersonationLevel)
+        {
+#if DEBUG
+            using (GlobalLog.SetThreadKind(ThreadKinds.User | ThreadKinds.Sync))
+            {
+#endif
+                _negoState.ValidateCreateContext(_package, false, credential, targetName, binding, requiredProtectionLevel, allowedImpersonationLevel);
+                _negoState.ProcessAuthentication(null);
 #if DEBUG
             }
 #endif

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -7,15 +7,18 @@ using System.Net.Test.Common;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
 
 namespace System.Net.Security.Tests
 {
-    public class SslStreamStreamToStreamTest
+    public abstract class SslStreamStreamToStreamTest
     {
         private readonly byte[] _sampleMsg = Encoding.UTF8.GetBytes("Sample Test Message");
+
+        protected abstract bool DoHandshake(SslStream clientSslStream, SslStream serverSslStream);
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
@@ -29,12 +32,7 @@ namespace System.Net.Security.Tests
             using (var server = new SslStream(serverStream))
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
             {
-                Task[] auth = new Task[2];
-                auth[0] = client.AuthenticateAsClientAsync(certificate.GetNameInfo(X509NameType.SimpleName, false));
-                auth[1] = server.AuthenticateAsServerAsync(certificate);
-
-                bool finished = Task.WaitAll(auth, TestConfiguration.PassingTestTimeoutMilliseconds);
-                Assert.True(finished, "Handshake completed in the allotted time");
+                Assert.True(DoHandshake(client, server), "Handshake completed in the allotted time");
             }
         }
 
@@ -228,18 +226,49 @@ namespace System.Net.Security.Tests
                 return false;
             }
         }
+    }
 
-        private bool DoHandshake(SslStream clientSslStream, SslStream serverSslStream)
+    public sealed class SslStreamStreamToStreamTest_Async : SslStreamStreamToStreamTest
+    {
+        protected override bool DoHandshake(SslStream clientSslStream, SslStream serverSslStream)
         {
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
             {
-                Task[] auth = new Task[2];
+                Task t1 = clientSslStream.AuthenticateAsClientAsync(certificate.GetNameInfo(X509NameType.SimpleName, false));
+                Task t2 = serverSslStream.AuthenticateAsServerAsync(certificate);
+                return Task.WaitAll(new[] { t1, t2 }, TestConfiguration.PassingTestTimeoutMilliseconds);
+            }
+        }
+    }
 
-                auth[0] = clientSslStream.AuthenticateAsClientAsync(certificate.GetNameInfo(X509NameType.SimpleName, false));
-                auth[1] = serverSslStream.AuthenticateAsServerAsync(certificate);
+    public sealed class SslStreamStreamToStreamTest_BeginEnd : SslStreamStreamToStreamTest
+    {
+        protected override bool DoHandshake(SslStream clientSslStream, SslStream serverSslStream)
+        {
+            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            {
+                IAsyncResult a1 = clientSslStream.BeginAuthenticateAsClient(certificate.GetNameInfo(X509NameType.SimpleName, false), null, null);
+                IAsyncResult a2 = serverSslStream.BeginAuthenticateAsServer(certificate, null, null);
+                if (WaitHandle.WaitAll(new[] { a1.AsyncWaitHandle, a2.AsyncWaitHandle }, TestConfiguration.PassingTestTimeoutMilliseconds))
+                {
+                    clientSslStream.EndAuthenticateAsClient(a1);
+                    serverSslStream.EndAuthenticateAsServer(a2);
+                    return true;
+                }
+                return false;
+            }
+        }
+    }
 
-                bool finished = Task.WaitAll(auth, TestConfiguration.PassingTestTimeoutMilliseconds);
-                return finished;
+    public sealed class SslStreamStreamToStreamTest_Sync : SslStreamStreamToStreamTest
+    {
+        protected override bool DoHandshake(SslStream clientSslStream, SslStream serverSslStream)
+        {
+            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            {
+                Task t1 = Task.Run(() => clientSslStream.AuthenticateAsClient(certificate.GetNameInfo(X509NameType.SimpleName, false)));
+                Task t2 = Task.Run(() => serverSslStream.AuthenticateAsServer(certificate));
+                return Task.WaitAll(new[] { t1, t2 }, TestConfiguration.PassingTestTimeoutMilliseconds);
             }
         }
     }

--- a/src/System.Net.Security/tests/UnitTests/SslStreamAllowedProtocolsTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/SslStreamAllowedProtocolsTest.cs
@@ -5,136 +5,136 @@
 using System.IO;
 using System.Net.Test.Common;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
 using Xunit;
 
 namespace System.Net.Security.Tests
 {
-    public class SslStreamAllowedProtocolsTest
+    public abstract class SslStreamAllowedProtocolsTest
     {
+        protected abstract void AuthenticateAsClient(
+            SslStream stream, bool waitForCompletion,
+            string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation);
+
         [Theory]
         [ClassData(typeof(SslProtocolSupport.UnsupportedSslProtocolsTestData))]
         public void SslStream_AuthenticateAsClientAsync_NotSupported_Fails(SslProtocols protocol)
         {
-            SslStream stream = new SslStream(new FakeStream());
-            Assert.Throws<NotSupportedException>(() => { stream.AuthenticateAsClientAsync("host", null, protocol, false); });
+            SslStream stream = new SslStream(new NotImplementedStream());
+            Assert.Throws<NotSupportedException>(() => AuthenticateAsClient(stream, false, "host", null, protocol, false));
         }
 
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
-        public async Task SslStream_AuthenticateAsClientAsync_Supported_Success(SslProtocols protocol)
+        public void SslStream_AuthenticateAsClientAsync_Supported_Success(SslProtocols protocol)
         {
-            SslStream stream = new SslStream(new FakeStream());
-            await stream.AuthenticateAsClientAsync("host", null, protocol, false);
+            SslStream stream = new SslStream(new NotImplementedStream());
+            AuthenticateAsClient(stream, true, "host", null, protocol, false);
+        }
+
+        [Theory]
+        [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
+        public void SslStream_AuthenticateAsClient_Supported_Success(SslProtocols protocol)
+        {
+            SslStream stream = new SslStream(new NotImplementedStream());
+            AuthenticateAsClient(stream, true, "host", null, protocol, false);
         }
 
         [Fact]
         public void SslStream_AuthenticateAsClientAsync_Invalid_Fails()
         {
-            SslStream stream = new SslStream(new FakeStream());
-            Assert.Throws<NotSupportedException>(() => { stream.AuthenticateAsClientAsync("host", null, (SslProtocols)4096, false); });
+            SslStream stream = new SslStream(new NotImplementedStream());
+            Assert.Throws<NotSupportedException>(() => AuthenticateAsClient(stream, false, "host", null, (SslProtocols)4096, false));
+        }
+
+        [Fact]
+        public void SslStream_AuthenticateAsClient_Invalid_Fails()
+        {
+            SslStream stream = new SslStream(new NotImplementedStream());
+            Assert.Throws<NotSupportedException>(() => AuthenticateAsClient(stream, false, "host", null, (SslProtocols)4096, false));
         }
 
         [Fact]
         public void SslStream_AuthenticateAsClientAsync_AllUnsuported_Fails()
         {
-            SslStream stream = new SslStream(new FakeStream());
-            Assert.Throws<NotSupportedException>(() => { stream.AuthenticateAsClientAsync("host", null, SslProtocolSupport.UnsupportedSslProtocols, false); });
+            SslStream stream = new SslStream(new NotImplementedStream());
+            Assert.Throws<NotSupportedException>(() => AuthenticateAsClient(stream, false, "host", null, SslProtocolSupport.UnsupportedSslProtocols, false));
         }
 
         [Fact]
-        public async Task SslStream_AuthenticateAsClientAsync_AllSupported_Success()
+        public void SslStream_AuthenticateAsClientAsync_AllSupported_Success()
         {
-            SslStream stream = new SslStream(new FakeStream());
-            await stream.AuthenticateAsClientAsync("host", null, SslProtocolSupport.SupportedSslProtocols, false);
+            SslStream stream = new SslStream(new NotImplementedStream());
+            AuthenticateAsClient(stream, true, "host", null, SslProtocolSupport.SupportedSslProtocols, false);
         }
 
         [Fact]
-        public async Task SslStream_AuthenticateAsClientAsync_None_Success()
+        public void SslStream_AuthenticateAsClientAsync_None_Success()
         {
-            SslStream stream = new SslStream(new FakeStream());
-            await stream.AuthenticateAsClientAsync("host", null, SslProtocols.None, false);
+            SslStream stream = new SslStream(new NotImplementedStream());
+            AuthenticateAsClient(stream, true, "host", null, SslProtocols.None, false);
         }
 
         [Fact]
-        public async Task SslStream_AuthenticateAsClientAsync_Default_Success()
+        public void SslStream_AuthenticateAsClientAsync_Default_Success()
         {
-            SslStream stream = new SslStream(new FakeStream());
-            await stream.AuthenticateAsClientAsync("host", null, SslProtocolSupport.DefaultSslProtocols, false);
+            SslStream stream = new SslStream(new NotImplementedStream());
+            AuthenticateAsClient(stream, true, "host", null, SslProtocolSupport.DefaultSslProtocols, false);
         }
 
-        private class FakeStream : Stream
+
+        public sealed class SslStreamAllowedProtocolsTest_Async : SslStreamAllowedProtocolsTest
         {
-            public override bool CanRead
+            protected override void AuthenticateAsClient(
+                SslStream stream, bool waitForCompletion,
+                string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
             {
-                get
+                Task t = stream.AuthenticateAsClientAsync(targetHost, clientCertificates, enabledSslProtocols, checkCertificateRevocation);
+                if (waitForCompletion)
                 {
-                    throw new NotImplementedException();
+                    t.GetAwaiter().GetResult();
                 }
             }
+        }
 
-            public override bool CanSeek
+        public sealed class SslStreamAllowedProtocolsTest_BeginEnd : SslStreamAllowedProtocolsTest
+        {
+            protected override void AuthenticateAsClient(
+                SslStream stream, bool waitForCompletion,
+                string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
             {
-                get
+                IAsyncResult iar = stream.BeginAuthenticateAsClient(targetHost, clientCertificates, enabledSslProtocols, checkCertificateRevocation, null, null);
+                if (waitForCompletion)
                 {
-                    throw new NotImplementedException();
+                    stream.EndAuthenticateAsClient(iar);
                 }
             }
+        }
 
-            public override bool CanWrite
+        public sealed class SslStreamAllowedProtocolsTest_Sync : SslStreamAllowedProtocolsTest
+        {
+            protected override void AuthenticateAsClient(
+                SslStream stream, bool waitForCompletion,
+                string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
             {
-                get
-                {
-                    throw new NotImplementedException();
-                }
+                stream.AuthenticateAsClient(targetHost, clientCertificates, enabledSslProtocols, checkCertificateRevocation);
             }
+        }
 
-            public override long Length
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-            }
-
-            public override long Position
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-
-                set
-                {
-                    throw new NotImplementedException();
-                }
-            }
-
-            public override void Flush()
-            {
-                throw new NotImplementedException();
-            }
-
-            public override int Read(byte[] buffer, int offset, int count)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override long Seek(long offset, SeekOrigin origin)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override void SetLength(long value)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override void Write(byte[] buffer, int offset, int count)
-            {
-                throw new NotImplementedException();
-            }
+        private sealed class NotImplementedStream : Stream
+        {
+            public override bool CanRead { get { throw new NotImplementedException(); } }
+            public override bool CanSeek { get { throw new NotImplementedException(); } }
+            public override bool CanWrite { get { throw new NotImplementedException(); } }
+            public override long Length { get { throw new NotImplementedException(); } }
+            public override long Position { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } }
+            public override void Flush() { throw new NotImplementedException(); }
+            public override int Read(byte[] buffer, int offset, int count) { throw new NotImplementedException(); }
+            public override long Seek(long offset, SeekOrigin origin) { throw new NotImplementedException(); }
+            public override void SetLength(long value) { throw new NotImplementedException(); }
+            public override void Write(byte[] buffer, int offset, int count) { throw new NotImplementedException(); }
         }
     }
 }

--- a/src/System.Net.Security/tests/UnitTests/SslStreamAllowedProtocolsTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/SslStreamAllowedProtocolsTest.cs
@@ -15,61 +15,50 @@ namespace System.Net.Security.Tests
     {
         [Theory]
         [ClassData(typeof(SslProtocolSupport.UnsupportedSslProtocolsTestData))]
-        public async Task SslStream_AuthenticateAsClient_NotSupported_Fails(SslProtocols protocol)
+        public void SslStream_AuthenticateAsClientAsync_NotSupported_Fails(SslProtocols protocol)
         {
             SslStream stream = new SslStream(new FakeStream());
-            await Assert.ThrowsAsync<NotSupportedException>(
-                () => stream.AuthenticateAsClientAsync("host", null, protocol, false));
+            Assert.Throws<NotSupportedException>(() => { stream.AuthenticateAsClientAsync("host", null, protocol, false); });
         }
 
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
-        public async Task SslStream_AuthenticateAsClient_Supported_Success(SslProtocols protocol)
+        public async Task SslStream_AuthenticateAsClientAsync_Supported_Success(SslProtocols protocol)
         {
             SslStream stream = new SslStream(new FakeStream());
             await stream.AuthenticateAsClientAsync("host", null, protocol, false);
         }
 
         [Fact]
-        public async Task SslStream_AuthenticateAsClient_Invalid_Fails()
+        public void SslStream_AuthenticateAsClientAsync_Invalid_Fails()
         {
             SslStream stream = new SslStream(new FakeStream());
-            await Assert.ThrowsAsync<NotSupportedException>(
-                () => stream.AuthenticateAsClientAsync("host", null, (SslProtocols)4096, false));
+            Assert.Throws<NotSupportedException>(() => { stream.AuthenticateAsClientAsync("host", null, (SslProtocols)4096, false); });
         }
 
         [Fact]
-        public async Task SslStream_AuthenticateAsClient_AllUnsuported_Fails()
+        public void SslStream_AuthenticateAsClientAsync_AllUnsuported_Fails()
         {
             SslStream stream = new SslStream(new FakeStream());
-            await Assert.ThrowsAsync<NotSupportedException>(
-                () => stream.AuthenticateAsClientAsync(
-                    "host",
-                    null,
-                    SslProtocolSupport.UnsupportedSslProtocols,
-                    false));
+            Assert.Throws<NotSupportedException>(() => { stream.AuthenticateAsClientAsync("host", null, SslProtocolSupport.UnsupportedSslProtocols, false); });
         }
 
         [Fact]
-        public async Task SslStream_AuthenticateAsClient_AllSupported_Success()
+        public async Task SslStream_AuthenticateAsClientAsync_AllSupported_Success()
         {
             SslStream stream = new SslStream(new FakeStream());
-            await stream.AuthenticateAsClientAsync(
-                "host",
-                null,
-                SslProtocolSupport.SupportedSslProtocols,
-                false);
+            await stream.AuthenticateAsClientAsync("host", null, SslProtocolSupport.SupportedSslProtocols, false);
         }
 
         [Fact]
-        public async Task SslStream_AuthenticateAsClient_None_Success()
+        public async Task SslStream_AuthenticateAsClientAsync_None_Success()
         {
             SslStream stream = new SslStream(new FakeStream());
             await stream.AuthenticateAsClientAsync("host", null, SslProtocols.None, false);
         }
 
         [Fact]
-        public async Task SslStream_AuthenticateAsClient_Default_Success()
+        public async Task SslStream_AuthenticateAsClientAsync_Default_Success()
         {
             SslStream stream = new SslStream(new FakeStream());
             await stream.AuthenticateAsClientAsync("host", null, SslProtocolSupport.DefaultSslProtocols, false);
@@ -149,4 +138,3 @@ namespace System.Net.Security.Tests
         }
     }
 }
-


### PR DESCRIPTION
Adds back the missing 30 methods on SslStream and NegotiateStream, all of which were the Begin/End and synchronous variants of the XxAsync methods.

Approach:
- Made the Begin/End methods public, and ensured they were doing the same validation as the XxAsync methods
- Added back synchronous methods with (minimal) implementation from desktop
- Extended a few of the existing test classes currently using XxAsync to run all of the tests with the Begin/End and synchronous variants as well

cc: @davidsh, @cipop, @ericeil, @danmosemsft, @joperezr 