### PR TITLE
Use CommonCrypto CSPRNG for GetTempFileName on macOS

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.CommonCrypto.cs
+++ b/src/Common/src/Interop/OSX/Interop.CommonCrypto.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    // Direct support on top of Apple CommonCrypto.
+    // In general, this should not be used, the System.Security.Cryptography.Native.Apple shim
+    // being preferred. But when there is a layering complication, or other compelling reason,
+    // then this can be used directly.
+    internal static partial class CommonCrypto
+    {
+        [DllImport(Libraries.LibSystemCommonCrypto)]
+        internal static unsafe extern int CCRandomGenerateBytes(byte* bytes, int byteCount);
+    }
+}

--- a/src/Common/src/Interop/OSX/Interop.Libraries.cs
+++ b/src/Common/src/Interop/OSX/Interop.Libraries.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
         internal const string CoreFoundationLibrary = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
         internal const string CoreServicesLibrary   = "/System/Library/Frameworks/CoreServices.framework/CoreServices";
         internal const string libproc = "libproc";
+        internal const string LibSystemCommonCrypto = "/usr/lib/system/libcommonCrypto";
         internal const string LibSystemKernel = "/usr/lib/system/libsystem_kernel";
         internal const string SystemConfigurationLibrary = "/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration";
         internal const string AppleCryptoNative = "System.Security.Cryptography.Native.Apple";

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -274,6 +274,12 @@
     <Compile Include="System\Environment.Unix.cs" />
     <Compile Include="System\Diagnostics\Stopwatch.Unix.cs" />
     <Compile Include="System\IO\Path.Unix.cs" />
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+      <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CommonCrypto.cs">
+      <Link>Common\Interop\OSX\Interop.CommonCrypto.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>

--- a/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
@@ -38,7 +38,7 @@ namespace System
             }
             return results;
         });
-        private static readonly bool IsMac = Interop.Sys.GetUnixName() == "OSX";
+        internal static readonly bool IsMac = Interop.Sys.GetUnixName() == "OSX";
         private static Func<string, IEnumerable<string>> s_fileReadLines;
         private static Action<string> s_directoryCreateDirectory;
 

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace System.IO
@@ -204,6 +205,29 @@ namespace System.IO
         }
 
         private static unsafe void GetCryptoRandomBytes(byte* bytes, int byteCount)
+        {
+            if (Environment.IsMac)
+            {
+                GetCryptoRandomBytesApple(bytes, byteCount);
+            }
+            else
+            {
+                GetCryptoRandomBytesOpenSsl(bytes, byteCount);
+            }
+        }
+
+        private static unsafe void GetCryptoRandomBytesApple(byte* bytes, int byteCount)
+        {
+            Debug.Assert(bytes != null);
+            Debug.Assert(byteCount >= 0);
+
+            if (Interop.CommonCrypto.CCRandomGenerateBytes(bytes, byteCount) != 0)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_Cryptography);
+            }
+        }
+
+        private static unsafe void GetCryptoRandomBytesOpenSsl(byte* bytes, int byteCount)
         {
             Debug.Assert(bytes != null);
             Debug.Assert(byteCount >= 0);


### PR DESCRIPTION
In the Unix build use the existing calculation of IsMac to determine if
Interop.Crypto (powered by OpenSSL) or CommonCrypto should be used
for the CSPRNG.

GetTempFileName is the most often reported hit of a failure in Interop+Crypto.cctor
, but that didn't benefit from when the macOS
implementation of System.Security.Cryptography.RandomNumberGenerator
changed to use CommonCrypto (via the new Apple-specific shim).

This rectifies that, and should take a significant burden off of the first run
experiences for macOS users who have not installed OpenSSL in a manner
where we can find it.

cc: @stephentoub

Validation: Attached a lldb to the xunit process and ran the PathTests suite, found 100 calls to CCRandomGenerateBytes after the change, 0 before.  The tests also executed with System.Security.Cryptography.Native(.OpenSsl).dylib unable to be found through probing, ensuring that the cctor is not firing with the current level of method isolation.