### PR TITLE
Improving code consistency in interpreter + using C# 6.0

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Dynamic.Utils;
-using System.Reflection;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -13,17 +11,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Add"; }
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Add";
 
-
-        private AddInstruction()
-        {
-        }
+        private AddInstruction() { }
 
         internal sealed class AddInt32 : AddInstruction
         {
@@ -200,17 +192,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "AddOvf";
 
-        public override string InstructionName
-        {
-            get { return "AddOvf"; }
-        }
-
-        private AddOvfInstruction()
-        {
-        }
+        private AddOvfInstruction() { }
 
         internal sealed class AddOvfInt32 : AddOvfInstruction
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Linq.Expressions.Interpreter
 {
     internal sealed class NewArrayInitInstruction : Instruction
@@ -17,12 +15,9 @@ namespace System.Linq.Expressions.Interpreter
             _elementCount = elementCount;
         }
 
-        public override int ConsumedStack { get { return _elementCount; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "NewArrayInit"; }
-        }
+        public override int ConsumedStack => _elementCount;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "NewArrayInit";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -45,12 +40,9 @@ namespace System.Linq.Expressions.Interpreter
             _elementType = elementType;
         }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "NewArray"; }
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "NewArray";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -76,12 +68,9 @@ namespace System.Linq.Expressions.Interpreter
             _rank = rank;
         }
 
-        public override int ConsumedStack { get { return _rank; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "NewArrayBounds"; }
-        }
+        public override int ConsumedStack => _rank;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "NewArrayBounds";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -110,12 +99,9 @@ namespace System.Linq.Expressions.Interpreter
 
         internal GetArrayItemInstruction() { }
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "GetArrayItem"; }
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "GetArrayItem";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -132,12 +118,9 @@ namespace System.Linq.Expressions.Interpreter
 
         internal SetArrayItemInstruction() { }
 
-        public override int ConsumedStack { get { return 3; } }
-        public override int ProducedStack { get { return 0; } }
-        public override string InstructionName
-        {
-            get { return "SetArrayItem"; }
-        }
+        public override int ConsumedStack => 3;
+        public override int ProducedStack => 0;
+        public override string InstructionName => "SetArrayItem";
 
         public override int Run(InterpretedFrame frame)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/BranchLabel.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/BranchLabel.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Globalization;
@@ -33,40 +32,20 @@ namespace System.Linq.Expressions.Interpreter
         internal const int UnknownIndex = Int32.MinValue;
         internal const int UnknownDepth = Int32.MinValue;
 
-        internal int _labelIndex = UnknownIndex;
-        internal int _targetIndex = UnknownIndex;
-        internal int _stackDepth = UnknownDepth;
-        internal int _continuationStackDepth = UnknownDepth;
+        private int _targetIndex = UnknownIndex;
+        private int _stackDepth = UnknownDepth;
+        private int _continuationStackDepth = UnknownDepth;
 
         // Offsets of forward branching instructions targeting this label 
         // that need to be updated after we emit the label.
         private List<int> _forwardBranchFixups;
 
-        public BranchLabel()
-        {
-        }
+        public BranchLabel() { }
 
