### PR TITLE
Expose remaining APIs in String and StringComparer

### DIFF
--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -716,10 +716,15 @@ namespace System
         protected StringComparer() { }
         public static System.StringComparer CurrentCulture { get { return default(System.StringComparer); } }
         public static System.StringComparer CurrentCultureIgnoreCase { get { return default(System.StringComparer); } }
+        public static System.StringComparer InvariantCulture { get { throw null; } }
+        public static System.StringComparer InvariantCultureIgnoreCase { get { throw null; } }
         public static System.StringComparer Ordinal { get { return default(System.StringComparer); } }
         public static System.StringComparer OrdinalIgnoreCase { get { return default(System.StringComparer); } }
         public abstract int Compare(string x, string y);
+        public static System.StringComparer Create(System.Globalization.CultureInfo culture, bool ignoreCase) { return default(System.StringComparer); }
+        public new bool Equals(object x, object y) { return default(bool); }
         public abstract bool Equals(string x, string y);
+        public int GetHashCode(object obj) { return default(int); }
         public abstract int GetHashCode(string obj);
         int System.Collections.IComparer.Compare(object x, object y) { return default(int); }
         bool System.Collections.IEqualityComparer.Equals(object x, object y) { return default(bool); }

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -25,19 +25,23 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU' " />
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+    <Compile Include="System\Convert.netstandard1.7.cs" />
+    <Compile Include="System\EnvironmentTests.cs" />
+    <Compile Include="System\IO\PathTests.netstandard1.7.cs" />
+    <Compile Include="System\Math.netstandard1.7.cs" />
+    <Compile Include="System\StringComparer.netstandard1.7.cs" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
-    <Compile Include="System\EnvironmentTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="System\Environment.MachineName.cs" />
     <Compile Include="System\IO\Path.Combine.cs" />
-    <Compile Include="System\IO\PathTests.netstandard1.7.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />
     <Compile Include="System\IO\PathTests.cs" />
     <Compile Include="System\Net\WebUtility.cs" />
     <Compile Include="System\BitConverter.cs" />
     <Compile Include="System\Convert.BoxedObjectCheck.cs" />
     <Compile Include="System\Convert.FromBase64.cs" />
-    <Compile Include="System\Convert.netstandard1.7.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="System\Convert.TestBase.cs" />
     <Compile Include="System\Convert.ToBase64CharArray.cs" />
     <Compile Include="System\Convert.ToBase64String.cs" />
