### PR TITLE
Reducing list allocations and copying

### DIFF
--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -144,6 +144,7 @@
     <Compile Include="System\Linq\Expressions\StackGuard.cs" />
     <Compile Include="System\Linq\IQueryable.cs" />
     <Compile Include="System\Runtime\CompilerServices\IRuntimeVariables.cs" />
+    <Compile Include="System\Linq\Expressions\Common\ArrayBuilder.cs" />
     <Compile Include="System\Linq\Expressions\Common\ConstantCheck.cs" />
     <Compile Include="System\Linq\Expressions\Common\CachedReflectionInfo.cs" />
     <Compile Include="System\Runtime\CompilerServices\ReadOnlyCollectionBuilder.cs" />

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -266,25 +266,25 @@ namespace System.Linq.Expressions
 
             var index = (IndexExpression)_left;
 
-            var vars = new List<ParameterExpression>(index.ArgumentCount + 2);
-            var exprs = new List<Expression>(index.ArgumentCount + 3);
+            var vars = new ArrayBuilder<ParameterExpression>(index.ArgumentCount + 2);
+            var exprs = new ArrayBuilder<Expression>(index.ArgumentCount + 3);
 
             var tempObj = Expression.Variable(index.Object.Type, "tempObj");
             vars.Add(tempObj);
             exprs.Add(Expression.Assign(tempObj, index.Object));
 
             var n = index.ArgumentCount;
-            var tempArgs = new List<Expression>(n);
+            var tempArgs = new ArrayBuilder<Expression>(n);
             for (var i = 0; i < n; i++)
             {
                 var arg = index.GetArgument(i);
-                var tempArg = Expression.Variable(arg.Type, "tempArg" + tempArgs.Count);
+                var tempArg = Expression.Variable(arg.Type, "tempArg" + i);
                 vars.Add(tempArg);
                 tempArgs.Add(tempArg);
                 exprs.Add(Expression.Assign(tempArg, arg));
             }
 
-            var tempIndex = Expression.MakeIndex(tempObj, index.Indexer, tempArgs);
+            var tempIndex = Expression.MakeIndex(tempObj, index.Indexer, tempArgs.ToReadOnly());
 
             // tempValue = tempObj[tempArg0, ... tempArgN] (op) r
             ExpressionType binaryOp = GetBinaryOpFromAssignmentOp(NodeType);
@@ -301,7 +301,7 @@ namespace System.Linq.Expressions
             // tempObj[tempArg0, ... tempArgN] = tempValue
             exprs.Add(Expression.Assign(tempIndex, tempValue));
 
-            return Expression.Block(vars, exprs);
+            return Expression.Block(vars.ToReadOnly(), exprs.ToReadOnly());
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/ArrayBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/ArrayBuilder.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Linq.Expressions
+{
+    /// <summary>
+    /// Utility to create and populate arrays in a left-to-right manner.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the array.</typeparam>
+    internal struct ArrayBuilder<T>
+    {
+        private readonly T[] _array;
+        private int _count;
+
+        /// <summary>
+        /// Creates a new array of the specified length.
+        /// </summary>
+        /// <param name="length">The length of the array.</param>
+        public ArrayBuilder(int length)
+        {
+            Debug.Assert(length > 0);
+
+            _array = new T[length];
+            _count = 0;
+        }
+
+        /// <summary>
+        /// Adds an element to the next slot in the array and advances the cursor to the next slot.
+        /// </summary>
+        /// <param name="item">The element to add to the array.</param>
+        public void Add(T item)
+        {
+            _array[_count++] = item;
+        }
+
+        /// <summary>
+        /// Returns the array that was built.
+        /// Note that this method does not create a copy of the array.
+        /// </summary>
+        public T[] ToArray()
+        {
+            Debug.Assert(_count == _array.Length);
+            return _array;
+        }
+
+        /// <summary>
+        /// Returns a read-only collection wrapper around the array that was built.
+        /// Note that this method does not create a copy of the array.
+        /// </summary>
+        public ReadOnlyCollection<T> ToReadOnly()
+        {
+            Debug.Assert(_count == _array.Length);
+            return new TrueReadOnlyCollection<T>(_array);
+        }
+    }
+}

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
@@ -169,10 +169,10 @@ namespace System.Linq.Expressions.Compiler
 
         internal void EmitVariableAccess(LambdaCompiler lc, ReadOnlyCollection<ParameterExpression> vars)
         {
-            if (NearestHoistedLocals != null)
+            if (NearestHoistedLocals != null && vars.Count > 0)
             {
                 // Find what array each variable is on & its index
-                var indexes = new List<long>(vars.Count);
+                var indexes = new ArrayBuilder<long>(vars.Count);
 
                 foreach (var variable in vars)
                 {
@@ -193,18 +193,15 @@ namespace System.Linq.Expressions.Compiler
                     indexes.Add((long)index);
                 }
 
-                if (indexes.Count > 0)
-                {
-                    EmitGet(NearestHoistedLocals.SelfVariable);
-                    lc.EmitConstantArray(indexes.ToArray());
-                    lc.IL.Emit(OpCodes.Call, RuntimeOps_CreateRuntimeVariables_ObjectArray_Int64Array);
-                    return;
-                }
+                EmitGet(NearestHoistedLocals.SelfVariable);
+                lc.EmitConstantArray(indexes.ToArray());
+                lc.IL.Emit(OpCodes.Call, RuntimeOps_CreateRuntimeVariables_ObjectArray_Int64Array);
             }
-
-            // No visible variables
-            lc.IL.Emit(OpCodes.Call, RuntimeOps_CreateRuntimeVariables);
-            return;
+            else
+            {
+                // No visible variables
+                lc.IL.Emit(OpCodes.Call, RuntimeOps_CreateRuntimeVariables);
+            }
         }
 
         #endregion

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
@@ -340,7 +340,7 @@ namespace System.Linq.Expressions.Compiler
             // Emit indexes. We don't allow byref args, so no need to worry
             // about write-backs or EmitAddress
             var n = node.ArgumentCount;
