### PR TITLE
Add remaining missing members of System.Security namespace (not child ns)

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -5659,15 +5659,32 @@ namespace System.Runtime.Versioning
 }
 namespace System.Security
 {
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false, Inherited=false)]
     public sealed partial class AllowPartiallyTrustedCallersAttribute : System.Attribute
     {
         public AllowPartiallyTrustedCallersAttribute() { }
+        public System.Security.PartialTrustVisibilityLevel PartialTrustVisibilityLevel { get { throw null; } set { } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(5501), AllowMultiple = false, Inherited = false)]
+    public enum PartialTrustVisibilityLevel
+    {
+        NotVisibleByDefault = 1,
+        VisibleToAllHosts = 0,
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5501), AllowMultiple=false, Inherited=false)]
     public sealed partial class SecurityCriticalAttribute : System.Attribute
     {
         public SecurityCriticalAttribute() { }
+#pragma warning disable 0618        
+        public SecurityCriticalAttribute(System.Security.SecurityCriticalScope scope) { }
+#pragma warning restore 0618
+        [System.ObsoleteAttribute("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
+        public System.Security.SecurityCriticalScope Scope { get { throw null; } }
+    }
+    [System.ObsoleteAttribute("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
+    public enum SecurityCriticalScope
+    {
+        Everything = 1,
+        Explicit = 0,
     }
     public partial class SecurityException : System.Exception
     {
@@ -5678,22 +5695,73 @@ namespace System.Security
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { return default(string); }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(5500), AllowMultiple = false, Inherited = false)]
+    /*
+    public partial class SecurityException : System.SystemException
+    {
+        public SecurityException() { }
+        protected SecurityException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public SecurityException(string message) { }
+        public SecurityException(string message, System.Exception inner) { }
+        public SecurityException(string message, System.Type type) { }
+        public SecurityException(string message, System.Type type, string state) { }
+        public object Demanded { get { throw null; } set { } }
+        public object DenySetInstance { get { throw null; } set { } }
+        public System.Reflection.AssemblyName FailedAssemblyInfo { get { throw null; } set { } }
+        public string GrantedSet { get { throw null; } set { } }
+        public System.Reflection.MethodInfo Method { get { throw null; } set { } }
+        public string PermissionState { get { throw null; } set { } }
+        public System.Type PermissionType { get { throw null; } set { } }
+        public object PermitOnlySetInstance { get { throw null; } set { } }
+        public string RefusedSet { get { throw null; } set { } }
+        public string Url { get { throw null; } set { } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public override string ToString() { throw null; }
+    }*/
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false)]
+    public sealed partial class SecurityRulesAttribute : System.Attribute
+    {
+        public SecurityRulesAttribute(System.Security.SecurityRuleSet ruleSet) { }
+        public System.Security.SecurityRuleSet RuleSet { get { throw null; } }
+        public bool SkipVerificationInFullTrust { get { throw null; } set { } }
+    }
+    public enum SecurityRuleSet : byte
+    {
+        Level1 = (byte)1,
+        Level2 = (byte)2,
+        None = (byte)0,
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5500), AllowMultiple=false, Inherited=false)]
     public sealed partial class SecuritySafeCriticalAttribute : System.Attribute
     {
         public SecuritySafeCriticalAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false, Inherited=false)]
     public sealed partial class SecurityTransparentAttribute : System.Attribute
     {
         public SecurityTransparentAttribute() { }
     }
