### PR TITLE
Make SqlClient support win10-arm64 using master runtime package

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -15,6 +15,9 @@
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
     <AppXRunnerVersion>1.0.3-prerelease-00614-01</AppXRunnerVersion>
+
+    <!-- Depend on win10-arm64 version from master to provide support, although this will not be shipped. -->
+    <RuntimeWin10Arm64RuntimeNativeSystemDataSqlClientSniVersion>4.3.0-beta-24514-00</RuntimeWin10Arm64RuntimeNativeSystemDataSqlClientSniVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -13,7 +13,7 @@
       <Version>$(PackageVersion)-$(ExternalExpectedPrerelease)</Version>
     </Dependency>
     <Dependency Include="runtime.win10-arm64.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(PackageVersion)-$(ExternalExpectedPrerelease)</Version>
+      <Version>$(RuntimeWin10Arm64RuntimeNativeSystemDataSqlClientSniVersion)</Version>
     </Dependency>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
Fixes issue discussed in https://github.com/dotnet/corefx/pull/11659. The latest release/1.1.0 runtime.native.System.Data.SqlClient.sni package depended on a nonexistent win10-arm64 package. This changes to depend on the latest build from master.

This doesn't auto-update with new projectk builds, but stores the info in dependencies.props along with similar info.

@wtgodbe @gkhanna79
/cc @ericstj @weshaggard 