### PR TITLE
Re-enable tests for System.IO.FileSystem.Watcher and System.Net.Ping, on Windows Subsystem for Linux

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
@@ -9,7 +9,7 @@ namespace System.IO.Tests
 {
     public class Directory_Changed_Tests : FileSystemWatcherTest
     {
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_Directory_Changed_LastWrite()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -23,7 +23,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_Directory_Changed_WatchedFolder()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -36,7 +36,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public void FileSystemWatcher_Directory_Changed_Nested(bool includeSubdirectories)
@@ -58,7 +58,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(CanCreateSymbolicLinks), nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
         public void FileSystemWatcher_Directory_Changed_SymLink()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Create.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Create.cs
@@ -9,7 +9,7 @@ namespace System.IO.Tests
 {
     public class Directory_Create_Tests : FileSystemWatcherTest
     {
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_Directory_Create()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -25,7 +25,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_Directory_Create_InNestedDirectory()
         {
             using (var dir = new TempDirectory(GetTestFilePath()))
@@ -64,7 +64,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(CanCreateSymbolicLinks), nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
         public void FileSystemWatcher_Directory_Create_SymLink()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Delete.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Delete.cs
@@ -10,7 +10,7 @@ namespace System.IO.Tests
 {
     public class Directory_Delete_Tests : FileSystemWatcherTest
     {
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_Directory_Delete()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -27,7 +27,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_Directory_Delete_InNestedDirectory()
         {
             using (var dir = new TempDirectory(GetTestFilePath()))
@@ -68,7 +68,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(CanCreateSymbolicLinks), nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
         public void FileSystemWatcher_Directory_Delete_SymLink()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
@@ -15,7 +15,7 @@ namespace System.IO.Tests
             DirectoryMove_SameDirectory(WatcherChangeTypes.Renamed);
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void Directory_Move_From_Watched_To_Unwatched()
         {
             DirectoryMove_FromWatchedToUnwatched(WatcherChangeTypes.Deleted);
@@ -35,13 +35,13 @@ namespace System.IO.Tests
             DirectoryMove_DifferentWatchedDirectory(0);
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void Directory_Move_From_Unwatched_To_Watched()
         {
             DirectoryMove_FromUnwatchedToWatched(WatcherChangeTypes.Created);
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public void Directory_Move_In_Nested_Directory(bool includeSubdirectories)
@@ -49,7 +49,7 @@ namespace System.IO.Tests
             DirectoryMove_NestedDirectory(includeSubdirectories ? WatcherChangeTypes.Renamed : 0, includeSubdirectories);
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void Directory_Move_With_Set_NotifyFilter()
         {
             DirectoryMove_WithNotifyFilter(WatcherChangeTypes.Renamed);

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.NotifyFilter.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.NotifyFilter.cs
@@ -19,7 +19,7 @@ namespace System.IO.Tests
         private const uint DACL_SECURITY_INFORMATION = 0x00000004;
         private const uint SE_FILE_OBJECT = 0x1;
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_Directory_NotifyFilter_Attributes(NotifyFilters filter)
         {
@@ -46,7 +46,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_Directory_NotifyFilter_CreationTime(NotifyFilters filter)
         {
@@ -69,7 +69,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_Directory_NotifyFilter_DirectoryName(NotifyFilters filter)
         {
@@ -94,7 +94,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_Directory_NotifyFilter_LastAccessTime(NotifyFilters filter)
         {
@@ -117,7 +117,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_Directory_NotifyFilter_LastWriteTime(NotifyFilters filter)
         {
@@ -181,7 +181,7 @@ namespace System.IO.Tests
         /// <summary>
         /// Tests a changed event on a file when filtering for LastWrite and directory name.
         /// </summary>
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_Directory_NotifyFilter_LastWriteAndFileName()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -201,7 +201,7 @@ namespace System.IO.Tests
         /// Tests the watcher behavior when two events - a Modification and a Creation - happen closely
         /// after each other.
         /// </summary>
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_Directory_NotifyFilter_ModifyAndCreate()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -228,7 +228,7 @@ namespace System.IO.Tests
         /// Tests the watcher behavior when two events - a Modification and a Deletion - happen closely
         /// after each other.
         /// </summary>
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_Directory_NotifyFilter_ModifyAndDelete()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Changed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Changed.cs
@@ -9,7 +9,7 @@ namespace System.IO.Tests
 {
     public class File_Changed_Tests : FileSystemWatcherTest
     {
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_File_Changed_LastWrite()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -23,7 +23,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public void FileSystemWatcher_File_Changed_Nested(bool includeSubdirectories)
@@ -46,7 +46,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_File_Changed_DataModification()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -65,7 +65,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(CanCreateSymbolicLinks), nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
         public void FileSystemWatcher_File_Changed_SymLink()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
@@ -10,7 +10,7 @@ namespace System.IO.Tests
 {
     public class File_Create_Tests : FileSystemWatcherTest
     {
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_File_Create()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -26,7 +26,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_File_Create_ForcedRestart()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -46,7 +46,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_File_Create_InNestedDirectory()
         {
             using (var dir = new TempDirectory(GetTestFilePath()))
@@ -85,7 +85,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(CanCreateSymbolicLinks), nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
         public void FileSystemWatcher_File_Create_SymLink()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
@@ -10,7 +10,7 @@ namespace System.IO.Tests
 {
     public class File_Delete_Tests : FileSystemWatcherTest
     {
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_File_Delete()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -27,7 +27,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_File_Delete_ForcedRestart()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -48,7 +48,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_File_Delete_InNestedDirectory()
         {
             using (var dir = new TempDirectory(GetTestFilePath()))
@@ -89,7 +89,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(CanCreateSymbolicLinks), nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
         public void FileSystemWatcher_File_Delete_SymLink()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
@@ -15,14 +15,14 @@ namespace System.IO.Tests
             FileMove_SameDirectory(WatcherChangeTypes.Renamed);
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
         public void Unix_File_Move_To_Same_Directory()
         {
             FileMove_SameDirectory(WatcherChangeTypes.Created | WatcherChangeTypes.Deleted);
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void File_Move_From_Watched_To_Unwatched()
         {
             FileMove_FromWatchedToUnwatched(WatcherChangeTypes.Deleted);
@@ -42,14 +42,14 @@ namespace System.IO.Tests
             FileMove_DifferentWatchedDirectory(WatcherChangeTypes.Changed);
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         [PlatformSpecific(PlatformID.Linux)]
         public void Linux_File_Move_To_Different_Watched_Directory()
         {
             FileMove_DifferentWatchedDirectory(0);
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void File_Move_From_Unwatched_To_Watched()
         {
             FileMove_FromUnwatchedToWatched(WatcherChangeTypes.Created);
@@ -64,7 +64,7 @@ namespace System.IO.Tests
             FileMove_NestedDirectory(includeSubdirectories ? WatcherChangeTypes.Renamed : 0, includeSubdirectories);
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         [PlatformSpecific(PlatformID.AnyUnix)]
@@ -80,7 +80,7 @@ namespace System.IO.Tests
             FileMove_WithNotifyFilter(WatcherChangeTypes.Renamed);
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
         public void Unix_File_Move_With_Set_NotifyFilter()
         {

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
@@ -21,7 +21,7 @@ namespace System.IO.Tests
         private const uint DACL_SECURITY_INFORMATION = 0x00000004;
         private const uint SE_FILE_OBJECT = 0x1;
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_File_NotifyFilter_Attributes(NotifyFilters filter)
         {
@@ -49,7 +49,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_File_NotifyFilter_CreationTime(NotifyFilters filter)
         {
@@ -72,7 +72,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_File_NotifyFilter_DirectoryName(NotifyFilters filter)
         {
@@ -98,7 +98,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_File_NotifyFilter_LastAccessTime(NotifyFilters filter)
         {
@@ -120,7 +120,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_File_NotifyFilter_LastWriteTime(NotifyFilters filter)
         {
@@ -142,7 +142,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Theory]
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_File_NotifyFilter_Size(NotifyFilters filter)
         {
@@ -208,7 +208,7 @@ namespace System.IO.Tests
         /// <summary>
         /// Tests a changed event on a directory when filtering for LastWrite and FileName.
         /// </summary>
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_File_NotifyFilter_LastWriteAndFileName()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -228,7 +228,7 @@ namespace System.IO.Tests
         /// Tests the watcher behavior when two events - a Modification and a Creation - happen closely
         /// after each other.
         /// </summary>
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_File_NotifyFilter_ModifyAndCreate()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -255,7 +255,7 @@ namespace System.IO.Tests
         /// Tests the watcher behavior when two events - a Modification and a Deletion - happen closely
         /// after each other.
         /// </summary>
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_File_NotifyFilter_ModifyAndDelete()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -573,7 +573,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         [PlatformSpecific(PlatformID.Linux)]
         [OuterLoop("This test has high system resource demands and may cause failures in other concurrent tests")]
         public void FileSystemWatcher_CreateManyConcurrentWatches()
@@ -608,7 +608,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_StopCalledOnBackgroundThreadDoesNotDeadlock()
         {
             // Check the case where Stop or Dispose (they do the same thing) is called from 
@@ -644,7 +644,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/216
+        [Fact]
         public void FileSystemWatcher_WatchingAliasedFolderResolvesToRealPathWhenWatching()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -59,7 +59,7 @@ namespace System.Net.NetworkInformation.Tests
             Assert.Throws<ArgumentException>("buffer", () => { p.SendPingAsync(TestSettings.LocalHost, 1, new byte[65501]); });
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/561
+        [Fact]
         public async Task SendPingAsyncWithIPAddress()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -73,7 +73,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/561
+        [Fact]
         public async Task SendPingAsyncWithIPAddress_AddressAsString()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -87,7 +87,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/561
+        [Fact]
         public async Task SendPingAsyncWithIPAddressAndTimeout()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -120,7 +120,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [PlatformSpecific(PlatformID.AnyUnix)]
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/561
+        [Fact]
         public async Task SendPingAsyncWithIPAddressAndTimeoutAndBuffer_Unix()
         {
             byte[] buffer = TestSettings.PayloadAsBytes;
@@ -165,7 +165,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [PlatformSpecific(PlatformID.AnyUnix)]
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/561
+        [Fact]
         public async Task SendPingAsyncWithIPAddressAndTimeoutAndBufferAndPingOptions_Unix()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -190,7 +190,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/561
+        [Fact]
         public async Task SendPingAsyncWithHost()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -204,7 +204,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/561
+        [Fact]
         public async Task SendPingAsyncWithHostAndTimeout()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -237,7 +237,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [PlatformSpecific(PlatformID.AnyUnix)]
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/561
+        [Fact]
         public async Task SendPingAsyncWithHostAndTimeoutAndBuffer_Unix()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -281,7 +281,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [PlatformSpecific(PlatformID.AnyUnix)]
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/561
+        [Fact]
         public async Task SendPingAsyncWithHostAndTimeoutAndBufferAndPingOptions_Unix()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -306,7 +306,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/561
+        [Fact]
         public static async Task SendPings_ReuseInstance_Hostname()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();

--- a/src/System.Net.Ping/tests/FunctionalTests/UnixPingUtilityTests.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/UnixPingUtilityTests.cs
@@ -17,7 +17,7 @@ namespace System.Net.NetworkInformation.Tests
     {
         private const int IcmpHeaderLengthInBytes = 8;
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/561
+        [Theory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(50)]


### PR DESCRIPTION
These tests now pass, as of Windows 10 preview build 14926.