### PR TITLE
Simplifying EmitInstance call sites

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
@@ -123,7 +123,7 @@ namespace System.Linq.Expressions.Compiler
                 Type objectType = null;
                 if (node.Expression != null)
                 {
-                    EmitInstance(node.Expression, objectType = node.Expression.Type);
+                    EmitInstance(node.Expression, out objectType);
                 }
                 EmitMemberAddress(node.Member, objectType);
             }
@@ -281,7 +281,7 @@ namespace System.Linq.Expressions.Compiler
             Type instanceType = null;
             if (node.Expression != null)
             {
-                EmitInstance(node.Expression, instanceType = node.Expression.Type);
+                EmitInstance(node.Expression, out instanceType);
 
                 // store in local
                 _ilg.Emit(OpCodes.Dup);
@@ -330,7 +330,7 @@ namespace System.Linq.Expressions.Compiler
             Type instanceType = null;
             if (node.Object != null)
             {
-                EmitInstance(node.Object, instanceType = node.Object.Type);
+                EmitInstance(node.Object, out instanceType);
 
                 // store in local
                 _ilg.Emit(OpCodes.Dup);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -230,7 +230,7 @@ namespace System.Linq.Expressions.Compiler
             Type objectType = null;
             if (node.Object != null)
             {
-                EmitInstance(node.Object, objectType = node.Object.Type);
+                EmitInstance(node.Object, out objectType);
             }
 
             // Emit indexes. We don't allow byref args, so no need to worry
@@ -254,7 +254,7 @@ namespace System.Linq.Expressions.Compiler
             Type objectType = null;
             if (index.Object != null)
             {
-                EmitInstance(index.Object, objectType = index.Object.Type);
+                EmitInstance(index.Object, out objectType);
             }
 
             // Emit indexes. We don't allow byref args, so no need to worry
@@ -369,7 +369,8 @@ namespace System.Linq.Expressions.Compiler
             Type objectType = null;
             if (!method.IsStatic)
             {
-                EmitInstance(obj, objectType = obj.Type);
+                Debug.Assert(obj != null);
+                EmitInstance(obj, out objectType);
             }
             // if the obj has a value type, its address is passed to the method call so we cannot destroy the 
             // stack by emitting a tail call
@@ -774,7 +775,7 @@ namespace System.Linq.Expressions.Compiler
             Type objectType = null;
             if (lvalue.Expression != null)
             {
-                EmitInstance(lvalue.Expression, objectType = lvalue.Expression.Type);
+                EmitInstance(lvalue.Expression, out objectType);
             }
 
             // emit value
@@ -822,7 +823,7 @@ namespace System.Linq.Expressions.Compiler
             Type instanceType = null;
             if (node.Expression != null)
             {
-                EmitInstance(node.Expression, instanceType = node.Expression.Type);
+                EmitInstance(node.Expression, out instanceType);
             }
 
             EmitMemberGet(node.Member, instanceType);
@@ -876,18 +877,17 @@ namespace System.Linq.Expressions.Compiler
                 return false;
             }
         }
-        private void EmitInstance(Expression instance, Type type)
+        private void EmitInstance(Expression instance, out Type type)
         {
-            if (instance != null)
+            type = instance.Type;
+
+            if (type.GetTypeInfo().IsValueType)
             {
-                if (type.GetTypeInfo().IsValueType)
-                {
-                    EmitAddress(instance, type);
-                }
-                else
-                {
-                    EmitExpression(instance);
-                }
+                EmitAddress(instance, type);
+            }
+            else
+            {
+                EmitExpression(instance);
             }
         }
 


### PR DESCRIPTION
Noticed this odd pattern with a redundant null check in the callee and redundant member accesses in the caller of `EmitInstance` while investigating #11740 (where I'm looking into compiler-internal-only use of ref locals which need additional logic on determining the type of the instance based on whether it already is a `ref` or still needs a `ldloca`, `ldarga`, etc. family instruction to obtain the `ref`).