### PR TITLE
Add back Socket.Disconnect, Socket.Begin/EndDisconnect, Socket.DisconnectAsync

### DIFF
--- a/src/Common/tests/System/Net/Sockets/SocketTestServer.cs
+++ b/src/Common/tests/System/Net/Sockets/SocketTestServer.cs
@@ -12,6 +12,7 @@ namespace System.Net.Sockets.Tests
         private const int DefaultReceiveBufferSize = 1024;
 
         protected abstract int Port { get; }
+        public abstract EndPoint EndPoint { get; }
 
         public static SocketTestServer SocketTestServerFactory(SocketImplementationType type, EndPoint endpoint, ProtocolType protocolType = ProtocolType.Tcp)
         {

--- a/src/Common/tests/System/Net/Sockets/SocketTestServerAPM.cs
+++ b/src/Common/tests/System/Net/Sockets/SocketTestServerAPM.cs
@@ -16,6 +16,7 @@ namespace System.Net.Sockets.Tests
         private volatile bool _disposed = false;
 
         protected sealed override int Port { get { return ((IPEndPoint)_socket.LocalEndPoint).Port; } }
+        public sealed override EndPoint EndPoint { get { return _socket.LocalEndPoint; } }
 
         public SocketTestServerAPM(int numConnections, int receiveBufferSize, EndPoint localEndPoint)
         {

--- a/src/Common/tests/System/Net/Sockets/SocketTestServerAsync.cs
+++ b/src/Common/tests/System/Net/Sockets/SocketTestServerAsync.cs
@@ -37,6 +37,7 @@ namespace System.Net.Sockets.Tests
         private object _listenSocketLock = new object();
 
         protected sealed override int Port { get { return ((IPEndPoint)_listenSocket.LocalEndPoint).Port; } }
+        public sealed override EndPoint EndPoint { get { return _listenSocket.LocalEndPoint; } }
 
         public SocketTestServerAsync(int numConnections, int receiveBufferSize, EndPoint localEndPoint, ProtocolType protocolType = ProtocolType.Tcp)
         {

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -195,6 +195,7 @@ namespace System.Net.Sockets
         public IAsyncResult BeginConnect(IPAddress address, int port, AsyncCallback requestCallback, object state) { return default(IAsyncResult); }
         public IAsyncResult BeginConnect(IPAddress[] addresses, int port, AsyncCallback requestCallback, object state) { return default(IAsyncResult); }
         public IAsyncResult BeginConnect(EndPoint remoteEP, AsyncCallback callback, object state) { return default(IAsyncResult); }
+        public IAsyncResult BeginDisconnect(bool reuseSocket, AsyncCallback callback, object state) { return default(IAsyncResult); }
         public IAsyncResult BeginReceive(byte[] buffer, int offset, int size, SocketFlags socketFlags, AsyncCallback callback, object state) { return default(IAsyncResult); }
         public IAsyncResult BeginReceive(byte[] buffer, int offset, int size, SocketFlags socketFlags, out SocketError errorCode, AsyncCallback callback, object state) { errorCode = default(SocketError); return default(IAsyncResult); }
         public IAsyncResult BeginReceive(Collections.Generic.IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, AsyncCallback callback, object state) { return default(IAsyncResult); }
@@ -219,9 +220,12 @@ namespace System.Net.Sockets
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         ~Socket() { }
+        public void Disconnect(bool reuseSocket) { }
+        public bool DisconnectAsync(SocketAsyncEventArgs e) { return default(bool); }
         public SocketInformation DuplicateAndClose(int targetProcessId) { return default(SocketInformation); }
         public Socket EndAccept(IAsyncResult asyncResult) { return default(Socket); }
         public void EndConnect(IAsyncResult asyncResult) { }
+        public void EndDisconnect(IAsyncResult asyncResult) { }
         public int EndReceive(IAsyncResult asyncResult) { return default(int); }
         public int EndReceive(IAsyncResult asyncResult, out SocketError errorCode) { errorCode = default(SocketError); return default(int); }
         public int EndReceiveFrom(IAsyncResult asyncResult, ref EndPoint endPoint) { return default(int); }
@@ -284,6 +288,7 @@ namespace System.Net.Sockets
         public System.Exception ConnectByNameError { get { return default(System.Exception); } }
         public System.Net.Sockets.Socket ConnectSocket { get { return default(System.Net.Sockets.Socket); } }
         public int Count { get { return default(int); } }
+        public bool DisconnectReuseSocket { get { return default(bool); } set { } }
         public System.Net.Sockets.SocketAsyncOperation LastOperation { get { return default(System.Net.Sockets.SocketAsyncOperation); } }
         public int Offset { get { return default(int); } }
         public System.Net.Sockets.IPPacketInformation ReceiveMessageFromPacketInfo { get { return default(System.Net.Sockets.IPPacketInformation); } }

--- a/src/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/System.Net.Sockets/src/Resources/Strings.resx
@@ -288,4 +288,7 @@
   <data name="net_sockets_duplicateandclose_notsupported" xml:space="preserve">
     <value>This platform does not support Socket.DuplicateAndClose.  Instead, create a new socket.</value>
   </data>
+  <data name="net_sockets_disconnect_notsupported" xml:space="preserve">
+    <value>This platform does not support disconnecting a Socket.  Instead, close the Socket and create a new one.</value>
+  </data>
 </root>

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -38,6 +38,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- All configurations -->
+    <Compile Include="System\Net\Sockets\TransmitFileOptions.cs" />
     <Compile Include="System\Net\Sockets\SocketReceiveFromResult.cs" />
     <Compile Include="System\Net\Sockets\SocketReceiveMessageFromResult.cs" />
     <Compile Include="System\Net\Sockets\SocketTaskExtensions.cs" />
@@ -71,6 +72,7 @@
     <Compile Include="System\Net\Sockets\AcceptOverlappedAsyncResult.cs" />
     <Compile Include="System\Net\Sockets\BaseOverlappedAsyncResult.cs" />
     <Compile Include="System\Net\Sockets\ConnectOverlappedAsyncResult.cs" />
+    <Compile Include="System\Net\Sockets\DisconnectOverlappedAsyncResult.cs" />
     <Compile Include="System\Net\Sockets\MultipleConnectAsync.cs" />
     <Compile Include="System\Net\Sockets\OverlappedAsyncResult.cs" />
     <Compile Include="System\Net\Sockets\ReceiveMessageOverlappedAsyncResult.cs" />

--- a/src/System.Net.Sockets/src/System/Net/Sockets/DisconnectOverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/DisconnectOverlappedAsyncResult.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Sockets
+{
+    // DisconnectOverlappedAsyncResult - used to take care of storage for async Socket BeginAccept call.
+    internal class DisconnectOverlappedAsyncResult : BaseOverlappedAsyncResult
+    {
+        internal DisconnectOverlappedAsyncResult(Socket socket, Object asyncState, AsyncCallback asyncCallback) :
+            base(socket, asyncState, asyncCallback)
+        {
+        }
+
+        // This method will be called by us when the IO completes synchronously and
+        // by the ThreadPool when the IO completes asynchronously.
+        internal override object PostCompletion(int numBytes)
+        {
+            if (ErrorCode == (int)SocketError.Success)
+            {
+                Socket socket = (Socket)AsyncObject;
+                socket.SetToDisconnected();
+                socket._remoteEndPoint = null;
+            }
+            return base.PostCompletion(numBytes);
+        }
+    }
+}

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -71,6 +71,22 @@ namespace System.Net.Sockets
                 out remoteSocketAddressLength);
         }
 
+        internal bool DisconnectEx(SafeCloseSocket socketHandle, SafeHandle overlapped, int flags, int reserved)
+        {
+            EnsureDynamicWinsockMethods();
+            DisconnectExDelegate disconnectEx = _dynamicWinsockMethods.GetDelegate<DisconnectExDelegate>(socketHandle);
+
+            return disconnectEx(socketHandle, overlapped, flags, reserved);
+        }
+
+        internal bool DisconnectExBlocking(SafeCloseSocket socketHandle, IntPtr overlapped, int flags, int reserved)
+        {
+            EnsureDynamicWinsockMethods();
+            DisconnectExDelegateBlocking disconnectEx_Blocking = _dynamicWinsockMethods.GetDelegate<DisconnectExDelegateBlocking>(socketHandle);
+
+            return disconnectEx_Blocking(socketHandle, overlapped, flags, reserved);
+        }
+
         internal bool ConnectEx(SafeCloseSocket socketHandle,
             IntPtr socketAddress,
             int socketAddressSize,

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -90,9 +90,14 @@ namespace System.Net.Sockets
             return handle.AsyncContext.ConnectAsync(_socketAddress.Buffer, _socketAddress.Size, ConnectCompletionCallback);
         }
 
+        internal SocketError DoOperationDisconnect(Socket socket, SafeCloseSocket handle)
+        {
+            throw new PlatformNotSupportedException(SR.net_sockets_disconnect_notsupported);
+        }
+
         private void InnerStartOperationDisconnect()
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.net_sockets_disconnect_notsupported);
         }
 
         private Action<int, byte[], int, SocketFlags, SocketError> TransferCompletionCallback =>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -244,6 +244,24 @@ namespace System.Net.Sockets
             CheckPinNoBuffer();
         }
 
