### PR TITLE
Fix Performance package references after dev/api merge

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -17,6 +17,7 @@
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
     <AppXRunnerVersion>1.0.3-prerelease-00808-02</AppXRunnerVersion>
+    <XunitPerfAnalysisPackageVersion>1.0.0-alpha-build0040</XunitPerfAnalysisPackageVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->
@@ -97,6 +98,11 @@
     <DependencyBuildInfo Include="uwpRunnerVersion">
       <PackageId>microsoft.xunit.runner.uwp</PackageId>
       <Version>$(AppXRunnerVersion)</Version>
+    </DependencyBuildInfo>
+
+    <DependencyBuildInfo Include="XunitPerfAnalysisPackageVersion">
+      <PackageId>Microsoft.DotNet.xunit.performance</PackageId>
+      <Version>$(XunitPerfAnalysisPackageVersion)</Version>
     </DependencyBuildInfo>
   </ItemGroup>
 </Project>

--- a/dir.props
+++ b/dir.props
@@ -18,10 +18,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <XunitPerfAnalysisPackageVersion>1.0.0-alpha-build0040</XunitPerfAnalysisPackageVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <InputOSGroup Condition="'$(InputOSGroup)'==''">$(OSEnvironment)</InputOSGroup>
   </PropertyGroup>
 
@@ -71,8 +67,8 @@
   <!-- Provides package dependency version properties and verification/auto-upgrade configuration -->
   <Import Project="$(MSBuildThisFileDirectory)dependencies.props" />
 
-  <!-- Explicitly setting 
-       - SupportsUWP to true when TargetGroup is uap101*. This will enable the correct pinvoke checker to be picked 
+  <!-- Explicitly setting
+       - SupportsUWP to true when TargetGroup is uap101*. This will enable the correct pinvoke checker to be picked
        - BlockReflectionAttribute to true. This will enable injecting BlockReflectionAttribute.cs into the compile target.
        TODO: Both of these properties are being set in buildtools targets, however they need to be updated to reflect uap101 changes.
   -->
@@ -470,7 +466,7 @@
     <TestTFM Condition="'$(TestTFM)'=='' AND '$(TargetGroup)'=='netstandard1.7'">netcoreapp1.1</TestTFM>
     <TestTFM Condition="'$(TestTFM)'==''">netcoreapp1.0</TestTFM>
     <!-- we default FilterToTestTFM to netcoreapp1.1 if it is not explicity defined -->
-    <FilterToTestTFM Condition="'$(FilterToTestTFM)'==''">netcoreapp1.1</FilterToTestTFM>        
+    <FilterToTestTFM Condition="'$(FilterToTestTFM)'==''">netcoreapp1.1</FilterToTestTFM>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Common/tests/project.json
+++ b/src/Common/tests/project.json
@@ -27,7 +27,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Collections.NonGeneric/tests/Performance/project.json
+++ b/src/System.Collections.NonGeneric/tests/Performance/project.json
@@ -20,7 +20,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -20,7 +20,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Collections/tests/Performance/project.json
+++ b/src/System.Collections/tests/Performance/project.json
@@ -18,7 +18,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -19,7 +19,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.ComponentModel.TypeConverter/tests/Performance/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/Performance/project.json
@@ -17,7 +17,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -18,7 +18,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.5": {},

--- a/src/System.Console/tests/Performance/project.json
+++ b/src/System.Console/tests/Performance/project.json
@@ -21,7 +21,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -21,7 +21,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Diagnostics.Process/tests/Performance/project.json
+++ b/src/System.Diagnostics.Process/tests/Performance/project.json
@@ -29,7 +29,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.4": {}

--- a/src/System.Diagnostics.Process/tests/project.json
+++ b/src/System.Diagnostics.Process/tests/project.json
@@ -29,7 +29,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.4": {}

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
@@ -15,7 +15,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Globalization/tests/Performance/project.json
+++ b/src/System.Globalization/tests/Performance/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040",
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24516-03",
     "System.Diagnostics.Process": "4.3.0-beta-24516-03",
     "System.Globalization": "4.3.0-beta-24516-03",

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040",
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24516-03",
     "System.Diagnostics.Process": "4.3.0-beta-24516-03",
     "System.Globalization": "4.3.0-beta-24516-03",

