### PR TITLE
Use exact versions of 1.0.0 RTM runtimes from TFS

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -15,6 +15,8 @@
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
     <AppXRunnerVersion>1.0.3-prerelease-00614-01</AppXRunnerVersion>
+    <RuntimeWin7RuntimeNativeSystemDataSqlClientSniVersion>4.0.1</RuntimeWin7RuntimeNativeSystemDataSqlClientSniVersion>
+    <RuntimeWin10RuntimeNativeSystemIOCompressionVersion>4.0.1</RuntimeWin10RuntimeNativeSystemIOCompressionVersion>
 
     <!-- Depend on win10-arm64 version from master to provide support, although this will not be shipped. -->
     <RuntimeWin10Arm64RuntimeNativeSystemDataSqlClientSniVersion>4.3.0-beta-24514-00</RuntimeWin10Arm64RuntimeNativeSystemDataSqlClientSniVersion>

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Dependency Include="runtime.win7-x64.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(PackageVersion)-$(ExternalExpectedPrerelease)</Version>
+      <Version>$(RuntimeWin7RuntimeNativeSystemDataSqlClientSniVersion)</Version>
     </Dependency>
     <Dependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(PackageVersion)-$(ExternalExpectedPrerelease)</Version>
+      <Version>$(RuntimeWin7RuntimeNativeSystemDataSqlClientSniVersion)</Version>
     </Dependency>
     <Dependency Include="runtime.win10-arm64.runtime.native.System.Data.SqlClient.sni">
       <Version>$(RuntimeWin10Arm64RuntimeNativeSystemDataSqlClientSniVersion)</Version>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -10,17 +10,17 @@
          below should be updated to $(PackageVersion)-$(ExternalExpectedPrerelease) -->
     <RuntimeDependency Include="runtime.win10-x64-aot.runtime.native.System.IO.Compression">
       <TargetRuntime>win10-amd64-aot</TargetRuntime>
-      <Version>4.1.1-$(ExternalExpectedPrerelease)</Version>
+      <Version>$(RuntimeWin10RuntimeNativeSystemIOCompressionVersion)</Version>
       <SkipVersionCheck>true</SkipVersionCheck>
     </RuntimeDependency>
     <RuntimeDependency Include="runtime.win10-arm-aot.runtime.native.System.IO.Compression">
       <TargetRuntime>win10-arm-aot</TargetRuntime>
-      <Version>4.1.1-$(ExternalExpectedPrerelease)</Version>
+      <Version>$(RuntimeWin10RuntimeNativeSystemIOCompressionVersion)</Version>
       <SkipVersionCheck>true</SkipVersionCheck>
     </RuntimeDependency>
     <RuntimeDependency Include="runtime.win10-x86-aot.runtime.native.System.IO.Compression">
       <TargetRuntime>win10-x86-aot</TargetRuntime>
-      <Version>4.1.1-$(ExternalExpectedPrerelease)</Version>
+      <Version>$(RuntimeWin10RuntimeNativeSystemIOCompressionVersion)</Version>
       <SkipVersionCheck>true</SkipVersionCheck>
     </RuntimeDependency>
     <!-- make this package installable and noop in a packages.config-based project -->


### PR DESCRIPTION
Fixes native runtimes to use full version properties to avoid errors from bad assembly. (https://github.com/dotnet/corefx/pull/11659#issuecomment-247727361)

https://github.com/dotnet/corefx/pull/11804 was incomplete, only fixing the reference from master.

@gkhanna79 @wtgodbe @chcosta
/cc @ericstj @weshaggard