-    public partial class VerificationException : System.Exception
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5501), AllowMultiple=false, Inherited=false)]
+    [System.ObsoleteAttribute("SecurityTreatAsSafe is only used for .NET 2.0 transparency compatibility.  Please use the SecuritySafeCriticalAttribute instead.")]
+    public sealed partial class SecurityTreatAsSafeAttribute : System.Attribute
+    {
+        public SecurityTreatAsSafeAttribute() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5188), AllowMultiple=true, Inherited=false)]
+    public sealed partial class SuppressUnmanagedCodeSecurityAttribute : System.Attribute
+    {
+        public SuppressUnmanagedCodeSecurityAttribute() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(2), AllowMultiple=true, Inherited=false)]
+    public sealed partial class UnverifiableCodeAttribute : System.Attribute
+    {
+        public UnverifiableCodeAttribute() { }
+    }
+    public partial class VerificationException : System.SystemException
     {
         public VerificationException() { }
+        protected VerificationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public VerificationException(string message) { }
         public VerificationException(string message, System.Exception innerException) { }
-        protected VerificationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
 }
 namespace System.Text

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -5689,16 +5689,6 @@ namespace System.Security
     public partial class SecurityException : System.Exception
     {
         public SecurityException() { }
-        public SecurityException(string message) { }
-        public SecurityException(string message, System.Exception inner) { }
-        protected SecurityException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public override string ToString() { return default(string); }
-    }
-    /*
-    public partial class SecurityException : System.SystemException
-    {
-        public SecurityException() { }
         protected SecurityException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public SecurityException(string message) { }
         public SecurityException(string message, System.Exception inner) { }
@@ -5716,7 +5706,7 @@ namespace System.Security
         public string Url { get { throw null; } set { } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
-    }*/
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false)]
     public sealed partial class SecurityRulesAttribute : System.Attribute
     {

--- a/src/System.Runtime/src/ApiCompatBaseline.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.txt
@@ -1,4 +1,1 @@
-MembersMustExist : Member 'System.Type.IsSecurityCritical.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Type.IsSecuritySafeCritical.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Type.IsSecurityTransparent.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Reflection.Pointer..ctor()' does not exist in the implementation but it does exist in the contract.
+Total Issues: 0

--- a/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
@@ -23,7 +23,6 @@ MembersMustExist : Member 'System.ArgumentException..ctor(System.Runtime.Seriali
 MembersMustExist : Member 'System.ArgumentNullException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.ArgumentOutOfRangeException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.ArithmeticException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Array.AsReadOnly<T>(T[])' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Array.ConvertAll<TInput, TOutput>(TInput[], System.Converter<TInput, TOutput>)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Array.Copy(System.Array, System.Array, System.Int64)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Array.Copy(System.Array, System.Int64, System.Array, System.Int64, System.Int64)' does not exist in the implementation but it does exist in the contract.
@@ -188,6 +187,7 @@ MembersMustExist : Member 'System.String.Compare(System.String, System.String, S
 MembersMustExist : Member 'System.String.Compare(System.String, System.String, System.Globalization.CultureInfo, System.Globalization.CompareOptions)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.Copy(System.String)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.EndsWith(System.String, System.Boolean, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.GetEnumerator()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.Intern(System.String)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.IsInterned(System.String)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.IsNormalized()' does not exist in the implementation but it does exist in the contract.
@@ -359,6 +359,7 @@ TypesMustExist : Type 'System.Runtime.CompilerServices.SuppressIldasmAttribute' 
 TypesMustExist : Type 'System.Runtime.InteropServices.ExternalException' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.Serialization.SerializationException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Security.SecurityException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.VerificationException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.Security.VerificationException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Text.Decoder.Convert(System.Byte*, System.Int32, System.Char*, System.Int32, System.Boolean, System.Int32, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Text.Decoder.GetCharCount(System.Byte*, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
@@ -378,5 +379,4 @@ MembersMustExist : Member 'System.Text.Encoding.IsMailNewsSave.get()' does not e
 MembersMustExist : Member 'System.Text.Encoding.WindowsCodePage.get()' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Text.EncodingInfo' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Text.NormalizationForm' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.String.GetEnumerator()' does not exist in the implementation but it does exist in the contract.
 Total Issues: 380

--- a/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
@@ -358,7 +358,6 @@ CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.CompilerServices.Conditio
 TypesMustExist : Type 'System.Runtime.CompilerServices.SuppressIldasmAttribute' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.InteropServices.ExternalException' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.Serialization.SerializationException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.SecurityException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Security.VerificationException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.Security.VerificationException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Text.Decoder.Convert(System.Byte*, System.Int32, System.Char*, System.Int32, System.Boolean, System.Int32, System.Int32, System.Boolean)' does not exist in the implementation but it does exist in the contract.
@@ -379,4 +378,4 @@ MembersMustExist : Member 'System.Text.Encoding.IsMailNewsSave.get()' does not e
 MembersMustExist : Member 'System.Text.Encoding.WindowsCodePage.get()' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Text.EncodingInfo' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Text.NormalizationForm' does not exist in the implementation but it does exist in the contract.
-Total Issues: 380
+Total Issues: 379

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -34,6 +34,7 @@
     <Compile Include="System\Collections\Generic\ISet.cs" />
     <Compile Include="System\ComponentModel\EditorBrowsableAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\StrongBox.cs" />
+    <Compile Include="System\Security\Attributes.cs" />
     <Compile Condition="'$(TargetGroup)'!='uap101aot'" Include="System\Reflection\AssemblyNameProxy.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'!='netcore50aot' And '$(TargetGroup)'!='uap101aot' And '$(TargetGroup)'!='net462' AND '$(TargetGroup)'!='net463'">

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -35,6 +35,7 @@
     <Compile Include="System\ComponentModel\EditorBrowsableAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\StrongBox.cs" />
     <Compile Include="System\Security\Attributes.cs" />
+    <Compile Include="System\Security\SecurityException.cs" />
     <Compile Condition="'$(TargetGroup)'!='uap101aot'" Include="System\Reflection\AssemblyNameProxy.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'!='netcore50aot' And '$(TargetGroup)'!='uap101aot' And '$(TargetGroup)'!='net462' AND '$(TargetGroup)'!='net463'">

--- a/src/System.Runtime/src/System/Security/Attributes.cs
+++ b/src/System.Runtime/src/System/Security/Attributes.cs
@@ -1,0 +1,147 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Security
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+    sealed public class SuppressUnmanagedCodeSecurityAttribute : System.Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Module, AllowMultiple = true, Inherited = false)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+    sealed public class UnverifiableCodeAttribute : System.Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+    sealed public class AllowPartiallyTrustedCallersAttribute : System.Attribute
+    {
+        public AllowPartiallyTrustedCallersAttribute() { }
+
+        public PartialTrustVisibilityLevel PartialTrustVisibilityLevel
+        {
+            get;
+            set;
+        }
+    }
+
+    public enum PartialTrustVisibilityLevel
+    {
+        VisibleToAllHosts = 0,
+        NotVisibleByDefault = 1
+    }
+
+    [Obsolete("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
+    public enum SecurityCriticalScope
+    {
+        Explicit = 0,
+        Everything = 0x1
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly |
+                    AttributeTargets.Class |
+                    AttributeTargets.Struct |
+                    AttributeTargets.Enum |
+                    AttributeTargets.Constructor |
+                    AttributeTargets.Method |
+                    AttributeTargets.Field |
+                    AttributeTargets.Interface |
+                    AttributeTargets.Delegate,
+        AllowMultiple = false,
+        Inherited = false)]
+    sealed public class SecurityCriticalAttribute : System.Attribute
+    {
+#pragma warning disable 618
+        private SecurityCriticalScope _val;
+
+        public SecurityCriticalAttribute() { }
+
+        public SecurityCriticalAttribute(SecurityCriticalScope scope)
+        {
+            _val = scope;
+        }
+
+        [Obsolete("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
+        public SecurityCriticalScope Scope
+        {
+            get
+            {
+                return _val;
+            }
+        }
+#pragma warning restore 618
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly |
+                    AttributeTargets.Class |
+                    AttributeTargets.Struct |
+                    AttributeTargets.Enum |
+                    AttributeTargets.Constructor |
+                    AttributeTargets.Method |
+                    AttributeTargets.Field |
+                    AttributeTargets.Interface |
+                    AttributeTargets.Delegate,
+        AllowMultiple = false,
+        Inherited = false)]
+    [Obsolete("SecurityTreatAsSafe is only used for .NET 2.0 transparency compatibility.  Please use the SecuritySafeCriticalAttribute instead.")]
+    sealed public class SecurityTreatAsSafeAttribute : System.Attribute
+    {
+        public SecurityTreatAsSafeAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Class |
+                    AttributeTargets.Struct |
+                    AttributeTargets.Enum |
+                    AttributeTargets.Constructor |
+                    AttributeTargets.Method |
+                    AttributeTargets.Field |
+                    AttributeTargets.Interface |
+                    AttributeTargets.Delegate,
+        AllowMultiple = false,
+        Inherited = false)]
+    sealed public class SecuritySafeCriticalAttribute : System.Attribute
+    {
+        public SecuritySafeCriticalAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+    sealed public class SecurityTransparentAttribute : System.Attribute
+    {
+        public SecurityTransparentAttribute() { }
+    }
+
+    public enum SecurityRuleSet : byte
+    {
+        None = 0,
+        Level1 = 1,
+        Level2 = 2,
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+    public sealed class SecurityRulesAttribute : Attribute
+    {
+        private SecurityRuleSet _ruleSet;
+
+        public SecurityRulesAttribute(SecurityRuleSet ruleSet)
+        {
+            _ruleSet = ruleSet;
+        }
+
+        public bool SkipVerificationInFullTrust
+        {
+            get;
+            set;
+        }
+
+        public SecurityRuleSet RuleSet
+        {
+            get { return _ruleSet; }
+        }
+    }
+}

--- a/src/System.Runtime/src/System/Security/SecurityException.cs
+++ b/src/System.Runtime/src/System/Security/SecurityException.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Security
+{
+    // Stub SecurityException
+    // This will not de/serialize correctly
+    public class SecurityException : Exception
+    {
+        private const int COR_E_SECURITY = unchecked((int)0x8013150A);
+
+        public SecurityException()
+        {
+            HResult = COR_E_SECURITY;
+        }
+
+        public SecurityException(string message)
+            : base(message)
+        {
+            HResult = COR_E_SECURITY;
+        }
+
+        public SecurityException(string message, System.Exception inner) 
+            : base(message, inner)
+        {
+            HResult = COR_E_SECURITY;
+        }
+
+        public SecurityException(String message, Type type)
+            : base(message)
+        {
+            HResult = COR_E_SECURITY;
+            PermissionType = type;
+        }
+
+        public SecurityException(string message, System.Type type, string state)
+            : base(message)
+        {
+            HResult = COR_E_SECURITY;
+            PermissionType = type;
+            PermissionState = state;
+        }
+
+        protected SecurityException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+
+        public object Demanded { get; set; }
+        public object DenySetInstance { get; set; }
+        public System.Reflection.AssemblyName FailedAssemblyInfo { get; set; }
+        public string GrantedSet { get; set; }
+        public System.Reflection.MethodInfo Method { get; set; }
+        public string PermissionState { get; set; }
+        public System.Type PermissionType { get; set; }
+        public object PermitOnlySetInstance { get; set; }
+        public string RefusedSet { get; set; }
+        public string Url { get; set; }
+    }
+}

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -112,6 +112,7 @@
     <Compile Include="System\ExecutionEngineExceptionTests.cs" />
     <Compile Include="System\GuidTests.netstandard1.7.cs" />    
     <Compile Include="System\NotFiniteNumberExceptionTests.cs" />
+    <Compile Include="System\Security\SecurityAttributeTests.cs" /> 
     <Compile Include="System\StackOverflowExceptionTests.cs" />
     <Compile Include="System\SystemExceptionTests.cs" />
     <Compile Include="System\StringTests.netstandard1.7.cs" />

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="System\GuidTests.netstandard1.7.cs" />    
     <Compile Include="System\NotFiniteNumberExceptionTests.cs" />
     <Compile Include="System\Security\SecurityAttributeTests.cs" /> 
+    <Compile Include="System\Security\SecurityExceptionTests.cs" /> 
     <Compile Include="System\StackOverflowExceptionTests.cs" />
     <Compile Include="System\SystemExceptionTests.cs" />
     <Compile Include="System\StringTests.netstandard1.7.cs" />

--- a/src/System.Runtime/tests/System/Security/SecurityAttributeTests.cs
+++ b/src/System.Runtime/tests/System/Security/SecurityAttributeTests.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security;
+using Xunit;
+
+namespace System.Tests
+{
+#pragma warning disable 618
+    public static class SecurityAttributeTests
+    {
+        public static void InstantiateSecurityAttributes()
+        {
+            var t = new SecurityTreatAsSafeAttribute();
+            var u = new SecuritySafeCriticalAttribute();
+            var v = new SecurityTransparentAttribute();
+            var w = new SecurityCriticalAttribute();
+            var x = new SuppressUnmanagedCodeSecurityAttribute();
+            var y = new UnverifiableCodeAttribute();
+            var z = new AllowPartiallyTrustedCallersAttribute();
+        }
+
+        public static void SecurityCriticalAttribute_Test()
+        {
+            var att = new SecurityCriticalAttribute(SecurityCriticalScope.Everything);
+
+            Assert.Equal(SecurityCriticalScope.Everything, att.Scope);
+        }
+
+        public static void AllowPartiallyTrustedCallersAttribute_Test()
+        {
+            var att = new AllowPartiallyTrustedCallersAttribute();
+            att.PartialTrustVisibilityLevel = PartialTrustVisibilityLevel.NotVisibleByDefault;
+
+            Assert.Equal(PartialTrustVisibilityLevel.NotVisibleByDefault, att.PartialTrustVisibilityLevel);
+        }
+
+        public static void SecurityRulesAttribute_Test()
+        {
+            var att = new SecurityRulesAttribute(SecurityRuleSet.Level1);
+
+            Assert.Equal(SecurityRuleSet.Level1, att.RuleSet);
+
+            att.SkipVerificationInFullTrust = true;
+            Assert.Equal(!true, att.SkipVerificationInFullTrust);
+        }
+    }
+#pragma warning restore 618
+}

--- a/src/System.Runtime/tests/System/Security/SecurityExceptionTests.cs
+++ b/src/System.Runtime/tests/System/Security/SecurityExceptionTests.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security;
+using Xunit;
+
+namespace System.Tests
+{
+    public static class SecurityExceptionTests
+    {
+        [Fact]
+        public static void Instantiate()
+        {
+            var a = new SecurityException();
+            var b = new SecurityException("msg");
+            var c = new SecurityException("msg", b);
+            var d = new SecurityException("msg", typeof(string));
+            var e = new SecurityException("msg", typeof(string), "state");
+
+            Assert.Equal("msg", b.Message);
+            Assert.Equal(b, c.InnerException);
+            Assert.Equal(typeof(string), d.PermissionType);
+            Assert.Equal("state", e.PermissionState);
+        }
+    }
+}


### PR DESCRIPTION
Excepting SecurityException, which needs a PR in CoreCLR to fill it out first.

By adding the types here (helpful for CoreRT later) we imply that there is no type exchange necessary with core library for them. This is not true for SecurityException which is why I can't move it into CoreFX.

@weshaggard 