-        internal int LabelIndex
-        {
-            get { return _labelIndex; }
-            set { _labelIndex = value; }
-        }
-
-        internal bool HasRuntimeLabel
-        {
-            get { return _labelIndex != UnknownIndex; }
-        }
-
-        internal int TargetIndex
-        {
-            get { return _targetIndex; }
-        }
-
-        internal int StackDepth
-        {
-            get { return _stackDepth; }
-        }
-
+        internal int LabelIndex { get; set; } = UnknownIndex;
+        internal bool HasRuntimeLabel => LabelIndex != UnknownIndex;
+        internal int TargetIndex => _targetIndex;
+        
         internal RuntimeLabel ToRuntimeLabel()
         {
             Debug.Assert(_targetIndex != UnknownIndex && _stackDepth != UnknownDepth && _continuationStackDepth != UnknownDepth);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
 using System.Dynamic.Utils;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
 
@@ -190,14 +188,14 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class ActionCallInstruction : CallInstruction
     {
         private readonly Action _target;
-        public override int ArgumentCount { get { return 0; } }
+        public override int ArgumentCount => 0;
 
         public ActionCallInstruction(Action target)
         {
             _target = target;
         }
 
-        public override int ProducedStack { get { return 0; } }
+        public override int ProducedStack => 0;
 
         public ActionCallInstruction(MethodInfo target)
         {
@@ -215,8 +213,8 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class ActionCallInstruction<T0> : CallInstruction
     {
         private readonly Action<T0> _target;
-        public override int ProducedStack { get { return 0; } }
-        public override int ArgumentCount { get { return 1; } }
+        public override int ProducedStack => 0;
+        public override int ArgumentCount => 1;
 
         public ActionCallInstruction(Action<T0> target)
         {
@@ -239,8 +237,8 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class ActionCallInstruction<T0, T1> : CallInstruction
     {
         private readonly Action<T0, T1> _target;
-        public override int ProducedStack { get { return 0; } }
-        public override int ArgumentCount { get { return 2; } }
+        public override int ProducedStack => 0;
+        public override int ArgumentCount => 2;
 
         public ActionCallInstruction(Action<T0, T1> target)
         {
@@ -263,8 +261,8 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class FuncCallInstruction<TRet> : CallInstruction
     {
         private readonly Func<TRet> _target;
-        public override int ProducedStack { get { return 1; } }
-        public override int ArgumentCount { get { return 0; } }
+        public override int ProducedStack => 1;
+        public override int ArgumentCount => 0;
 
         public FuncCallInstruction(Func<TRet> target)
         {
@@ -287,8 +285,8 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class FuncCallInstruction<T0, TRet> : CallInstruction
     {
         private readonly Func<T0, TRet> _target;
-        public override int ProducedStack { get { return 1; } }
-        public override int ArgumentCount { get { return 1; } }
+        public override int ProducedStack => 1;
+        public override int ArgumentCount => 1;
 
         public FuncCallInstruction(Func<T0, TRet> target)
         {
@@ -311,8 +309,8 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class FuncCallInstruction<T0, T1, TRet> : CallInstruction
     {
         private readonly Func<T0, T1, TRet> _target;
-        public override int ProducedStack { get { return 1; } }
-        public override int ArgumentCount { get { return 2; } }
+        public override int ProducedStack => 1;
+        public override int ArgumentCount => 2;
 
         public FuncCallInstruction(Func<T0, T1, TRet> target)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -20,10 +19,8 @@ namespace System.Linq.Expressions.Interpreter
         #region Construction
 
         internal CallInstruction() { }
-        public override string InstructionName
-        {
-            get { return "Call"; }
-        }
+
+        public override string InstructionName => "Call";
 
 #if FEATURE_DLG_INVOKE
         private static readonly Dictionary<MethodInfo, CallInstruction> _cache = new Dictionary<MethodInfo, CallInstruction>();
@@ -260,12 +257,10 @@ namespace System.Linq.Expressions.Interpreter
 
         #region Instruction
 
-        public override int ConsumedStack { get { return ArgumentCount; } }
+        public override int ConsumedStack => ArgumentCount;
 
-        public override string ToString()
-        {
-            return "Call()";
-        }
+        public override string ToString() => "Call()";
+        
         #endregion
 
         /// <summary>
@@ -314,7 +309,7 @@ namespace System.Linq.Expressions.Interpreter
         protected readonly MethodInfo _target;
         protected readonly int _argumentCount;
 
-        public override int ArgumentCount { get { return _argumentCount; } }
+        public override int ArgumentCount => _argumentCount;
 
         internal MethodInfoCallInstruction(MethodInfo target, int argumentCount)
         {
@@ -322,7 +317,7 @@ namespace System.Linq.Expressions.Interpreter
             _argumentCount = argumentCount;
         }
 
-        public override int ProducedStack { get { return _target.ReturnType == typeof(void) ? 0 : 1; } }
+        public override int ProducedStack => _target.ReturnType == typeof(void) ? 0 : 1;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -412,7 +407,7 @@ namespace System.Linq.Expressions.Interpreter
             _byrefArgs = byrefArgs;
         }
 
-        public override int ProducedStack { get { return (_target.ReturnType == typeof(void) ? 0 : 1); } }
+        public override int ProducedStack => _target.ReturnType == typeof(void) ? 0 : 1;
 
         public sealed override int Run(InterpretedFrame frame)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -47,10 +47,8 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class BranchFalseInstruction : OffsetInstruction
     {
         private static Instruction[] s_cache;
-        public override string InstructionName
-        {
-            get { return "BranchFalse"; }
-        }
+
+        public override string InstructionName => "BranchFalse";
 
         public override Instruction[] Cache
         {
@@ -64,11 +62,9 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal BranchFalseInstruction()
-        {
-        }
+        internal BranchFalseInstruction() { }
 
-        public override int ConsumedStack { get { return 1; } }
+        public override int ConsumedStack => 1;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -86,10 +82,8 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class BranchTrueInstruction : OffsetInstruction
     {
         private static Instruction[] s_cache;
-        public override string InstructionName
-        {
-            get { return "BranchTrue"; }
-        }
+
+        public override string InstructionName => "BranchTrue";
 
         public override Instruction[] Cache
         {
@@ -103,11 +97,9 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal BranchTrueInstruction()
-        {
-        }
+        internal BranchTrueInstruction() { }
 
-        public override int ConsumedStack { get { return 1; } }
+        public override int ConsumedStack => 1;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -125,10 +117,8 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class CoalescingBranchInstruction : OffsetInstruction
     {
         private static Instruction[] s_cache;
-        public override string InstructionName
-        {
-            get { return "CoalescingBranch"; }
-        }
+
+        public override string InstructionName => "CoalescingBranch";
 
         public override Instruction[] Cache
         {
@@ -142,12 +132,10 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal CoalescingBranchInstruction()
-        {
-        }
+        internal CoalescingBranchInstruction() { }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -165,10 +153,8 @@ namespace System.Linq.Expressions.Interpreter
     internal class BranchInstruction : OffsetInstruction
     {
         private static Instruction[][][] s_caches;
-        public override string InstructionName
-        {
-            get { return "Branch"; }
-        }
+
+        public override string InstructionName => "Branch";
 
         public override Instruction[] Cache
         {
@@ -196,15 +182,8 @@ namespace System.Linq.Expressions.Interpreter
             _hasValue = hasValue;
         }
 
-        public override int ConsumedStack
-        {
-            get { return _hasValue ? 1 : 0; }
-        }
-
-        public override int ProducedStack
-        {
-            get { return _hasResult ? 1 : 0; }
-        }
+        public override int ConsumedStack => _hasValue ? 1 : 0;
+        public override int ProducedStack => _hasResult ? 1 : 0;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -273,10 +252,8 @@ namespace System.Linq.Expressions.Interpreter
         private const int Variants = 8;
         private static readonly GotoInstruction[] s_cache = new GotoInstruction[Variants * CacheSize];
 
-        public override string InstructionName
-        {
-            get { return "Goto"; }
-        }
+        public override string InstructionName => "Goto";
+        
         private readonly bool _hasResult;
 
         private readonly bool _hasValue;
@@ -287,18 +264,11 @@ namespace System.Linq.Expressions.Interpreter
         // and at meantime produce a new _pendingContinuation. However, in case of forward gotos, we don't not know that is the 
         // case until the label is emitted. By then the consumed and produced stack information is useless.
         // The important thing here is that the stack balance is 0.
-        public override int ConsumedContinuations { get { return 0; } }
-        public override int ProducedContinuations { get { return 0; } }
+        public override int ConsumedContinuations => 0;
+        public override int ProducedContinuations => 0;
 
-        public override int ConsumedStack
-        {
-            get { return _hasValue ? 1 : 0; }
-        }
-
-        public override int ProducedStack
-        {
-            get { return _hasResult ? 1 : 0; }
-        }
+        public override int ConsumedStack => _hasValue ? 1 : 0;
+        public override int ProducedStack => _hasResult ? 1 : 0;
 
         private GotoInstruction(int targetIndex, bool hasResult, bool hasValue, bool labelTargetGetsValue)
             : base(targetIndex)
@@ -342,7 +312,7 @@ namespace System.Linq.Expressions.Interpreter
             _tryHandler = tryHandler;
         }
 
-        public override int ProducedContinuations { get { return _hasFinally ? 1 : 0; } }
+        public override int ProducedContinuations => _hasFinally ? 1 : 0;
 
         private EnterTryCatchFinallyInstruction(int targetIndex, bool hasFinally)
             : base(targetIndex)
@@ -463,15 +433,9 @@ namespace System.Linq.Expressions.Interpreter
             return frame.InstructionIndex - prevInstrIndex;
         }
 
-        public override string InstructionName
-        {
-            get { return _hasFinally ? "EnterTryFinally" : "EnterTryCatch"; }
-        }
+        public override string InstructionName => _hasFinally ? "EnterTryFinally" : "EnterTryCatch";
 
-        public override string ToString()
-        {
-            return _hasFinally ? "EnterTryFinally[" + _labelIndex + "]" : "EnterTryCatch";
-        }
+        public override string ToString() => _hasFinally ? "EnterTryFinally[" + _labelIndex + "]" : "EnterTryCatch";
     }
 
     internal sealed class EnterTryFaultInstruction : IndexedBranchInstruction
@@ -559,12 +523,9 @@ namespace System.Linq.Expressions.Interpreter
     {
         private readonly static EnterFinallyInstruction[] s_cache = new EnterFinallyInstruction[CacheSize];
 
-        public override string InstructionName
-        {
-            get { return "EnterFinally"; }
-        }
-        public override int ProducedStack { get { return 2; } }
-        public override int ConsumedContinuations { get { return 1; } }
+        public override string InstructionName => "EnterFinally";
+        public override int ProducedStack => 2;
+        public override int ConsumedContinuations => 1;
 
         private EnterFinallyInstruction(int labelIndex)
             : base(labelIndex)
@@ -603,14 +564,10 @@ namespace System.Linq.Expressions.Interpreter
     {
         internal static readonly Instruction Instance = new LeaveFinallyInstruction();
 
-        public override int ConsumedStack { get { return 2; } }
-        public override string InstructionName
-        {
-            get { return "LeaveFinally"; }
-        }
-        private LeaveFinallyInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override string InstructionName => "LeaveFinally";
+
+        private LeaveFinallyInstruction() { }
 
         public override int Run(InterpretedFrame frame)
         {
@@ -668,9 +625,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "LeaveFault";
 
-        private LeaveFaultInstruction()
-        {
-        }
+        private LeaveFaultInstruction() { }
 
         public override int Run(InterpretedFrame frame)
         {
@@ -687,9 +642,7 @@ namespace System.Linq.Expressions.Interpreter
     {
         internal static readonly EnterExceptionFilterInstruction Instance = new EnterExceptionFilterInstruction();
 
-        private EnterExceptionFilterInstruction()
-        {
-        }
+        private EnterExceptionFilterInstruction() { }
 
         public override string InstructionName => "EnterExceptionFilter";
 
@@ -707,9 +660,7 @@ namespace System.Linq.Expressions.Interpreter
     {
         internal static readonly LeaveExceptionFilterInstruction Instance = new LeaveExceptionFilterInstruction();
 
-        private LeaveExceptionFilterInstruction()
-        {
-        }
+        private LeaveExceptionFilterInstruction() { }
 
         public override string InstructionName => "LeaveExceptionFilter";
 
@@ -730,10 +681,8 @@ namespace System.Linq.Expressions.Interpreter
 
         // True if try-expression is non-void.
         private readonly bool _hasValue;
-        public override string InstructionName
-        {
-            get { return "EnterExceptionHandler"; }
-        }
+        public override string InstructionName => "EnterExceptionHandler";
+
         private EnterExceptionHandlerInstruction(bool hasValue)
         {
             _hasValue = hasValue;
@@ -744,11 +693,11 @@ namespace System.Linq.Expressions.Interpreter
         // However, while emitting instructions try block falls thru the catch block with a value on stack. 
         // We need to declare it consumed so that the stack state upon entry to the handler corresponds to the real 
         // stack depth after throw jumped to this catch block.
-        public override int ConsumedStack { get { return _hasValue ? 1 : 0; } }
+        public override int ConsumedStack => _hasValue ? 1 : 0;
 
         // A variable storing the current exception is pushed to the stack by exception handling.
         // Catch handlers: The value is immediately popped and stored into a local.
-        public override int ProducedStack { get { return 1; } }
+        public override int ProducedStack => 1;
 
         [ExcludeFromCodeCoverage] // Known to be a no-op, this instruction is skipped on execution.
         public override int Run(InterpretedFrame frame)
@@ -766,20 +715,11 @@ namespace System.Linq.Expressions.Interpreter
         private static LeaveExceptionHandlerInstruction[] s_cache = new LeaveExceptionHandlerInstruction[2 * CacheSize];
 
         private readonly bool _hasValue;
-        public override string InstructionName
-        {
-            get { return "LeaveExceptionHandler"; }
-        }
-        // The catch block yields a value if the body is non-void. This value is left on the stack. 
-        public override int ConsumedStack
-        {
-            get { return _hasValue ? 1 : 0; }
-        }
+        public override string InstructionName => "LeaveExceptionHandler";
 
-        public override int ProducedStack
-        {
-            get { return _hasValue ? 1 : 0; }
-        }
+        // The catch block yields a value if the body is non-void. This value is left on the stack. 
+        public override int ConsumedStack => _hasValue ? 1 : 0;
+        public override int ProducedStack => _hasValue ? 1 : 0;
 
         private LeaveExceptionHandlerInstruction(int labelIndex, bool hasValue)
             : base(labelIndex)
@@ -815,28 +755,16 @@ namespace System.Linq.Expressions.Interpreter
         internal static readonly ThrowInstruction VoidRethrow = new ThrowInstruction(false, true);
 
         private readonly bool _hasResult, _rethrow;
-        public override string InstructionName
-        {
-            get { return "Throw"; }
-        }
+        public override string InstructionName => "Throw";
+
         private ThrowInstruction(bool hasResult, bool isRethrow)
         {
             _hasResult = hasResult;
             _rethrow = isRethrow;
         }
 
-        public override int ProducedStack
-        {
-            get { return _hasResult ? 1 : 0; }
-        }
-
-        public override int ConsumedStack
-        {
-            get
-            {
-                return 1;
-            }
-        }
+        public override int ProducedStack => _hasResult ? 1 : 0;
+        public override int ConsumedStack => 1;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -853,18 +781,16 @@ namespace System.Linq.Expressions.Interpreter
     {
         private readonly Dictionary<T, int> _cases;
 
-        public override string InstructionName
-        {
-            get { return "IntSwitch"; }
-        }
+        public override string InstructionName => "IntSwitch";
+
         internal IntSwitchInstruction(Dictionary<T, int> cases)
         {
             Assert.NotNull(cases);
             _cases = cases;
         }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 0; } }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 0;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -878,10 +804,8 @@ namespace System.Linq.Expressions.Interpreter
         private readonly Dictionary<string, int> _cases;
         private readonly StrongBox<int> _nullCase;
 
-        public override string InstructionName
-        {
-            get { return "StringSwitch"; }
-        }
+        public override string InstructionName => "StringSwitch";
+
         internal StringSwitchInstruction(Dictionary<string, int> cases, StrongBox<int> nullCase)
         {
             Assert.NotNull(cases);
@@ -890,8 +814,8 @@ namespace System.Linq.Expressions.Interpreter
             _nullCase = nullCase;
         }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 0; } }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 0;
 
         public override int Run(InterpretedFrame frame)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Reflection;
@@ -13,16 +12,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Div"; }
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Div";
 
-        private DivInstruction()
-        {
-        }
+        private DivInstruction() { }
 
         internal sealed class DivInt32 : DivInstruction
         {
@@ -200,16 +194,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Modulo"; }
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Modulo";
 
-        private ModuloInstruction()
-        {
-        }
+        private ModuloInstruction() { }
 
         internal sealed class ModuloInt32 : ModuloInstruction
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -17,15 +13,11 @@ namespace System.Linq.Expressions.Interpreter
         private static Instruction s_reference, s_boolean, s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
         private static Instruction s_referenceLiftedToNull, s_booleanLiftedToNull, s_SByteLiftedToNull, s_int16LiftedToNull, s_charLiftedToNull, s_int32LiftedToNull, s_int64LiftedToNull, s_byteLiftedToNull, s_UInt16LiftedToNull, s_UInt32LiftedToNull, s_UInt64LiftedToNull, s_singleLiftedToNull, s_doubleLiftedToNull;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Equal"; }
-        }
-        private EqualInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Equal";
+        
+        private EqualInstruction() { }
 
         internal sealed class EqualBoolean : EqualInstruction
         {
@@ -606,9 +598,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        public override string ToString()
-        {
-            return "Equal()";
-        }
+        public override string ToString() => "Equal()";
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -20,12 +17,8 @@ namespace System.Linq.Expressions.Interpreter
             _field = field;
         }
 
-        public override string InstructionName
-        {
-            get { return "LoadStaticField"; }
-        }
-
-        public override int ProducedStack { get { return 1; } }
+        public override string InstructionName => "LoadStaticField";
+        public override int ProducedStack => 1;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -44,12 +37,9 @@ namespace System.Linq.Expressions.Interpreter
             _field = field;
         }
 
-        public override string InstructionName
-        {
-            get { return "LoadField"; }
-        }
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
+        public override string InstructionName => "LoadField";
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -70,12 +60,10 @@ namespace System.Linq.Expressions.Interpreter
             Assert.NotNull(field);
             _field = field;
         }
-        public override string InstructionName
-        {
-            get { return "StoreField"; }
-        }
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 0; } }
+
+        public override string InstructionName => "StoreField";
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 0;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -98,12 +86,9 @@ namespace System.Linq.Expressions.Interpreter
             _field = field;
         }
 
-        public override string InstructionName
-        {
-            get { return "StoreStaticField"; }
-        }
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 0; } }
+        public override string InstructionName => "StoreStaticField";
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 0;
 
         public override int Run(InterpretedFrame frame)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -17,12 +14,9 @@ namespace System.Linq.Expressions.Interpreter
         private static Instruction s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
         private static Instruction s_liftedToNullSByte, s_liftedToNullInt16, s_liftedToNullChar, s_liftedToNullInt32, s_liftedToNullInt64, s_liftedToNullByte, s_liftedToNullUInt16, s_liftedToNullUInt32, s_liftedToNullUInt64, s_liftedToNullSingle, s_liftedToNullDouble;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "GreaterThan"; }
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "GreaterThan";
 
         private GreaterThanInstruction(object nullValue)
         {
@@ -327,10 +321,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        public override string ToString()
-        {
-            return "GreaterThan()";
-        }
+        public override string ToString() => "GreaterThan()";
     }
 
     internal abstract class GreaterThanOrEqualInstruction : Instruction
@@ -339,12 +330,10 @@ namespace System.Linq.Expressions.Interpreter
         private static Instruction s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
         private static Instruction s_liftedToNullSByte, s_liftedToNullInt16, s_liftedToNullChar, s_liftedToNullInt32, s_liftedToNullInt64, s_liftedToNullByte, s_liftedToNullUInt16, s_liftedToNullUInt32, s_liftedToNullUInt64, s_liftedToNullSingle, s_liftedToNullDouble;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "GreaterThanOrEqual"; }
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "GreaterThanOrEqual";
+        
         private GreaterThanOrEqualInstruction(object nullValue)
         {
             _nullValue = nullValue;
@@ -648,9 +637,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        public override string ToString()
-        {
-            return "GreaterThanOrEqual()";
-        }
+        public override string ToString() => "GreaterThanOrEqual()";
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Dynamic.Utils;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -15,42 +11,23 @@ namespace System.Linq.Expressions.Interpreter
     {
         public const int UnknownInstrIndex = int.MaxValue;
 
-        public virtual int ConsumedStack { get { return 0; } }
-        public virtual int ProducedStack { get { return 0; } }
-        public virtual int ConsumedContinuations { get { return 0; } }
-        public virtual int ProducedContinuations { get { return 0; } }
+        public virtual int ConsumedStack => 0;
+        public virtual int ProducedStack => 0;
+        public virtual int ConsumedContinuations => 0;
+        public virtual int ProducedContinuations => 0;
 
-        public int StackBalance
-        {
-            get { return ProducedStack - ConsumedStack; }
-        }
-
-        public int ContinuationsBalance
-        {
-            get { return ProducedContinuations - ConsumedContinuations; }
-        }
+        public int StackBalance => ProducedStack - ConsumedStack;
+        public int ContinuationsBalance => ProducedContinuations - ConsumedContinuations;
 
         public abstract int Run(InterpretedFrame frame);
 
-        public abstract string InstructionName
-        {
-            get;
-        }
+        public abstract string InstructionName { get; }
 
-        public override string ToString()
-        {
-            return InstructionName + "()";
-        }
+        public override string ToString() => InstructionName + "()";
 
-        public virtual string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IList<object> objects)
-        {
-            return ToString();
-        }
+        public virtual string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IList<object> objects) => ToString();
 
-        public virtual object GetDebugCookie(LightCompiler compiler)
-        {
-            return null;
-        }
+        public virtual object GetDebugCookie(LightCompiler compiler) => null;
 
         // throws NRE when o is null
         protected static void NullCheck(object o)
@@ -67,16 +44,10 @@ namespace System.Linq.Expressions.Interpreter
         public static readonly Instruction Instance = new NullCheckInstruction();
 
         private NullCheckInstruction() { }
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
 
-        public override string InstructionName
-        {
-            get
-            {
-                return "Unbox";
-            }
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Unbox";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -94,13 +65,10 @@ namespace System.Linq.Expressions.Interpreter
         public static Instruction _Bool, _Int64, _Int32, _Int16, _UInt64, _UInt32, _UInt16, _Byte, _SByte;
 
         private NotInstruction() { }
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
 
-        public override string InstructionName
-        {
-            get { return "Not"; }
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Not";
 
         private class BoolNot : NotInstruction
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -241,30 +241,12 @@ namespace System.Linq.Expressions.Interpreter
 #endif
         }
 
-        public int Count
-        {
-            get { return _instructions.Count; }
-        }
+        public int Count => _instructions.Count;
+        public int CurrentStackDepth => _currentStackDepth;
+        public int CurrentContinuationsDepth => _currentContinuationsDepth;
+        public int MaxStackDepth => _maxStackDepth;
 
-        public int CurrentStackDepth
-        {
-            get { return _currentStackDepth; }
-        }
-
-        public int CurrentContinuationsDepth
-        {
-            get { return _currentContinuationsDepth; }
-        }
-
-        public int MaxStackDepth
-        {
-            get { return _maxStackDepth; }
-        }
-
-        internal Instruction GetInstruction(int index)
-        {
-            return _instructions[index];
-        }
+        internal Instruction GetInstruction(int index) => _instructions[index];
 
 #if STATS
         private static Dictionary<string, int> _executedInstructions = new Dictionary<string, int>();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -66,10 +64,7 @@ namespace System.Linq.Expressions.Interpreter
             return DebugInfo.GetMatchingDebugInfo(Interpreter._debugInfos, instructionIndex);
         }
 
-        public string Name
-        {
-            get { return Interpreter._name; }
-        }
+        public string Name => Interpreter.Name;
 
         #region Data Stack Operations
 
@@ -288,7 +283,7 @@ namespace System.Linq.Expressions.Interpreter
             _pendingValue = value;
             return YieldToCurrentContinuation();
         }
-        #endregion
 
+        #endregion
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Interpreter.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Interpreter.cs
@@ -2,14 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -27,66 +22,31 @@ namespace System.Linq.Expressions.Interpreter
         internal static readonly object NoValue = new object();
         internal const int RethrowOnReturn = Int32.MaxValue;
 
-        private readonly int _localCount;
-        private readonly HybridReferenceDictionary<LabelTarget, BranchLabel> _labelMapping;
-        private readonly Dictionary<ParameterExpression, LocalVariable> _closureVariables;
-
         private readonly InstructionArray _instructions;
         internal readonly object[] _objects;
         internal readonly RuntimeLabel[] _labels;
-
-        internal readonly string _name;
         internal readonly DebugInfo[] _debugInfos;
 
         internal Interpreter(string name, LocalVariables locals, HybridReferenceDictionary<LabelTarget, BranchLabel> labelMapping,
             InstructionArray instructions, DebugInfo[] debugInfos)
         {
-            _name = name;
-            _localCount = locals.LocalCount;
-            _closureVariables = locals.ClosureVariables;
+            Name = name;
+            LocalCount = locals.LocalCount;
+            LabelMapping = labelMapping;
+            ClosureVariables = locals.ClosureVariables;
 
             _instructions = instructions;
             _objects = instructions.Objects;
             _labels = instructions.Labels;
-            _labelMapping = labelMapping;
-
             _debugInfos = debugInfos;
         }
 
-        internal int ClosureSize
-        {
-            get
-            {
-                if (_closureVariables == null)
-                {
-                    return 0;
-                }
-                return _closureVariables.Count;
-            }
-        }
-
-        internal int LocalCount
-        {
-            get
-            {
-                return _localCount;
-            }
-        }
-
-        internal InstructionArray Instructions
-        {
-            get { return _instructions; }
-        }
-
-        internal Dictionary<ParameterExpression, LocalVariable> ClosureVariables
-        {
-            get { return _closureVariables; }
-        }
-
-        internal HybridReferenceDictionary<LabelTarget, BranchLabel> LabelMapping
-        {
-            get { return _labelMapping; }
-        }
+        internal string Name { get; }
+        internal int LocalCount { get; }
+        internal int ClosureSize => ClosureVariables?.Count ?? 0;
+        internal InstructionArray Instructions => _instructions;
+        internal Dictionary<ParameterExpression, LocalVariable> ClosureVariables { get; }
+        internal HybridReferenceDictionary<LabelTarget, BranchLabel> LabelMapping { get; }
 
         /// <summary>
         /// Runs instructions within the given frame.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LabelInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LabelInfo.cs
@@ -2,14 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Text;
-using System.Reflection.Emit;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -188,13 +182,7 @@ namespace System.Linq.Expressions.Interpreter
             return false;
         }
 
-        private bool HasDefinitions
-        {
-            get
-            {
-                return _definitions != null;
-            }
-        }
+        private bool HasDefinitions => _definitions != null;
 
         private LabelScopeInfo FirstDefinition()
         {
@@ -227,13 +215,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private bool HasMultipleDefinitions
-        {
-            get
-            {
-                return _definitions is HashSet<LabelScopeInfo>;
-            }
-        }
+        private bool HasMultipleDefinitions => _definitions is HashSet<LabelScopeInfo>;
 
         internal static T CommonNode<T>(T first, T second, Func<T, T> parent) where T : class
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -18,12 +15,10 @@ namespace System.Linq.Expressions.Interpreter
         private static Instruction s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
         private static Instruction s_liftedToNullSByte, s_liftedToNullInt16, s_liftedToNullChar, s_liftedToNullInt32, s_liftedToNullInt64, s_liftedToNullByte, s_liftedToNullUInt16, s_liftedToNullUInt32, s_liftedToNullUInt64, s_liftedToNullSingle, s_liftedToNullDouble;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "LessThan"; }
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "LessThan";
+
         private LessThanInstruction(object nullValue)
         {
             _nullValue = nullValue;
@@ -333,12 +328,10 @@ namespace System.Linq.Expressions.Interpreter
         private static Instruction s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
         private static Instruction s_liftedToNullSByte, s_liftedToNullInt16, s_liftedToNullChar, s_liftedToNullInt32, s_liftedToNullInt64, s_liftedToNullByte, s_liftedToNullUInt16, s_liftedToNullUInt32, s_liftedToNullUInt64, s_liftedToNullSingle, s_liftedToNullDouble;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "LessThanOrEqual"; }
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "LessThanOrEqual";
+        
         private LessThanOrEqualInstruction(object nullValue)
         {
             _nullValue = nullValue;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -79,10 +79,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal bool IsCatchBlockExist
-        {
-            get { return (_handlers != null); }
-        }
+        internal bool IsCatchBlockExist => _handlers != null;
 
         /// <summary>
         /// No finally block
@@ -225,7 +222,7 @@ namespace System.Linq.Expressions.Interpreter
         public static DebugInfo GetMatchingDebugInfo(DebugInfo[] debugInfos, int index)
         {
             //Create a faked DebugInfo to do the search
-            DebugInfo d = new DebugInfo { Index = index };
+            var d = new DebugInfo { Index = index };
 
             //to find the closest debug info before the current index
 
@@ -308,15 +305,8 @@ namespace System.Linq.Expressions.Interpreter
             _parent = parent;
         }
 
-        public InstructionList Instructions
-        {
-            get { return _instructions; }
-        }
-
-        public LocalVariables Locals
-        {
-            get { return _locals; }
-        }
+        public InstructionList Instructions => _instructions;
+        public LocalVariables Locals => _locals;
 
         public LightDelegateCreator CompileTop(LambdaExpression node)
         {
@@ -669,7 +659,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private void CompileMemberAssignment(bool asVoid, MemberInfo refMember, Expression value, bool forBinding)
         {
-            PropertyInfo pi = refMember as PropertyInfo;
+            var pi = refMember as PropertyInfo;
             if (pi != null)
             {
                 var method = pi.GetSetMethod(true);
@@ -697,7 +687,7 @@ namespace System.Linq.Expressions.Interpreter
             else
             {
                 // other types inherited from MemberInfo (EventInfo\MethodBase\Type) cannot be used in MemberAssignment
-                FieldInfo fi = (FieldInfo)refMember;
+                var fi = (FieldInfo)refMember;
                 Debug.Assert(fi != null);
                 if (fi.IsLiteral)
                 {
@@ -1665,7 +1655,7 @@ namespace System.Linq.Expressions.Interpreter
                 int caseOffset = _instructions.Count - switchIndex;
                 foreach (ConstantExpression testValue in switchCase.TestValues)
                 {
-                    string key = (string)testValue.Value;
+                    var key = (string)testValue.Value;
                     if (key == null)
                     {
                         if (nullCase.Value == 1)
@@ -2249,7 +2239,7 @@ namespace System.Linq.Expressions.Interpreter
 
                         return new ParameterByRefUpdater(ResolveLocal((ParameterExpression)node), index);
                     case ExpressionType.ArrayIndex:
-                        BinaryExpression array = (BinaryExpression)node;
+                        var array = (BinaryExpression)node;
 
                         return CompileArrayIndexAddress(array.Left, array.Right, index);
                     case ExpressionType.Index:
@@ -2265,7 +2255,7 @@ namespace System.Linq.Expressions.Interpreter
                                 _instructions.EmitStoreLocal(objTmp.Value.Index);
                             }
 
-                            List<LocalDefinition> indexLocals = new List<LocalDefinition>();
+                            var indexLocals = new List<LocalDefinition>();
                             for (int i = 0; i < indexNode.ArgumentCount; i++)
                             {
                                 var arg = indexNode.GetArgument(i);
@@ -2302,7 +2292,7 @@ namespace System.Linq.Expressions.Interpreter
                             _instructions.EmitStoreLocal(memberTemp.Value.Index);
                         }
 
-                        FieldInfo field = member.Member as FieldInfo;
+                        var field = member.Member as FieldInfo;
                         if (field != null)
                         {
                             _instructions.EmitLoadField(field);
@@ -2313,7 +2303,7 @@ namespace System.Linq.Expressions.Interpreter
                             return null;
                         }
                         Debug.Assert(member.Member is PropertyInfo);
-                        PropertyInfo property = (PropertyInfo)member.Member;
+                        var property = (PropertyInfo)member.Member;
                         _instructions.EmitCall(property.GetGetMethod(true));
                         if (property.CanWrite)
                         {
@@ -2326,7 +2316,7 @@ namespace System.Linq.Expressions.Interpreter
                         // get the address of a member of a multi-dimensional array, we'll be trying to
                         // get the address of a Get method, and it will fail to do so. Instead, detect
                         // this situation and replace it with a call to the Address method.
-                        MethodCallExpression call = (MethodCallExpression)node;
+                        var call = (MethodCallExpression)node;
                         if (!call.Method.IsStatic &&
                             call.Object.Type.IsArray &&
                             call.Method == call.Object.Type.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance))
@@ -2352,7 +2342,7 @@ namespace System.Linq.Expressions.Interpreter
             _instructions.EmitDup();
             _instructions.EmitStoreLocal(objTmp.Index);
 
-            List<LocalDefinition> indexLocals = new List<LocalDefinition>();
+            var indexLocals = new List<LocalDefinition>();
             for (int i = 0; i < arguments.ArgumentCount; i++)
             {
                 var arg = arguments.GetArgument(i);
@@ -2429,7 +2419,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private void CompileMember(Expression from, MemberInfo member, bool forBinding)
         {
-            FieldInfo fi = member as FieldInfo;
+            var fi = member as FieldInfo;
             if (fi != null)
             {
                 if (fi.IsLiteral)
@@ -2466,7 +2456,7 @@ namespace System.Linq.Expressions.Interpreter
             else
             {
                 // MemberExpression can use either FieldInfo or PropertyInfo - other types derived from MemberInfo are not permitted
-                PropertyInfo pi = (PropertyInfo)member;
+                var pi = (PropertyInfo)member;
                 if (pi != null)
                 {
                     var method = pi.GetGetMethod(true);
@@ -2731,9 +2721,9 @@ namespace System.Linq.Expressions.Interpreter
 
         private static Type GetMemberType(MemberInfo member)
         {
-            FieldInfo fi = member as FieldInfo;
+            var fi = member as FieldInfo;
             if (fi != null) return fi.FieldType;
-            PropertyInfo pi = member as PropertyInfo;
+            var pi = member as PropertyInfo;
             if (pi != null) return pi.PropertyType;
             throw new InvalidOperationException("MemberNotFieldOrProperty");
         }
@@ -2741,12 +2731,12 @@ namespace System.Linq.Expressions.Interpreter
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "expr")]
         private void CompileQuoteUnaryExpression(Expression expr)
         {
-            UnaryExpression unary = (UnaryExpression)expr;
+            var unary = (UnaryExpression)expr;
 
             var visitor = new QuoteVisitor();
             visitor.Visit(unary.Operand);
 
-            Dictionary<ParameterExpression, LocalVariable> mapping = new Dictionary<ParameterExpression, LocalVariable>();
+            var mapping = new Dictionary<ParameterExpression, LocalVariable>();
 
             foreach (var local in visitor._hoistedParameters)
             {
@@ -3216,7 +3206,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override void Update(InterpretedFrame frame, object value)
         {
-            object[] args = new object[_args.Length + 1];
+            var args = new object[_args.Length + 1];
             for (int i = 0; i < args.Length - 1; i++)
             {
                 args[i] = frame.Data[_args[i].Index];

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.Generated.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.CompilerServices;
 using System.Reflection;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Dynamic.Utils;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
@@ -42,12 +40,8 @@ namespace System.Linq.Expressions.Interpreter
         {
         }
 
-        public override int ProducedStack { get { return 1; } }
-
-        public override string InstructionName
-        {
-            get { return "LoadLocal"; }
-        }
+        public override int ProducedStack => 1;
+        public override string InstructionName => "LoadLocal";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -68,12 +62,8 @@ namespace System.Linq.Expressions.Interpreter
         {
         }
 
-        public override int ProducedStack { get { return 1; } }
-
-        public override string InstructionName
-        {
-            get { return "LoadLocalBox"; }
-        }
+        public override int ProducedStack => 1;
+        public override string InstructionName => "LoadLocalBox";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -90,12 +80,8 @@ namespace System.Linq.Expressions.Interpreter
         {
         }
 
-        public override int ProducedStack { get { return 1; } }
-
-        public override string InstructionName
-        {
-            get { return "LoadLocalClosure"; }
-        }
+        public override int ProducedStack => 1;
+        public override string InstructionName => "LoadLocalClosure";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -112,12 +98,8 @@ namespace System.Linq.Expressions.Interpreter
         {
         }
 
-        public override int ProducedStack { get { return 1; } }
-
-        public override string InstructionName
-        {
-            get { return "LoadLocal"; }
-        }
+        public override int ProducedStack => 1;
+        public override string InstructionName => "LoadLocal";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -138,13 +120,9 @@ namespace System.Linq.Expressions.Interpreter
         {
         }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-
-        public override string InstructionName
-        {
-            get { return "AssignLocal"; }
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "AssignLocal";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -165,12 +143,8 @@ namespace System.Linq.Expressions.Interpreter
         {
         }
 
-        public override int ConsumedStack { get { return 1; } }
-
-        public override string InstructionName
-        {
-            get { return "StoreLocal"; }
-        }
+        public override int ConsumedStack => 1;
+        public override string InstructionName => "StoreLocal";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -191,13 +165,9 @@ namespace System.Linq.Expressions.Interpreter
         {
         }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-
-        public override string InstructionName
-        {
-            get { return "AssignLocalBox"; }
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "AssignLocalBox";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -214,13 +184,9 @@ namespace System.Linq.Expressions.Interpreter
         {
         }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 0; } }
-
-        public override string InstructionName
-        {
-            get { return "StoreLocalBox"; }
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 0;
+        public override string InstructionName => "StoreLocalBox";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -237,13 +203,9 @@ namespace System.Linq.Expressions.Interpreter
         {
         }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-
-        public override string InstructionName
-        {
-            get { return "AssignLocalClosure"; }
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "AssignLocalClosure";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -257,17 +219,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         public static readonly ValueTypeCopyInstruction Instruction = new ValueTypeCopyInstruction();
 
-        public ValueTypeCopyInstruction()
-        {
-        }
+        public ValueTypeCopyInstruction() { }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-
-        public override string InstructionName
-        {
-            get { return "ValueTypeCopy"; }
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "ValueTypeCopy";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -307,10 +263,7 @@ namespace System.Linq.Expressions.Interpreter
                 return (index == _index) ? InstructionList.InitImmutableRefBox(index) : null;
             }
 
-            public override string InstructionName
-            {
-                get { return "InitRef"; }
-            }
+            public override string InstructionName => "InitRef";
         }
 
         internal sealed class ImmutableValue : InitializeLocalInstruction, IBoxableInstruction
@@ -335,10 +288,7 @@ namespace System.Linq.Expressions.Interpreter
                 return (index == _index) ? new ImmutableBox(index, _defaultValue) : null;
             }
 
-            public override string InstructionName
-            {
-                get { return "InitImmutableValue"; }
-            }
+            public override string InstructionName => "InitImmutableValue";
         }
 
         internal sealed class ImmutableBox : InitializeLocalInstruction
@@ -359,10 +309,7 @@ namespace System.Linq.Expressions.Interpreter
                 return 1;
             }
 
-            public override string InstructionName
-            {
-                get { return "InitImmutableBox"; }
-            }
+            public override string InstructionName => "InitImmutableBox";
         }
 
         internal sealed class ImmutableRefBox : InitializeLocalInstruction
@@ -379,10 +326,7 @@ namespace System.Linq.Expressions.Interpreter
                 return 1;
             }
 
-            public override string InstructionName
-            {
-                get { return "InitImmutableBox"; }
-            }
+            public override string InstructionName => "InitImmutableBox";
         }
 
         internal sealed class ParameterBox : InitializeLocalInstruction
@@ -398,10 +342,7 @@ namespace System.Linq.Expressions.Interpreter
                 return 1;
             }
 
-            public override string InstructionName
-            {
-                get { return "InitParameterBox"; }
-            }
+            public override string InstructionName => "InitParameterBox";
         }
 
         internal sealed class Parameter : InitializeLocalInstruction, IBoxableInstruction
@@ -426,10 +367,7 @@ namespace System.Linq.Expressions.Interpreter
                 return null;
             }
 
-            public override string InstructionName
-            {
-                get { return "InitParameter"; }
-            }
+            public override string InstructionName => "InitParameter";
         }
 
         internal sealed class MutableValue : InitializeLocalInstruction, IBoxableInstruction
@@ -462,10 +400,7 @@ namespace System.Linq.Expressions.Interpreter
                 return (index == _index) ? new MutableBox(index, _type) : null;
             }
 
-            public override string InstructionName
-            {
-                get { return "InitMutableValue"; }
-            }
+            public override string InstructionName => "InitMutableValue";
         }
 
         internal sealed class MutableBox : InitializeLocalInstruction
@@ -497,10 +432,7 @@ namespace System.Linq.Expressions.Interpreter
                 return 1;
             }
 
-            public override string InstructionName
-            {
-                get { return "InitMutableBox"; }
-            }
+            public override string InstructionName => "InitMutableBox";
         }
     }
 
@@ -517,8 +449,8 @@ namespace System.Linq.Expressions.Interpreter
             _count = count;
         }
 
-        public override int ProducedStack { get { return 1; } }
-        public override int ConsumedStack { get { return _count; } }
+        public override int ProducedStack => 1;
+        public override int ConsumedStack => _count;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -531,15 +463,9 @@ namespace System.Linq.Expressions.Interpreter
             return +1;
         }
 
-        public override string InstructionName
-        {
-            get { return "GetRuntimeVariables"; }
-        }
+        public override string InstructionName => "GetRuntimeVariables";
 
-        public override string ToString()
-        {
-            return "GetRuntimeVariables()";
-        }
+        public override string ToString() => "GetRuntimeVariables()";
     }
     #endregion
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
@@ -35,10 +33,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        public bool InClosure
-        {
-            get { return (_flags & InClosureFlag) != 0; }
-        }
+        public bool InClosure => (_flags & InClosureFlag) != 0;
 
         internal LocalVariable(int index, bool closure)
         {
@@ -60,30 +55,14 @@ namespace System.Linq.Expressions.Interpreter
 
     internal struct LocalDefinition
     {
-        private readonly int _index;
-        private readonly ParameterExpression _parameter;
-
         internal LocalDefinition(int localIndex, ParameterExpression parameter)
         {
-            _index = localIndex;
-            _parameter = parameter;
+            Index = localIndex;
+            Parameter = parameter;
         }
 
-        public int Index
-        {
-            get
-            {
-                return _index;
-            }
-        }
-
-        public ParameterExpression Parameter
-        {
-            get
-            {
-                return _parameter;
-            }
-        }
+        public int Index { get; }
+        public ParameterExpression Parameter { get; }
 
         public override bool Equals(object obj)
         {
@@ -98,11 +77,11 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int GetHashCode()
         {
-            if (_parameter == null)
+            if (Parameter == null)
             {
                 return 0;
             }
-            return _parameter.GetHashCode() ^ _index.GetHashCode();
+            return Parameter.GetHashCode() ^ Index.GetHashCode();
         }
 
         public static bool operator ==(LocalDefinition self, LocalDefinition other)
@@ -129,8 +108,8 @@ namespace System.Linq.Expressions.Interpreter
 
         public LocalDefinition DefineLocal(ParameterExpression variable, int start)
         {
-            LocalVariable result = new LocalVariable(_localCount++, false);
-            _maxLocalCount = System.Math.Max(_localCount, _maxLocalCount);
+            var result = new LocalVariable(_localCount++, false);
+            _maxLocalCount = Math.Max(_localCount, _maxLocalCount);
 
             VariableScope existing, newScope;
             if (_variables.TryGetValue(variable, out existing))
@@ -192,10 +171,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        public int LocalCount
-        {
-            get { return _maxLocalCount; }
-        }
+        public int LocalCount => _maxLocalCount;
 
         public int GetOrDefineLocal(ParameterExpression var)
         {
@@ -255,13 +231,7 @@ namespace System.Linq.Expressions.Interpreter
         /// <summary>
         /// Gets the variables which are defined in an outer scope and available within the current scope.
         /// </summary>
-        internal Dictionary<ParameterExpression, LocalVariable> ClosureVariables
-        {
-            get
-            {
-                return _closureVariables;
-            }
-        }
+        internal Dictionary<ParameterExpression, LocalVariable> ClosureVariables => _closureVariables;
 
         internal LocalVariable AddClosureVariable(ParameterExpression variable)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Dynamic.Utils;
-using System.Reflection;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -13,15 +11,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Mul"; }
-        }
-        private MulInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Mul";
+
+        private MulInstruction() { }
 
         internal sealed class MulInt32 : MulInstruction
         {
@@ -199,15 +193,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "MulOvf"; }
-        }
-        private MulOvfInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "MulOvf";
+        
+        private MulOvfInstruction() { }
 
         internal sealed class MulOvfInt32 : MulOvfInstruction
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -17,15 +13,11 @@ namespace System.Linq.Expressions.Interpreter
         private static Instruction s_reference, s_boolean, s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
         private static Instruction s_referenceLiftedToNull, s_booleanLiftedToNull, s_SByteLiftedToNull, s_int16LiftedToNull, s_charLiftedToNull, s_int32LiftedToNull, s_int64LiftedToNull, s_byteLiftedToNull, s_UInt16LiftedToNull, s_UInt32LiftedToNull, s_UInt64LiftedToNull, s_singleLiftedToNull, s_doubleLiftedToNull;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "NotEqual"; }
-        }
-        private NotEqualInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "NotEqual";
+
+        private NotEqualInstruction() { }
 
         internal sealed class NotEqualBoolean : NotEqualInstruction
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
@@ -46,22 +46,16 @@ namespace System.Linq.Expressions.Interpreter
 
         protected abstract object Convert(object obj);
 
-        public override string InstructionName
-        {
-            get { return "NumericConvert"; }
-        }
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
+        public override string InstructionName => "NumericConvert";
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
 
-        public override string ToString()
-        {
-            return InstructionName + "(" + _from + "->" + _to + ")";
-        }
+        public override string ToString() => InstructionName + "(" + _from + "->" + _to + ")";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
         internal sealed class Unchecked : NumericConvertInstruction
         {
-            public override string InstructionName { get { return "UncheckedConvert"; } }
+            public override string InstructionName => "UncheckedConvert";
 
             public Unchecked(TypeCode from, TypeCode to, bool isLiftedToNull)
                 : base(from, to, isLiftedToNull)
@@ -184,7 +178,7 @@ namespace System.Linq.Expressions.Interpreter
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
         internal sealed class Checked : NumericConvertInstruction
         {
-            public override string InstructionName { get { return "CheckedConvert"; } }
+            public override string InstructionName => "CheckedConvert";
 
             public Checked(TypeCode from, TypeCode to, bool isLiftedToNull)
                 : base(from, to, isLiftedToNull)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RuntimeVariables.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RuntimeVariables.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
@@ -16,13 +15,7 @@ namespace System.Linq.Expressions.Interpreter
             _boxes = boxes;
         }
 
-        int IRuntimeVariables.Count
-        {
-            get
-            {
-                return _boxes.Length;
-            }
-        }
+        int IRuntimeVariables.Count => _boxes.Length;
 
         object IRuntimeVariables.this[int index]
         {
@@ -36,9 +29,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal static IRuntimeVariables Create(IStrongBox[] boxes)
-        {
-            return new RuntimeVariables(boxes);
-        }
+        internal static IRuntimeVariables Create(IStrongBox[] boxes) => new RuntimeVariables(boxes);
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System;
-using System.Diagnostics;
 using System.Globalization;
 
 namespace System.Linq.Expressions.Interpreter
@@ -18,12 +16,8 @@ namespace System.Linq.Expressions.Interpreter
             _value = value;
         }
 
-        public override int ProducedStack { get { return 1; } }
-
-        public override string InstructionName
-        {
-            get { return "LoadObject"; }
-        }
+        public override int ProducedStack => 1;
+        public override string InstructionName => "LoadObject";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -31,10 +25,7 @@ namespace System.Linq.Expressions.Interpreter
             return +1;
         }
 
-        public override string ToString()
-        {
-            return "LoadObject(" + (_value ?? "null") + ")";
-        }
+        public override string ToString() => "LoadObject(" + (_value ?? "null") + ")";
     }
 
     internal sealed class LoadCachedObjectInstruction : Instruction
@@ -46,12 +37,8 @@ namespace System.Linq.Expressions.Interpreter
             _index = index;
         }
 
-        public override int ProducedStack { get { return 1; } }
-
-        public override string InstructionName
-        {
-            get { return "LoadCachedObject"; }
-        }
+        public override int ProducedStack => 1;
+        public override string InstructionName => "LoadCachedObject";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -64,10 +51,7 @@ namespace System.Linq.Expressions.Interpreter
             return String.Format(CultureInfo.InvariantCulture, "LoadCached({0}: {1})", _index, objects[(int)_index]);
         }
 
-        public override string ToString()
-        {
-            return "LoadCached(" + _index + ")";
-        }
+        public override string ToString() => "LoadCached(" + _index + ")";
     }
 
     internal sealed class PopInstruction : Instruction
@@ -76,21 +60,16 @@ namespace System.Linq.Expressions.Interpreter
 
         private PopInstruction() { }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Pop"; }
-        }
+        public override int ConsumedStack => 1;
+        public override string InstructionName =>"Pop";
+        
         public override int Run(InterpretedFrame frame)
         {
             frame.Pop();
             return +1;
         }
 
-        public override string ToString()
-        {
-            return "Pop()";
-        }
+        public override string ToString() => "Pop()";
     }
 
     internal sealed class DupInstruction : Instruction
