### PR TITLE
Fix Zlib-Intel Build Warnings

### DIFF
--- a/src/Native/Windows/clrcompression/zlib-intel/crc_folding.c
+++ b/src/Native/Windows/clrcompression/zlib-intel/crc_folding.c
@@ -284,7 +284,7 @@ ZLIB_INTERNAL void crc_fold_copy(deflate_state *z_const s,
         goto partial;
     }
 
-    algn_diff = 0 - (unsigned long)src & 0xF;
+    algn_diff = (unsigned char*)0 -src & 0xF;
     if (algn_diff) {
         xmm_crc_part = _mm_loadu_si128((__m128i *)src);
         _mm_storeu_si128((__m128i *)dst, xmm_crc_part);
@@ -417,7 +417,7 @@ unsigned ZLIB_INTERNAL crc_fold_512to32(deflate_state *z_const s)
     z_const __m128i xmm_mask2 = _mm_load_si128((__m128i *)crc_mask2);
 
     unsigned crc;
-    __m128i x_tmp0, x_tmp1, x_tmp2, x_tmp3, crc_fold;
+    __m128i x_tmp0, x_tmp1, x_tmp2, crc_fold;
 
     CRC_LOAD(s)
 

--- a/src/Native/Windows/clrcompression/zlib-intel/match.c
+++ b/src/Native/Windows/clrcompression/zlib-intel/match.c
@@ -45,7 +45,7 @@ local unsigned std1_longest_match(deflate_state *z_const s, IPos cur_match)
 	 */
 	best_len = s->prev_length;
 	chain_length = s->max_chain_length;
-	if (best_len >= s->good_match)
+	if ((unsigned)best_len >= s->good_match)
 		chain_length >>= 2;
 
 	/*
@@ -164,7 +164,7 @@ local unsigned std2_longest_match(deflate_state *z_const s, IPos cur_match)
 	 */
 	best_len = s->prev_length;
 	chain_length = s->max_chain_length;
-	if (best_len >= s->good_match)
+	if ((unsigned)best_len >= s->good_match)
 		chain_length >>= 2;
 
 	/*
@@ -309,5 +309,5 @@ local unsigned fastest_longest_match(deflate_state *z_const s, IPos cur_match)
 		return MIN_MATCH-1;
 	
 	s->match_start = cur_match;
-	return len <= s->lookahead ? len : s->lookahead;
+	return (unsigned)len <= s->lookahead ? len : s->lookahead;
 }


### PR DESCRIPTION
Simple fixes that get rid of compile time warnings.

https://github.com/dotnet/corefx/issues/11440