+        internal SocketError DoOperationDisconnect(Socket socket, SafeCloseSocket handle)
+        {
+            PrepareIOCPOperation();
+
+            SocketError socketError = SocketError.Success;
+
+            if (!socket.DisconnectEx(
+                    handle,
+                    _ptrNativeOverlapped,
+                    (int)(DisconnectReuseSocket ? TransmitFileOptions.ReuseSocket : 0),
+                    0))
+            {
+                socketError = (SocketError)Marshal.GetLastWin32Error();
+            }
+
+            return socketError;
+        }
+
         private void InnerStartOperationReceive()
         {
             // WWSARecv uses a WSABuffer array describing buffers of data to send.

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -36,6 +36,9 @@ namespace System.Net.Sockets
         private event EventHandler<SocketAsyncEventArgs> _completed;
         private bool _completedChanged;
 
+        // DisconnectReuseSocket propery variables.
+        private bool _disconnectReuseSocket;
+
         // LastOperation property variables.
         private SocketAsyncOperation _completedOperation;
 
@@ -166,6 +169,13 @@ namespace System.Net.Sockets
             {
                 handler(e._currentSocket, e);
             }
+        }
+
+        // DisconnectResuseSocket property.
+        public bool DisconnectReuseSocket
+        {
+            get { return _disconnectReuseSocket; }
+            set { _disconnectReuseSocket = value; }
         }
 
         public SocketAsyncOperation LastOperation
