### PR TITLE
Port to 1.1: Fix leak of WinHttpRequestState objects during HTTP resends

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -49,10 +49,13 @@ namespace System.Net.Http
 
         public void Pin()
         {
+            if (!_operationHandle.IsAllocated)
+            {
 #if DEBUG
-            Interlocked.Increment(ref s_dbg_pin);
+                Interlocked.Increment(ref s_dbg_pin);
 #endif
-            _operationHandle = GCHandle.Alloc(this);
+                _operationHandle = GCHandle.Alloc(this);
+            }
         }
 
         public static WinHttpRequestState FromIntPtr(IntPtr gcHandle)


### PR DESCRIPTION
Port PR #11733 

WinHttpRequestState objects were being leaked when the HTTP request
needed to be retried.  The InternalSendRequestAsync method calls the
Pin method. But since it is called in a loop, we need to check to see
if the GCHandle has already been allocated.

Fixes #11693