### PR TITLE
Removing support for netcore50 for some System.Private.Xml tests projects to fix PipeBuild

### DIFF
--- a/src/System.Private.Xml.Linq/tests/System.Private.Xml.Linq.Tests.builds
+++ b/src/System.Private.Xml.Linq/tests/System.Private.Xml.Linq.Tests.builds
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="axes\System.Xml.Linq.Axes.Tests.csproj" >
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="events\System.Xml.Linq.Events.Tests.csproj" >

--- a/src/System.Private.Xml.Linq/tests/axes/project.json
+++ b/src/System.Private.Xml.Linq/tests/axes/project.json
@@ -19,7 +19,6 @@
     "netstandard1.3": {}
   },
   "supports": {
-    "coreFx.Test.netcore50": {},
     "coreFx.Test.netcoreapp1.0": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},

--- a/src/System.Private.Xml/tests/Readers/NameTable/project.json
+++ b/src/System.Private.Xml/tests/Readers/NameTable/project.json
@@ -20,7 +20,6 @@
     "netstandard1.3": {}
   },
   "supports": {
-    "coreFx.Test.netcore50": {},
     "coreFx.Test.netcoreapp1.0": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},

--- a/src/System.Private.Xml/tests/System.Private.Xml.Tests.builds
+++ b/src/System.Private.Xml/tests/System.Private.Xml.Tests.builds
@@ -15,7 +15,7 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="Readers\NameTable\System.Xml.RW.NameTable.Tests.csproj" >
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="Readers\ReaderSettings\System.Xml.RW.ReaderSettings.Tests.csproj" >
@@ -63,11 +63,11 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="XmlSchema\XmlSchemaSet\System.Xml.XmlSchemaSet.Tests.csproj" >
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="XmlSchema\XmlSchemaValidatorApi\System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj" >
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="Xslt\XslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj" >
@@ -79,7 +79,7 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="XPath\XPathDocument\System.Xml.XPath.Tests.csproj" >
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="XPath\XmlDocument\System.Xml.XPath.XmlDocument.Tests.csproj" >

--- a/src/System.Private.Xml/tests/XPath/XPathDocument/project.json
+++ b/src/System.Private.Xml/tests/XPath/XPathDocument/project.json
@@ -24,7 +24,6 @@
     "netstandard1.3": {}
   },
   "supports": {
-    "coreFx.Test.netcore50": {},
     "coreFx.Test.netcoreapp1.0": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/project.json
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/project.json
@@ -21,7 +21,6 @@
     "netstandard1.3": {}
   },
   "supports": {
-    "coreFx.Test.netcore50": {},
     "coreFx.Test.netcoreapp1.0": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/project.json
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/project.json
@@ -21,7 +21,6 @@
     "netstandard1.3": {}
   },
   "supports": {
-    "coreFx.Test.netcore50": {},
     "coreFx.Test.netcoreapp1.0": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},


### PR DESCRIPTION
cc: @weshaggard @chcosta @AlfredoMS 

When merging dev/api into master, the Pipeline Builds got broken since some test projects now added a dependency to System.Private.Xml, which doesn't support netcore50 in all of it's platforms. This caused that Pipeline Tests builds couldn't restore the generated project.jsons. With this change, I'm removing the supports claim for netcore50 for these projects.