@@ -99,12 +78,10 @@ namespace System.Linq.Expressions.Interpreter
 
         private DupInstruction() { }
 
-        public override int ConsumedStack { get { return 0; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Dup"; }
-        }
+        public override int ConsumedStack => 0;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Dup";
+        
         public override int Run(InterpretedFrame frame)
         {
             var value = frame.Peek();
@@ -112,9 +89,6 @@ namespace System.Linq.Expressions.Interpreter
             return +1;
         }
 
-        public override string ToString()
-        {
-            return "Dup()";
-        }
+        public override string ToString() => "Dup()";
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Dynamic.Utils;
-using System.Reflection;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -13,15 +11,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Sub"; }
-        }
-        private SubInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Sub";
+
+        private SubInstruction() { }
 
         internal sealed class SubInt32 : SubInstruction
         {
@@ -198,15 +192,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "SubOvf"; }
-        }
-        private SubOvfInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "SubOvf";
+
+        private SubOvfInstruction() { }
 
         internal sealed class SubOvfInt32 : SubOvfInstruction
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic.Utils;
@@ -20,12 +19,10 @@ namespace System.Linq.Expressions.Interpreter
             _creator = delegateCreator;
         }
 
-        public override int ConsumedStack { get { return _creator.Interpreter.ClosureSize; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "CreateDelegate"; }
-        }
+        public override int ConsumedStack => _creator.Interpreter.ClosureSize;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "CreateDelegate";
+
         public override int Run(InterpretedFrame frame)
         {
             IStrongBox[] closure;
@@ -59,12 +56,11 @@ namespace System.Linq.Expressions.Interpreter
             _constructor = constructor;
             _argumentCount = argumentCount;
         }
