### PR TITLE
Remove CreateManyConcurrent test

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -545,37 +545,6 @@ namespace System.IO.Tests
         [Fact]
         [PlatformSpecific(TestPlatforms.Linux)]
         [OuterLoop("This test has high system resource demands and may cause failures in other concurrent tests")]
-        public void FileSystemWatcher_CreateManyConcurrentInstances()
-        {
-            int maxUserInstances = int.Parse(File.ReadAllText("/proc/sys/fs/inotify/max_user_instances"));
-            var watchers = new List<FileSystemWatcher>();
-
-            using (var dir = new TempDirectory(GetTestFilePath()))
-            {
-                try
-                {
-                    Assert.Throws<IOException>(() =>
-                    {
-                        // Create enough inotify instances to exceed the number of allowed watches
-                        for (int i = 0; i <= maxUserInstances; i++)
-                        {
-                            watchers.Add(new FileSystemWatcher(dir.Path) { EnableRaisingEvents = true });
-                        }
-                    });
-                }
-                finally
-                {
-                    foreach (FileSystemWatcher watcher in watchers)
-                    {
-                        watcher.Dispose();
-                    }
-                }
-            }
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Linux)]
-        [OuterLoop("This test has high system resource demands and may cause failures in other concurrent tests")]
         public void FileSystemWatcher_CreateManyConcurrentWatches()
         {
             int maxUserWatches = int.Parse(File.ReadAllText("/proc/sys/fs/inotify/max_user_watches"));


### PR DESCRIPTION
<strike>Adds a conditionalFact to the CreateManyConcurrentInstances test so we don't run the test when max_user_instances is greater than 200. That's just too many instances to create and has the potential to cause OOM exceptions. I also cleaned up the project and solution files to play nicely with VS.</strike>

The test is causing intermittent failures in other tests and is also intermittently failing itself. Without modifying system resources we can't make this test trustworthy, so it's better to remove it for the sake of stability.

resolves https://github.com/dotnet/corefx/issues/11622
resolves https://github.com/dotnet/corefx/issues/5660