@@ -90,7 +94,6 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
-    <Compile Condition="'$(TargetGroup)'=='netstandard1.7'" Include="System\Math.netstandard1.7.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.netstandard1.7.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.netstandard1.7.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using Xunit;
+
+namespace System.Tests
+{
+    public static class MiscStringComparerTests
+    {
+        public static IEnumerable<object[]> UpperLowerCasing_TestData()
+        {
+            //                          lower                upper          Culture
+            yield return new object[] { "abcd",             "ABCD",         "en-US" };
+            yield return new object[] { "latin i",          "LATIN I",      "en-US" };
+            yield return new object[] { "turky \u0131",     "TURKY I",      "tr-TR" };
+            yield return new object[] { "turky i",          "TURKY \u0130", "tr-TR" };
+        }
+
+        [Theory]
+        [MemberData(nameof(UpperLowerCasing_TestData))]
+        [ActiveIssue(11815, Xunit.PlatformID.AnyUnix)]
+        public static void CreateWithCulturesTest(string lowerForm, string upperForm, string cultureName)
+        {
+            CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
+            StringComparer sc = StringComparer.Create(ci, false);
+            Assert.False(sc.Equals(lowerForm, upperForm), "Not expected to have the lowercase equals the uppercase with ignore case is false");
+            Assert.False(sc.Equals((object) lowerForm, (object) upperForm), "Not expected to have the lowercase object equals the uppercase with ignore case is false");
+            Assert.NotEqual(sc.GetHashCode(lowerForm), sc.GetHashCode(upperForm));
+            Assert.NotEqual(sc.GetHashCode((object) lowerForm), sc.GetHashCode((object) upperForm));
+
+            sc = StringComparer.Create(ci, true);
+            Assert.True(sc.Equals(lowerForm, upperForm), "It is expected to have the lowercase equals the uppercase with ignore case is true"); 
+            Assert.True(sc.Equals((object) lowerForm, (object) upperForm), "It is expected to have the lowercase object equals the uppercase with ignore case is true"); 
+            Assert.Equal(sc.GetHashCode(lowerForm), sc.GetHashCode(upperForm));
+            Assert.Equal(sc.GetHashCode((object) lowerForm), sc.GetHashCode((object) upperForm));
+        }
+
+        [Fact]
+        [ActiveIssue(11815, Xunit.PlatformID.AnyUnix)]
+        public static void InvariantTest()
+        {
+            Assert.True(StringComparer.InvariantCulture.Equals("test", "test"), "Same casing strings with StringComparer.InvariantCulture should be equal");
+            Assert.True(StringComparer.InvariantCulture.Equals((object) "test", (object) "test"), "Same casing objects with StringComparer.InvariantCulture should be equal");
+            Assert.Equal(StringComparer.InvariantCulture.GetHashCode("test"), StringComparer.InvariantCulture.GetHashCode("test"));
+            Assert.Equal(0, StringComparer.InvariantCulture.Compare("test", "test"));
+            
+            Assert.False(StringComparer.InvariantCulture.Equals("test", "TEST"), "different casing strings with StringComparer.InvariantCulture should not be equal");
+            Assert.False(StringComparer.InvariantCulture.Equals((object) "test", (object) "TEST"), "different casing objects with StringComparer.InvariantCulture should not be equal");
+            Assert.NotEqual(StringComparer.InvariantCulture.GetHashCode("test"), StringComparer.InvariantCulture.GetHashCode("TEST"));
+            Assert.NotEqual(0, StringComparer.InvariantCulture.Compare("test", "TEST"));
+
+            Assert.True(StringComparer.InvariantCultureIgnoreCase.Equals("test", "test"), "Same casing strings with StringComparer.InvariantCultureIgnoreCase should be equal");
+            Assert.True(StringComparer.InvariantCultureIgnoreCase.Equals((object) "test", (object) "test"), "Same casing objects with StringComparer.InvariantCultureIgnoreCase should be equal");
+            Assert.Equal(StringComparer.InvariantCultureIgnoreCase.GetHashCode("test"), StringComparer.InvariantCulture.GetHashCode("test"));
+            Assert.Equal(0, StringComparer.InvariantCultureIgnoreCase.Compare("test", "test"));
+            
+            Assert.True(StringComparer.InvariantCultureIgnoreCase.Equals("test", "TEST"), "same strings with different casing with StringComparer.InvariantCultureIgnoreCase should be equal");
+            Assert.True(StringComparer.InvariantCultureIgnoreCase.Equals((object) "test", (object) "TEST"), "same objects with different casing with StringComparer.InvariantCultureIgnoreCase should be equal");
+            Assert.Equal(StringComparer.InvariantCultureIgnoreCase.GetHashCode("test"), StringComparer.InvariantCultureIgnoreCase.GetHashCode("TEST"));
+            Assert.Equal(0, StringComparer.InvariantCultureIgnoreCase.Compare("test", "TEST"));
+        }
+    }
+}

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -1793,8 +1793,7 @@ namespace System
         public static string Format(string format, object arg0, object arg1) { return default(string); }
         public static string Format(string format, object arg0, object arg1, object arg2) { return default(string); }
         public static string Format(string format, params object[] args) { return default(string); }
-        // tracking issue #10216.
-        // public System.CharEnumerator GetEnumerator() { return default(System.CharEnumerator); }
+        public System.CharEnumerator GetEnumerator() { return default(System.CharEnumerator); }
         public override int GetHashCode() { return default(int); }
         public int IndexOf(char value) { return default(int); }
         public int IndexOf(char value, int startIndex) { return default(int); }

--- a/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
@@ -378,4 +378,5 @@ MembersMustExist : Member 'System.Text.Encoding.IsMailNewsSave.get()' does not e
 MembersMustExist : Member 'System.Text.Encoding.WindowsCodePage.get()' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Text.EncodingInfo' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Text.NormalizationForm' does not exist in the implementation but it does exist in the contract.
-Total Issues: 379
+MembersMustExist : Member 'System.String.GetEnumerator()' does not exist in the implementation but it does exist in the contract.
+Total Issues: 380

--- a/src/System.Runtime/tests/System/StringTests.netstandard1.7.cs
+++ b/src/System.Runtime/tests/System/StringTests.netstandard1.7.cs
@@ -223,6 +223,31 @@ namespace System.Tests
             normalized = s.Normalize(NormalizationForm.FormKD);
             Assert.True(normalized.IsNormalized(NormalizationForm.FormKD), "Expected to have the normalized string with FormKD");
         }
-        
+
+        [Fact]
+        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
+        public static unsafe void GetEnumeratorTest()
+        {
+            string s = "This is some string to enumerate its characters using String.GetEnumerator";
+            CharEnumerator chEnum = s.GetEnumerator();
+
+            int calculatedLength = 0;
+            while (chEnum.MoveNext())
+            {
+                calculatedLength++;
+            }
+
+            Assert.Equal(s.Length, calculatedLength);
+            chEnum.Reset();
+
+            // enumerate twice in same time
+            foreach (char c in s)
+            {
+                Assert.True(chEnum.MoveNext(), "expect to have characters to enumerate in the string");
+                Assert.Equal(c, chEnum.Current); 
+            }
+
+            Assert.False(chEnum.MoveNext(), "expect to not having any characters to enumerate");
+        }
     }
 }


### PR DESCRIPTION
This change should be exposing the remaining APIs in String and StringComparer classes for net standard 2.0 and adding the tests too.