### PR TITLE
Fixing value type property check in BindingRewriter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Bindings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Bindings.cs
@@ -47,6 +47,16 @@ namespace System.Linq.Expressions.Compiler
                 }
                 throw Error.UnhandledBinding();
             }
+
+            protected void RequireNoValueProperty()
+            {
+                var property = _binding.Member as PropertyInfo;
+
+                if (property != null && property.PropertyType.GetTypeInfo().IsValueType)
+                {
+                    throw Error.CannotAutoInitializeValueTypeMemberThroughProperty(property);
+                }
+            }
         }
 
         private class MemberMemberBindingRewriter : BindingRewriter
@@ -86,10 +96,7 @@ namespace System.Linq.Expressions.Compiler
 
             internal override Expression AsExpression(Expression target)
             {
-                if (target.Type.GetTypeInfo().IsValueType && _binding.Member is System.Reflection.PropertyInfo)
-                {
-                    throw Error.CannotAutoInitializeValueTypeMemberThroughProperty(_binding.Member);
-                }
+                RequireNoValueProperty();
                 RequireNotRefInstance(target);
 
                 MemberExpression member = Expression.MakeMemberAccess(target, _binding.Member);
@@ -170,10 +177,7 @@ namespace System.Linq.Expressions.Compiler
 
             internal override Expression AsExpression(Expression target)
             {
-                if (target.Type.GetTypeInfo().IsValueType && _binding.Member is System.Reflection.PropertyInfo)
-                {
-                    throw Error.CannotAutoInitializeValueTypeElementThroughProperty(_binding.Member);
-                }
+                RequireNoValueProperty();
                 RequireNotRefInstance(target);
 
                 MemberExpression member = Expression.MakeMemberAccess(target, _binding.Member);


### PR DESCRIPTION
This fixes issue #11770. More tests coming as part of code coverage for `StackSpiller` and a possible improvement for issue #11740.