### PR TITLE
Use singleton instance of Empty where appropriate

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -739,7 +739,7 @@ namespace System.Linq.Expressions.Compiler
                     Expression.Assign(switchIndex, Expression.Constant(nullCase)),
                     Expression.IfThenElse(
                         Expression.Call(dictInit, "TryGetValue", null, switchValue, switchIndex),
-                        Expression.Empty(),
+                        Utils.Empty(),
                         Expression.Assign(switchIndex, Expression.Constant(-1))
                     )
                 ),

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Bindings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Bindings.cs
@@ -114,7 +114,7 @@ namespace System.Linq.Expressions.Compiler
                 }
                 else
                 {
-                    block[_bindings.Count + 1] = Expression.Empty();
+                    block[_bindings.Count + 1] = Utils.Empty();
                 }
                 return MakeBlock(block);
             }
@@ -199,7 +199,7 @@ namespace System.Linq.Expressions.Compiler
                 }
                 else
                 {
-                    block[_inits.Count + 1] = Expression.Empty();
+                    block[_inits.Count + 1] = Utils.Empty();
                 }
                 return MakeBlock(block);
             }
@@ -239,7 +239,7 @@ namespace System.Linq.Expressions.Compiler
                 return MakeBlock(
                     Expression.Assign(memberTemp, _rhs),
                     Expression.Assign(member, memberTemp),
-                    Expression.Empty()
+                    Utils.Empty()
                 );
             }
         }


### PR DESCRIPTION
We have this instance sitting around for use by `IfThen` nodes but we don't leverage it elsewhere. Note we can only use it in places where the object identity doesn't leak to users. This restricts usage to internal-only `Reduce` methods. Doing just this here, in `StackSpiller` and `LambdaCompiler` (where trees are headed down the path to `ILGen` and eventual certain death by GC).