### PR TITLE
Add back missing System.Net.Ping APIs

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1184,7 +1184,7 @@
       "BaselineVersion": "4.0.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
-        "4.0.1.0": "4.3.0"
+        "4.1.0.0": "4.3.0"
       }
     },
     "System.Net.Primitives": {

--- a/src/System.Net.Ping/dir.props
+++ b/src/System.Net.Ping/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>
 

--- a/src/System.Net.Ping/ref/System.Net.Ping.cs
+++ b/src/System.Net.Ping/ref/System.Net.Ping.cs
@@ -38,6 +38,25 @@ namespace System.Net.NetworkInformation
     public partial class Ping
     {
         public Ping() { }
+        public event System.Net.NetworkInformation.PingCompletedEventHandler PingCompleted { add { } remove { } }
+        protected void OnPingCompleted(System.Net.NetworkInformation.PingCompletedEventArgs e) { }
+        public PingReply Send(string hostNameOrAddress) { return default(System.Net.NetworkInformation.PingReply); }
+        public PingReply Send(string hostNameOrAddress, int timeout) { return default(System.Net.NetworkInformation.PingReply); }
+        public PingReply Send(System.Net.IPAddress address) { return default(System.Net.NetworkInformation.PingReply); }
+        public PingReply Send(System.Net.IPAddress address, int timeout) { return default(System.Net.NetworkInformation.PingReply); }
+        public PingReply Send(string hostNameOrAddress, int timeout, byte[] buffer) { return default(System.Net.NetworkInformation.PingReply); }
+        public PingReply Send(System.Net.IPAddress address, int timeout, byte[] buffer) { return default(System.Net.NetworkInformation.PingReply); }
+        public PingReply Send(string hostNameOrAddress, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options) { return default(System.Net.NetworkInformation.PingReply); }
+        public PingReply Send(System.Net.IPAddress address, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options) { return default(System.Net.NetworkInformation.PingReply); }
+        public void SendAsync(string hostNameOrAddress, object userToken) { }
+        public void SendAsync(string hostNameOrAddress, int timeout, object userToken) { }
+        public void SendAsync(System.Net.IPAddress address, object userToken) { }
+        public void SendAsync(System.Net.IPAddress address, int timeout, object userToken) { }
+        public void SendAsync(string hostNameOrAddress, int timeout, byte[] buffer, object userToken) { }
+        public void SendAsync(System.Net.IPAddress address, int timeout, byte[] buffer, object userToken) { }
+        public void SendAsync(string hostNameOrAddress, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options, object userToken) { }
+        public void SendAsync(System.Net.IPAddress address, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options, object userToken) { }
+        public void SendAsyncCancel() { }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(System.Net.IPAddress address) { return default(System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply>); }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(System.Net.IPAddress address, int timeout) { return default(System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply>); }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(System.Net.IPAddress address, int timeout, byte[] buffer) { return default(System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply>); }
@@ -46,6 +65,12 @@ namespace System.Net.NetworkInformation
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(string hostNameOrAddress, int timeout) { return default(System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply>); }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer) { return default(System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply>); }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options) { return default(System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply>); }
+    }
+    public delegate void PingCompletedEventHandler(object sender, PingCompletedEventArgs e);
+    public class PingCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    {
+        internal PingCompletedEventArgs() : base(null, false, null) { }
+        public PingReply Reply { get; }
     }
     public partial class PingException : System.InvalidOperationException
     {

--- a/src/System.Net.Ping/ref/project.json
+++ b/src/System.Net.Ping/ref/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "System.ComponentModel.EventBasedAsync": "4.0.10",
     "System.Net.Primitives": "4.0.10",
     "System.Runtime": "4.0.0",
     "System.Threading.Tasks": "4.0.0"

--- a/src/System.Net.Ping/src/System.Net.Ping.csproj
+++ b/src/System.Net.Ping/src/System.Net.Ping.csproj
@@ -23,6 +23,7 @@
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
     <Compile Include="System\Net\NetworkInformation\IPStatus.cs" />
     <Compile Include="System\Net\NetworkInformation\Ping.cs" />
+    <Compile Include="System\Net\NetworkInformation\PingCompletedEventArgs.cs" />
     <Compile Include="System\Net\NetworkInformation\PingException.cs" />
     <Compile Include="System\Net\NetworkInformation\PingOptions.cs" />
     <Compile Include="System\Net\NetworkInformation\PingReply.cs" />

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -25,7 +25,12 @@ namespace System.Net.NetworkInformation
                 Task<PingReply> t = RawSocketPermissions.CanUseRawSockets(address.AddressFamily) ?
                     SendIcmpEchoRequestOverRawSocket(address, buffer, timeout, options) :
                     SendWithPingUtility(address, buffer, timeout, options);
-                return await t.ConfigureAwait(false);
+                PingReply reply = await t.ConfigureAwait(false);
+                if (_canceled)
+                {
+                    throw new OperationCanceledException();
+                }
+                return reply;
             }
             finally
             {

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Threading;
@@ -16,8 +17,11 @@ namespace System.Net.NetworkInformation
         private const int MaxBufferSize = 65500;       // Artificial constraint due to win32 api limitations.
         private const int MaxUdpPacket = 0xFFFF + 256; // Marshal.SizeOf(typeof(Icmp6EchoReply)) * 2 + ip header info;
 
+        private readonly ManualResetEventSlim _lockObject = new ManualResetEventSlim(initialState: true); // doubles as the ability to wait on the current operation
+        private SendOrPostCallback _onPingCompletedDelegate;
         private bool _disposeRequested = false;
         private byte[] _defaultSendBuffer = null;
+        private bool _canceled;
 
         // Thread safety:
         private const int Free = 0;
@@ -49,21 +53,38 @@ namespace System.Net.NetworkInformation
                 throw new ObjectDisposedException(GetType().FullName);
             }
 
