### PR TITLE
Avoiding repeated virtual calls in loop constructs

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/ContractUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ContractUtils.cs
@@ -74,7 +74,7 @@ namespace System.Dynamic.Utils
             Debug.Assert(arrayName != null);
             RequiresNotNull(array, arrayName);
 
-            for (int i = 0; i < array.Count; i++)
+            for (int i = 0, n = array.Count; i < n; i++)
             {
                 if (array[i] == null)
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -1082,17 +1082,18 @@ namespace System.Linq.Expressions.Compiler
 
         #region Arrays
 
+#if FEATURE_COMPILE_TO_METHODBUILDER
         /// <summary>
-        /// Emits an array of constant values provided in the given list.
+        /// Emits an array of constant values provided in the given array.
         /// The array is strongly typed.
         /// </summary>
-        internal static void EmitArray<T>(this ILGenerator il, IList<T> items)
+        internal static void EmitArray<T>(this ILGenerator il, T[] items)
         {
             Debug.Assert(items != null);
 
-            il.EmitInt(items.Count);
+            il.EmitInt(items.Length);
             il.Emit(OpCodes.Newarr, typeof(T));
-            for (int i = 0; i < items.Count; i++)
+            for (int i = 0; i < items.Length; i++)
             {
                 il.Emit(OpCodes.Dup);
                 il.EmitInt(i);
@@ -1100,6 +1101,7 @@ namespace System.Linq.Expressions.Compiler
                 il.EmitStoreElement(typeof(T));
             }
         }
+#endif
 
         /// <summary>
         /// Emits an array of values of count size.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
@@ -296,7 +296,7 @@ namespace System.Linq.Expressions
         {
             Debug.Assert(items != null);
             // this is called a lot, avoid allocating an enumerator if we can...
-            for (int i = 0; i < items.Count; i++)
+            for (int i = 0, n = items.Count; i < n; i++)
             {
                 RequiresCanRead(items[i], paramName, i);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -119,8 +119,10 @@ namespace System.Linq.Expressions.Interpreter
                 var cookieEnumerator = (debugCookies != null ? debugCookies : new KeyValuePair<int, object>[0]).GetEnumerator();
                 var hasCookie = cookieEnumerator.MoveNext();
 
-                for (int i = 0; i < instructions.Count; i++)
+                for (int i = 0, n = instructions.Count; i < n; i++)
                 {
+                    Instruction instruction = instructions[i];
+
                     object cookie = null;
                     while (hasCookie && cookieEnumerator.Current.Key == i)
                     {
@@ -128,10 +130,10 @@ namespace System.Linq.Expressions.Interpreter
                         hasCookie = cookieEnumerator.MoveNext();
                     }
 
-                    int stackDiff = instructions[i].StackBalance;
-                    int contDiff = instructions[i].ContinuationsBalance;
-                    string name = instructions[i].ToDebugString(i, cookie, labelIndexer, objects);
-                    result.Add(new InstructionView(instructions[i], name, i, stackDepth, continuationsDepth));
+                    int stackDiff = instruction.StackBalance;
+                    int contDiff = instruction.ContinuationsBalance;
+                    string name = instruction.ToDebugString(i, cookie, labelIndexer, objects);
+                    result.Add(new InstructionView(instruction, name, i, stackDepth, continuationsDepth));
 
                     index++;
                     stackDepth += stackDiff;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Globalization;
@@ -2666,16 +2667,17 @@ namespace System.Linq.Expressions.Interpreter
             CompileListInit(initializers);
         }
 
-        private void CompileListInit(IList<ElementInit> initializers)
+        private void CompileListInit(ReadOnlyCollection<ElementInit> initializers)
         {
             for (int i = 0; i < initializers.Count; i++)
             {
+                ElementInit initializer = initializers[i];
                 _instructions.EmitDup();
-                foreach (var arg in initializers[i].Arguments)
+                foreach (var arg in initializer.Arguments)
                 {
                     Compile(arg);
                 }
-                var add = initializers[i].AddMethod;
+                var add = initializer.AddMethod;
                 _instructions.EmitCall(add);
                 if (add.ReturnType != typeof(void))
                     _instructions.EmitPop();
@@ -2690,7 +2692,7 @@ namespace System.Linq.Expressions.Interpreter
             CompileMemberInit(node.Bindings);
         }
 
-        private void CompileMemberInit(Collections.ObjectModel.ReadOnlyCollection<MemberBinding> bindings)
+        private void CompileMemberInit(ReadOnlyCollection<MemberBinding> bindings)
         {
             foreach (var binding in bindings)
             {


### PR DESCRIPTION
Addressing some left-overs of this pattern by either caching the count in a local (as we do pretty much everywhere else) or changing the static type to be more derived.