-        public override int ConsumedStack { get { return _argumentCount; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "New"; }
-        }
+
+        public override int ConsumedStack => _argumentCount;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "New";
+
         public override int Run(InterpretedFrame frame)
         {
             int first = frame.StackIndex - _argumentCount;
@@ -107,10 +103,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        public override string ToString()
-        {
-            return "New " + _constructor.DeclaringType.Name + "(" + _constructor + ")";
-        }
+        public override string ToString() => "New " + _constructor.DeclaringType.Name + "(" + _constructor + ")";
     }
 
     internal partial class ByRefNewInstruction : NewInstruction
@@ -123,10 +116,8 @@ namespace System.Linq.Expressions.Interpreter
             _byrefArgs = byrefArgs;
         }
 
-        public override string InstructionName
-        {
-            get { return "ByRefNew"; }
-        }
+        public override string InstructionName => "ByRefNew";
+        
         public sealed override int Run(InterpretedFrame frame)
         {
             int first = frame.StackIndex - _argumentCount;
@@ -172,12 +163,10 @@ namespace System.Linq.Expressions.Interpreter
             _type = type;
         }
 
-        public override int ConsumedStack { get { return 0; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "DefaultValue"; }
-        }
+        public override int ConsumedStack => 0;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "DefaultValue";
+        
         public override int Run(InterpretedFrame frame)
         {
             object value = _type.GetTypeInfo().IsValueType ? Activator.CreateInstance(_type) : null;
@@ -185,10 +174,7 @@ namespace System.Linq.Expressions.Interpreter
             return +1;
         }
 
