### PR TITLE
Handle Linux NetworkInterfaces which report their speed as '-1'.

### DIFF
--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -71,7 +71,7 @@ namespace System.Net.NetworkInformation.Tests
                 try
                 {
                     _log.WriteLine("Speed: " + nic.Speed);
-                    Assert.InRange(nic.Speed, 0, long.MaxValue);
+                    Assert.InRange(nic.Speed, -1, long.MaxValue);
                 }
                 // We cannot guarantee this works on all devices.
                 catch (PlatformNotSupportedException pnse)


### PR DESCRIPTION
Some network interfaces report their speed as "-1" in the /sys/class/net/name/speed file. The `Speed` property indicates the returned value is in "bits per second" and does not imply that a negative value is valid. If we encounter this, we just treat it like other situations where we cannot retrieve the necessary information: we throw a PlatformNotSupportedException (`"The information requested in unavailable on the current platform."`).

We have seen this very occasionally on our current platforms, but it seems to be happening every time on the new Ubuntu 16.10 VM's we are using.

Fixes https://github.com/dotnet/corefx/issues/10769

@ericeil 