### PR TITLE
Expose MemoryStream.GetBuffer and add tests

### DIFF
--- a/src/System.IO/ref/System.IO.cs
+++ b/src/System.IO/ref/System.IO.cs
@@ -142,6 +142,7 @@ namespace System.IO
         public override void EndWrite(System.IAsyncResult asyncResult) { return; }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
+        public virtual byte[] GetBuffer() { return default(byte[]); }
         public override int Read(byte[] buffer, int offset, int count) { buffer = default(byte[]); return default(int); }
         public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task<int>); }
         public override int ReadByte() { return default(int); }

--- a/src/System.IO/src/Resources/Strings.netcore50aot.resx
+++ b/src/System.IO/src/Resources/Strings.netcore50aot.resx
@@ -222,4 +222,7 @@
   <data name="NotSupported_CannotWriteToBufferedStreamIfReadBufferCannotBeFlushed" xml:space="preserve">
     <value>Cannot write to a BufferedStream while the read buffer is not empty if the underlying stream is not seekable. Ensure that the stream underlying this BufferedStream can seek or avoid interleaving read and write operations on this BufferedStream.</value>
   </data>
+  <data name="UnauthorizedAccess_MemStreamBuffer" xml:space="preserve">
+    <value>MemoryStream's internal buffer cannot be accessed.</value>
+  </data>
 </root>

--- a/src/System.IO/src/Resources/Strings.resx
+++ b/src/System.IO/src/Resources/Strings.resx
@@ -135,7 +135,7 @@
   <data name="Argument_InvalidOffLen" xml:space="preserve">
     <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
   </data>
-    <data name="NotSupported_UnseekableStream" xml:space="preserve">
+  <data name="NotSupported_UnseekableStream" xml:space="preserve">
     <value>Stream does not support seeking.</value>
   </data>
   <data name="NotSupported_UnreadableStream" xml:space="preserve">

--- a/src/System.IO/src/System/IO/MemoryStream.cs
+++ b/src/System.IO/src/System/IO/MemoryStream.cs
@@ -214,7 +214,12 @@ namespace System.IO
             return true;
         }
 
-        // -------------- PERF: Internal functions for fast direct access of MemoryStream buffer (cf. BinaryReader for usage) ---------------
+        public virtual byte[] GetBuffer()
+        {
+            if (!_exposable)
+                throw new UnauthorizedAccessException(SR.UnauthorizedAccess_MemStreamBuffer);
+            return _buffer;
+        }
 
         // PERF: Internal sibling of GetBuffer, always returns a buffer (cf. GetBuffer())
         internal byte[] InternalGetBuffer()

--- a/src/System.IO/tests/MemoryStream/MemoryStream.GetBufferTests.cs
+++ b/src/System.IO/tests/MemoryStream/MemoryStream.GetBufferTests.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class MemoryStream_GetBufferTests
+    {
+        [Fact]
+        public void MemoryStream_GetBuffer_Length()
+        {
+            MemoryStream ms = new MemoryStream();
+            byte[] buffer = ms.GetBuffer();
+            Assert.Equal(0, buffer.Length);
+        }
+
+        [Fact]
+        public void MemoryStream_GetBuffer_NonExposable()
+        {
+            MemoryStream ms = new MemoryStream(new byte[100]);
+            Assert.Throws<UnauthorizedAccessException>(() => ms.GetBuffer());
+        }
+
+        [Fact]
+        public void MemoryStream_GetBuffer_Exposable()
+        {
+            MemoryStream ms = new MemoryStream(new byte[500], 0, 100, true, true);
+            byte[] buffer = ms.GetBuffer();
+            Assert.Equal(500, buffer.Length);
+        }
+
+        [Fact]
+        public void MemoryStream_GetBuffer()
+        {
+            byte[] testdata = new byte[100];
+            new Random(45135).NextBytes(testdata);
+            MemoryStream ms = new MemoryStream(100);
+            byte[] buffer = ms.GetBuffer();
+            Assert.Equal(100, buffer.Length);
+
+            ms.Write(testdata, 0, 100);
+            ms.Write(testdata, 0, 100);
+            Assert.Equal(200, ms.Length);
+            buffer = ms.GetBuffer();
+            Assert.Equal(256, buffer.Length); // Minimun size after writing
+        }
+    }
+}

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -22,6 +22,7 @@
     <Compile Include="BufferedStream\BufferedStreamTests.cs" />
     <Compile Include="InvalidDataException\InvalidDataExceptionTests.cs" />
     <Compile Include="MemoryStream\MemoryStream.ConstructorTests.cs" />
+    <Compile Include="MemoryStream\MemoryStream.GetBufferTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="MemoryStream\MemoryStream.TryGetBufferTests.cs" />
     <Compile Include="MemoryStream\MemoryStreamTests.cs" />
     <Compile Include="StreamReader\StreamReader.CtorTests.cs" />


### PR DESCRIPTION
GetBuffer is already exported in mscorlib, so this commit ports it to the duplicate MemoryStream.cs file, adds it to the ref, and adds tests for it conditionally included on netstandard1.7.

progress towards https://github.com/dotnet/corefx/issues/9465

@stephentoub @danmosemsft @JeremyKuhne 