-            int currentStatus = Interlocked.CompareExchange(ref _status, InProgress, Free);
+            int currentStatus;
+            lock (_lockObject)
+            {
+                currentStatus = _status;
+                if (currentStatus == Free)
+                {
+                    _canceled = false;
+                    _status = InProgress;
+                    _lockObject.Reset();
+                    return;
+                }
+            }
+
             if (currentStatus == InProgress)
             {
                 throw new InvalidOperationException(SR.net_inasync);
             }
-            else if (currentStatus == Disposed)
+            else
             {
+                Debug.Assert(currentStatus == Disposed, $"Expected currentStatus == Disposed, got {currentStatus}");
                 throw new ObjectDisposedException(GetType().FullName);
             }
         }
 
         private void Finish()
         {
-            Debug.Assert(_status == InProgress, "Invalid status: " + _status);
-            _status = Free;
+            lock (_lockObject)
+            {
+                Debug.Assert(_status == InProgress, $"Invalid status: {_status}");
+                _status = Free;
+                _lockObject.Set();
+            }
 
             if (_disposeRequested)
             {
@@ -76,10 +97,14 @@ namespace System.Net.NetworkInformation
         {
             _disposeRequested = true;
 
-            if (Interlocked.CompareExchange(ref _status, Disposed, Free) != Free)
+            lock (_lockObject)
             {
-                // Already disposed, or Finish will call Dispose again once Free.
-                return;
+                if (_status != Free)
+                {
+                    // Already disposed, or Finish will call Dispose again once Free.
+                    return;
+                }
+                _status = Disposed;
             }
 
             InternalDisposeCore();
@@ -98,6 +123,104 @@ namespace System.Net.NetworkInformation
                 // Only on explicit dispose.  Otherwise, the GC can cleanup everything else.
                 InternalDispose();
             }
+        }
+
+        public event PingCompletedEventHandler PingCompleted;
+
+        protected void OnPingCompleted(PingCompletedEventArgs e)
+        {
+            PingCompleted?.Invoke(this, e);
+        }
+
+        public PingReply Send(string hostNameOrAddress)
+        {
+            return Send(hostNameOrAddress, DefaultTimeout, DefaultSendBuffer);
+        }
+
+        public PingReply Send(string hostNameOrAddress, int timeout)
+        {
+            return Send(hostNameOrAddress, timeout, DefaultSendBuffer);
+        }
+
+        public PingReply Send(IPAddress address)
+        {
+            return Send(address, DefaultTimeout, DefaultSendBuffer);
+        }
+
+        public PingReply Send(IPAddress address, int timeout)
+        {
+            return Send(address, timeout, DefaultSendBuffer);
+        }
+
+        public PingReply Send(string hostNameOrAddress, int timeout, byte[] buffer)
+        {
+            return Send(hostNameOrAddress, timeout, buffer, null);
+        }
+
+        public PingReply Send(IPAddress address, int timeout, byte[] buffer)
+        {
+            return Send(address, timeout, buffer, null);
+        }
+
+        public PingReply Send(string hostNameOrAddress, int timeout, byte[] buffer, PingOptions options)
+        {
+            return SendPingAsync(hostNameOrAddress, timeout, buffer, options).GetAwaiter().GetResult();
+        }
+
+        public PingReply Send(IPAddress address, int timeout, byte[] buffer, PingOptions options)
+        {
+            return SendPingAsync(address, timeout, buffer, options).GetAwaiter().GetResult();
+        }
+
+        public void SendAsync(string hostNameOrAddress, object userToken)
+        {
+            SendAsync(hostNameOrAddress, DefaultTimeout, DefaultSendBuffer, userToken);
+        }
+
+        public void SendAsync(string hostNameOrAddress, int timeout, object userToken)
+        {
+            SendAsync(hostNameOrAddress, timeout, DefaultSendBuffer, userToken);
+        }
+
+        public void SendAsync(IPAddress address, object userToken)
+        {
+            SendAsync(address, DefaultTimeout, DefaultSendBuffer, userToken);
+        }
+
+        public void SendAsync(IPAddress address, int timeout, object userToken)
+        {
+            SendAsync(address, timeout, DefaultSendBuffer, userToken);
+        }
+
+        public void SendAsync(string hostNameOrAddress, int timeout, byte[] buffer, object userToken)
+        {
+            SendAsync(hostNameOrAddress, timeout, buffer, null, userToken);
+        }
+
+        public void SendAsync(IPAddress address, int timeout, byte[] buffer, object userToken)
+        {
+            SendAsync(address, timeout, buffer, null, userToken);
+        }
+
+        public void SendAsync(string hostNameOrAddress, int timeout, byte[] buffer, PingOptions options, object userToken)
+        {
+            TranslateTaskToEap(userToken, SendPingAsync(hostNameOrAddress, timeout, buffer, options));
+        }
+
+        public void SendAsync(IPAddress address, int timeout, byte[] buffer, PingOptions options, object userToken)
+        {
+            TranslateTaskToEap(userToken, SendPingAsync(address, timeout, buffer, options));
+        }
+
+        private void TranslateTaskToEap(object userToken, Task<PingReply> pingTask)
+        {
+            pingTask.ContinueWith((t, state) =>
+            {
+                var asyncOp = (AsyncOperation)state;
+                var e = new PingCompletedEventArgs(t.Status == TaskStatus.RanToCompletion ? t.Result : null, t.Exception, t.IsCanceled, asyncOp.UserSuppliedState);
+                SendOrPostCallback callback = _onPingCompletedDelegate ?? (_onPingCompletedDelegate = new SendOrPostCallback(o => { OnPingCompleted((PingCompletedEventArgs)o); }));
+                asyncOp.PostOperationCompleted(callback, e);
+            }, AsyncOperationManager.CreateOperation(userToken), CancellationToken.None, TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
         public Task<PingReply> SendPingAsync(IPAddress address)
@@ -210,16 +333,42 @@ namespace System.Net.NetworkInformation
             return GetAddressAndSendAsync(hostNameOrAddress, timeout, buffer, options);
         }
 
+        public void SendAsyncCancel()
+        {
+            lock (_lockObject)
+            {
+                if (!_lockObject.IsSet)
+                {
+                    // As in the .NET Framework, this doesn't actually cancel an in-progress operation.  It just marks it such that
+                    // when the operation completes, it's flagged as canceled.
+                    _canceled = true;
+                }
+            }
+
+            // As in the .NET Framework, synchronously wait for the in-flight operation to complete.
+            // If there isn't one in flight, this event will already be set.
+            _lockObject.Wait();
+        }
+
         private async Task<PingReply> GetAddressAndSendAsync(string hostNameOrAddress, int timeout, byte[] buffer, PingOptions options)
         {
+            bool requiresFinish = true;
             try
             {
                 IPAddress[] addresses = await Dns.GetHostAddressesAsync(hostNameOrAddress).ConfigureAwait(false);
-                return await SendPingAsyncCore(addresses[0], buffer, timeout, options).ConfigureAwait(false);
+                Task<PingReply> pingReplyTask = SendPingAsyncCore(addresses[0], buffer, timeout, options);
+                requiresFinish = false;
+                return await pingReplyTask.ConfigureAwait(false);
             }
             catch (Exception e)
             {
-                Finish();
+                // SendPingAsyncCore will call Finish before completing the Task.  If SendPingAsyncCore isn't invoked
+                // because an exception is thrown first, or if it throws out an exception synchronously, then
+                // we need to invoke Finish; otherwise, it has the responsibility to invoke Finish.
+                if (requiresFinish)
+                {
+                    Finish();
+                }
                 throw new PingException(SR.net_ping, e);
             }
         }

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/PingCompletedEventArgs.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/PingCompletedEventArgs.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+
+namespace System.Net.NetworkInformation
+{
+    public delegate void PingCompletedEventHandler(object sender, PingCompletedEventArgs e);
+
+    public class PingCompletedEventArgs : AsyncCompletedEventArgs
+    {
+        internal PingCompletedEventArgs(PingReply reply, Exception error, bool cancelled, object userToken) : base(error, cancelled, userToken)
+        {
+            Reply = reply;
+        }
+
+        public PingReply Reply { get; }
+    }
+}

--- a/src/System.Net.Ping/src/project.json
+++ b/src/System.Net.Ping/src/project.json
@@ -5,6 +5,7 @@
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.Win32.Primitives": "4.0.0",
         "System.Collections": "4.0.10",
+        "System.ComponentModel.EventBasedAsync": "4.0.10",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.Tracing": "4.0.20",

--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net.Test.Common;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -41,22 +42,42 @@ namespace System.Net.NetworkInformation.Tests
             // Null address
             Assert.Throws<ArgumentNullException>("address", () => { p.SendPingAsync((IPAddress)null); });
             Assert.Throws<ArgumentNullException>("hostNameOrAddress", () => { p.SendPingAsync((string)null); });
+            Assert.Throws<ArgumentNullException>("address", () => { p.SendAsync((IPAddress)null, null); });
+            Assert.Throws<ArgumentNullException>("hostNameOrAddress", () => { p.SendAsync((string)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { p.Send((IPAddress)null); });
+            Assert.Throws<ArgumentNullException>("hostNameOrAddress", () => { p.Send((string)null); });
 
             // Invalid address
             Assert.Throws<ArgumentException>("address", () => { p.SendPingAsync(IPAddress.Any); });
             Assert.Throws<ArgumentException>("address", () => { p.SendPingAsync(IPAddress.IPv6Any); });
+            Assert.Throws<ArgumentException>("address", () => { p.SendAsync(IPAddress.Any, null); });
+            Assert.Throws<ArgumentException>("address", () => { p.SendAsync(IPAddress.IPv6Any, null); });
+            Assert.Throws<ArgumentException>("address", () => { p.Send(IPAddress.Any); });
+            Assert.Throws<ArgumentException>("address", () => { p.Send(IPAddress.IPv6Any); });
 
             // Negative timeout
             Assert.Throws<ArgumentOutOfRangeException>("timeout", () => { p.SendPingAsync(localIpAddress, -1); });
             Assert.Throws<ArgumentOutOfRangeException>("timeout", () => { p.SendPingAsync(TestSettings.LocalHost, -1); });
+            Assert.Throws<ArgumentOutOfRangeException>("timeout", () => { p.SendAsync(localIpAddress, -1, null); });
+            Assert.Throws<ArgumentOutOfRangeException>("timeout", () => { p.SendAsync(TestSettings.LocalHost, -1, null); });
+            Assert.Throws<ArgumentOutOfRangeException>("timeout", () => { p.Send(localIpAddress, -1); });
+            Assert.Throws<ArgumentOutOfRangeException>("timeout", () => { p.Send(TestSettings.LocalHost, -1); });
 
             // Null byte[]
             Assert.Throws<ArgumentNullException>("buffer", () => { p.SendPingAsync(localIpAddress, 0, null); });
             Assert.Throws<ArgumentNullException>("buffer", () => { p.SendPingAsync(TestSettings.LocalHost, 0, null); });
+            Assert.Throws<ArgumentNullException>("buffer", () => { p.SendAsync(localIpAddress, 0, null, null); });
+            Assert.Throws<ArgumentNullException>("buffer", () => { p.SendAsync(TestSettings.LocalHost, 0, null, null); });
+            Assert.Throws<ArgumentNullException>("buffer", () => { p.Send(localIpAddress, 0, null); });
+            Assert.Throws<ArgumentNullException>("buffer", () => { p.Send(TestSettings.LocalHost, 0, null); });
 
             // Too large byte[]
             Assert.Throws<ArgumentException>("buffer", () => { p.SendPingAsync(localIpAddress, 1, new byte[65501]); });
             Assert.Throws<ArgumentException>("buffer", () => { p.SendPingAsync(TestSettings.LocalHost, 1, new byte[65501]); });
+            Assert.Throws<ArgumentException>("buffer", () => { p.SendAsync(localIpAddress, 1, new byte[65501], null); });
+            Assert.Throws<ArgumentException>("buffer", () => { p.SendAsync(TestSettings.LocalHost, 1, new byte[65501], null); });
+            Assert.Throws<ArgumentException>("buffer", () => { p.Send(localIpAddress, 1, new byte[65501]); });
+            Assert.Throws<ArgumentException>("buffer", () => { p.Send(TestSettings.LocalHost, 1, new byte[65501]); });
         }
 
         [Fact]
@@ -319,6 +340,63 @@ namespace System.Net.NetworkInformation.Tests
                     Assert.Equal(IPStatus.Success, pingReply.Status);
                     Assert.True(pingReply.Address.Equals(localIpAddress));
                 }
+            }
+        }
+
+        [Fact]
+        public static async Task Sends_ReuseInstance_Hostname()
+        {
+            IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
+
+            using (Ping p = new Ping())
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    PingReply pingReply = p.Send(TestSettings.LocalHost);
+                    Assert.Equal(IPStatus.Success, pingReply.Status);
+                    Assert.True(pingReply.Address.Equals(localIpAddress));
+                }
+            }
+        }
+
+        [Fact]
+        public static async Task SendAsyncs_ReuseInstance_Hostname()
+        {
+            IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
+
+            using (Ping p = new Ping())
+            {
+                var mres = new ManualResetEventSlim();
+                PingCompletedEventArgs ea = null;
+                p.PingCompleted += (s, e) =>
+                {
+                    ea = e;
+                    mres.Set();
+                };
+
+                // Several normal iterations
+                for (int i = 0; i < 3; i++)
+                {
+                    ea = null;
+                    mres.Reset();
+                    p.SendAsync(TestSettings.LocalHost, null);
+                    mres.Wait();
+
+                    Assert.NotNull(ea);
+                    Assert.Equal(IPStatus.Success, ea.Reply.Status);
+                    Assert.True(ea.Reply.Address.Equals(localIpAddress));
+                }
+
+                // Several canceled iterations
+                for (int i = 0; i < 3; i++)
+                {
+                    ea = null;
+                    mres.Reset();
+                    p.SendAsync(TestSettings.LocalHost, null);
+                    p.SendAsyncCancel(); // will block until operation can be started again
+                }
+                mres.Wait();
+                Assert.True(ea.Cancelled ^ (ea.Error != null) ^ (ea.Reply != null));
             }
         }
 

--- a/src/System.Net.Ping/tests/FunctionalTests/project.json
+++ b/src/System.Net.Ping/tests/FunctionalTests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "4.3.0-beta-devapi-24512-01",
+    "System.ComponentModel.EventBasedAsync": "4.3.0-beta-devapi-24512-01",
     "System.Diagnostics.Process": "4.3.0-beta-devapi-24512-01",
     "System.IO.FileSystem": "4.3.0-beta-devapi-24512-01",
     "System.Linq.Expressions": "4.3.0-beta-devapi-24512-01",
@@ -8,6 +9,7 @@
     "System.ObjectModel": "4.3.0-beta-devapi-24512-01",
     "System.Text.RegularExpressions": "4.3.0-beta-devapi-24512-01",
     "System.Net.NameResolution": "4.3.0-beta-devapi-24512-01",
+    "System.Threading": "4.3.0-beta-devapi-24512-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"


### PR DESCRIPTION
Adds back all of the missing Send and SendAsync overloads, plus the support for the SendAsync overloads like PingCompletedEventArgs and SendAsyncCancel.

cc: @davidsh, @cipop, @ericeil, @mellino, @karelz 