--- a/src/System.IO.Compression/tests/Performance/project.json
+++ b/src/System.IO.Compression/tests/Performance/project.json
@@ -23,7 +23,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -23,7 +23,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.FileSystem/tests/Performance/project.json
+++ b/src/System.IO.FileSystem/tests/Performance/project.json
@@ -28,7 +28,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.7": {},

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -31,7 +31,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.IO.MemoryMappedFiles/tests/Performance/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/Performance/project.json
@@ -20,7 +20,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.MemoryMappedFiles/tests/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/project.json
@@ -20,7 +20,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.Pipes.AccessControl/tests/project.json
+++ b/src/System.IO.Pipes.AccessControl/tests/project.json
@@ -29,7 +29,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.Pipes/tests/Performance/project.json
+++ b/src/System.IO.Pipes/tests/Performance/project.json
@@ -22,7 +22,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.IO.Pipes/tests/project.json
+++ b/src/System.IO.Pipes/tests/project.json
@@ -22,7 +22,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Json/tests/project.json
+++ b/src/System.Json/tests/project.json
@@ -24,7 +24,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Linq/tests/Performance/project.json
+++ b/src/System.Linq/tests/Performance/project.json
@@ -16,7 +16,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -16,7 +16,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Net.Primitives/tests/PerformanceTests/project.json
+++ b/src/System.Net.Primitives/tests/PerformanceTests/project.json
@@ -13,7 +13,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Numerics.Vectors/tests/Performance/project.json
+++ b/src/System.Numerics.Vectors/tests/Performance/project.json
@@ -19,7 +19,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Numerics.Vectors/tests/project.json
+++ b/src/System.Numerics.Vectors/tests/project.json
@@ -19,7 +19,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlDocument/Performance/project.json
+++ b/src/System.Private.Xml/tests/XmlDocument/Performance/project.json
@@ -14,7 +14,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlDocument/project.json
+++ b/src/System.Private.Xml/tests/XmlDocument/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040",
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24516-03",
     "Microsoft.Win32.Registry": "4.3.0-beta-24516-03",
     "System.Linq.Expressions": "4.3.0-beta-24516-03",

--- a/src/System.Private.Xml/tests/XmlSerializer/Performance/ContractReferences/project.json
+++ b/src/System.Private.Xml/tests/XmlSerializer/Performance/ContractReferences/project.json
@@ -23,7 +23,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlSerializer/Performance/project.json
+++ b/src/System.Private.Xml/tests/XmlSerializer/Performance/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040",
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24516-03",
     "System.Collections": "4.3.0-beta-24516-03",
     "System.Collections.NonGeneric": "4.3.0-beta-24516-03",

--- a/src/System.Private.Xml/tests/XmlSerializer/project.json
+++ b/src/System.Private.Xml/tests/XmlSerializer/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0037",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040",
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24516-03",
     "System.Collections": "4.3.0-beta-24516-03",
     "System.Collections.NonGeneric": "4.3.0-beta-24516-03",

--- a/src/System.Runtime.Extensions/tests/Performance/project.json
+++ b/src/System.Runtime.Extensions/tests/Performance/project.json
@@ -19,7 +19,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -28,7 +28,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.5": {},

--- a/src/System.Runtime.Serialization.Json/tests/Performance/ContractReferences/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/ContractReferences/project.json
@@ -29,7 +29,7 @@
     "Newtonsoft.Json": "8.0.4-beta1",
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Serialization.Json/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/project.json
@@ -26,7 +26,7 @@
     "Newtonsoft.Json": "8.0.4-beta1",
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Serialization.Json/tests/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/project.json
@@ -26,7 +26,7 @@
     "Newtonsoft.Json": "8.0.4-beta1",
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/ContractReferences/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/ContractReferences/project.json
@@ -28,7 +28,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/project.json
@@ -28,7 +28,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -26,7 +26,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Runtime/tests/Performance/project.json
+++ b/src/System.Runtime/tests/Performance/project.json
@@ -20,7 +20,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Runtime/tests/project.json
+++ b/src/System.Runtime/tests/project.json
@@ -23,7 +23,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.5": {},

--- a/src/System.Security.AccessControl/tests/project.json
+++ b/src/System.Security.AccessControl/tests/project.json
@@ -33,7 +33,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Security.Cryptography.Encoding/tests/project.json
+++ b/src/System.Security.Cryptography.Encoding/tests/project.json
@@ -15,7 +15,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040",
     "System.Xml.XmlSerializer": "4.3.0-beta-24516-03"
   },
   "frameworks": {

--- a/src/System.Security.SecureString/tests/project.json
+++ b/src/System.Security.SecureString/tests/project.json
@@ -8,7 +8,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Text.Encoding/tests/Performance/project.json
+++ b/src/System.Text.Encoding/tests/Performance/project.json
@@ -16,7 +16,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Text.Encoding/tests/project.json
+++ b/src/System.Text.Encoding/tests/project.json
@@ -16,7 +16,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading/tests/Performance/project.json
+++ b/src/System.Threading/tests/Performance/project.json
@@ -19,7 +19,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Threading/tests/project.json
+++ b/src/System.Threading/tests/project.json
@@ -19,7 +19,7 @@
     },
     "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0039"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
     "netstandard1.3": {}


### PR DESCRIPTION
The performance package versions were reverted after the dev/api merge.

This change bumps them back up as well as adds validation for the package
version so we should catch this in the future.

cc @joperezr 