### PR TITLE
Fill out System.Reflection

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -4308,11 +4308,13 @@ namespace System.Reflection
         public System.Reflection.ProcessorArchitecture ProcessorArchitecture { get { return default(System.Reflection.ProcessorArchitecture); } set { } }
         public System.Version Version { get { return default(System.Version); } set { } }
         public object Clone() { return default(object); }
+        public static System.Reflection.AssemblyName GetAssemblyName(System.String assemblyFile) { return default(System.Reflection.AssemblyName); }
         public byte[] GetPublicKey() { return default(byte[]); }
         public byte[] GetPublicKeyToken() { return default(byte[]); }
         public void SetPublicKey(byte[] publicKey) { }
         public void SetPublicKeyToken(byte[] publicKeyToken) { }
         public override string ToString() { return default(string); }
+        static public bool ReferenceMatchesDefinition(System.Reflection.AssemblyName reference, System.Reflection.AssemblyName definition) { return default(bool); }
         [System.Security.SecurityCriticalAttribute]
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { return; }
         public void OnDeserialization(Object sender) { return; }
@@ -4329,6 +4331,7 @@ namespace System.Reflection
     public class AssemblyNameProxy : System.MarshalByRefObject
     {
         public AssemblyNameProxy() { }
+        public System.Reflection.AssemblyName GetAssemblyName(System.String assemblyFile) { return default(System.Reflection.AssemblyName); }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
     public sealed partial class AssemblyProductAttribute : System.Attribute
@@ -4784,6 +4787,8 @@ namespace System.Reflection
         public bool IsSpecialName { get { return default(bool); } }
         public bool IsStatic { get { return default(bool); } }
         public bool IsVirtual { get { return default(bool); } }
+        public virtual bool IsSecurityCritical { get { return default(bool); } }
+        public virtual bool IsSecurityTransparent { get { return default(bool); } }
         public abstract System.RuntimeMethodHandle MethodHandle { get; }
         public virtual System.Reflection.MethodImplAttributes MethodImplementationFlags { get { return default(System.Reflection.MethodImplAttributes); } }
         public override bool Equals(object obj) { return default(bool); }

--- a/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
@@ -379,4 +379,8 @@ MembersMustExist : Member 'System.Text.Encoding.WindowsCodePage.get()' does not 
 TypesMustExist : Type 'System.Text.EncodingInfo' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Text.NormalizationForm' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.GetEnumerator()' does not exist in the implementation but it does exist in the contract.
-Total Issues: 380
+MembersMustExist : Member 'System.Reflection.AssemblyName.GetAssemblyName(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.ReferenceMatchesDefinition(System.Reflection.AssemblyName, System.Reflection.AssemblyName)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase.IsSecurityCritical.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.MethodBase.IsSecurityTransparent.get()' does not exist in the implementation but it does exist in the contract.
+Total Issues: 384

--- a/src/System.Runtime/src/System/Reflection/AssemblyNameProxy.cs
+++ b/src/System.Runtime/src/System/Reflection/AssemblyNameProxy.cs
@@ -5,14 +5,13 @@
 namespace System.Reflection {
     using System;
     using System.Runtime.Versioning;
-    using System.Runtime.Loader;
 
     [System.Runtime.InteropServices.ComVisible(true)]
     public class AssemblyNameProxy : MarshalByRefObject
     {
         public AssemblyName GetAssemblyName(String assemblyFile)
         {
-            return AssemblyLoadContext.GetAssemblyName(assemblyFile);
+            return AssemblyName.GetAssemblyName(assemblyFile);
         }
     }
 }

--- a/src/System.Runtime/tests/System/Reflection/AssemblyNameTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/AssemblyNameTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Globalization;
 using Xunit;
@@ -57,6 +58,43 @@ namespace System.Reflection.Tests
             object an2 = an1.Clone();
             Assert.Equal(an1.FullName, ((AssemblyName)an2).FullName);
             Assert.Equal(AssemblyNameFlags.PublicKey | AssemblyNameFlags.EnableJITcompileOptimizer, ((AssemblyName)an2).Flags);
+        }
+
+        [Fact]
+        public static void GetAssemblyName()
+        {
+            Assert.Throws<ArgumentNullException>("assemblyFile", () => AssemblyName.GetAssemblyName(null));
+            Assert.Throws<ArgumentException>(() => AssemblyName.GetAssemblyName(string.Empty));
+            Assert.Throws<System.IO.FileNotFoundException>(() => AssemblyName.GetAssemblyName("IDontExist"));
+
+            Assembly a = typeof(AssemblyNameTests).Assembly;
+            Assert.Equal(new AssemblyName(a.FullName).ToString(), AssemblyName.GetAssemblyName(a.Location).ToString());
+        }
+
+        [Fact]
+        public static void GetAssemblyName_AssemblyNameProxy()
+        {
+            AssemblyNameProxy anp = new AssemblyNameProxy();
+            Assert.Throws<ArgumentNullException>("assemblyFile", () => anp.GetAssemblyName(null));
+            Assert.Throws<ArgumentException>(() => anp.GetAssemblyName(string.Empty));
+            Assert.Throws<System.IO.FileNotFoundException>(() => anp.GetAssemblyName("IDontExist"));
+
+            Assembly a = typeof(AssemblyNameTests).Assembly;
+            Assert.Equal(new AssemblyName(a.FullName).ToString(), anp.GetAssemblyName(System.IO.Path.GetFullPath(a.Location)).ToString());
+        }
+
+        public static IEnumerable<object[]> ReferenceMatchesDefinition_TestData()
+        {
+            yield return new object[] { new AssemblyName(typeof(AssemblyNameTests).Assembly.FullName), new AssemblyName(typeof(AssemblyNameTests).Assembly.FullName), true };
+            yield return new object[] { new AssemblyName(typeof(AssemblyNameProxy).GetTypeInfo().Assembly.FullName), new AssemblyName("System.Runtime"), true };
+            yield return new object[] { new AssemblyName(typeof(AssemblyNameTests).Assembly.FullName), new AssemblyName("System.Runtime"), false };
+        }
+
+        [Theory]
+        [MemberData(nameof(ReferenceMatchesDefinition_TestData))]
+        public static void ReferenceMatchesDefinition(AssemblyName a1, AssemblyName a2, bool expected)
+        {
+            Assert.Equal(expected, AssemblyName.ReferenceMatchesDefinition(a1, a2));
         }
     }
 }


### PR DESCRIPTION
Adding the last exposable System.Reflection APIs. System.Reflection now matches netstandard2.0 ref except for few assembly load APIs listed in https://github.com/dotnet/corefx/issues/11655

cc: @danmosemsft @weshaggard 