-        public override string ToString()
-        {
-            return "New " + _type;
-        }
+        public override string ToString() => "New " + _type;
     }
 
     internal sealed class TypeIsInstruction : Instruction
@@ -200,22 +186,17 @@ namespace System.Linq.Expressions.Interpreter
             _type = type;
         }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "TypeIs"; }
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "TypeIs";
+        
         public override int Run(InterpretedFrame frame)
         {
             frame.Push(ScriptingRuntimeHelpers.BooleanToObject(_type.IsInstanceOfType(frame.Pop())));
             return +1;
         }
 
-        public override string ToString()
-        {
-            return "TypeIs " + _type.ToString();
-        }
+        public override string ToString() => "TypeIs " + _type.ToString();
     }
 
     internal sealed class TypeAsInstruction : Instruction
@@ -227,12 +208,10 @@ namespace System.Linq.Expressions.Interpreter
             _type = type;
         }
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "TypeAs"; }
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "TypeAs";
+        
         public override int Run(InterpretedFrame frame)
         {
             object value = frame.Pop();
@@ -247,25 +226,18 @@ namespace System.Linq.Expressions.Interpreter
             return +1;
         }
 
-        public override string ToString()
-        {
-            return "TypeAs " + _type.ToString();
-        }
+        public override string ToString() => "TypeAs " + _type.ToString();
     }
 
     internal sealed class TypeEqualsInstruction : Instruction
     {
         public static readonly TypeEqualsInstruction Instance = new TypeEqualsInstruction();
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "TypeEquals"; }
-        }
-        private TypeEqualsInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "TypeEquals";
+
+        private TypeEqualsInstruction() { }
 
         public override int Run(InterpretedFrame frame)
         {
@@ -280,15 +252,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         public static readonly NullableTypeEqualsInstruction Instance = new NullableTypeEqualsInstruction();
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "NullableTypeEquals"; }
-        }
-        private NullableTypeEqualsInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "NullableTypeEquals";
+
+        private NullableTypeEqualsInstruction() { }
 
         public override int Run(InterpretedFrame frame)
         {
@@ -303,15 +271,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         public static readonly ArrayLengthInstruction Instance = new ArrayLengthInstruction();
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "ArrayLength"; }
-        }
-        private ArrayLengthInstruction()
-        {
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "ArrayLength";
+        
+        private ArrayLengthInstruction() { }
 
         public override int Run(InterpretedFrame frame)
         {
@@ -325,15 +289,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_single, s_double;
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Negate"; }
-        }
-        private NegateInstruction()
-        {
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Negate";
+        
+        private NegateInstruction() { }
 
         internal sealed class NegateInt32 : NegateInstruction
         {
@@ -441,15 +401,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_single, s_double;
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "NegateChecked"; }
-        }
-        private NegateCheckedInstruction()
-        {
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "NegateChecked";
+        
+        private NegateCheckedInstruction() { }
 
         internal sealed class NegateCheckedInt32 : NegateCheckedInstruction
         {
@@ -555,15 +511,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_byte, s_sbyte, s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64;
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "OnesComplement"; }
-        }
-        private OnesComplementInstruction()
-        {
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "OnesComplement";
+
+        private OnesComplementInstruction() { }
 
         internal sealed class OnesComplementInt32 : OnesComplementInstruction
         {
@@ -725,15 +677,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Increment"; }
-        }
-        private IncrementInstruction()
-        {
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Increment";
+        
+        private IncrementInstruction() { }
 
         internal sealed class IncrementInt32 : IncrementInstruction
         {
@@ -895,15 +843,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Decrement"; }
-        }
-        private DecrementInstruction()
-        {
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Decrement";
+
+        private DecrementInstruction() { }
 
         internal sealed class DecrementInt32 : DecrementInstruction
         {
@@ -1066,15 +1010,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_SByte, s_int16, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "LeftShift"; }
-        }
-        private LeftShiftInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "LeftShift";
+        
+        private LeftShiftInstruction() { }
 
         internal sealed class LeftShiftSByte : LeftShiftInstruction
         {
@@ -1246,15 +1186,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_SByte, s_int16, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "RightShift"; }
-        }
-        private RightShiftInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "RightShift";
+        
+        private RightShiftInstruction() { }
 
         internal sealed class RightShiftSByte : RightShiftInstruction
         {
@@ -1426,15 +1362,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_SByte, s_int16, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_bool;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "ExclusiveOr"; }
-        }
-        private ExclusiveOrInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "ExclusiveOr";
+        
+        private ExclusiveOrInstruction() { }
 
         internal sealed class ExclusiveOrSByte : ExclusiveOrInstruction
         {
@@ -1612,15 +1544,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_SByte, s_int16, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_bool;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Or"; }
-        }
-        private OrInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Or";
+        
+        private OrInstruction() { }
 
         internal sealed class OrSByte : OrInstruction
         {
@@ -1805,15 +1733,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static Instruction s_SByte, s_int16, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_bool;
 
-        public override int ConsumedStack { get { return 2; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "And"; }
-        }
-        private AndInstruction()
-        {
-        }
+        public override int ConsumedStack => 2;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "And";
+        
+        private AndInstruction() { }
 
         internal sealed class AndSByte : AndInstruction
         {
@@ -1998,15 +1922,11 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static NullableMethodCallInstruction s_hasValue, s_value, s_equals, s_getHashCode, s_getValueOrDefault1, s_toString;
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "NullableMethod"; }
-        }
-        private NullableMethodCallInstruction()
-        {
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "NullableMethod";
+
+        private NullableMethodCallInstruction() { }
 
         private class HasValue : NullableMethodCallInstruction
         {
@@ -2053,7 +1973,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private class GetValueOrDefault1 : NullableMethodCallInstruction
         {
-            public override int ConsumedStack { get { return 2; } }
+            public override int ConsumedStack => 2;
 
             public override int Run(InterpretedFrame frame)
             {
@@ -2073,7 +1993,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private class EqualsClass : NullableMethodCallInstruction
         {
-            public override int ConsumedStack { get { return 2; } }
+            public override int ConsumedStack => 2;
 
             public override int Run(InterpretedFrame frame)
             {
@@ -2163,12 +2083,9 @@ namespace System.Linq.Expressions.Interpreter
     {
         private static CastInstruction s_boolean, s_byte, s_char, s_dateTime, s_decimal, s_double, s_int16, s_int32, s_int64, s_SByte, s_single, s_string, s_UInt16, s_UInt32, s_UInt64;
 
-        public override int ConsumedStack { get { return 1; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Cast"; }
-        }
+        public override int ConsumedStack => 1;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Cast";
 
         private class CastInstructionT<T> : CastInstruction
         {
@@ -2411,12 +2328,9 @@ namespace System.Linq.Expressions.Interpreter
             _hoistedVariables = hoistedVariables;
         }
 
-        public override int ConsumedStack { get { return 0; } }
-        public override int ProducedStack { get { return 1; } }
-        public override string InstructionName
-        {
-            get { return "Quote"; }
-        }
+        public override int ConsumedStack => 0;
+        public override int ProducedStack => 1;
+        public override string InstructionName => "Quote";
 
         public override int Run(InterpretedFrame frame)
         {
@@ -2590,10 +2504,7 @@ namespace System.Linq.Expressions.Interpreter
                     _boxes = boxes;
                 }
 
-                int IRuntimeVariables.Count
-                {
-                    get { return _boxes.Length; }
-                }
+                int IRuntimeVariables.Count => _boxes.Length;
 
                 object IRuntimeVariables.this[int index]
                 {
@@ -2628,10 +2539,7 @@ namespace System.Linq.Expressions.Interpreter
                     _indexes = indexes;
                 }
 
-                public int Count
-                {
-                    get { return _indexes.Length; }
-                }
+                public int Count => _indexes.Length;
 
                 public object this[int index]
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic.Utils;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
@@ -216,10 +216,7 @@ namespace System.Runtime.CompilerServices
                 _boxes = boxes;
             }
 
-            int IRuntimeVariables.Count
-            {
-                get { return _boxes.Length; }
-            }
+            int IRuntimeVariables.Count => _boxes.Length;
 
             object IRuntimeVariables.this[int index]
             {
@@ -254,10 +251,7 @@ namespace System.Runtime.CompilerServices
                 _indexes = indexes;
             }
 
-            public int Count
-            {
-                get { return _indexes.Length; }
-            }
+            public int Count => _indexes.Length;
 
             public object this[int index]
             {


### PR DESCRIPTION
A while back, some instructions for exception handling were added, using the much briefer C# 6.0 syntax for read-only properties and expression-bodied members. I did run one of my Roslyn code fixes on the Interpreter code to turn typical properties like `InstructionName`, `ConsumedStack`, `ProducedStack`, etc. into expression-bodied ones. After this pass, I cleaned up some redundant `using` directives and addressed some whitespace issues. Also added `var` in a few places where the type is obvious.