-            List<LocalBuilder> args = new List<LocalBuilder>(n);
+            var args = new LocalBuilder[n];
             for (var i = 0; i < n; i++)
             {
                 var arg = node.GetArgument(i);
@@ -349,7 +349,7 @@ namespace System.Linq.Expressions.Compiler
                 var argLocal = GetLocal(arg.Type);
                 _ilg.Emit(OpCodes.Dup);
                 _ilg.Emit(OpCodes.Stloc, argLocal);
-                args.Add(argLocal);
+                args[i] = argLocal;
             }
 
             // emit the get

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -667,7 +667,7 @@ namespace System.Linq.Expressions.Compiler
             // immediately. But that would cause the two code paths to be more
             // different than they really need to be.
             var initializers = new List<ElementInit>(tests);
-            var cases = new List<SwitchCase>(node.Cases.Count);
+            var cases = new ArrayBuilder<SwitchCase>(node.Cases.Count);
 
             int nullCase = -1;
             MethodInfo add = DictionaryOfStringInt32_Add_String_Int32;
@@ -743,7 +743,7 @@ namespace System.Linq.Expressions.Compiler
                         Expression.Assign(switchIndex, Expression.Constant(-1))
                     )
                 ),
-                Expression.Switch(node.Type, switchIndex, node.DefaultBody, null, cases)
+                Expression.Switch(node.Type, switchIndex, node.DefaultBody, null, cases.ToReadOnly())
             );
 
             EmitExpression(reduced, flags);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2256,8 +2256,9 @@ namespace System.Linq.Expressions.Interpreter
                                 _instructions.EmitStoreLocal(objTmp.Value.Index);
                             }
 
-                            var indexLocals = new List<LocalDefinition>();
-                            for (int i = 0; i < indexNode.ArgumentCount; i++)
+                            int count = indexNode.ArgumentCount;
+                            var indexLocals = new LocalDefinition[count];
+                            for (int i = 0; i < count; i++)
                             {
                                 var arg = indexNode.GetArgument(i);
                                 Compile(arg);
@@ -2266,12 +2267,12 @@ namespace System.Linq.Expressions.Interpreter
                                 _instructions.EmitDup();
                                 _instructions.EmitStoreLocal(argTmp.Index);
 
-                                indexLocals.Add(argTmp);
+                                indexLocals[i] = argTmp;
                             }
 
                             EmitIndexGet(indexNode);
 
-                            return new IndexMethodByRefUpdater(objTmp, indexLocals.ToArray(), indexNode.Indexer.GetSetMethod(), index);
+                            return new IndexMethodByRefUpdater(objTmp, indexLocals, indexNode.Indexer.GetSetMethod(), index);
                         }
                         else if (indexNode.ArgumentCount == 1)
                         {
@@ -2343,8 +2344,9 @@ namespace System.Linq.Expressions.Interpreter
             _instructions.EmitDup();
             _instructions.EmitStoreLocal(objTmp.Index);
 
-            var indexLocals = new List<LocalDefinition>();
-            for (int i = 0; i < arguments.ArgumentCount; i++)
+            int count = arguments.ArgumentCount;
+            var indexLocals = new LocalDefinition[count];
+            for (int i = 0; i < count; i++)
             {
                 var arg = arguments.GetArgument(i);
                 Compile(arg);
@@ -2353,12 +2355,12 @@ namespace System.Linq.Expressions.Interpreter
                 _instructions.EmitDup();
                 _instructions.EmitStoreLocal(argTmp.Index);
 
-                indexLocals.Add(argTmp);
+                indexLocals[i] = argTmp;
             }
 
             _instructions.EmitCall(array.Type.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance));
 
-            return new IndexMethodByRefUpdater(objTmp, indexLocals.ToArray(), array.Type.GetMethod("Set", BindingFlags.Public | BindingFlags.Instance), index);
+            return new IndexMethodByRefUpdater(objTmp, indexLocals, array.Type.GetMethod("Set", BindingFlags.Public | BindingFlags.Instance), index);
         }
 
         private void CompileNewExpression(Expression expr)


### PR DESCRIPTION
This addresses issue #11837. In places where keeping track of the index of the next element to write into the array is rather clumsy, I'm using a small `ArrayBuilder<T>` helper type which exposes an `Add` method, so the original `List<T>`-like code keeps working and no index tracking is needed. This utility is also responsible to either return the array or return a `TrueReadOnlyCollection<T>` wrapping it (ownership transfer semantics), so we can pass it along to e.g. an expression factory method without causing it to create an unnecessary copy.