### PR TITLE
Disable failing tests

### DIFF
--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Win32.RegistryTests
             });
         }
 
-        [Fact(Skip = "This test fails on Win10 Anniversary Update Issue #10546")]
+        [ActiveIssue(10546)]
+        [Fact]
         public void NegativeTest_DeeplyNestedKey()
         {
             // Max number of parts to the registry key path is 509 (failing once it hits 510). 

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str.cs
@@ -21,18 +21,6 @@ namespace Microsoft.Win32.RegistryTests
             const int maxValueNameLength = 255;
             Assert.Throws<ArgumentException>(() => TestRegistryKey.CreateSubKey(new string('a', maxValueNameLength + 1)));
 
-            // Max number of parts to the registry key path is 509 (failing once it hits 510). 
-            // As TestRegistryKey is already a subkey, that gives us 507 remaining parts before an 
-            // exception is thrown.
-            const int maxNestedLevel = 507;
-            string exceedsNestedSubkeyName = string.Join(@"\", Enumerable.Repeat("a", maxNestedLevel));
-            using (RegistryKey k = TestRegistryKey.CreateSubKey(exceedsNestedSubkeyName))
-            {
-                // Verify TestRegistryKey is already nested, with 508 slashes meaning 509 parts
-                Assert.Equal(maxNestedLevel + 1, k.Name.Count(c => c == '\\')); 
-            }
-            Assert.Throws<IOException>(() => TestRegistryKey.CreateSubKey(exceedsNestedSubkeyName + @"\" + maxNestedLevel));
-
             // Should throw if RegistryKey is readonly
             const string name = "FooBar";
             TestRegistryKey.SetValue(name, 42);
@@ -51,6 +39,22 @@ namespace Microsoft.Win32.RegistryTests
                 TestRegistryKey.Dispose();
                 TestRegistryKey.CreateSubKey(TestRegistryKeyName);
             });
+        }
+
+        [Fact(Skip = "This test fails on Win10 Anniversary Update Issue #10546")]
+        public void NegativeTest_DeeplyNestedKey()
+        {
+            // Max number of parts to the registry key path is 509 (failing once it hits 510). 
+            // As TestRegistryKey is already a subkey, that gives us 507 remaining parts before an 
+            // exception is thrown.
+            const int maxNestedLevel = 507;
+            string exceedsNestedSubkeyName = string.Join(@"\", Enumerable.Repeat("a", maxNestedLevel));
+            using (RegistryKey k = TestRegistryKey.CreateSubKey(exceedsNestedSubkeyName))
+            {
+                // Verify TestRegistryKey is already nested, with 508 slashes meaning 509 parts
+                Assert.Equal(maxNestedLevel + 1, k.Name.Count(c => c == '\\'));
+            }
+            Assert.Throws<IOException>(() => TestRegistryKey.CreateSubKey(exceedsNestedSubkeyName + @"\" + maxNestedLevel));
         }
 
         [Fact]

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str_rkpc.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str_rkpc.cs
@@ -49,11 +49,6 @@ namespace Microsoft.Win32.RegistryTests
             const int maxValueNameLength = 255;
             Assert.Throws<ArgumentException>(() => TestRegistryKey.CreateSubKey(new string('a', maxValueNameLength + 1)));
 
-            //According to msdn documentation max nesting level exceeds is 510 but actual is 508
-            const int maxNestedLevel = 508;
-            string exceedsNestedSubkeyName = string.Join(@"\", Enumerable.Repeat("a", maxNestedLevel));
-            Assert.Throws<IOException>(() => TestRegistryKey.CreateSubKey(exceedsNestedSubkeyName, true));
-
             // Should throw if RegistryKey is readonly
             const string name = "FooBar";
             TestRegistryKey.SetValue(name, 42);
@@ -72,6 +67,15 @@ namespace Microsoft.Win32.RegistryTests
                 TestRegistryKey.Dispose();
                 TestRegistryKey.CreateSubKey(TestRegistryKeyName, true);
             });
+        }
+
+        [Fact(Skip = "This test fails on Win10 Anniversary Update Issue #10546")]
+        public void NegativeTest_DeeplyNestedKey()
+        {
+            //According to msdn documentation max nesting level exceeds is 510 but actual is 508
+            const int maxNestedLevel = 508;
+            string exceedsNestedSubkeyName = string.Join(@"\", Enumerable.Repeat("a", maxNestedLevel));
+            Assert.Throws<IOException>(() => TestRegistryKey.CreateSubKey(exceedsNestedSubkeyName, true));
         }
 
         [Fact]

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str_rkpc.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str_rkpc.cs
@@ -69,7 +69,8 @@ namespace Microsoft.Win32.RegistryTests
             });
         }
 
-        [Fact(Skip = "This test fails on Win10 Anniversary Update Issue #10546")]
+        [ActiveIssue(10546)]
+        [Fact]
         public void NegativeTest_DeeplyNestedKey()
         {
             //According to msdn documentation max nesting level exceeds is 510 but actual is 508


### PR DESCRIPTION
Break out sections of registry tests that fail on Win10 Anniversary Update
(RS1). These tests are checking for a Windows limit that has been changed.

See #10546 

@ianhays, @danmosemsft, @joperezr 