@@ -501,6 +511,14 @@ namespace System.Net.Sockets
                 }
             }
         }
+
+        internal void StartOperationDisconnect()
+        {
+            // Remember the operation type.
+            _completedOperation = SocketAsyncOperation.Disconnect;
+            InnerStartOperationDisconnect();
+        }
+
         internal void StartOperationReceive()
         {
             // Remember the operation type.

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -706,11 +706,6 @@ namespace System.Net.Sockets
             }
         }
 
-        public static SocketError Disconnect(Socket socket, SafeCloseSocket handle, bool reuseSocket)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
         public static SocketError Send(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out int bytesTransferred)
         {
             var bufferList = buffers;
@@ -1321,6 +1316,16 @@ namespace System.Net.Sockets
             byte[] socketAddressBuffer = new byte[socketAddressSize];
 
             return handle.AsyncContext.AcceptAsync(socketAddressBuffer, socketAddressSize, asyncResult.CompletionCallback);
+        }
+
+        internal static SocketError DisconnectAsync(Socket socket, SafeCloseSocket handle, bool reuseSocket, DisconnectOverlappedAsyncResult asyncResult)
+        {
+            throw new PlatformNotSupportedException(SR.net_sockets_disconnect_notsupported);
+        }
+
+        internal static SocketError Disconnect(Socket socket, SafeCloseSocket handle, bool reuseSocket)
+        {
+            throw new PlatformNotSupportedException(SR.net_sockets_disconnect_notsupported);
         }
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -939,5 +939,32 @@ namespace System.Net.Sockets
         {
             // Dual-mode sockets support received packet info on Windows.
         }
