### PR TITLE
Adding KeepAllProjectReferences to some test projects in order to fix PipeBuild

### DIFF
--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/System.Xml.XmlSchemaSet.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/System.Xml.XmlSchemaSet.Tests.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>System.Xml.XmlSchema.XmlSchemaSet.Tests</AssemblyName>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
     <RootNamespace>System.Xml.Tests</RootNamespace>
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests</AssemblyName>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
     <RootNamespace>System.Xml.Tests</RootNamespace>
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
@@ -17,6 +17,7 @@
       -->
       <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
       <TestTFM>netcoreapp1.1</TestTFM>
+      <KeepAllProjectReferences>true</KeepAllProjectReferences>
     </PropertyGroup>
   <ItemGroup>
     <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>System.Xml.Xsl.XslCompiledTransformApi.Tests</AssemblyName>
     <RootNamespace>System.Xml.Tests</RootNamespace>
     <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>System.Xml.Xsl.XslTransformApi.Tests</AssemblyName>
     <RootNamespace>System.Xml.Tests</RootNamespace>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Runtime.Serialization.Json/tests/Performance/System.Runtime.Serialization.Json.Performance.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/System.Runtime.Serialization.Json.Performance.Tests.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>System.Runtime.Serialization.Json.Performance.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Serialization.Json.Performance.Tests</AssemblyName>
     <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseContractReferences)' == 'true'" >
     <ProjectJson>ContractReferences/project.json</ProjectJson>

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>System.Runtime.Serialization.Xml.Tests</AssemblyName>
     <ProjectGuid>{30CAB353-089E-4294-B23B-F2DD1D945654}</ProjectGuid>
     <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Utils.cs" />

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -12,6 +12,7 @@
     <RootNamespace>System.Security.Cryptography.OpenSsl.Tests</RootNamespace>
     <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7' AND '$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
     <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.6</NugetTargetMoniker>
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU'" />


### PR DESCRIPTION
cc: @weshaggard @chcosta @AlfredoMS 

Forcing the use of P2P on Pipeline build in order to get it green again.