### PR TITLE
Removing adaptive compilation leftovers in LightDelegateCreator

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightDelegateCreator.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightDelegateCreator.cs
@@ -2,59 +2,35 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
 {
     /// <summary>
-    /// Manages creation of interpreted delegates. These delegates will get
-    /// compiled if they are executed often enough.
+    /// Manages creation of interpreted delegates.
     /// </summary>
     internal sealed class LightDelegateCreator
     {
-        // null if we are forced to compile
-        private readonly Interpreter _interpreter;
-        private readonly Expression _lambda;
+        private readonly LambdaExpression _lambda;
 
         internal LightDelegateCreator(Interpreter interpreter, LambdaExpression lambda)
         {
-            Assert.NotNull(lambda);
-            _interpreter = interpreter;
+            Debug.Assert(interpreter != null);
+            Debug.Assert(lambda != null);
+
+            Interpreter = interpreter;
             _lambda = lambda;
         }
 
-        internal Interpreter Interpreter
-        {
-            get { return _interpreter; }
-        }
+        internal Interpreter Interpreter { get; }
 
-        public Delegate CreateDelegate()
-        {
-            return CreateDelegate(null);
-        }
+        public Delegate CreateDelegate() => CreateDelegate(null);
 
         internal Delegate CreateDelegate(IStrongBox[] closure)
         {
             // we'll create an interpreted LightLambda
-            return new LightLambda(this, closure).MakeDelegate(DelegateType);
-        }
-
-        private Type DelegateType
-        {
-            get
-            {
-                LambdaExpression le = _lambda as LambdaExpression;
-                if (le != null)
-                {
-                    return le.Type;
-                }
-
-                return null;
-            }
+            return new LightLambda(this, closure).MakeDelegate(_lambda.Type);
         }
     }
 }


### PR DESCRIPTION
This was taken from the DLR and a bunch of code in support of adaptive compilation (interpretation changing to compilation) was deleted before. The remainder has redundant null checks, type checks, and misleading comments.