+
+        internal static SocketError DisconnectAsync(Socket socket, SafeCloseSocket handle, bool reuseSocket, DisconnectOverlappedAsyncResult asyncResult)
+        {
+            asyncResult.SetUnmanagedStructures(null);
+
+            // This can throw ObjectDisposedException
+            SocketError errorCode = SocketError.Success;
+            if (!socket.DisconnectEx(handle, asyncResult.OverlappedHandle, (int)(reuseSocket ? TransmitFileOptions.ReuseSocket : 0), 0))
+            {
+                errorCode = GetLastSocketError();
+            }
+
+            return errorCode;
+        }
+
+        internal static SocketError Disconnect(Socket socket, SafeCloseSocket handle, bool reuseSocket)
+        {
+            SocketError errorCode = SocketError.Success;
+
+            // This can throw ObjectDisposedException (handle, and retrieving the delegate).
+            if (!socket.DisconnectExBlocking(handle, IntPtr.Zero, (int)(reuseSocket ? TransmitFileOptions.ReuseSocket : 0), 0))
+            {
+                errorCode = (SocketError)Marshal.GetLastWin32Error();
+            }
+
+            return errorCode;
+        }
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TransmitFileOptions.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TransmitFileOptions.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Net.Sockets
+{
+    [Flags]
+    public enum TransmitFileOptions
+    {
+        UseDefaultWorkerThread = 0x00,
+        Disconnect = 0x01,
+        ReuseSocket = 0x02,
+        WriteBehind = 0x04,
+        UseSystemThread = 0x10,
+        UseKernelApc = 0x20,
+    };
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/DisconnectTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DisconnectTest.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// TODO: make sure everything's OuterLoop and Windows-only!
-
 using System.Net.Test.Common;
 using System.Threading;
 
@@ -28,7 +26,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [OuterLoop]
+        [OuterLoop("Issue #11345")]
         [PlatformSpecific(PlatformID.Windows)]
         public void Disconnect_Success()
         {
@@ -62,7 +60,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [OuterLoop]
+        [OuterLoop("Issue #11345")]
         [PlatformSpecific(PlatformID.Windows)]
         public void DisconnectAsync_Success()
         {
@@ -98,7 +96,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [OuterLoop]
+        [OuterLoop("Issue #11345")]
         [PlatformSpecific(PlatformID.Windows)]
         public void BeginDisconnect_Success()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/DisconnectTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DisconnectTest.cs
@@ -1,0 +1,165 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// TODO: make sure everything's OuterLoop and Windows-only!
+
+using System.Net.Test.Common;
+using System.Threading;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Sockets.Tests
+{
+    public class DisconnectTest
+    {
+        private readonly ITestOutputHelper _log;
+
+        public DisconnectTest(ITestOutputHelper output)
+        {
+            _log = TestLogging.GetInstance();
+            Assert.True(Capability.IPv4Support() || Capability.IPv6Support());
+        }
+        public void OnCompleted(object sender, SocketAsyncEventArgs args)
+        {
+            EventWaitHandle handle = (EventWaitHandle)args.UserToken;
+            handle.Set();
+        }
+
+        [Fact]
+        [OuterLoop]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void Disconnect_Success()
+        {
+            AutoResetEvent completed = new AutoResetEvent(false);
+
+            IPEndPoint loopback = new IPEndPoint(IPAddress.Loopback, 0);
+            using (var server1 = SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, loopback))
+            using (var server2 = SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, loopback))
+            {
+                SocketAsyncEventArgs args = new SocketAsyncEventArgs();
+                args.Completed += OnCompleted;
+                args.UserToken = completed;
+                args.RemoteEndPoint = server1.EndPoint;
+                args.DisconnectReuseSocket = true;
+
+                using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    Assert.True(client.ConnectAsync(args));
+                    completed.WaitOne();
+                    Assert.Equal(SocketError.Success, args.SocketError);
+
+                    client.Disconnect(true);
+
+                    args.RemoteEndPoint = server2.EndPoint;
+
+                    Assert.True(client.ConnectAsync(args));
+                    completed.WaitOne();
+                    Assert.Equal(SocketError.Success, args.SocketError);
+                }
+            }
+        }
+
+        [Fact]
+        [OuterLoop]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void DisconnectAsync_Success()
+        {
+            AutoResetEvent completed = new AutoResetEvent(false);
+
+            IPEndPoint loopback = new IPEndPoint(IPAddress.Loopback, 0);
+            using (var server1 = SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, loopback))
+            using (var server2 = SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, loopback))
+            {
+                SocketAsyncEventArgs args = new SocketAsyncEventArgs();
+                args.Completed += OnCompleted;
+                args.UserToken = completed;
+                args.RemoteEndPoint = server1.EndPoint;
+                args.DisconnectReuseSocket = true;
+
+                using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    Assert.True(client.ConnectAsync(args));
+                    completed.WaitOne();
+                    Assert.Equal(SocketError.Success, args.SocketError);
+
+                    Assert.True(client.DisconnectAsync(args));
+                    completed.WaitOne();
+                    Assert.Equal(SocketError.Success, args.SocketError);
+
+                    args.RemoteEndPoint = server2.EndPoint;
+
+                    Assert.True(client.ConnectAsync(args));
+                    completed.WaitOne();
+                    Assert.Equal(SocketError.Success, args.SocketError);
+                }
+            }
+        }
+
+        [Fact]
+        [OuterLoop]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void BeginDisconnect_Success()
+        {
+            AutoResetEvent completed = new AutoResetEvent(false);
+
+            IPEndPoint loopback = new IPEndPoint(IPAddress.Loopback, 0);
+            using (var server1 = SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, loopback))
+            using (var server2 = SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, loopback))
+            {
+                SocketAsyncEventArgs args = new SocketAsyncEventArgs();
+                args.Completed += OnCompleted;
+                args.UserToken = completed;
+                args.RemoteEndPoint = server1.EndPoint;
+
+                using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    Assert.True(client.ConnectAsync(args));
+                    completed.WaitOne();
+                    Assert.Equal(SocketError.Success, args.SocketError);
+
+                    client.EndDisconnect(client.BeginDisconnect(true, null, null));
+
+                    args.RemoteEndPoint = server2.EndPoint;
+
+                    Assert.True(client.ConnectAsync(args));
+                    completed.WaitOne();
+                    Assert.Equal(SocketError.Success, args.SocketError);
+                }
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(~PlatformID.Windows)]
+        public void Disconnect_NonWindows_NotSupported()
+        {
+            using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => client.Disconnect(true));
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(~PlatformID.Windows)]
+        public void DisconnectAsync_NonWindows_NotSupported()
+        {
+            using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                SocketAsyncEventArgs args = new SocketAsyncEventArgs();
+                args.DisconnectReuseSocket = true;
+                Assert.Throws<PlatformNotSupportedException>(() => client.DisconnectAsync(args));
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(~PlatformID.Windows)]
+        public void BeginDisconnect_NonWindows_NotSupported()
+        {
+            using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => client.BeginDisconnect(true, null, null));
+            }
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -15,6 +15,7 @@
     <Compile Include="AcceptAsync.cs" />
     <Compile Include="AgnosticListenerTest.cs" />
     <Compile Include="ArgumentValidationTests.cs" />
+    <Compile Include="DisconnectTest.cs" />
     <Compile Include="Handle.cs" />
     <Compile Include="ConnectAsync.cs" />
     <Compile Include="ConnectExTest.cs" />

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketTestServerAPMMock.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketTestServerAPMMock.cs
@@ -10,6 +10,7 @@ namespace System.Net.Sockets.Tests
     public class SocketTestServerAPM : SocketTestServer
     {
         protected override int Port { get { throw new NotSupportedException(); } }
+        public override EndPoint EndPoint { get { throw new NotSupportedException(); } }
 
         public SocketTestServerAPM(int numConnections, int receiveBufferSize, EndPoint localEndPoint)
         {


### PR DESCRIPTION
These can only be supported on Windows, as Unix has no equivalent concept.  Ported the product code and tests from the CLR.  Part of #11788.

@stephentoub @CIPop @davidsh 