### PR TITLE
Remove P2P reference in XmlSchemaSet tests

### DIFF
--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/System.Xml.XmlSchemaSet.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/System.Xml.XmlSchemaSet.Tests.csproj
@@ -60,7 +60,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\System.Private.Xml.csproj" />
     <ProjectReference Include="..\..\..\..\System.Xml.ReaderWriter\src\System.Xml.ReaderWriter.csproj" />
-    <ProjectReference Include="..\..\..\..\Microsoft.Win32.Registry\pkg\Microsoft.Win32.Registry.pkgproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/project.json
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24516-03",
+    "Microsoft.Win32.Registry": "4.3.0-beta-24516-03",
     "System.IO": "4.3.0-beta-24516-03",
     "System.Collections.NonGeneric": "4.3.0-beta-24516-03",
     "System.IO.FileSystem": "4.3.0-beta-24516-03",


### PR DESCRIPTION
No need to have a P2P reference to the live Registry package, so moving it to the project.json instead. This is to unblock the Windows Pipeline builds.

cc: @chcosta @weshaggard @AlfredoMS 