### PR TITLE
System.Reflection.Emit.Lightweight.Tests: changing test IDSubClass and delegates from internal to public

### DIFF
--- a/src/System.Reflection.Emit.Lightweight/tests/DynamicMethodCreateDelegate.cs
+++ b/src/System.Reflection.Emit.Lightweight/tests/DynamicMethodCreateDelegate.cs
@@ -125,14 +125,14 @@ namespace System.Reflection.Emit.Tests
         }
     }
 
-    internal class IDSubClass : IDClass
+    public class IDSubClass : IDClass
     {
         public IDSubClass(int id) : base(id) { }
         public IDSubClass() : base() { }
     }
 
-    internal delegate int IDClassDelegate(IDClass owner, int id);
-    internal delegate IDClass InvalidRetType(int id);
-    internal delegate int WrongParamNumber(int id, int m);
-    internal delegate int InvalidParamType(IDClass owner);
+    public delegate int IDClassDelegate(IDClass owner, int id);
+    public delegate IDClass InvalidRetType(int id);
+    public delegate int WrongParamNumber(int id, int m);
+    public delegate int InvalidParamType(IDClass owner);
 }


### PR DESCRIPTION
This should not affect the outcome of System.Reflection.Emit.Lightweight tests. 

Stress runs reflect on the binaries produced and attempts to load the types indicated in the Theory. Since the types were marked as internal, it randomly (since we generate by grabbing random test files) crashes our stress runs. 

The two fixes I came up with is to harden our runs against these, or just change the tests. Hardening our runs would basically mean excluding these tests (many ways to do that), but in the interest of stressing as much of corefx as we can I figure the most harmless thing is to just alter the tests. 

@MattGal @markwilkie @schaabs 