### PR TITLE
Add WebClient to System.Net.Requests

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1316,6 +1316,11 @@
         "4.2.0.0": "4.3.0"
       }
     },
+    "System.Net.WebClient": {
+      "AssemblyVersionInPackageVersion": {
+        "4.0.0.0": "4.3.0"
+      }
+    },
     "System.Net.WebHeaderCollection": {
       "StableVersions": [
         "4.0.0",

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -946,6 +946,13 @@
         ]
     },
     {
+        "Name": "System.Net.WebClient",
+        "Description": "Provides the System.Net.WebClient class, which supports sending data to and receiving data from a resource identified by a URI.",
+        "CommonTypes": [
+            "System.Net.WebClient"
+        ]
+    },
+    {
         "Name": "System.Net.WebHeaderCollection",
         "Description": "Contains types that represent HTTP request and response headers. This library is used with classes such as System.Net.HttpWebRequest and System.Net.HttpWebResponse and allows developers to query/edit header names/values.",
         "CommonTypes": [

--- a/src/Common/src/System/IO/ChunkedMemoryStream.cs
+++ b/src/Common/src/System/IO/ChunkedMemoryStream.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO
+{
+    /// <summary>Provides an in-memory stream composed of non-contiguous chunks.</summary>
+    internal sealed class ChunkedMemoryStream : Stream
+    {
+        private MemoryChunk _headChunk;
+        private MemoryChunk _currentChunk;
+
+        private const int InitialChunkDefaultSize = 1024;
+        private const int MaxChunkSize = 1024 * InitialChunkDefaultSize;
+        private int _totalLength;
+
+        internal ChunkedMemoryStream() { }
+
+        public byte[] ToArray()
+        {
+            byte[] result = new byte[_totalLength];
+            int offset = 0;
+            for (MemoryChunk chunk = _headChunk; chunk != null; chunk = chunk._next)
+            {
+                Debug.Assert(chunk._next == null || chunk._freeOffset == chunk._buffer.Length);
+                Buffer.BlockCopy(chunk._buffer, 0, result, offset, chunk._freeOffset);
+                offset += chunk._freeOffset;
+            }
+            return result;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            while (count > 0)
+            {
+                if (_currentChunk != null)
+                {
+                    int remaining = _currentChunk._buffer.Length - _currentChunk._freeOffset;
+                    if (remaining > 0)
+                    {
+                        int toCopy = Math.Min(remaining, count);
+                        Buffer.BlockCopy(buffer, offset, _currentChunk._buffer, _currentChunk._freeOffset, toCopy);
+                        count -= toCopy;
+                        offset += toCopy;
+                        _totalLength += toCopy;
+                        _currentChunk._freeOffset += toCopy;
+                        continue;
+                    }
+                }
+
+                AppendChunk(count);
+            }
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
+
+            Write(buffer, offset, count);
+            return Task.CompletedTask;
+        }
+
+        private void AppendChunk(long count)
+        {
+            int nextChunkLength = _currentChunk != null ? _currentChunk._buffer.Length * 2 : InitialChunkDefaultSize;
+            if (count > nextChunkLength)
+            {
+                nextChunkLength = (int)Math.Min(count, MaxChunkSize);
+            }
+
+            MemoryChunk newChunk = new MemoryChunk(nextChunkLength);
+
+            if (_currentChunk == null)
+            {
+                Debug.Assert(_headChunk == null);
+                _headChunk = _currentChunk = newChunk;
+            }
+            else
+            {
+                Debug.Assert(_headChunk != null);
+                _currentChunk._next = newChunk;
+                _currentChunk = newChunk;
+            }
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => _totalLength;
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override long Position { get { throw new NotSupportedException(); } set { throw new NotSupportedException(); } }
+        public override int Read(byte[] buffer, int offset, int count) { throw new NotSupportedException(); }
+        public override long Seek(long offset, SeekOrigin origin) { throw new NotSupportedException(); }
+        public override void SetLength(long value)
+        {
+            if (_currentChunk != null) throw new NotSupportedException();
+            AppendChunk(value);
+        }
+
+        private sealed class MemoryChunk
+        {
+            internal readonly byte[] _buffer;
+            internal int _freeOffset;
+            internal MemoryChunk _next;
+
+            internal MemoryChunk(int bufferSize) { _buffer = new byte[bufferSize]; }
+        }
+    }
+
+}

--- a/src/Common/src/System/Threading/Tasks/BeginEndAwaitableAdapter.cs
+++ b/src/Common/src/System/Threading/Tasks/BeginEndAwaitableAdapter.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Threading.Tasks
+{
+    /// <summary>Enables awaiting a Begin/End method pair.</summary>
+    internal sealed class BeginEndAwaitableAdapter : ICriticalNotifyCompletion
+    {
+        private readonly static Action CALLBACK_RAN = () => { };
+        private IAsyncResult _asyncResult;
+        private Action _continuation;
+
+        public readonly static AsyncCallback Callback = asyncResult =>
+        {
+            Debug.Assert(asyncResult != null);
+            Debug.Assert(asyncResult.IsCompleted);
+            Debug.Assert(asyncResult.AsyncState is BeginEndAwaitableAdapter);
+
+            BeginEndAwaitableAdapter adapter = (BeginEndAwaitableAdapter)asyncResult.AsyncState;
+            adapter._asyncResult = asyncResult;
+
+            Action continuation = Interlocked.Exchange(ref adapter._continuation, CALLBACK_RAN);
+            if (continuation != null)
+            {
+                Debug.Assert(continuation != CALLBACK_RAN);
+                continuation();
+            }
+        };
+
+        public BeginEndAwaitableAdapter GetAwaiter() => this;
+
+        public bool IsCompleted => _continuation == CALLBACK_RAN;
+
+        public void UnsafeOnCompleted(Action continuation) => OnCompleted(continuation);
+
+        public void OnCompleted(Action continuation)
+        {
+            if (_continuation == CALLBACK_RAN || Interlocked.CompareExchange(ref _continuation, continuation, null) == CALLBACK_RAN)
+            {
+                Task.Run(continuation);
+            }
+        }
+
+        public IAsyncResult GetResult()
+        {
+            IAsyncResult result = _asyncResult;
+            Debug.Assert(result != null && result.IsCompleted);
+
+            _asyncResult = null;
+            _continuation = null;
+
+            return result;
+        }
+
+    }
+}

--- a/src/System.Net.WebClient/System.Net.WebClient.sln
+++ b/src/System.Net.WebClient/System.Net.WebClient.sln
@@ -1,0 +1,59 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{350C956A-B4ED-4376-9B04-2908528D10FF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.WebClient", "ref\System.Net.WebClient.csproj", "{14FAFC3A-8266-45C7-8604-8C2CB567E50D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827B5CCD-073A-4A75-9661-73D54F0A3528}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.WebClient", "src\System.Net.WebClient.csproj", "{53D09AF4-0C13-4197-B8AD-9746F0374E88}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{096E7AD0-17A2-4EAF-9AC5-2F0FC67A4112}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.WebClient.Tests", "tests\System.Net.WebClient.Tests.csproj", "{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		net46_Debug|Any CPU = net46_Debug|Any CPU
+		net46_Release|Any CPU = net46_Release|Any CPU
+		netstandard1.7_Debug|Any CPU = netstandard1.7_Debug|Any CPU
+		netstandard1.7_Release|Any CPU = netstandard1.7_Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{14FAFC3A-8266-45C7-8604-8C2CB567E50D}.net46_Debug|Any CPU.ActiveCfg = netstandard1.7_Release|Any CPU
+		{14FAFC3A-8266-45C7-8604-8C2CB567E50D}.net46_Debug|Any CPU.Build.0 = netstandard1.7_Release|Any CPU
+		{14FAFC3A-8266-45C7-8604-8C2CB567E50D}.net46_Release|Any CPU.ActiveCfg = netstandard1.7_Release|Any CPU
+		{14FAFC3A-8266-45C7-8604-8C2CB567E50D}.net46_Release|Any CPU.Build.0 = netstandard1.7_Release|Any CPU
+		{14FAFC3A-8266-45C7-8604-8C2CB567E50D}.netstandard1.7_Debug|Any CPU.ActiveCfg = netstandard1.7_Debug|Any CPU
+		{14FAFC3A-8266-45C7-8604-8C2CB567E50D}.netstandard1.7_Debug|Any CPU.Build.0 = netstandard1.7_Debug|Any CPU
+		{14FAFC3A-8266-45C7-8604-8C2CB567E50D}.netstandard1.7_Release|Any CPU.ActiveCfg = netstandard1.7_Release|Any CPU
+		{14FAFC3A-8266-45C7-8604-8C2CB567E50D}.netstandard1.7_Release|Any CPU.Build.0 = netstandard1.7_Release|Any CPU
+		{53D09AF4-0C13-4197-B8AD-9746F0374E88}.net46_Debug|Any CPU.ActiveCfg = net463_Release|Any CPU
+		{53D09AF4-0C13-4197-B8AD-9746F0374E88}.net46_Debug|Any CPU.Build.0 = net463_Release|Any CPU
+		{53D09AF4-0C13-4197-B8AD-9746F0374E88}.net46_Release|Any CPU.ActiveCfg = net463_Release|Any CPU
+		{53D09AF4-0C13-4197-B8AD-9746F0374E88}.net46_Release|Any CPU.Build.0 = net463_Release|Any CPU
+		{53D09AF4-0C13-4197-B8AD-9746F0374E88}.netstandard1.7_Debug|Any CPU.ActiveCfg = netstandard1.7_Debug|Any CPU
+		{53D09AF4-0C13-4197-B8AD-9746F0374E88}.netstandard1.7_Debug|Any CPU.Build.0 = netstandard1.7_Debug|Any CPU
+		{53D09AF4-0C13-4197-B8AD-9746F0374E88}.netstandard1.7_Release|Any CPU.ActiveCfg = netstandard1.7_Release|Any CPU
+		{53D09AF4-0C13-4197-B8AD-9746F0374E88}.netstandard1.7_Release|Any CPU.Build.0 = netstandard1.7_Release|Any CPU
+		{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}.net46_Debug|Any CPU.ActiveCfg = netstandard1.7_Release|Any CPU
+		{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}.net46_Debug|Any CPU.Build.0 = netstandard1.7_Release|Any CPU
+		{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}.net46_Release|Any CPU.ActiveCfg = netstandard1.7_Release|Any CPU
+		{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}.net46_Release|Any CPU.Build.0 = netstandard1.7_Release|Any CPU
+		{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}.netstandard1.7_Debug|Any CPU.ActiveCfg = netstandard1.7_Debug|Any CPU
+		{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}.netstandard1.7_Debug|Any CPU.Build.0 = netstandard1.7_Debug|Any CPU
+		{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}.netstandard1.7_Release|Any CPU.ActiveCfg = netstandard1.7_Release|Any CPU
+		{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}.netstandard1.7_Release|Any CPU.Build.0 = netstandard1.7_Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{14FAFC3A-8266-45C7-8604-8C2CB567E50D} = {350C956A-B4ED-4376-9B04-2908528D10FF}
+		{53D09AF4-0C13-4197-B8AD-9746F0374E88} = {827B5CCD-073A-4A75-9661-73D54F0A3528}
+		{0D1E2954-A5C7-4B8C-932A-31EB4A96A726} = {096E7AD0-17A2-4EAF-9AC5-2F0FC67A4112}
+	EndGlobalSection
+EndGlobal

--- a/src/System.Net.WebClient/dir.props
+++ b/src/System.Net.WebClient/dir.props
@@ -1,0 +1,7 @@
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>
+

--- a/src/System.Net.WebClient/pkg/System.Net.WebClient.builds
+++ b/src/System.Net.WebClient/pkg/System.Net.WebClient.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Net.WebClient.pkgproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Net.WebClient/pkg/System.Net.WebClient.pkgproj
+++ b/src/System.Net.WebClient/pkg/System.Net.WebClient.pkgproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Net.WebClient.csproj">
+      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Net.WebClient.builds" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.WebClient/ref/System.Net.WebClient.cs
+++ b/src/System.Net.WebClient/ref/System.Net.WebClient.cs
@@ -1,0 +1,215 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.Net
+{
+    public class DownloadDataCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    {
+        internal DownloadDataCompletedEventArgs(byte[] result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        public byte[] Result { get { throw null; } }
+    }
+    public delegate void DownloadDataCompletedEventHandler(object sender, System.Net.DownloadDataCompletedEventArgs e);
+    public class DownloadProgressChangedEventArgs : System.ComponentModel.ProgressChangedEventArgs
+    {
+        internal DownloadProgressChangedEventArgs(int progressPercentage, object userToken, long bytesReceived, long totalBytesToReceive) : base(progressPercentage, userToken) { }
+        public long BytesReceived { get { throw null; } }
+        public long TotalBytesToReceive { get { throw null; } }
+    }
+    public delegate void DownloadProgressChangedEventHandler(object sender, System.Net.DownloadProgressChangedEventArgs e);
+    public class DownloadStringCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    {
+        internal DownloadStringCompletedEventArgs(string result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        public string Result { get { throw null; } }
+    }
+    public delegate void DownloadStringCompletedEventHandler(object sender, System.Net.DownloadStringCompletedEventArgs e);
+    public delegate void OpenReadCompletedEventHandler(object sender, System.Net.OpenReadCompletedEventArgs e);
+    public class OpenReadCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    {
+        internal OpenReadCompletedEventArgs(System.IO.Stream result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        public System.IO.Stream Result { get { throw null; } }
+    }
+    public delegate void OpenWriteCompletedEventHandler(object sender, System.Net.OpenWriteCompletedEventArgs e);
+    public class OpenWriteCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    {
+        internal OpenWriteCompletedEventArgs(System.IO.Stream result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        public System.IO.Stream Result { get { throw null; } }
+    }
+    public class UploadDataCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    {
+        internal UploadDataCompletedEventArgs(byte[] result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        public byte[] Result { get { throw null; } }
+    }
+    public delegate void UploadDataCompletedEventHandler(object sender, System.Net.UploadDataCompletedEventArgs e);
+    public class UploadFileCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    {
+        internal UploadFileCompletedEventArgs(byte[] result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        public byte[] Result { get { throw null; } }
+    }
+    public delegate void UploadFileCompletedEventHandler(object sender, System.Net.UploadFileCompletedEventArgs e);
+    public class UploadProgressChangedEventArgs : System.ComponentModel.ProgressChangedEventArgs
+    {
+        internal UploadProgressChangedEventArgs(int progressPercentage, object userToken, long bytesSent, long totalBytesToSend, long bytesReceived, long totalBytesToReceive) : base(progressPercentage, userToken) { }
+        public long BytesReceived { get { throw null; } }
+        public long TotalBytesToReceive { get { throw null; } }
+        public long BytesSent { get { throw null; } }
+        public long TotalBytesToSend { get { throw null; } }
+    }
+    public delegate void UploadProgressChangedEventHandler(object sender, System.Net.UploadProgressChangedEventArgs e);
+    public class UploadStringCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    {
+        internal UploadStringCompletedEventArgs(string result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        public string Result { get { throw null; } }
+    }
+    public delegate void UploadStringCompletedEventHandler(object sender, System.Net.UploadStringCompletedEventArgs e);
+    public class UploadValuesCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    {
+        internal UploadValuesCompletedEventArgs(byte[] result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        public byte[] Result { get { throw null; } }
+    }
+    public delegate void UploadValuesCompletedEventHandler(object sender, System.Net.UploadValuesCompletedEventArgs e);
+    public class WebClient
+    {
+        public WebClient() { }
+        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public bool AllowReadStreamBuffering { get { throw null; } set { } }
+        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public bool AllowWriteStreamBuffering { get { throw null; } set { } }
+        public string BaseAddress { get { throw null; } set { } }
+        //public System.Net.Cache.RequestCachePolicy CachePolicy { get { throw null; } set { } } // TODO: Add back when System.Net.Cache types are available
+        public System.Net.ICredentials Credentials { get { throw null; } set { } }
+        public System.Text.Encoding Encoding { get { throw null; } set { } }
+        public System.Net.WebHeaderCollection Headers { get { throw null; } set { } }
+        public bool IsBusy { get { throw null; } }
+        public System.Net.IWebProxy Proxy { get { throw null; } set { } }
+        public System.Collections.Specialized.NameValueCollection QueryString { get { throw null; } set { } }
+        public System.Net.WebHeaderCollection ResponseHeaders { get { throw null; } }
+        public bool UseDefaultCredentials { get { throw null; } set { } }
+        public event System.Net.DownloadDataCompletedEventHandler DownloadDataCompleted { add { } remove { } }
+        public event System.ComponentModel.AsyncCompletedEventHandler DownloadFileCompleted { add { } remove { } }
+        public event System.Net.DownloadProgressChangedEventHandler DownloadProgressChanged { add { } remove { } }
+        public event System.Net.DownloadStringCompletedEventHandler DownloadStringCompleted { add { } remove { } }
+        public event System.Net.OpenReadCompletedEventHandler OpenReadCompleted { add { } remove { } }
+        public event System.Net.OpenWriteCompletedEventHandler OpenWriteCompleted { add { } remove { } }
+        public event System.Net.UploadDataCompletedEventHandler UploadDataCompleted { add { } remove { } }
+        public event System.Net.UploadFileCompletedEventHandler UploadFileCompleted { add { } remove { } }
+        public event System.Net.UploadProgressChangedEventHandler UploadProgressChanged { add { } remove { } }
+        public event System.Net.UploadStringCompletedEventHandler UploadStringCompleted { add { } remove { } }
+        public event System.Net.UploadValuesCompletedEventHandler UploadValuesCompleted { add { } remove { } }
+        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public event System.Net.WriteStreamClosedEventHandler WriteStreamClosed { add { } remove { } }
+        public void CancelAsync() { }
+        public byte[] DownloadData(string address) { throw null; }
+        public byte[] DownloadData(System.Uri address) { throw null; }
+        public void DownloadDataAsync(System.Uri address) { }
+        public void DownloadDataAsync(System.Uri address, object userToken) { }
+        public System.Threading.Tasks.Task<byte[]> DownloadDataTaskAsync(string address) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> DownloadDataTaskAsync(System.Uri address) { throw null; }
+        public void DownloadFile(string address, string fileName) { }
+        public void DownloadFile(System.Uri address, string fileName) { }
+        public void DownloadFileAsync(System.Uri address, string fileName) { }
+        public void DownloadFileAsync(System.Uri address, string fileName, object userToken) { }
+        public System.Threading.Tasks.Task DownloadFileTaskAsync(string address, string fileName) { throw null; }
+        public System.Threading.Tasks.Task DownloadFileTaskAsync(System.Uri address, string fileName) { throw null; }
+        public string DownloadString(string address) { throw null; }
+        public string DownloadString(System.Uri address) { throw null; }
+        public void DownloadStringAsync(System.Uri address) { }
+        public void DownloadStringAsync(System.Uri address, object userToken) { }
+        public System.Threading.Tasks.Task<string> DownloadStringTaskAsync(string address) { throw null; }
+        public System.Threading.Tasks.Task<string> DownloadStringTaskAsync(System.Uri address) { throw null; }
+        protected virtual System.Net.WebRequest GetWebRequest(System.Uri address) { throw null; }
+        protected virtual System.Net.WebResponse GetWebResponse(System.Net.WebRequest request) { throw null; }
+        protected virtual System.Net.WebResponse GetWebResponse(System.Net.WebRequest request, System.IAsyncResult result) { throw null; }
+        protected virtual void OnDownloadDataCompleted(System.Net.DownloadDataCompletedEventArgs e) { }
+        protected virtual void OnDownloadFileCompleted(System.ComponentModel.AsyncCompletedEventArgs e) { }
+        protected virtual void OnDownloadStringCompleted(System.Net.DownloadStringCompletedEventArgs e) { }
+        protected virtual void OnOpenReadCompleted(System.Net.OpenReadCompletedEventArgs e) { }
+        protected virtual void OnOpenWriteCompleted(System.Net.OpenWriteCompletedEventArgs e) { }
+        protected virtual void OnUploadDataCompleted(System.Net.UploadDataCompletedEventArgs e) { }
+        protected virtual void OnUploadFileCompleted(System.Net.UploadFileCompletedEventArgs e) { }
+        protected virtual void OnUploadStringCompleted(System.Net.UploadStringCompletedEventArgs e) { }
+        protected virtual void OnUploadValuesCompleted(System.Net.UploadValuesCompletedEventArgs e) { }
+        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected virtual void OnWriteStreamClosed(System.Net.WriteStreamClosedEventArgs e) { }
+        public System.IO.Stream OpenRead(string address) { throw null; }
+        public System.IO.Stream OpenRead(System.Uri address) { throw null; }
+        public void OpenReadAsync(System.Uri address) { }
+        public void OpenReadAsync(System.Uri address, object userToken) { }
+        public System.Threading.Tasks.Task<System.IO.Stream> OpenReadTaskAsync(string address) { throw null; }
+        public System.Threading.Tasks.Task<System.IO.Stream> OpenReadTaskAsync(System.Uri address) { throw null; }
+        public System.IO.Stream OpenWrite(string address) { throw null; }
+        public System.IO.Stream OpenWrite(System.Uri address) { throw null; }
+        public System.IO.Stream OpenWrite(string address, string method) { throw null; }
+        public System.IO.Stream OpenWrite(System.Uri address, string method) { throw null; }
+        public void OpenWriteAsync(System.Uri address) { }
+        public void OpenWriteAsync(System.Uri address, string method) { }
+        public void OpenWriteAsync(System.Uri address, string method, object userToken) { }
+        public System.Threading.Tasks.Task<System.IO.Stream> OpenWriteTaskAsync(string address) { throw null; }
+        public System.Threading.Tasks.Task<System.IO.Stream> OpenWriteTaskAsync(System.Uri address) { throw null; }
+        public System.Threading.Tasks.Task<System.IO.Stream> OpenWriteTaskAsync(string address, string method) { throw null; }
+        public System.Threading.Tasks.Task<System.IO.Stream> OpenWriteTaskAsync(System.Uri address, string method) { throw null; }
+        public byte[] UploadData(string address, byte[] data) { throw null; }
+        public byte[] UploadData(System.Uri address, byte[] data) { throw null; }
+        public byte[] UploadData(string address, string method, byte[] data) { throw null; }
+        public byte[] UploadData(System.Uri address, string method, byte[] data) { throw null; }
+        public void UploadDataAsync(System.Uri address, byte[] data) { }
+        public void UploadDataAsync(System.Uri address, string method, byte[] data) { }
+        public void UploadDataAsync(System.Uri address, string method, byte[] data, object userToken) { }
+        public System.Threading.Tasks.Task<byte[]> UploadDataTaskAsync(string address, byte[] data) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadDataTaskAsync(System.Uri address, byte[] data) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadDataTaskAsync(string address, string method, byte[] data) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadDataTaskAsync(System.Uri address, string method, byte[] data) { throw null; }
+        public byte[] UploadFile(string address, string fileName) { throw null; }
+        public byte[] UploadFile(System.Uri address, string fileName) { throw null; }
+        public byte[] UploadFile(string address, string method, string fileName) { throw null; }
+        public byte[] UploadFile(System.Uri address, string method, string fileName) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(string address, string fileName) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(System.Uri address, string fileName) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(string address, string method, string fileName) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(System.Uri address, string method, string fileName) { throw null; }
+        public void UploadFileAsync(System.Uri address, string fileName) { }
+        public void UploadFileAsync(System.Uri address, string method, string fileName) { }
+        public void UploadFileAsync(System.Uri address, string method, string fileName, object userToken) { }
+        public string UploadString(string address, string data) { throw null; }
+        public string UploadString(System.Uri address, string data) { throw null; }
+        public string UploadString(string address, string method, string data) { throw null; }
+        public string UploadString(System.Uri address, string method, string data) { throw null; }
+        public void UploadStringAsync(System.Uri address, string data) { }
+        public void UploadStringAsync(System.Uri address, string method, string data) { }
+        public void UploadStringAsync(System.Uri address, string method, string data, object userToken) { }
+        public System.Threading.Tasks.Task<string> UploadStringTaskAsync(string address, string data) { throw null; }
+        public System.Threading.Tasks.Task<string> UploadStringTaskAsync(System.Uri address, string data) { throw null; }
+        public System.Threading.Tasks.Task<string> UploadStringTaskAsync(string address, string method, string data) { throw null; }
+        public System.Threading.Tasks.Task<string> UploadStringTaskAsync(System.Uri address, string method, string data) { throw null; }
+        public byte[] UploadValues(string address, System.Collections.Specialized.NameValueCollection data) { throw null; }
+        public byte[] UploadValues(System.Uri address, System.Collections.Specialized.NameValueCollection data) { throw null; }
+        public byte[] UploadValues(string address, string method, System.Collections.Specialized.NameValueCollection data) { throw null; }
+        public byte[] UploadValues(System.Uri address, string method, System.Collections.Specialized.NameValueCollection data) { throw null; }
+        public void UploadValuesAsync(System.Uri address, System.Collections.Specialized.NameValueCollection data) { }
+        public void UploadValuesAsync(System.Uri address, string method, System.Collections.Specialized.NameValueCollection data) { }
+        public void UploadValuesAsync(System.Uri address, string method, System.Collections.Specialized.NameValueCollection data, object userToken) { }
+        public System.Threading.Tasks.Task<byte[]> UploadValuesTaskAsync(string address, System.Collections.Specialized.NameValueCollection data) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadValuesTaskAsync(string address, string method, System.Collections.Specialized.NameValueCollection data) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadValuesTaskAsync(System.Uri address, System.Collections.Specialized.NameValueCollection data) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadValuesTaskAsync(System.Uri address, string method, System.Collections.Specialized.NameValueCollection data) { throw null; }
+    }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public class WriteStreamClosedEventArgs : System.EventArgs
+    {
+        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public WriteStreamClosedEventArgs() { }
+        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public System.Exception Error { get { return null; } }
+    }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public delegate void WriteStreamClosedEventHandler(object sender, System.Net.WriteStreamClosedEventArgs e);
+}

--- a/src/System.Net.WebClient/ref/System.Net.WebClient.csproj
+++ b/src/System.Net.WebClient/ref/System.Net.WebClient.csproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System.Net.WebClient.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.WebClient/ref/project.json
+++ b/src/System.Net.WebClient/ref/project.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": {
+    "System.Collections.Specialized": "4.0.0",
+    "System.ComponentModel": "4.0.0",
+    "System.ComponentModel.EventBasedAsync": "4.0.0",
+    "System.IO": "4.0.0",
+    "System.Net.Primitives": "4.0.10",
+    "System.Net.Requests": "4.0.11",
+    "System.Net.WebHeaderCollection": "4.0.0",
+    "System.Runtime": "4.0.0",
+    "System.Text.Encoding": "4.0.0",
+    "System.Threading.Tasks": "4.0.0"
+  },
+  "frameworks": {
+    "netstandard1.7": {
+      "imports": [
+        "dotnet5.8"
+      ]
+    }
+  }
+}

--- a/src/System.Net.WebClient/src/Resources/Strings.resx
+++ b/src/System.Net.WebClient/src/Resources/Strings.resx
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+
+  <data name="net_webclient" xml:space="preserve">
+    <value>An exception occurred during a WebClient request.</value>
+  </data>
+  <data name="net_webclient_ContentType" xml:space="preserve">
+    <value>The Content-Type header cannot be changed from its default value for this request.</value>
+  </data>
+  <data name="net_webclient_Multipart" xml:space="preserve">
+    <value>The Content-Type header cannot be set to a multipart type for this request.</value>
+  </data>
+  <data name="net_webclient_no_concurrent_io_allowed" xml:space="preserve">
+    <value>WebClient does not support concurrent I/O operations.</value>
+  </data>
+  <data name="net_webclient_invalid_baseaddress" xml:space="preserve">
+    <value>The specified value is not a valid base address.</value>
+  </data>
+  <data name="net_webstatus_MessageLengthLimitExceeded" xml:space="preserve">
+    <value>The message length limit was exceeded</value>
+  </data>
+  <data name="net_clsmall" xml:space="preserve">
+    <value>The Content-Length value must be greater than or equal to zero.</value>
+  </data>
+</root>

--- a/src/System.Net.WebClient/src/System.Net.WebClient.builds
+++ b/src/System.Net.WebClient/src/System.Net.WebClient.builds
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Net.WebClient.csproj" />
+    <Project Include="System.Net.WebClient.csproj">
+        <TargetGroup>net463</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Net.WebClient/src/System.Net.WebClient.csproj
+++ b/src/System.Net.WebClient/src/System.Net.WebClient.csproj
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{53D09AF4-0C13-4197-B8AD-9746F0374E88}</ProjectGuid>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net463'">true</IsPartialFacadeAssembly>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
+    <Compile Include="System\Net\WebClient.cs" />
+    <Compile Include="$(CommonPath)\System\IO\DelegatingStream.cs">
+      <Link>Common\System\IO\DelegatingStream.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\ChunkedMemoryStream.cs">
+      <Link>Common\System\IO\ChunkedMemoryStream.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Threading\Tasks\BeginEndAwaitableAdapter.cs">
+      <Link>Common\System\Threading\Tasks\BeginEndAwaitableAdapter.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+      <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
+    <TargetingPackReference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.WebClient/src/System/Net/WebClient.cs
+++ b/src/System.Net.WebClient/src/System/Net/WebClient.cs
@@ -1,0 +1,2124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Security;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net
+{
+    public class WebClient // TODO #11271: Make WebClient inherit from Component once it's available
+    {
+        private const int DefaultCopyBufferLength = 8192;
+        private const int DefaultDownloadBufferLength = 65536;
+        private const string DefaultUploadFileContentType = "application/octet-stream";
+        private const string UploadFileContentType = "multipart/form-data";
+        private const string UploadValuesContentType = "application/x-www-form-urlencoded";
+
+        private Uri _baseAddress;
+        private ICredentials _credentials;
+        private WebHeaderCollection _headers;
+        private NameValueCollection _requestParameters;
+        private WebResponse _webResponse;
+        private WebRequest _webRequest;
+        private Encoding _encoding = Encoding.Default;
+        private string _method;
+        private long _contentLength = -1;
+        private bool _initWebClientAsync;
+        private bool _canceled;
+        private ProgressData _progress;
+        private IWebProxy _proxy;
+        private bool _proxySet;
+        //private RequestCachePolicy _cachePolicy;
+        private int _callNesting; // > 0 if we're in a Read/Write call
+        private AsyncOperation _asyncOp;
+
+        private SendOrPostCallback _downloadDataOperationCompleted;
+        private SendOrPostCallback _openReadOperationCompleted;
+        private SendOrPostCallback _openWriteOperationCompleted;
+        private SendOrPostCallback _downloadStringOperationCompleted;
+        private SendOrPostCallback _downloadFileOperationCompleted;
+        private SendOrPostCallback _uploadStringOperationCompleted;
+        private SendOrPostCallback _uploadDataOperationCompleted;
+        private SendOrPostCallback _uploadFileOperationCompleted;
+        private SendOrPostCallback _uploadValuesOperationCompleted;
+        private SendOrPostCallback _reportDownloadProgressChanged;
+        private SendOrPostCallback _reportUploadProgressChanged;
+
+        public WebClient()
+        {
+            // We don't know if derived types need finalizing, but WebClient doesn't.
+            if (GetType() == typeof(WebClient))
+            {
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        public event DownloadStringCompletedEventHandler DownloadStringCompleted;
+        public event DownloadDataCompletedEventHandler DownloadDataCompleted;
+        public event AsyncCompletedEventHandler DownloadFileCompleted;
+        public event UploadStringCompletedEventHandler UploadStringCompleted;
+        public event UploadDataCompletedEventHandler UploadDataCompleted;
+        public event UploadFileCompletedEventHandler UploadFileCompleted;
+        public event UploadValuesCompletedEventHandler UploadValuesCompleted;
+        public event OpenReadCompletedEventHandler OpenReadCompleted;
+        public event OpenWriteCompletedEventHandler OpenWriteCompleted;
+        public event DownloadProgressChangedEventHandler DownloadProgressChanged;
+        public event UploadProgressChangedEventHandler UploadProgressChanged;
+
+        protected virtual void OnDownloadStringCompleted(DownloadStringCompletedEventArgs e) => DownloadStringCompleted?.Invoke(this, e);
+        protected virtual void OnDownloadDataCompleted(DownloadDataCompletedEventArgs e) => DownloadDataCompleted?.Invoke(this, e);
+        protected virtual void OnDownloadFileCompleted(AsyncCompletedEventArgs e) => DownloadFileCompleted?.Invoke(this, e);
+        protected virtual void OnUploadStringCompleted(UploadStringCompletedEventArgs e) => UploadStringCompleted?.Invoke(this, e);
+        protected virtual void OnUploadDataCompleted(UploadDataCompletedEventArgs e) => UploadDataCompleted?.Invoke(this, e);
+        protected virtual void OnUploadFileCompleted(UploadFileCompletedEventArgs e) => UploadFileCompleted?.Invoke(this, e);
+        protected virtual void OnUploadValuesCompleted(UploadValuesCompletedEventArgs e) => UploadValuesCompleted?.Invoke(this, e);
+        protected virtual void OnOpenReadCompleted(OpenReadCompletedEventArgs e) => OpenReadCompleted?.Invoke(this, e);
+        protected virtual void OnOpenWriteCompleted(OpenWriteCompletedEventArgs e) => OpenWriteCompleted?.Invoke(this, e);
+
+        private void StartOperation()
+        {
+            if (Interlocked.Increment(ref _callNesting) > 1)
+            {
+                EndOperation();
+                throw new NotSupportedException(SR.net_webclient_no_concurrent_io_allowed);
+            }
+
+            _contentLength = -1;
+            _webResponse = null;
+            _webRequest = null;
+            _method = null;
+            _canceled = false;
+
+            _progress?.Reset();
+        }
+
+        private AsyncOperation StartAsyncOperation(object userToken)
+        {
+            if (!_initWebClientAsync)
+            {
+                // Set up the async delegates
+                _openReadOperationCompleted = arg => OnOpenReadCompleted((OpenReadCompletedEventArgs)arg);
+                _openWriteOperationCompleted = arg => OnOpenWriteCompleted((OpenWriteCompletedEventArgs)arg);
+                _downloadStringOperationCompleted = arg => OnDownloadStringCompleted((DownloadStringCompletedEventArgs)arg);
+                _downloadDataOperationCompleted = arg => OnDownloadDataCompleted((DownloadDataCompletedEventArgs)arg);
+                _downloadFileOperationCompleted = arg => OnDownloadFileCompleted((AsyncCompletedEventArgs)arg);
+                _uploadStringOperationCompleted = arg => OnUploadStringCompleted((UploadStringCompletedEventArgs)arg);
+                _uploadDataOperationCompleted = arg => OnUploadDataCompleted((UploadDataCompletedEventArgs)arg);
+                _uploadFileOperationCompleted = arg => OnUploadFileCompleted((UploadFileCompletedEventArgs)arg);
+                _uploadValuesOperationCompleted = arg => OnUploadValuesCompleted((UploadValuesCompletedEventArgs)arg);
+
+                _reportDownloadProgressChanged = arg => DownloadProgressChanged?.Invoke(this, (DownloadProgressChangedEventArgs)arg);
+                _reportUploadProgressChanged = arg => UploadProgressChanged?.Invoke(this, (UploadProgressChangedEventArgs)arg);
+
+                _progress = new ProgressData();
+                _initWebClientAsync = true;
+            }
+
+            AsyncOperation asyncOp = AsyncOperationManager.CreateOperation(userToken);
+
+            StartOperation();
+            _asyncOp = asyncOp;
+
+            return asyncOp;
+        }
+
+        private void EndOperation() => Interlocked.Decrement(ref _callNesting);
+
+        public Encoding Encoding
+        {
+            get { return _encoding; }
+            set
+            {
+                ThrowIfNull(value, nameof(Encoding));
+                _encoding = value;
+            }
+        }
+
+        public string BaseAddress
+        {
+            get { return _baseAddress != null ? _baseAddress.ToString() : string.Empty; }
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    _baseAddress = null;
+                }
+                else
+                {
+                    try
+                    {
+                        _baseAddress = new Uri(value);
+                    }
+                    catch (UriFormatException e)
+                    {
+                        throw new ArgumentException(SR.net_webclient_invalid_baseaddress, nameof(value), e);
+                    }
+                }
+            }
+        }
+
+        public ICredentials Credentials
+        {
+            get { return _credentials; }
+            set { _credentials = value; }
+        }
+
+        public bool UseDefaultCredentials
+        {
+            get { return _credentials == CredentialCache.DefaultCredentials; }
+            set { _credentials = value ? CredentialCache.DefaultCredentials : null; }
+        }
+
+        public WebHeaderCollection Headers
+        {
+            get { return _headers ?? (_headers = new WebHeaderCollection()); }
+            set { _headers = value; }
+        }
+
+        public NameValueCollection QueryString
+        {
+            get { return _requestParameters ?? (_requestParameters = new NameValueCollection()); }
+            set { _requestParameters = value; }
+        }
+
+        public WebHeaderCollection ResponseHeaders => _webResponse?.Headers;
+
+        public IWebProxy Proxy
+        {
+            get { return _proxySet ? _proxy : WebRequest.DefaultWebProxy; }
+            set
+            {
+                _proxy = value;
+                _proxySet = true;
+            }
+        }
+
+        //public RequestCachePolicy CachePolicy
+        //{
+        //    get { return _cachePolicy; }
+        //    set { _cachePolicy = value; }
+        //}
+
+        public bool IsBusy => _asyncOp != null;
+
+        protected virtual WebRequest GetWebRequest(Uri address)
+        {
+            WebRequest request = WebRequest.Create(address);
+            CopyHeadersTo(request);
+
+            if (Credentials != null)
+            {
+                request.Credentials = Credentials;
+            }
+
+            if (_method != null)
+            {
+                request.Method = _method;
+            }
+
+            if (_contentLength != -1)
+            {
+                //request.ContentLength = _contentLength; // TODO #11881: Uncomment once member is available
+            }
+
+            if (_proxySet)
+            {
+                request.Proxy = _proxy;
+            }
+
+            // TODO #11881: Uncomment once member is available
+            //if (_cachePolicy != null)
+            //{
+            //    request.CachePolicy = _cachePolicy;
+            //}
+
+            return request;
+        }
+
+        protected virtual WebResponse GetWebResponse(WebRequest request)
+        {
+            WebResponse response = request.EndGetResponse(request.BeginGetResponse(null, null)); // request.GetResponse(); // TODO #11881: Uncomment once member is available
+            _webResponse = response;
+            return response;
+        }
+
+        protected virtual WebResponse GetWebResponse(WebRequest request, IAsyncResult result)
+        {
+            WebResponse response = request.EndGetResponse(result);
+            _webResponse = response;
+            return response;
+        }
+
+        private async Task<WebResponse> GetWebResponseTaskAsync(WebRequest request)
+        {
+            // We would like to simply await request.GetResponseAsync(), but WebClient exposes
+            // a protected member GetWebResponse(WebRequest, IAsyncResult) that derived instances expect to
+            // be used to get the response, and it needs to be passed the IAsyncResult that was returned
+            // from WebRequest.BeginGetResponse.
+            var awaitable = new BeginEndAwaitableAdapter();
+            IAsyncResult iar = request.BeginGetResponse(BeginEndAwaitableAdapter.Callback, awaitable);
+            return GetWebResponse(request, await awaitable);
+        }
+
+        public byte[] DownloadData(string address) =>
+            DownloadData(GetUri(address));
+
+        public byte[] DownloadData(Uri address)
+        {
+            ThrowIfNull(address, nameof(address));
+
+            StartOperation();
+            try
+            {
+                WebRequest request;
+                return DownloadDataInternal(address, out request);
+            }
+            finally
+            {
+                EndOperation();
+            }
+        }
+
+        private byte[] DownloadDataInternal(Uri address, out WebRequest request)
+        {
+            request = null;
+            try
+            {
+                request = _webRequest = GetWebRequest(GetUri(address));
+                return DownloadBits(request, new ChunkedMemoryStream());
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                AbortRequest(request);
+                if (e is WebException || e is SecurityException) throw;
+                throw new WebException(SR.net_webclient, e);
+            }
+        }
+
+        public void DownloadFile(string address, string fileName) =>
+            DownloadFile(GetUri(address), fileName);
+
+        public void DownloadFile(Uri address, string fileName)
+        {
+            ThrowIfNull(address, nameof(address));
+            ThrowIfNull(fileName, nameof(fileName));
+
+            WebRequest request = null;
+            FileStream fs = null;
+            bool succeeded = false;
+            StartOperation();
+            try
+            {
+                fs = new FileStream(fileName, FileMode.Create, FileAccess.Write);
+                request = _webRequest = GetWebRequest(GetUri(address));
+                DownloadBits(request, fs);
+                succeeded = true;
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                AbortRequest(request);
+                if (e is WebException || e is SecurityException) throw;
+                throw new WebException(SR.net_webclient, e);
+            }
+            finally
+            {
+                if (fs != null)
+                {
+                    fs.Close();
+                    if (!succeeded)
+                    {
+                        File.Delete(fileName);
+                    }
+                }
+                EndOperation();
+            }
+        }
+
+        public Stream OpenRead(string address) =>
+            OpenRead(GetUri(address));
+
+        public Stream OpenRead(Uri address)
+        {
+            ThrowIfNull(address, nameof(address));
+
+            WebRequest request = null;
+            StartOperation();
+            try
+            {
+                request = _webRequest = GetWebRequest(GetUri(address));
+                WebResponse response = _webResponse = GetWebResponse(request);
+                return response.GetResponseStream();
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                AbortRequest(request);
+                if (e is WebException || e is SecurityException) throw;
+                throw new WebException(SR.net_webclient, e);
+            }
+            finally
+            {
+                EndOperation();
+            }
+        }
+
+        public Stream OpenWrite(string address) =>
+            OpenWrite(GetUri(address), null);
+
+        public Stream OpenWrite(Uri address) =>
+            OpenWrite(address, null);
+
+        public Stream OpenWrite(string address, string method) =>
+            OpenWrite(GetUri(address), method);
+
+        public Stream OpenWrite(Uri address, string method)
+        {
+            ThrowIfNull(address, nameof(address));            
+            if (method == null)
+            {
+                method = MapToDefaultMethod(address);
+            }
+
+            WebRequest request = null;
+            StartOperation();
+            try
+            {
+                _method = method;
+                request = _webRequest = GetWebRequest(GetUri(address));
+                return new WebClientWriteStream(
+                    request.EndGetRequestStream(request.BeginGetRequestStream(null, null)), // request.GetRequestStream(); // TODO #11881: Uncomment once member is available
+                    request,
+                    this);
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                AbortRequest(request);
+                if (e is WebException || e is SecurityException) throw;
+                throw new WebException(SR.net_webclient, e);
+            }
+            finally
+            {
+                EndOperation();
+            }
+        }
+
+        public byte[] UploadData(string address, byte[] data) =>
+            UploadData(GetUri(address), null, data);
+
+        public byte[] UploadData(Uri address, byte[] data) =>
+            UploadData(address, null, data);
+
+        public byte[] UploadData(string address, string method, byte[] data) =>
+            UploadData(GetUri(address), method, data);
+
+        public byte[] UploadData(Uri address, string method, byte[] data)
+        {
+            ThrowIfNull(address, nameof(address));
+            ThrowIfNull(data, nameof(data));
+            if (method == null)
+            {
+                method = MapToDefaultMethod(address);
+            }
+
+            StartOperation();
+            try
+            {
+                WebRequest request;
+                return UploadDataInternal(address, method, data, out request);
+            }
+            finally
+            {
+                EndOperation();
+            }
+        }
+
+        private byte[] UploadDataInternal(Uri address, string method, byte[] data, out WebRequest request)
+        {
+            request = null;
+            try
+            {
+                _method = method;
+                _contentLength = data.Length;
+                request = _webRequest = GetWebRequest(GetUri(address));
+                return UploadBits(request, null, data, 0, null, null);
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                AbortRequest(request);
+                if (e is WebException || e is SecurityException) throw;
+                throw new WebException(SR.net_webclient, e);
+            }
+        }
+
+        private void OpenFileInternal(
+            bool needsHeaderAndBoundary, string fileName,
+            ref FileStream fs, ref byte[] buffer, ref byte[] formHeaderBytes, ref byte[] boundaryBytes)
+        {
+            fileName = Path.GetFullPath(fileName);
+
+            WebHeaderCollection headers = Headers;
+            string contentType = headers[HttpKnownHeaderNames.ContentType];
+
+            if (contentType == null)
+            {
+                contentType = DefaultUploadFileContentType;
+            }
+            else if (contentType.StartsWith("multipart/", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new WebException(SR.net_webclient_Multipart);
+            }
+
+            fs = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+
+            int buffSize = DefaultCopyBufferLength;
+            _contentLength = -1;
+
+            if (string.Equals(_method, "POST", StringComparison.Ordinal))
+            {
+                if (needsHeaderAndBoundary)
+                {
+                    string boundary = "---------------------" + DateTime.Now.Ticks.ToString("x", NumberFormatInfo.InvariantInfo);
+
+                    headers[HttpKnownHeaderNames.ContentType] = UploadFileContentType + "; boundary=" + boundary;
+
+                    string formHeader =
+                        "--" + boundary + "\r\n" +
+                        "Content-Disposition: form-data; name=\"file\"; filename=\"" + Path.GetFileName(fileName) + "\"\r\n" + // TODO: Should the filename path be encoded?
+                        "Content-Type: " + contentType + "\r\n" +
+                        "\r\n";
+                    formHeaderBytes = Encoding.UTF8.GetBytes(formHeader);
+                    boundaryBytes = Encoding.ASCII.GetBytes("\r\n--" + boundary + "--\r\n");
+                }
+                else
+                {
+                    formHeaderBytes = Array.Empty<byte>();
+                    boundaryBytes = Array.Empty<byte>();
+                }
+
+                if (fs.CanSeek)
+                {
+                    _contentLength = fs.Length + formHeaderBytes.Length + boundaryBytes.Length;
+                    buffSize = (int)Math.Min(DefaultCopyBufferLength, fs.Length);
+                }
+            }
+            else
+            {
+                headers[HttpKnownHeaderNames.ContentType] = contentType;
+
+                formHeaderBytes = null;
+                boundaryBytes = null;
+
+                if (fs.CanSeek)
+                {
+                    _contentLength = fs.Length;
+                    buffSize = (int)Math.Min(DefaultCopyBufferLength, fs.Length);
+                }
+            }
+
+            buffer = new byte[buffSize];
+        }
+
+        public byte[] UploadFile(string address, string fileName) =>
+            UploadFile(GetUri(address), fileName);
+
+        public byte[] UploadFile(Uri address, string fileName) =>
+            UploadFile(address, null, fileName);
+
+        public byte[] UploadFile(string address, string method, string fileName) =>
+            UploadFile(GetUri(address), method, fileName);
+
+        public byte[] UploadFile(Uri address, string method, string fileName)
+        {
+            ThrowIfNull(address, nameof(address));
+            ThrowIfNull(fileName, nameof(fileName));
+            if (method == null)
+            {
+                method = MapToDefaultMethod(address);
+            }
+
+            FileStream fs = null;
+            WebRequest request = null;
+            StartOperation();
+            try
+            {
+                _method = method;
+                byte[] formHeaderBytes = null, boundaryBytes = null, buffer = null;
+                Uri uri = GetUri(address);
+                bool needsHeaderAndBoundary = (uri.Scheme != Uri.UriSchemeFile);
+                OpenFileInternal(needsHeaderAndBoundary, fileName, ref fs, ref buffer, ref formHeaderBytes, ref boundaryBytes);
+                request = _webRequest = GetWebRequest(uri);
+                return UploadBits(request, fs, buffer, 0, formHeaderBytes, boundaryBytes);
+            }
+            catch (Exception e)
+            {
+                fs?.Close();
+                if (e is OutOfMemoryException) throw;
+                AbortRequest(request);
+                if (e is WebException || e is SecurityException) throw;
+                throw new WebException(SR.net_webclient, e);
+            }
+            finally
+            {
+                EndOperation();
+            }
+        }
+
+        private byte[] GetValuesToUpload(NameValueCollection data)
+        {
+            WebHeaderCollection headers = Headers;
+
+            string contentType = headers[HttpKnownHeaderNames.ContentType];
+            if (contentType != null && !string.Equals(contentType, UploadValuesContentType, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new WebException(SR.net_webclient_ContentType);
+            }
+
+            headers[HttpKnownHeaderNames.ContentType] = UploadValuesContentType;
+
+            string delimiter = string.Empty;
+            var values = new StringBuilder();
+            foreach (string name in data.AllKeys)
+            {
+                values.Append(delimiter);
+                values.Append(WebUtility.UrlEncode(name));
+                values.Append('=');
+                values.Append(WebUtility.UrlEncode(data[name]));
+                delimiter = "&";
+            }
+
+            byte[] buffer = Encoding.ASCII.GetBytes(values.ToString());
+            _contentLength = buffer.Length;
+            return buffer;
+        }
+
+        public byte[] UploadValues(string address, NameValueCollection data) =>
+            UploadValues(GetUri(address), null, data);
+
+        public byte[] UploadValues(Uri address, NameValueCollection data) =>
+            UploadValues(address, null, data);
+
+        public byte[] UploadValues(string address, string method, NameValueCollection data) =>
+            UploadValues(GetUri(address), method, data);
+
+        public byte[] UploadValues(Uri address, string method, NameValueCollection data)
+        {
+            ThrowIfNull(address, nameof(address));
+            ThrowIfNull(data, nameof(data));
+            if (method == null)
+            {
+                method = MapToDefaultMethod(address);
+            }
+
+            WebRequest request = null;
+            StartOperation();
+            try
+            {
+                byte[] buffer = GetValuesToUpload(data);
+                _method = method;
+                request = _webRequest = GetWebRequest(GetUri(address));
+                return UploadBits(request, null, buffer, 0, null, null);
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                AbortRequest(request);
+                if (e is WebException || e is SecurityException) throw;
+                throw new WebException(SR.net_webclient, e);
+            }
+            finally
+            {
+                EndOperation();
+            }
+        }
+
+        public string UploadString(string address, string data) =>
+            UploadString(GetUri(address), null, data);
+
+        public string UploadString(Uri address, string data) =>
+            UploadString(address, null, data);
+
+        public string UploadString(string address, string method, string data) =>
+            UploadString(GetUri(address), method, data);
+
+        public string UploadString(Uri address, string method, string data)
+        {
+            ThrowIfNull(address, nameof(address));
+            ThrowIfNull(data, nameof(data));
+            if (method == null)
+            {
+                method = MapToDefaultMethod(address);
+            }
+
+            StartOperation();
+            try
+            {
+                WebRequest request;
+                byte[] requestData = Encoding.GetBytes(data);
+                byte[] responseData = UploadDataInternal(address, method, requestData, out request);
+                return GetStringUsingEncoding(request, responseData);
+            }
+            finally
+            {
+                EndOperation();
+            }
+        }
+
+        public string DownloadString(string address) =>
+            DownloadString(GetUri(address));
+
+        public string DownloadString(Uri address)
+        {
+            ThrowIfNull(address, nameof(address));
+
+            StartOperation();
+            try
+            {
+                WebRequest request;
+                byte[] data = DownloadDataInternal(address, out request);
+                return GetStringUsingEncoding(request, data);
+            }
+            finally
+            {
+                EndOperation();
+            }
+        }
+
+        private static void AbortRequest(WebRequest request)
+        {
+            try { request?.Abort(); }
+            catch (Exception exception) when (!(exception is OutOfMemoryException)) { }
+        }
+
+        private void CopyHeadersTo(WebRequest request)
+        {
+            if (_headers == null)
+            {
+                return;
+            }
+
+            var hwr = request as HttpWebRequest;
+            if (hwr == null)
+            {
+                return;
+            }
+
+            string accept = _headers[HttpKnownHeaderNames.Accept];
+            string connection = _headers[HttpKnownHeaderNames.Connection];
+            string contentType = _headers[HttpKnownHeaderNames.ContentType];
+            string expect = _headers[HttpKnownHeaderNames.Expect];
+            string referrer = _headers[HttpKnownHeaderNames.Referer];
+            string userAgent = _headers[HttpKnownHeaderNames.UserAgent];
+            string host = _headers[HttpKnownHeaderNames.Host];
+
+            _headers.Remove(HttpKnownHeaderNames.Accept);
+            _headers.Remove(HttpKnownHeaderNames.Connection);
+            _headers.Remove(HttpKnownHeaderNames.ContentType);
+            _headers.Remove(HttpKnownHeaderNames.Expect);
+            _headers.Remove(HttpKnownHeaderNames.Referer);
+            _headers.Remove(HttpKnownHeaderNames.UserAgent);
+            _headers.Remove(HttpKnownHeaderNames.Host);
+
+            request.Headers = _headers;
+
+            if (!string.IsNullOrEmpty(accept))
+            {
+                hwr.Accept = accept;
+            }
+
+            if (!string.IsNullOrEmpty(connection))
+            {
+                //hwr.Connection = connection; // TODO #11881: Uncomment once member is available
+            }
+
+            if (!string.IsNullOrEmpty(contentType))
+            {
+                hwr.ContentType = contentType;
+            }
+
+            if (!string.IsNullOrEmpty(expect))
+            {
+                //hwr.Expect = expect; // TODO #11881: Uncomment once member is available
+            }
+
+            if (!string.IsNullOrEmpty(referrer))
+            {
+                //hwr.Referer = referrer; // TODO #11881: Uncomment once member is available
+            }
+
+            if (!string.IsNullOrEmpty(userAgent))
+            {
+                //hwr.UserAgent = userAgent; // TODO #11881: Uncomment once member is available
+            }
+
+            if (!string.IsNullOrEmpty(host))
+            {
+                //hwr.Host = host; // TODO #11881: Uncomment once member is available
+            }
+        }
+
+        private Uri GetUri(string address)
+        {
+            ThrowIfNull(address, nameof(address));
+
+            Uri uri;
+            if (_baseAddress != null)
+            {
+                if (!Uri.TryCreate(_baseAddress, address, out uri))
+                {
+                    return new Uri(Path.GetFullPath(address));
+                }
+            }
+            else if (!Uri.TryCreate(address, UriKind.Absolute, out uri))
+            {
+                return new Uri(Path.GetFullPath(address));
+            }
+
+            return GetUri(uri);
+        }
+
+        private Uri GetUri(Uri address)
+        {
+            ThrowIfNull(address, nameof(address));
+
+            Uri uri = address;
+
+            if (!address.IsAbsoluteUri && _baseAddress != null && !Uri.TryCreate(_baseAddress, address, out uri))
+            {
+                return address;
+            }
+
+            if (string.IsNullOrEmpty(uri.Query) && _requestParameters != null)
+            {
+                var sb = new StringBuilder();
+
+                string delimiter = string.Empty;
+                for (int i = 0; i < _requestParameters.Count; ++i)
+                {
+                    sb.Append(delimiter).Append(_requestParameters.AllKeys[i]).Append('=').Append(_requestParameters[i]);
+                    delimiter = "&";
+                }
+
+                uri = new UriBuilder(uri) { Query = sb.ToString() }.Uri;
+            }
+
+            return uri;
+        }
+
+        private byte[] DownloadBits(WebRequest request, Stream writeStream)
+        {
+            try
+            {
+                WebResponse response = _webResponse = GetWebResponse(request);
+
+                long contentLength = response.ContentLength;
+                byte[] copyBuffer = new byte[contentLength == -1 || contentLength > DefaultDownloadBufferLength ? DefaultDownloadBufferLength : contentLength];
+
+                if (writeStream is ChunkedMemoryStream)
+                {
+                    if (contentLength > int.MaxValue)
+                    {
+                        throw new WebException(SR.net_webstatus_MessageLengthLimitExceeded, WebExceptionStatus.MessageLengthLimitExceeded);
+                    }
+                    writeStream.SetLength(copyBuffer.Length);
+                }
+
+                using (Stream readStream = response.GetResponseStream())
+                {
+                    if (readStream != null)
+                    {
+                        int bytesRead;
+                        while ((bytesRead = readStream.Read(copyBuffer, 0, copyBuffer.Length)) != 0)
+                        {
+                            writeStream.Write(copyBuffer, 0, bytesRead);
+                        }
+                    }
+                }
+
+                return (writeStream as ChunkedMemoryStream)?.ToArray();
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                writeStream?.Close();
+                AbortRequest(request);
+                if (e is WebException || e is SecurityException) throw;
+                throw new WebException(SR.net_webclient, e);
+            }
+        }
+
+        private async void DownloadBitsAsync(
+            WebRequest request, Stream writeStream,
+            AsyncOperation asyncOp, Action<byte[], Exception, AsyncOperation> completionDelegate)
+        {
+            Debug.Assert(_progress != null, "ProgressData should have been initialized");
+            Debug.Assert(asyncOp != null);
+
+            Exception exception = null;
+            try
+            {
+                WebResponse response = _webResponse = await GetWebResponseTaskAsync(request).ConfigureAwait(false);
+
+                long contentLength = response.ContentLength;
+                byte[] copyBuffer = new byte[contentLength == -1 || contentLength > DefaultDownloadBufferLength ? DefaultDownloadBufferLength : contentLength];
+
+                if (writeStream is ChunkedMemoryStream)
+                {
+                    if (contentLength > int.MaxValue)
+                    {
+                        throw new WebException(SR.net_webstatus_MessageLengthLimitExceeded, WebExceptionStatus.MessageLengthLimitExceeded);
+                    }
+                    writeStream.SetLength(copyBuffer.Length);
+                }
+
+                using (writeStream)
+                using (Stream readStream = response.GetResponseStream())
+                {
+                    if (readStream != null)
+                    {
+                        while (true)
+                        {
+                            int bytesRead = await readStream.ReadAsync(copyBuffer, 0, copyBuffer.Length).ConfigureAwait(false);
+                            if (bytesRead == 0)
+                            {
+                                break;
+                            }
+
+                            _progress.BytesReceived += bytesRead;
+                            if (_progress.BytesReceived != _progress.TotalBytesToReceive)
+                            {
+                                PostProgressChanged(asyncOp, _progress);
+                            }
+
+                            await writeStream.WriteAsync(copyBuffer, 0, bytesRead).ConfigureAwait(false);
+                        }
+                    }
+
+                    if (_progress.TotalBytesToReceive < 0)
+                    {
+                        _progress.TotalBytesToReceive = _progress.BytesReceived;
+                    }
+                    PostProgressChanged(asyncOp, _progress);
+                }
+
+                completionDelegate((writeStream as ChunkedMemoryStream)?.ToArray(), null, asyncOp);
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                exception = GetExceptionToPropagate(e);
+                AbortRequest(request);
+                writeStream?.Close();
+            }
+            finally
+            {
+                if (exception != null)
+                {
+                    completionDelegate(null, exception, asyncOp);
+                }
+            }
+        }
+
+        private byte[] UploadBits(
+            WebRequest request, Stream readStream, byte[] buffer, int chunkSize,
+            byte[] header, byte[] footer)
+        {
+            try
+            {
+                if (request.RequestUri.Scheme == Uri.UriSchemeFile)
+                {
+                    header = footer = null;
+                }
+
+                using (Stream writeStream = request.EndGetRequestStream(request.BeginGetRequestStream(null, null))) // request.GetRequestStream() // TODO #11881: Uncomment once member is available
+                {
+                    if (header != null)
+                    {
+                        writeStream.Write(header, 0, header.Length);
+                    }
+
+                    if (readStream != null)
+                    {
+                        using (readStream)
+                        {
+                            while (true)
+                            {
+                                int bytesRead = readStream.Read(buffer, 0, buffer.Length);
+                                if (bytesRead <= 0) break;
+                                writeStream.Write(buffer, 0, bytesRead);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        for (int pos = 0; pos < buffer.Length;)
+                        {
+                            int toWrite = buffer.Length - pos;
+                            if (chunkSize != 0 && toWrite > chunkSize)
+                            {
+                                toWrite = chunkSize;
+                            }
+                            writeStream.Write(buffer, pos, toWrite);
+                            pos += toWrite;
+                        }
+                    }
+
+                    if (footer != null)
+                    {
+                        writeStream.Write(footer, 0, footer.Length);
+                    }
+                }
+
+                return DownloadBits(request, new ChunkedMemoryStream());
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                AbortRequest(request);
+                if (e is WebException || e is SecurityException) throw;
+                throw new WebException(SR.net_webclient, e);
+            }
+        }
+
+        private async void UploadBitsAsync(
+            WebRequest request, Stream readStream, byte[] buffer, int chunkSize,
+            byte[] header, byte[] footer,
+            AsyncOperation asyncOp, Action<byte[], Exception, AsyncOperation> completionDelegate)
+        {
+            Debug.Assert(asyncOp != null);
+            Debug.Assert(_progress != null, "ProgressData should have been initialized");
+            _progress.HasUploadPhase = true;
+
+            Exception exception = null;
+            try
+            {
+                if (request.RequestUri.Scheme == Uri.UriSchemeFile)
+                {
+                    header = footer = null;
+                }
+
+                using (Stream writeStream = await request.GetRequestStreamAsync().ConfigureAwait(false))
+                {
+                    if (header != null)
+                    {
+                        await writeStream.WriteAsync(header, 0, header.Length).ConfigureAwait(false);
+                        _progress.BytesSent += header.Length;
+                        PostProgressChanged(asyncOp, _progress);
+                    }
+
+                    if (readStream != null)
+                    {
+                        using (readStream)
+                        {
+                            while (true)
+                            {
+                                int bytesRead = await readStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+                                if (bytesRead <= 0) break;
+                                await writeStream.WriteAsync(buffer, 0, bytesRead).ConfigureAwait(false);
+
+                                _progress.BytesSent += bytesRead;
+                                PostProgressChanged(asyncOp, _progress);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        for (int pos = 0; pos < buffer.Length;)
+                        {
+                            int toWrite = buffer.Length - pos;
+                            if (chunkSize != 0 && toWrite > chunkSize)
+                            {
+                                toWrite = chunkSize;
+                            }
+                            await writeStream.WriteAsync(buffer, pos, toWrite).ConfigureAwait(false);
+                            pos += toWrite;
+                            _progress.BytesSent += toWrite;
+                            PostProgressChanged(asyncOp, _progress);
+                        }
+                    }
+
+                    if (footer != null)
+                    {
+                        await writeStream.WriteAsync(footer, 0, footer.Length).ConfigureAwait(false);
+                        _progress.BytesSent += footer.Length;
+                        PostProgressChanged(asyncOp, _progress);
+                    }
+                }
+
+                DownloadBitsAsync(request, new ChunkedMemoryStream(), asyncOp, completionDelegate);
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                exception = GetExceptionToPropagate(e);
+                AbortRequest(request);
+            }
+            finally
+            {
+                if (exception != null)
+                {
+                    completionDelegate(null, exception, asyncOp);
+                }
+            }
+        }
+
+        private static bool ByteArrayHasPrefix(byte[] prefix, byte[] byteArray)
+        {
+            if (prefix == null || byteArray == null || prefix.Length > byteArray.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < prefix.Length; i++)
+            {
+                if (prefix[i] != byteArray[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static readonly char[] s_parseContentTypeSeparators = new char[] { ';', '=', ' ' };
+        private static readonly Encoding[] s_knownEncodings = { Encoding.UTF8, Encoding.UTF32, Encoding.Unicode, Encoding.BigEndianUnicode };
+
+        private string GetStringUsingEncoding(WebRequest request, byte[] data)
+        {
+            Encoding enc = null;
+            int bomLengthInData = -1;
+
+            // Figure out encoding by first checking for encoding string in Content-Type HTTP header
+            // This can throw NotImplementedException if the derived class of WebRequest doesn't support it.
+            string contentType;
+            try
+            {
+                contentType = request.ContentType;
+            }
+            catch (Exception e) when (e is NotImplementedException || e is NotSupportedException) // some types do this
+            {
+                contentType = null;
+            }
+
+            if (contentType != null)
+            {
+                contentType = contentType.ToLower(CultureInfo.InvariantCulture);
+                string[] parsedList = contentType.Split(s_parseContentTypeSeparators);
+                bool nextItem = false;
+                foreach (string item in parsedList)
+                {
+                    if (item == "charset")
+                    {
+                        nextItem = true;
+                    }
+                    else if (nextItem)
+                    {
+                        try
+                        {
+                            enc = Encoding.GetEncoding(item);
+                        }
+                        catch (ArgumentException)
+                        {
+                            // Eat ArgumentException here.    
+                            // We'll assume that Content-Type encoding might have been garbled and wasn't present at all.
+                            break;
+                        }
+                        // Unexpected exceptions are thrown back to caller
+                    }
+                }
+            }
+
+            // If no content encoding listed in the ContentType HTTP header, or no Content-Type header present, then
+            // check for a byte-order-mark (BOM) in the data to figure out encoding.
+            if (enc == null)
+            {
+                // UTF32 must be tested before Unicode because it's BOM is the same but longer.
+                Encoding[] encodings = s_knownEncodings;
+                for (int i = 0; i < encodings.Length; i++)
+                {
+                    byte[] preamble = encodings[i].GetPreamble();
+                    if (ByteArrayHasPrefix(preamble, data))
+                    {
+                        enc = encodings[i];
+                        bomLengthInData = preamble.Length;
+                        break;
+                    }
+                }
+            }
+
+            // Do we have an encoding guess?  If not, use default.
+            if (enc == null)
+            {
+                enc = Encoding;
+            }
+
+            // Calculate BOM length based on encoding guess.  Then check for it in the data.
+            if (bomLengthInData == -1)
+            {
+                byte[] preamble = enc.GetPreamble();
+                bomLengthInData = ByteArrayHasPrefix(preamble, data) ? preamble.Length : 0;
+            }
+
+            // Convert byte array to string stripping off any BOM before calling Format().
+            // This is required since Format() doesn't handle stripping off BOM.
+            return enc.GetString(data, bomLengthInData, data.Length - bomLengthInData);
+        }
+
+        private string MapToDefaultMethod(Uri address)
+        {
+            Uri uri = !address.IsAbsoluteUri && _baseAddress != null ?
+                new Uri(_baseAddress, address) :
+                address;
+
+            return string.Equals(uri.Scheme, Uri.UriSchemeFtp, StringComparison.Ordinal) ?
+                "STOR" :
+                "POST";
+        }
+
+        private void InvokeOperationCompleted(AsyncOperation asyncOp, SendOrPostCallback callback, AsyncCompletedEventArgs eventArgs)
+        {
+            if (Interlocked.CompareExchange(ref _asyncOp, null, asyncOp) == asyncOp)
+            {
+                EndOperation();
+                asyncOp.PostOperationCompleted(callback, eventArgs);
+            }
+        }
+
+        public void OpenReadAsync(Uri address) =>
+            OpenReadAsync(address, null);
+
+        public void OpenReadAsync(Uri address, object userToken)
+        {
+            ThrowIfNull(address, nameof(address));
+
+            AsyncOperation asyncOp = StartAsyncOperation(userToken);
+            try
+            {
+                WebRequest request = _webRequest = GetWebRequest(GetUri(address));
+                request.BeginGetResponse(iar =>
+                {
+                    Stream stream = null;
+                    Exception exception = null;
+                    try
+                    {
+                        WebResponse response = _webResponse = GetWebResponse(request, iar);
+                        stream = response.GetResponseStream();
+                    }
+                    catch (Exception e) when (!(e is OutOfMemoryException))
+                    {
+                        exception = GetExceptionToPropagate(e);
+                    }
+
+                    InvokeOperationCompleted(asyncOp, _openReadOperationCompleted, new OpenReadCompletedEventArgs(stream, exception, _canceled, asyncOp.UserSuppliedState));
+                }, null);
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                InvokeOperationCompleted(asyncOp, _openReadOperationCompleted,
+                    new OpenReadCompletedEventArgs(null, GetExceptionToPropagate(e), _canceled, asyncOp.UserSuppliedState));
+            }
+        }
+
+        public void OpenWriteAsync(Uri address) =>
+            OpenWriteAsync(address, null, null);
+
+        public void OpenWriteAsync(Uri address, string method) =>
+            OpenWriteAsync(address, method, null);
+
+        public void OpenWriteAsync(Uri address, string method, object userToken)
+        {
+            ThrowIfNull(address, nameof(address));
+            if (method == null)
+            {
+                method = MapToDefaultMethod(address);
+            }
+
+            AsyncOperation asyncOp = StartAsyncOperation(userToken);
+            try
+            {
+                _method = method;
+                WebRequest request = _webRequest = GetWebRequest(GetUri(address));
+                request.BeginGetRequestStream(iar =>
+                {
+                    WebClientWriteStream stream = null;
+                    Exception exception = null;
+
+                    try
+                    {
+                        stream = new WebClientWriteStream(request.EndGetRequestStream(iar), request, this);
+                    }
+                    catch (Exception e) when (!(e is OutOfMemoryException))
+                    {
+                        exception = GetExceptionToPropagate(e);
+                    }
+
+                    InvokeOperationCompleted(asyncOp, _openWriteOperationCompleted, new OpenWriteCompletedEventArgs(stream, exception, _canceled, asyncOp.UserSuppliedState));
+                }, null);
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                var eventArgs = new OpenWriteCompletedEventArgs(null, GetExceptionToPropagate(e), _canceled, asyncOp.UserSuppliedState);
+                InvokeOperationCompleted(asyncOp, _openWriteOperationCompleted, eventArgs);
+            }
+        }
+
+        private void DownloadStringAsyncCallback(byte[] returnBytes, Exception exception, Object state)
+        {
+            AsyncOperation asyncOp = (AsyncOperation)state;
+            string stringData = null;
+            try
+            {
+                if (returnBytes != null)
+                {
+                    stringData = GetStringUsingEncoding(_webRequest, returnBytes);
+                }
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                exception = GetExceptionToPropagate(e);
+            }
+
+            var eventArgs = new DownloadStringCompletedEventArgs(stringData, exception, _canceled, asyncOp.UserSuppliedState);
+            InvokeOperationCompleted(asyncOp, _downloadStringOperationCompleted, eventArgs);
+        }
+
+
+        public void DownloadStringAsync(Uri address) =>
+            DownloadStringAsync(address, null);
+
+        public void DownloadStringAsync(Uri address, object userToken)
+        {
+            ThrowIfNull(address, nameof(address));
+
+            AsyncOperation asyncOp = StartAsyncOperation(userToken);
+            try
+            {
+                WebRequest request = _webRequest = GetWebRequest(GetUri(address));
+                DownloadBitsAsync(request, new ChunkedMemoryStream(), asyncOp, DownloadStringAsyncCallback);
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                DownloadStringAsyncCallback(null, GetExceptionToPropagate(e), asyncOp);
+            }
+        }
+
+        private void DownloadDataAsyncCallback(byte[] returnBytes, Exception exception, Object state)
+        {
+            AsyncOperation asyncOp = (AsyncOperation)state;
+            DownloadDataCompletedEventArgs eventArgs = new DownloadDataCompletedEventArgs(returnBytes, exception, _canceled, asyncOp.UserSuppliedState);
+            InvokeOperationCompleted(asyncOp, _downloadDataOperationCompleted, eventArgs);
+        }
+
+        public void DownloadDataAsync(Uri address) =>
+            DownloadDataAsync(address, null);
+
+        public void DownloadDataAsync(Uri address, object userToken)
+        {
+            ThrowIfNull(address, nameof(address));
+
+            AsyncOperation asyncOp = StartAsyncOperation(userToken);
+            try
+            {
+                WebRequest request = _webRequest = GetWebRequest(GetUri(address));
+                DownloadBitsAsync(request, new ChunkedMemoryStream(), asyncOp, DownloadDataAsyncCallback);
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                DownloadDataAsyncCallback(null, GetExceptionToPropagate(e), asyncOp);
+            }
+        }
+
+        private void DownloadFileAsyncCallback(byte[] returnBytes, Exception exception, Object state)
+        {
+            AsyncOperation asyncOp = (AsyncOperation)state;
+            AsyncCompletedEventArgs eventArgs = new AsyncCompletedEventArgs(exception, _canceled, asyncOp.UserSuppliedState);
+            InvokeOperationCompleted(asyncOp, _downloadFileOperationCompleted, eventArgs);
+        }
+
+        public void DownloadFileAsync(Uri address, string fileName) =>
+            DownloadFileAsync(address, fileName, null);
+
+        public void DownloadFileAsync(Uri address, string fileName, object userToken)
+        {
+            ThrowIfNull(address, nameof(address));
+            ThrowIfNull(fileName, nameof(fileName));
+
+            FileStream fs = null;
+            AsyncOperation asyncOp = StartAsyncOperation(userToken);
+            try
+            {
+                fs = new FileStream(fileName, FileMode.Create, FileAccess.Write);
+                WebRequest request = _webRequest = GetWebRequest(GetUri(address));
+                DownloadBitsAsync(request, fs, asyncOp, DownloadFileAsyncCallback);
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                fs?.Close();
+                DownloadFileAsyncCallback(null, GetExceptionToPropagate(e), asyncOp);
+            }
+        }
+
+        public void UploadStringAsync(Uri address, string data) =>
+            UploadStringAsync(address, null, data, null);
+
+        public void UploadStringAsync(Uri address, string method, string data) =>
+            UploadStringAsync(address, method, data, null);
+
+        public void UploadStringAsync(Uri address, string method, string data, object userToken)
+        {
+            ThrowIfNull(address, nameof(address));
+            ThrowIfNull(data, nameof(data));
+            if (method == null)
+            {
+                method = MapToDefaultMethod(address);
+            }
+
+            AsyncOperation asyncOp = StartAsyncOperation(userToken);
+            try
+            {
+                byte[] requestData = Encoding.GetBytes(data);
+                _method = method;
+                _contentLength = requestData.Length;
+                WebRequest request = _webRequest = GetWebRequest(GetUri(address));
+
+                UploadBitsAsync(
+                    request, null, requestData, 0, null, null, asyncOp,
+                    (bytesResult, error, uploadAsyncOp) =>
+                    {
+                        string stringResult = null;
+                        if (error == null && bytesResult != null)
+                        {
+                            try
+                            {
+                                stringResult = GetStringUsingEncoding(_webRequest, bytesResult);
+                            }
+                            catch (Exception e) when (!(e is OutOfMemoryException))
+                            {
+                                error = GetExceptionToPropagate(e);
+                            }
+                        }
+
+                        InvokeOperationCompleted(uploadAsyncOp, _uploadStringOperationCompleted,
+                            new UploadStringCompletedEventArgs(stringResult, error, _canceled, uploadAsyncOp.UserSuppliedState));
+                    });
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                var eventArgs = new UploadStringCompletedEventArgs(null, GetExceptionToPropagate(e), _canceled, asyncOp.UserSuppliedState);
+                InvokeOperationCompleted(asyncOp, _uploadStringOperationCompleted, eventArgs);
+            }
+        }
+
+        public void UploadDataAsync(Uri address, byte[] data) =>
+            UploadDataAsync(address, null, data, null);
+
+        public void UploadDataAsync(Uri address, string method, byte[] data) =>
+            UploadDataAsync(address, method, data, null);
+
+        public void UploadDataAsync(Uri address, string method, byte[] data, object userToken)
+        {
+            ThrowIfNull(address, nameof(address));
+            ThrowIfNull(data, nameof(data));
+            if (method == null)
+            {
+                method = MapToDefaultMethod(address);
+            }
+
+            AsyncOperation asyncOp = StartAsyncOperation(userToken);
+            try
+            {
+                _method = method;
+                _contentLength = data.Length;
+                WebRequest request = _webRequest = GetWebRequest(GetUri(address));
+
+                int chunkSize = 0;
+                if (UploadProgressChanged != null)
+                {
+                    // If ProgressCallback is requested, we should send the buffer in chunks
+                    chunkSize = (int)Math.Min((long)DefaultCopyBufferLength, data.Length);
+                }
+
+                UploadBitsAsync(
+                    request, null, data, chunkSize, null, null, asyncOp,
+                    (result, error, uploadAsyncOp) =>
+                        InvokeOperationCompleted(asyncOp, _uploadDataOperationCompleted, new UploadDataCompletedEventArgs(result, error, _canceled, uploadAsyncOp.UserSuppliedState)));
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                var eventArgs = new UploadDataCompletedEventArgs(null, GetExceptionToPropagate(e), _canceled, asyncOp.UserSuppliedState);
+                InvokeOperationCompleted(asyncOp, _uploadDataOperationCompleted, eventArgs);
+            }
+        }
+
+        public void UploadFileAsync(Uri address, string fileName) =>
+            UploadFileAsync(address, null, fileName, null);
+
+        public void UploadFileAsync(Uri address, string method, string fileName) =>
+            UploadFileAsync(address, method, fileName, null);
+
+        public void UploadFileAsync(Uri address, string method, string fileName, object userToken)
+        {
+            ThrowIfNull(address, nameof(address));
+            ThrowIfNull(fileName, nameof(fileName));
+            if (method == null)
+            {
+                method = MapToDefaultMethod(address);
+            }
+
+            FileStream fs = null;
+            AsyncOperation asyncOp = StartAsyncOperation(userToken);
+            try
+            {
+                _method = method;
+                byte[] formHeaderBytes = null, boundaryBytes = null, buffer = null;
+                Uri uri = GetUri(address);
+                bool needsHeaderAndBoundary = (uri.Scheme != Uri.UriSchemeFile);
+                OpenFileInternal(needsHeaderAndBoundary, fileName, ref fs, ref buffer, ref formHeaderBytes, ref boundaryBytes);
+                WebRequest request = _webRequest = GetWebRequest(uri);
+
+                UploadBitsAsync(
+                    request, fs, buffer, 0, formHeaderBytes, boundaryBytes, asyncOp,
+                    (result, error, uploadAsyncOp) =>
+                        InvokeOperationCompleted(asyncOp, _uploadFileOperationCompleted, new UploadFileCompletedEventArgs(result, error, _canceled, uploadAsyncOp.UserSuppliedState)));
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                fs?.Close();
+                var eventArgs = new UploadFileCompletedEventArgs(null, GetExceptionToPropagate(e), _canceled, asyncOp.UserSuppliedState);
+                InvokeOperationCompleted(asyncOp, _uploadFileOperationCompleted, eventArgs);
+            }
+        }
+
+        public void UploadValuesAsync(Uri address, NameValueCollection data) =>
+            UploadValuesAsync(address, null, data, null);
+
+        public void UploadValuesAsync(Uri address, string method, NameValueCollection data) =>
+            UploadValuesAsync(address, method, data, null);
+
+        public void UploadValuesAsync(Uri address, string method, NameValueCollection data, object userToken)
+        {
+            ThrowIfNull(address, nameof(address));
+            ThrowIfNull(data, nameof(data));
+            if (method == null)
+            {
+                method = MapToDefaultMethod(address);
+            }
+
+            AsyncOperation asyncOp = StartAsyncOperation(userToken);
+            try
+            {
+                byte[] buffer = GetValuesToUpload(data);
+                _method = method;
+                WebRequest request = _webRequest = GetWebRequest(GetUri(address));
+
+                int chunkSize = 0;
+                if (UploadProgressChanged != null)
+                {
+                    // If ProgressCallback is requested, we should send the buffer in chunks
+                    chunkSize = (int)Math.Min((long)DefaultCopyBufferLength, buffer.Length);
+                }
+
+                UploadBitsAsync(
+                    request, null, buffer, chunkSize, null, null, asyncOp,
+                    (result, error, uploadAsyncOp) =>
+                        InvokeOperationCompleted(asyncOp, _uploadValuesOperationCompleted, new UploadValuesCompletedEventArgs(result, error, _canceled, uploadAsyncOp.UserSuppliedState)));
+            }
+            catch (Exception e) when (!(e is OutOfMemoryException))
+            {
+                var eventArgs = new UploadValuesCompletedEventArgs(null, GetExceptionToPropagate(e), _canceled, asyncOp.UserSuppliedState);
+                InvokeOperationCompleted(asyncOp, _uploadValuesOperationCompleted, eventArgs);
+            }
+        }
+
+        private static Exception GetExceptionToPropagate(Exception e) =>
+            e is WebException || e is SecurityException ? e : new WebException(SR.net_webclient, e);
+
+        public void CancelAsync()
+        {
+            WebRequest request = _webRequest;
+            _canceled = true;
+            AbortRequest(request);
+        }
+
+        public Task<string> DownloadStringTaskAsync(string address) =>
+            DownloadStringTaskAsync(GetUri(address));
+        
+        public Task<string> DownloadStringTaskAsync(Uri address)
+        {
+            // Create the task to be returned
+            var tcs = new TaskCompletionSource<string>(address);
+
+            DownloadStringCompletedEventHandler handler = null;
+            handler = (sender, e) => HandleCompletion(tcs, e, (args) => args.Result, handler, (webClient, completion) => webClient.DownloadStringCompleted -= completion);
+            DownloadStringCompleted += handler;
+
+            // Start the async operation.
+            try { DownloadStringAsync(address, tcs); }
+            catch
+            {
+                DownloadStringCompleted -= handler;
+                throw;
+            }
+
+            // Return the task that represents the async operation
+            return tcs.Task;
+        }
+
+        public Task<Stream> OpenReadTaskAsync(string address) =>
+            OpenReadTaskAsync(GetUri(address));
+        
+        public Task<Stream> OpenReadTaskAsync(Uri address)
+        {
+            // Create the task to be returned
+            var tcs = new TaskCompletionSource<Stream>(address);
+
+            // Setup the callback event handler
+            OpenReadCompletedEventHandler handler = null;
+            handler = (sender, e) => HandleCompletion(tcs, e, (args) => args.Result, handler, (webClient, completion) => webClient.OpenReadCompleted -= completion);
+            OpenReadCompleted += handler;
+
+            // Start the async operation.
+            try { OpenReadAsync(address, tcs); }
+            catch
+            {
+                OpenReadCompleted -= handler;
+                throw;
+            }
+
+            // Return the task that represents the async operation
+            return tcs.Task;
+        }
+        
+        public Task<Stream> OpenWriteTaskAsync(string address) =>
+            OpenWriteTaskAsync(GetUri(address), null);
+        
+        public Task<Stream> OpenWriteTaskAsync(Uri address) =>
+            OpenWriteTaskAsync(address, null);
+        
+        public Task<Stream> OpenWriteTaskAsync(string address, string method) =>
+            OpenWriteTaskAsync(GetUri(address), method);
+        
+        public Task<Stream> OpenWriteTaskAsync(Uri address, string method)
+        {
+            // Create the task to be returned
+            var tcs = new TaskCompletionSource<Stream>(address);
+
+            // Setup the callback event handler
+            OpenWriteCompletedEventHandler handler = null;
+            handler = (sender, e) => HandleCompletion(tcs, e, (args) => args.Result, handler, (webClient, completion) => webClient.OpenWriteCompleted -= completion);
+            OpenWriteCompleted += handler;
+
+            // Start the async operation.
+            try { OpenWriteAsync(address, method, tcs); }
+            catch
+            {
+                OpenWriteCompleted -= handler;
+                throw;
+            }
+
+            // Return the task that represents the async operation
+            return tcs.Task;
+        }
+
+        public Task<string> UploadStringTaskAsync(string address, string data) =>
+            UploadStringTaskAsync(address, null, data);
+        
+        public Task<string> UploadStringTaskAsync(Uri address, string data) =>
+            UploadStringTaskAsync(address, null, data);
+        
+        public Task<string> UploadStringTaskAsync(string address, string method, string data) =>
+            UploadStringTaskAsync(GetUri(address), method, data);
+        
+        public Task<string> UploadStringTaskAsync(Uri address, string method, string data)
+        {
+            // Create the task to be returned
+            var tcs = new TaskCompletionSource<string>(address);
+
+            // Setup the callback event handler
+            UploadStringCompletedEventHandler handler = null;
+            handler = (sender, e) => HandleCompletion(tcs, e, (args) => args.Result, handler, (webClient, completion) => webClient.UploadStringCompleted -= completion);
+            UploadStringCompleted += handler;
+
+            // Start the async operation.
+            try { UploadStringAsync(address, method, data, tcs); }
+            catch
+            {
+                UploadStringCompleted -= handler;
+                throw;
+            }
+
+            // Return the task that represents the async operation
+            return tcs.Task;
+        }
+        
+        public Task<byte[]> DownloadDataTaskAsync(string address) =>
+            DownloadDataTaskAsync(GetUri(address));
+        
+        public Task<byte[]> DownloadDataTaskAsync(Uri address)
+        {
+            // Create the task to be returned
+            var tcs = new TaskCompletionSource<byte[]>(address);
+
+            // Setup the callback event handler
+            DownloadDataCompletedEventHandler handler = null;
+            handler = (sender, e) => HandleCompletion(tcs, e, (args) => args.Result, handler, (webClient, completion) => webClient.DownloadDataCompleted -= completion);
+            DownloadDataCompleted += handler;
+
+            // Start the async operation.
+            try { DownloadDataAsync(address, tcs); }
+            catch
+            {
+                DownloadDataCompleted -= handler;
+                throw;
+            }
+
+            // Return the task that represents the async operation
+            return tcs.Task;
+        }
+
+        public Task DownloadFileTaskAsync(string address, string fileName) =>
+            DownloadFileTaskAsync(GetUri(address), fileName);
+        
+        public Task DownloadFileTaskAsync(Uri address, string fileName)
+        {
+            // Create the task to be returned
+            var tcs = new TaskCompletionSource<object>(address);
+
+            // Setup the callback event handler
+            AsyncCompletedEventHandler handler = null;
+            handler = (sender, e) => HandleCompletion(tcs, e, (args) => null, handler, (webClient, completion) => webClient.DownloadFileCompleted -= completion);
+            DownloadFileCompleted += handler;
+
+            // Start the async operation.
+            try { DownloadFileAsync(address, fileName, tcs); }
+            catch
+            {
+                DownloadFileCompleted -= handler;
+                throw;
+            }
+
+            // Return the task that represents the async operation
+            return tcs.Task;
+        }
+
+        public Task<byte[]> UploadDataTaskAsync(string address, byte[] data) =>
+            UploadDataTaskAsync(GetUri(address), null, data);
+        
+        public Task<byte[]> UploadDataTaskAsync(Uri address, byte[] data) =>
+            UploadDataTaskAsync(address, null, data);
+        
+        public Task<byte[]> UploadDataTaskAsync(string address, string method, byte[] data) =>
+            UploadDataTaskAsync(GetUri(address), method, data);
+        
+        public Task<byte[]> UploadDataTaskAsync(Uri address, string method, byte[] data)
+        {
+            // Create the task to be returned
+            var tcs = new TaskCompletionSource<byte[]>(address);
+
+            // Setup the callback event handler
+            UploadDataCompletedEventHandler handler = null;
+            handler = (sender, e) => HandleCompletion(tcs, e, (args) => args.Result, handler, (webClient, completion) => webClient.UploadDataCompleted -= completion);
+            UploadDataCompleted += handler;
+
+            // Start the async operation.
+            try { UploadDataAsync(address, method, data, tcs); }
+            catch
+            {
+                UploadDataCompleted -= handler;
+                throw;
+            }
+
+            // Return the task that represents the async operation
+            return tcs.Task;
+        }
+        
+        public Task<byte[]> UploadFileTaskAsync(string address, string fileName) =>
+            UploadFileTaskAsync(GetUri(address), null, fileName);
+        
+        public Task<byte[]> UploadFileTaskAsync(Uri address, string fileName) =>
+            UploadFileTaskAsync(address, null, fileName);
+        
+        public Task<byte[]> UploadFileTaskAsync(string address, string method, string fileName) =>
+            UploadFileTaskAsync(GetUri(address), method, fileName);
+        
+        public Task<byte[]> UploadFileTaskAsync(Uri address, string method, string fileName)
+        {
+            // Create the task to be returned
+            var tcs = new TaskCompletionSource<byte[]>(address);
+
+            // Setup the callback event handler
+            UploadFileCompletedEventHandler handler = null;
+            handler = (sender, e) => HandleCompletion(tcs, e, (args) => args.Result, handler, (webClient, completion) => webClient.UploadFileCompleted -= completion);
+            UploadFileCompleted += handler;
+
+            // Start the async operation.
+            try { UploadFileAsync(address, method, fileName, tcs); }
+            catch
+            {
+                UploadFileCompleted -= handler;
+                throw;
+            }
+
+            // Return the task that represents the async operation
+            return tcs.Task;
+        }
+        
+        public Task<byte[]> UploadValuesTaskAsync(string address, NameValueCollection data) =>
+            UploadValuesTaskAsync(GetUri(address), null, data);
+        
+        public Task<byte[]> UploadValuesTaskAsync(string address, string method, NameValueCollection data) =>
+            UploadValuesTaskAsync(GetUri(address), method, data);
+        
+        public Task<byte[]> UploadValuesTaskAsync(Uri address, NameValueCollection data) =>
+            UploadValuesTaskAsync(address, null, data);
+        
+        public Task<byte[]> UploadValuesTaskAsync(Uri address, string method, NameValueCollection data)
+        {
+            // Create the task to be returned
+            var tcs = new TaskCompletionSource<byte[]>(address);
+
+            // Setup the callback event handler
+            UploadValuesCompletedEventHandler handler = null;
+            handler = (sender, e) => HandleCompletion(tcs, e, (args) => args.Result, handler, (webClient, completion) => webClient.UploadValuesCompleted -= completion);
+            UploadValuesCompleted += handler;
+
+            // Start the async operation.
+            try { UploadValuesAsync(address, method, data, tcs); }
+            catch
+            {
+                UploadValuesCompleted -= handler;
+                throw;
+            }
+
+            // Return the task that represents the async operation
+            return tcs.Task;
+        }
+
+        private void HandleCompletion<TAsyncCompletedEventArgs, TCompletionDelegate, T>(TaskCompletionSource<T> tcs, TAsyncCompletedEventArgs e, Func<TAsyncCompletedEventArgs, T> getResult, TCompletionDelegate handler, Action<WebClient, TCompletionDelegate> unregisterHandler)
+            where TAsyncCompletedEventArgs : AsyncCompletedEventArgs
+        {
+            if (e.UserState == tcs)
+            {
+                try { unregisterHandler(this, handler); }
+                finally
+                {
+                    if (e.Error != null) tcs.TrySetException(e.Error);
+                    else if (e.Cancelled) tcs.TrySetCanceled();
+                    else tcs.TrySetResult(getResult(e));
+                }
+            }
+        }
+
+        private void PostProgressChanged(AsyncOperation asyncOp, ProgressData progress)
+        {
+            if (asyncOp != null && (progress.BytesSent > 0 || progress.BytesReceived > 0))
+            {
+                int progressPercentage;
+                if (progress.HasUploadPhase)
+                {
+                    if (UploadProgressChanged != null)
+                    {
+                        progressPercentage = progress.TotalBytesToReceive < 0 && progress.BytesReceived == 0 ?
+                            progress.TotalBytesToSend < 0 ? 0 : progress.TotalBytesToSend == 0 ? 50 : (int)((50 * progress.BytesSent) / progress.TotalBytesToSend) :
+                            progress.TotalBytesToSend < 0 ? 50 : progress.TotalBytesToReceive == 0 ? 100 : (int)((50 * progress.BytesReceived) / progress.TotalBytesToReceive + 50);
+                        asyncOp.Post(_reportUploadProgressChanged, new UploadProgressChangedEventArgs(progressPercentage, asyncOp.UserSuppliedState, progress.BytesSent, progress.TotalBytesToSend, progress.BytesReceived, progress.TotalBytesToReceive));
+                    }
+                }
+                else if (DownloadProgressChanged != null)
+                {
+                    progressPercentage = progress.TotalBytesToReceive < 0 ? 0 : progress.TotalBytesToReceive == 0 ? 100 : (int)((100 * progress.BytesReceived) / progress.TotalBytesToReceive);
+                    asyncOp.Post(_reportDownloadProgressChanged, new DownloadProgressChangedEventArgs(progressPercentage, asyncOp.UserSuppliedState, progress.BytesReceived, progress.TotalBytesToReceive));
+                }
+            }
+        }
+
+        private static void ThrowIfNull(object argument, string parameterName)
+        {
+            if (argument == null)
+            {
+                throw new ArgumentNullException(parameterName);
+            }
+        }
+
+        #region Supporting Types
+        private sealed class ProgressData
+        {
+            internal long BytesSent = 0;
+            internal long TotalBytesToSend = -1;
+            internal long BytesReceived = 0;
+            internal long TotalBytesToReceive = -1;
+            internal bool HasUploadPhase = false;
+
+            internal void Reset()
+            {
+                BytesSent = 0;
+                TotalBytesToSend = -1;
+                BytesReceived = 0;
+                TotalBytesToReceive = -1;
+                HasUploadPhase = false;
+            }
+        }
+
+        private sealed class WebClientWriteStream : DelegatingStream
+        {
+            private readonly WebRequest _request;
+            private readonly WebClient _webClient;
+
+            public WebClientWriteStream(Stream stream, WebRequest request, WebClient webClient) : base(stream)
+            {
+                _request = request;
+                _webClient = webClient;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                try
+                {
+                    if (disposing)
+                    {
+                        _webClient.GetWebResponse(_request).Dispose();
+                    }
+                }
+                finally
+                {
+                    base.Dispose(disposing);
+                }
+            }
+        }
+        #endregion
+
+        #region Obsolete designer support
+        //introduced to support design-time loading of System.Windows.dll
+
+        [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool AllowReadStreamBuffering { get; set; }
+
+        [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool AllowWriteStreamBuffering { get; set; }
+
+        [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event WriteStreamClosedEventHandler WriteStreamClosed { add { } remove { } }
+
+        [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual void OnWriteStreamClosed(WriteStreamClosedEventArgs e) { }
+        #endregion
+    }
+
+    #region Delegates and supporting *CompletedEventArgs classes used by event-based async code
+    public delegate void OpenReadCompletedEventHandler(object sender, OpenReadCompletedEventArgs e);
+    public delegate void OpenWriteCompletedEventHandler(object sender, OpenWriteCompletedEventArgs e);
+    public delegate void DownloadStringCompletedEventHandler(object sender, DownloadStringCompletedEventArgs e);
+    public delegate void DownloadDataCompletedEventHandler(object sender, DownloadDataCompletedEventArgs e);
+    public delegate void UploadStringCompletedEventHandler(object sender, UploadStringCompletedEventArgs e);
+    public delegate void UploadDataCompletedEventHandler(object sender, UploadDataCompletedEventArgs e);
+    public delegate void UploadFileCompletedEventHandler(object sender, UploadFileCompletedEventArgs e);
+    public delegate void UploadValuesCompletedEventHandler(object sender, UploadValuesCompletedEventArgs e);
+    public delegate void DownloadProgressChangedEventHandler(object sender, DownloadProgressChangedEventArgs e);
+    public delegate void UploadProgressChangedEventHandler(object sender, UploadProgressChangedEventArgs e);
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public delegate void WriteStreamClosedEventHandler(object sender, WriteStreamClosedEventArgs e);
+
+    public class OpenReadCompletedEventArgs : AsyncCompletedEventArgs
+    {
+        private readonly Stream _result;
+
+        internal OpenReadCompletedEventArgs(Stream result, Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken)
+        {
+            _result = result;
+        }
+
+        public Stream Result
+        {
+            get
+            {
+                RaiseExceptionIfNecessary();
+                return _result;
+            }
+        }
+    }
+
+    public class OpenWriteCompletedEventArgs : AsyncCompletedEventArgs
+    {
+        private readonly Stream _result;
+
+        internal OpenWriteCompletedEventArgs(Stream result, Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken)
+        {
+            _result = result;
+        }
+
+        public Stream Result
+        {
+            get
+            {
+                RaiseExceptionIfNecessary();
+                return _result;
+            }
+        }
+    }
+
+    public class DownloadStringCompletedEventArgs : AsyncCompletedEventArgs
+    {
+        private readonly string _result;
+
+        internal DownloadStringCompletedEventArgs(string result, Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken)
+        {
+            _result = result;
+        }
+
+        public string Result
+        {
+            get
+            {
+                RaiseExceptionIfNecessary();
+                return _result;
+            }
+        }
+
+    }
+
+    public class DownloadDataCompletedEventArgs : AsyncCompletedEventArgs
+    {
+        private readonly byte[] _result;
+
+        internal DownloadDataCompletedEventArgs(byte[] result, Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken)
+        {
+            _result = result;
+        }
+
+        public byte[] Result
+        {
+            get
+            {
+                RaiseExceptionIfNecessary();
+                return _result;
+            }
+        }
+    }
+
+    public class UploadStringCompletedEventArgs : AsyncCompletedEventArgs
+    {
+        private readonly string _result;
+
+        internal UploadStringCompletedEventArgs(string result, Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken)
+        {
+            _result = result;
+        }
+
+        public string Result
+        {
+            get
+            {
+                RaiseExceptionIfNecessary();
+                return _result;
+            }
+        }
+    }
+
+    public class UploadDataCompletedEventArgs : AsyncCompletedEventArgs
+    {
+        private readonly byte[] _result;
+
+        internal UploadDataCompletedEventArgs(byte[] result, Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken)
+        {
+            _result = result;
+        }
+
+        public byte[] Result
+        {
+            get
+            {
+                RaiseExceptionIfNecessary();
+                return _result;
+            }
+        }
+    }
+
+    public class UploadFileCompletedEventArgs : AsyncCompletedEventArgs
+    {
+        private readonly byte[] _result;
+
+        internal UploadFileCompletedEventArgs(byte[] result, Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken)
+        {
+            _result = result;
+        }
+
+        public byte[] Result
+        {
+            get
+            {
+                RaiseExceptionIfNecessary();
+                return _result;
+            }
+        }
+    }
+
+    public class UploadValuesCompletedEventArgs : AsyncCompletedEventArgs
+    {
+        private readonly byte[] _result;
+
+        internal UploadValuesCompletedEventArgs(byte[] result, Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken)
+        {
+            _result = result;
+        }
+
+        public byte[] Result
+        {
+            get
+            {
+                RaiseExceptionIfNecessary();
+                return _result;
+            }
+        }
+    }
+
+    public class DownloadProgressChangedEventArgs : ProgressChangedEventArgs
+    {
+        internal DownloadProgressChangedEventArgs(int progressPercentage, object userToken, long bytesReceived, long totalBytesToReceive) :
+            base(progressPercentage, userToken)
+        {
+            BytesReceived = bytesReceived;
+            TotalBytesToReceive = totalBytesToReceive;
+        }
+
+        public long BytesReceived { get; }
+        public long TotalBytesToReceive { get; }
+    }
+
+
+    public class UploadProgressChangedEventArgs : ProgressChangedEventArgs
+    {
+        internal UploadProgressChangedEventArgs(int progressPercentage, object userToken, long bytesSent, long totalBytesToSend, long bytesReceived, long totalBytesToReceive) :
+            base(progressPercentage, userToken)
+        {
+            BytesReceived = bytesReceived;
+            TotalBytesToReceive = totalBytesToReceive;
+            BytesSent = bytesSent;
+            TotalBytesToSend = totalBytesToSend;
+        }
+
+        public long BytesReceived { get; }
+        public long TotalBytesToReceive { get; }
+        public long BytesSent { get; }
+        public long TotalBytesToSend { get; }
+    }
+
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WriteStreamClosedEventArgs : EventArgs
+    {
+        [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WriteStreamClosedEventArgs() { }
+
+        [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Exception Error { get { return null; } }
+    }
+    #endregion
+}

--- a/src/System.Net.WebClient/src/project.json
+++ b/src/System.Net.WebClient/src/project.json
@@ -1,0 +1,36 @@
+{
+  "frameworks": {
+    "netstandard1.7": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Collections": "4.3.0-beta-24516-03",
+        "System.Collections.Specialized": "4.3.0-beta-24516-03",
+        "System.ComponentModel": "4.3.0-beta-24516-03",
+        "System.ComponentModel.EventBasedAsync": "4.3.0-beta-24516-03",
+        "System.Diagnostics.Debug": "4.3.0-beta-24516-03",
+        "System.Diagnostics.Tools": "4.3.0-beta-24516-03",
+        "System.Diagnostics.Tracing": "4.3.0-beta-24516-03",
+        "System.IO": "4.3.0-beta-24516-03",
+        "System.IO.FileSystem": "4.3.0-beta-24516-03",
+        "System.Globalization": "4.3.0-beta-24516-03",
+        "System.Globalization.Extensions": "4.3.0-beta-24516-03",
+        "System.Net.Primitives": "4.3.0-beta-24516-03",
+        "System.Net.Requests": "4.3.0-beta-24516-03",
+        "System.Resources.ResourceManager": "4.3.0-beta-24516-03",
+        "System.Runtime": "4.3.0-beta-24516-03",
+        "System.Runtime.Extensions": "4.3.0-beta-24516-03",
+        "System.Text.Encoding": "4.3.0-beta-24516-03",
+        "System.Threading": "4.3.0-beta-24516-03",
+        "System.Threading.Tasks": "4.3.0-beta-24516-03"
+      },
+      "imports": [
+        "dotnet5.8"
+      ]
+    },
+    "net463": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    }
+  }
+}

--- a/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.builds
+++ b/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.builds
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Net.WebClient.Tests.csproj">
+    	<TestTFMs>netcoreapp1.1</TestTFMs>
+    </Project>
+    <Project Include="System.Net.WebClient.Tests.csproj">
+      <TestTFMs>net463</TestTFMs>
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
+++ b/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <!--
+      Until we get first class support for NS1.7 and Netcoreapp1.1
+      we need to hard code $(TestTFM) and $(TestNugetTargetMoniker)
+      in the project file.
+    -->
+    <TestTFM>netcoreapp1.1</TestTFM>
+    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <ProjectGuid>{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
+      <Folder>netcoreapp1.1</Folder>
+    </TestNugetTargetMoniker>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU' " />
+  <ItemGroup>
+    <Compile Include="WebClientTest.cs" />
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+      <Link>Common\System\Net\Configuration.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
+      <Link>Common\System\Net\Configuration.Certificates.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+      <Link>Common\System\Net\Configuration.Http.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.cs">
+      <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\pkg\System.Net.WebClient.pkgproj">
+      <Name>System.Net.WebClient</Name>
+      <Project>{53D09AF4-0C13-4197-B8AD-9746F0374E88}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/System.Net.WebClient/tests/WebClientTest.cs
@@ -1,0 +1,703 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Test.Common;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Tests
+{
+    public class WebClientTest
+    {
+        [Fact]
+        public static void DefaultCtor_PropertiesReturnExpectedValues()
+        {
+            var wc = new WebClient();
+
+            Assert.Empty(wc.BaseAddress);
+            //Assert.Null(wc.CachePolicy); // TODO: Uncomment when member added
+            Assert.Null(wc.Credentials);
+            Assert.Equal(Encoding.Default, wc.Encoding);
+            Assert.Empty(wc.Headers);
+            Assert.False(wc.IsBusy);
+            Assert.NotNull(wc.Proxy);
+            Assert.Empty(wc.QueryString);
+            Assert.False(wc.UseDefaultCredentials);
+        }
+
+        [Fact]
+        public static void Properties_InvalidArguments_ThrowExceptions()
+        {
+            var wc = new WebClient();
+
+            Assert.Throws<ArgumentException>("value", () => { wc.BaseAddress = "http::/invalid url"; });
+            Assert.Throws<ArgumentNullException>("Encoding", () => { wc.Encoding = null; });
+        }
+
+        [Fact]
+        public static void DownloadData_InvalidArguments_ThrowExceptions()
+        {
+            var wc = new WebClient();
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadData((string)null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadData((Uri)null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadDataAsync((Uri)null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadDataAsync((Uri)null, null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadDataTaskAsync((string)null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadDataTaskAsync((Uri)null); });
+        }
+
+        [Fact]
+        public static void DownloadFile_InvalidArguments_ThrowExceptions()
+        {
+            var wc = new WebClient();
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadFile((string)null, ""); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadFile((Uri)null, ""); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadFileAsync((Uri)null, ""); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadFileAsync((Uri)null, "", null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadFileTaskAsync((string)null, ""); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadFileTaskAsync((Uri)null, ""); });
+
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.DownloadFile("http://localhost", null); });
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.DownloadFile(new Uri("http://localhost"), null); });
+
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.DownloadFileAsync(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.DownloadFileAsync(new Uri("http://localhost"), null, null); });
+
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.DownloadFileTaskAsync("http://localhost", null); });
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.DownloadFileTaskAsync(new Uri("http://localhost"), null); });
+        }
+
+        [Fact]
+        public static void DownloadString_InvalidArguments_ThrowExceptions()
+        {
+            var wc = new WebClient();
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadString((string)null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadString((Uri)null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadStringAsync((Uri)null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadStringAsync((Uri)null, null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadStringTaskAsync((string)null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.DownloadStringTaskAsync((Uri)null); });
+        }
+
+        [Fact]
+        public static void UploadData_InvalidArguments_ThrowExceptions()
+        {
+            var wc = new WebClient();
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadData((string)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadData((string)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadData((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadData((Uri)null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadDataAsync((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadDataAsync((Uri)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadDataAsync((Uri)null, null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadDataTaskAsync((string)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadDataTaskAsync((string)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadDataTaskAsync((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadDataTaskAsync((Uri)null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadData("http://localhost", null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadData("http://localhost", null, null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadData(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadData(new Uri("http://localhost"), null, null); });
+
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadDataAsync(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadDataAsync(new Uri("http://localhost"), null, null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadDataAsync(new Uri("http://localhost"), null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadDataTaskAsync("http://localhost", null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadDataTaskAsync("http://localhost", null, null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadDataTaskAsync(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadDataTaskAsync(new Uri("http://localhost"), null, null); });
+        }
+
+        [Fact]
+        public static void UploadFile_InvalidArguments_ThrowExceptions()
+        {
+            var wc = new WebClient();
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadFile((string)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadFile((string)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadFile((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadFile((Uri)null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadFileAsync((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadFileAsync((Uri)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadFileAsync((Uri)null, null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadFileTaskAsync((string)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadFileTaskAsync((string)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadFileTaskAsync((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadFileTaskAsync((Uri)null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.UploadFile("http://localhost", null); });
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.UploadFile("http://localhost", null, null); });
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.UploadFile(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.UploadFile(new Uri("http://localhost"), null, null); });
+
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.UploadFileAsync(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.UploadFileAsync(new Uri("http://localhost"), null, null); });
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.UploadFileAsync(new Uri("http://localhost"), null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.UploadFileTaskAsync("http://localhost", null); });
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.UploadFileTaskAsync("http://localhost", null, null); });
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.UploadFileTaskAsync(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("fileName", () => { wc.UploadFileTaskAsync(new Uri("http://localhost"), null, null); });
+        }
+
+        [Fact]
+        public static void UploadString_InvalidArguments_ThrowExceptions()
+        {
+            var wc = new WebClient();
+            
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadString((string)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadString((string)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadString((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadString((Uri)null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadStringAsync((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadStringAsync((Uri)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadStringAsync((Uri)null, null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadStringTaskAsync((string)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadStringTaskAsync((string)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadStringTaskAsync((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadStringTaskAsync((Uri)null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadString("http://localhost", null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadString("http://localhost", null, null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadString(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadString(new Uri("http://localhost"), null, null); });
+
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadStringAsync(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadStringAsync(new Uri("http://localhost"), null, null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadStringAsync(new Uri("http://localhost"), null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadStringTaskAsync("http://localhost", null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadStringTaskAsync("http://localhost", null, null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadStringTaskAsync(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadStringTaskAsync(new Uri("http://localhost"), null, null); });
+        }
+
+        [Fact]
+        public static void UploadValues_InvalidArguments_ThrowExceptions()
+        {
+            var wc = new WebClient();
+            
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadValues((string)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadValues((string)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadValues((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadValues((Uri)null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadValuesAsync((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadValuesAsync((Uri)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadValuesAsync((Uri)null, null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadValuesTaskAsync((string)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadValuesTaskAsync((string)null, null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadValuesTaskAsync((Uri)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.UploadValuesTaskAsync((Uri)null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadValues("http://localhost", null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadValues("http://localhost", null, null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadValues(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadValues(new Uri("http://localhost"), null, null); });
+
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadValuesAsync(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadValuesAsync(new Uri("http://localhost"), null, null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadValuesAsync(new Uri("http://localhost"), null, null, null); });
+
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadValuesTaskAsync("http://localhost", null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadValuesTaskAsync("http://localhost", null, null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadValuesTaskAsync(new Uri("http://localhost"), null); });
+            Assert.Throws<ArgumentNullException>("data", () => { wc.UploadValuesTaskAsync(new Uri("http://localhost"), null, null); });
+        }
+
+        [Fact]
+        public static void OpenWrite_InvalidArguments_ThrowExceptions()
+        {
+            var wc = new WebClient();
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.OpenWrite((string)null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.OpenWrite((string)null, null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.OpenWrite((Uri)null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.OpenWrite((Uri)null, null); });
+        }
+
+        [Fact]
+        public static void OpenRead_InvalidArguments_ThrowExceptions()
+        {
+            var wc = new WebClient();
+
+            Assert.Throws<ArgumentNullException>("address", () => { wc.OpenRead((string)null); });
+            Assert.Throws<ArgumentNullException>("address", () => { wc.OpenRead((Uri)null); });
+        }
+
+        [Fact]
+        public static void BaseAddress_Roundtrips()
+        {
+            var wc = new WebClient();
+            wc.BaseAddress = "http://localhost/";
+            Assert.Equal("http://localhost/", wc.BaseAddress);
+            wc.BaseAddress = null;
+            Assert.Equal(string.Empty, wc.BaseAddress);
+        }
+
+        // TODO: Uncomment when member added
+        //[Fact]
+        //public static void CachePolicy_Roundtrips()
+        //{
+        //    var wc = new WebClient();
+        //    var c = new RequestCachePolicy(RequestCacheLevel.BypassCache);
+        //    wc.CachePolicy = c;
+        //    Assert.Same(c, wc.CachePolicy);
+        //}
+
+        [Fact]
+        public static void Credentials_Roundtrips()
+        {
+            var wc = new WebClient();
+            var c = new DummyCredentials();
+            wc.Credentials = c;
+            Assert.Same(c, wc.Credentials);
+            wc.Credentials = null;
+            Assert.Null(wc.Credentials);
+        }
+
+        private sealed class DummyCredentials : ICredentials
+        {
+            public NetworkCredential GetCredential(Uri uri, string authType) => null;
+        }
+
+        [Fact]
+        public static void Proxy_Roundtrips()
+        {
+            var wc = new WebClient();
+            Assert.Same(WebRequest.DefaultWebProxy, wc.Proxy);
+
+            var p = new DummyProxy();
+            wc.Proxy = p;
+            Assert.Same(p, wc.Proxy);
+
+            wc.Proxy = null;
+            Assert.Null(wc.Proxy);
+        }
+
+        private sealed class DummyProxy : IWebProxy
+        {
+            public ICredentials Credentials { get; set; }
+
+            public Uri GetProxy(Uri destination) => null;
+            public bool IsBypassed(Uri host) => false;
+        }
+
+        [Fact]
+        public static void Encoding_Roundtrips()
+        {
+            var wc = new WebClient();
+            Encoding e = Encoding.UTF8;
+            wc.Encoding = e;
+            Assert.Same(e, wc.Encoding);
+        }
+
+        [Fact]
+        public static void Headers_Roundtrips()
+        {
+            var wc = new WebClient();
+            Assert.NotNull(wc.Headers);
+            Assert.Empty(wc.Headers);
+
+            wc.Headers = null;
+            Assert.NotNull(wc.Headers);
+            Assert.Empty(wc.Headers);
+
+            var whc = new WebHeaderCollection();
+            wc.Headers = whc;
+            Assert.Same(whc, wc.Headers);
+        }
+
+        [Fact]
+        public static void QueryString_Roundtrips()
+        {
+            var wc = new WebClient();
+            Assert.NotNull(wc.QueryString);
+            Assert.Empty(wc.QueryString);
+
+            wc.QueryString = null;
+            Assert.NotNull(wc.QueryString);
+            Assert.Empty(wc.QueryString);
+
+            var nvc = new NameValueCollection();
+            wc.QueryString = nvc;
+            Assert.Same(nvc, wc.QueryString);
+        }
+
+        [Fact]
+        public static void UseDefaultCredentials_Roundtrips()
+        {
+            var wc = new WebClient();
+            for (int i = 0; i < 2; i++)
+            {
+                wc.UseDefaultCredentials = true;
+                Assert.True(wc.UseDefaultCredentials);
+                wc.UseDefaultCredentials = false;
+                Assert.False(wc.UseDefaultCredentials);
+            }
+        }
+
+        [Fact]
+        public static async Task ResponseHeaders_ContainsHeadersAfterOperation()
+        {
+            var wc = new DerivedWebClient(); // verify we can use a derived type as well
+            Assert.Null(wc.ResponseHeaders);
+
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                Task<string> download = wc.DownloadStringTaskAsync(url.ToString());
+                Assert.Null(wc.ResponseHeaders);
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        "HTTP/1.1 200 OK\r\n" +
+                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                        $"Content-Length: 0\r\n" +
+                        "ArbitraryHeader: ArbitraryValue\r\n" +
+                        "\r\n");
+                await download;
+            });
+
+            Assert.NotNull(wc.ResponseHeaders);
+            Assert.Equal("ArbitraryValue", wc.ResponseHeaders["ArbitraryHeader"]);
+        }
+
+        [Fact]
+        public static async Task RequestHeaders_SpecialHeaders_RequestSucceeds()
+        {
+            var wc = new WebClient();
+
+            wc.Headers["Accept"] = "text/html";
+            wc.Headers["Connection"] = "close";
+            wc.Headers["ContentType"] = "text/html; charset=utf-8";
+            wc.Headers["Expect"] = "100-continue";
+            wc.Headers["Referer"] = "http://localhost";
+            wc.Headers["User-Agent"] = ".NET";
+            wc.Headers["Host"] = "http://localhost";
+
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                Task<string> download = wc.DownloadStringTaskAsync(url.ToString());
+                Assert.Null(wc.ResponseHeaders);
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        "HTTP/1.1 200 OK\r\n" +
+                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                        $"Content-Length: 0\r\n" +
+                        "\r\n");
+                await download;
+            });
+        }
+
+        [Fact]
+        public static async Task ConcurrentOperations_Throw()
+        {
+            await LoopbackServer.CreateServerAsync((server, url) =>
+            {
+                var wc = new WebClient();
+                Task ignored = wc.DownloadDataTaskAsync(url); // won't complete
+                Assert.Throws<NotSupportedException>(() => { wc.DownloadData(url); });
+                Assert.Throws<NotSupportedException>(() => { wc.DownloadDataAsync(url); });
+                Assert.Throws<NotSupportedException>(() => { wc.DownloadDataTaskAsync(url); });
+                Assert.Throws<NotSupportedException>(() => { wc.DownloadString(url); });
+                Assert.Throws<NotSupportedException>(() => { wc.DownloadStringAsync(url); });
+                Assert.Throws<NotSupportedException>(() => { wc.DownloadStringTaskAsync(url); });
+                Assert.Throws<NotSupportedException>(() => { wc.DownloadFile(url, "path"); });
+                Assert.Throws<NotSupportedException>(() => { wc.DownloadFileAsync(url, "path"); });
+                Assert.Throws<NotSupportedException>(() => { wc.DownloadFileTaskAsync(url, "path"); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadData(url, new byte[42]); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadDataAsync(url, new byte[42]); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadDataTaskAsync(url, new byte[42]); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadString(url, "42"); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadStringAsync(url, "42"); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadStringTaskAsync(url, "42"); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadFile(url, "path"); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadFileAsync(url, "path"); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadFileTaskAsync(url, "path"); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadValues(url, new NameValueCollection()); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadValuesAsync(url, new NameValueCollection()); });
+                Assert.Throws<NotSupportedException>(() => { wc.UploadValuesTaskAsync(url, new NameValueCollection()); });
+                return Task.CompletedTask;
+            });
+        }
+
+        private sealed class DerivedWebClient : WebClient { }
+    }
+
+    public abstract class WebClientTestBase
+    {
+        public readonly static object[][] EchoServers = System.Net.Test.Common.Configuration.Http.EchoServers;
+        const string ExpectedText =
+            "To be, or not to be, that is the question:" +
+            "Whether 'tis Nobler in the mind to suffer" +
+            "The Slings and Arrows of outrageous Fortune," +
+            "Or to take Arms against a Sea of troubles," +
+            "And by opposing end them:";
+
+        protected abstract bool IsAsync { get; }
+
+        protected abstract Task<byte[]> DownloadDataAsync(WebClient wc, string address);
+        protected abstract Task DownloadFileAsync(WebClient wc, string address, string fileName);
+        protected abstract Task<string> DownloadStringAsync(WebClient wc, string address);
+
+        protected abstract Task<byte[]> UploadDataAsync(WebClient wc, string address, byte[] data);
+        protected abstract Task<byte[]> UploadFileAsync(WebClient wc, string address, string fileName);
+        protected abstract Task<string> UploadStringAsync(WebClient wc, string address, string data);
+        protected abstract Task<byte[]> UploadValuesAsync(WebClient wc, string address, NameValueCollection data);
+
+        protected abstract Task<Stream> OpenReadAsync(WebClient wc, string address);
+        protected abstract Task<Stream> OpenWriteAsync(WebClient wc, string address);
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("text/html; charset=utf-8")]
+        [InlineData("text/html; charset=us-ascii")]
+        public async Task DownloadString_Success(string contentType)
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                var wc = new WebClient();
+                if (contentType != null)
+                {
+                    wc.Headers[HttpRequestHeader.ContentType] = contentType;
+                }
+
+                Task<string> download = DownloadStringAsync(wc, url.ToString());
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        "HTTP/1.1 200 OK\r\n" +
+                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                        $"Content-Length: {ExpectedText.Length}\r\n" +
+                        "\r\n" +
+                        $"{ExpectedText}");
+                Assert.Equal(ExpectedText, await download);
+            });
+        }
+
+        [Fact]
+        public async Task DownloadData_Success()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                var wc = new WebClient();
+
+                var downloadProgressInvoked = new TaskCompletionSource<bool>();
+                wc.DownloadProgressChanged += (s, e) => downloadProgressInvoked.TrySetResult(true);
+
+                Task<byte[]> download = DownloadDataAsync(wc, url.ToString());
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        "HTTP/1.1 200 OK\r\n" +
+                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                        $"Content-Length: {ExpectedText.Length}\r\n" +
+                        "\r\n" +
+                        $"{ExpectedText}");
+                Assert.Equal(ExpectedText, Encoding.ASCII.GetString(await download));
+                Assert.True(!IsAsync || await downloadProgressInvoked.Task, "Expected download progress callback to be invoked");
+            });
+        }
+
+        [Theory]
+        public async Task DownloadData_LargeData_Success()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                string largeText = GetRandomText(1024 * 1024);
+
+                var wc = new WebClient();
+                Task<byte[]> download = DownloadDataAsync(wc, url.ToString());
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        "HTTP/1.1 200 OK\r\n" +
+                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                        $"Content-Length: {largeText.Length}\r\n" +
+                        "\r\n" +
+                        $"{largeText}");
+                Assert.Equal(largeText, Encoding.ASCII.GetString(await download));
+            });
+        }
+
+        [Fact]
+        public async Task DownloadFile_Success()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                string tempPath = Path.GetTempFileName();
+                try
+                {
+                    var wc = new WebClient();
+                    Task download = DownloadFileAsync(wc, url.ToString(), tempPath);
+                    await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                            "HTTP/1.1 200 OK\r\n" +
+                            $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                            $"Content-Length: {ExpectedText.Length}\r\n" +
+                            "\r\n" +
+                            $"{ExpectedText}");
+
+                    await download;
+                    Assert.Equal(ExpectedText, File.ReadAllText(tempPath));
+                }
+                finally
+                {
+                    File.Delete(tempPath);
+                }
+            });
+        }
+
+        [Fact]
+        public async Task OpenRead_Success()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                var wc = new WebClient();
+                Task<Stream> download = OpenReadAsync(wc, url.ToString());
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        "HTTP/1.1 200 OK\r\n" +
+                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                        $"Content-Length: {ExpectedText.Length}\r\n" +
+                        "\r\n" +
+                        $"{ExpectedText}");
+
+                using (var reader = new StreamReader(await download))
+                {
+                    Assert.Equal(ExpectedText, await reader.ReadToEndAsync());
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(EchoServers))]
+        public async Task OpenWrite_Success(Uri echoServer)
+        {
+            var wc = new WebClient();
+            using (Stream s = await OpenWriteAsync(wc, echoServer.ToString()))
+            {
+                byte[] data = Encoding.UTF8.GetBytes(ExpectedText);
+                await s.WriteAsync(data, 0, data.Length);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EchoServers))]
+        public async Task UploadData_Success(Uri echoServer)
+        {
+            var wc = new WebClient();
+
+            var uploadProgressInvoked = new TaskCompletionSource<bool>();
+            wc.UploadProgressChanged += (s, e) => uploadProgressInvoked.TrySetResult(true); // to enable chunking of the upload
+
+            byte[] result = await UploadDataAsync(wc, echoServer.ToString(), Encoding.UTF8.GetBytes(ExpectedText));
+            Assert.Contains(ExpectedText, Encoding.UTF8.GetString(result));
+            Assert.True(!IsAsync || await uploadProgressInvoked.Task, "Expected upload progress callback to be invoked");
+        }
+
+        [Theory]
+        [MemberData(nameof(EchoServers))]
+        public async Task UploadData_LargeData_Success(Uri echoServer)
+        {
+            var wc = new WebClient();
+            string largeText = GetRandomText(512 * 1024);
+            byte[] result = await UploadDataAsync(wc, echoServer.ToString(), Encoding.UTF8.GetBytes(largeText));
+            Assert.Contains(largeText, Encoding.UTF8.GetString(result));
+        }
+
+        private static string GetRandomText(int length)
+        {
+            var rand = new Random();
+            return new string(Enumerable.Range(0, 512 * 1024).Select(_ => (char)('a' + rand.Next(0, 26))).ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(EchoServers))]
+        public async Task UploadFile_Success(Uri echoServer)
+        {
+            string tempPath = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(tempPath, Encoding.UTF8.GetBytes(ExpectedText));
+                var wc = new WebClient();
+                byte[] result = await UploadFileAsync(wc, echoServer.ToString(), tempPath);
+                Assert.Contains(ExpectedText, Encoding.UTF8.GetString(result));
+            }
+            finally
+            {
+                File.Delete(tempPath);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EchoServers))]
+        public async Task UploadString_Success(Uri echoServer)
+        {
+            var wc = new WebClient();
+            string result = await UploadStringAsync(wc, echoServer.ToString(), ExpectedText);
+            Assert.Contains(ExpectedText, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(EchoServers))]
+        public async Task UploadValues_Success(Uri echoServer)
+        {
+            var wc = new WebClient();
+            byte[] result = await UploadValuesAsync(wc, echoServer.ToString(), new NameValueCollection() { { "Data", ExpectedText } });
+            Assert.Contains(WebUtility.UrlEncode(ExpectedText), Encoding.UTF8.GetString(result));
+        }
+    }
+
+    public class SyncWebClientTest : WebClientTestBase
+    {
+        protected override bool IsAsync => false;
+
+        protected override Task<byte[]> DownloadDataAsync(WebClient wc, string address) => Task.Run(() => wc.DownloadData(address));
+        protected override Task DownloadFileAsync(WebClient wc, string address, string fileName) => Task.Run(() => wc.DownloadFile(address, fileName));
+        protected override Task<string> DownloadStringAsync(WebClient wc, string address) => Task.Run(() => wc.DownloadString(address));
+
+        protected override Task<byte[]> UploadDataAsync(WebClient wc, string address, byte[] data) => Task.Run(() => wc.UploadData(address, data));
+        protected override Task<byte[]> UploadFileAsync(WebClient wc, string address, string fileName) => Task.Run(() => wc.UploadFile(address, fileName));
+        protected override Task<string> UploadStringAsync(WebClient wc, string address, string data) => Task.Run(() => wc.UploadString(address, data));
+        protected override Task<byte[]> UploadValuesAsync(WebClient wc, string address, NameValueCollection data) => Task.Run(() => wc.UploadValues(address, data));
+
+        protected override Task<Stream> OpenReadAsync(WebClient wc, string address) => Task.Run(() => wc.OpenRead(address));
+        protected override Task<Stream> OpenWriteAsync(WebClient wc, string address) => Task.Run(() => wc.OpenWrite(address));
+    }
+
+    // NOTE: Today the XxTaskAsync APIs are implemented as wrappers for the XxAsync APIs.
+    // If that changes, we should add an EapWebClientTest here that targets those directly.
+    // In the meantime, though, there's no benefit to the extra testing it would provide.
+    public class TaskWebClientTest : WebClientTestBase
+    {
+        protected override bool IsAsync => true;
+
+        protected override Task<byte[]> DownloadDataAsync(WebClient wc, string address) => wc.DownloadDataTaskAsync(address);
+        protected override Task DownloadFileAsync(WebClient wc, string address, string fileName) => wc.DownloadFileTaskAsync(address, fileName);
+        protected override Task<string> DownloadStringAsync(WebClient wc, string address) => wc.DownloadStringTaskAsync(address);
+
+        protected override Task<byte[]> UploadDataAsync(WebClient wc, string address, byte[] data) => wc.UploadDataTaskAsync(address, data);
+        protected override Task<byte[]> UploadFileAsync(WebClient wc, string address, string fileName) => wc.UploadFileTaskAsync(address, fileName);
+        protected override Task<string> UploadStringAsync(WebClient wc, string address, string data) => wc.UploadStringTaskAsync(address, data);
+        protected override Task<byte[]> UploadValuesAsync(WebClient wc, string address, NameValueCollection data) => wc.UploadValuesTaskAsync(address, data);
+
+        protected override Task<Stream> OpenReadAsync(WebClient wc, string address) => wc.OpenReadTaskAsync(address);
+        protected override Task<Stream> OpenWriteAsync(WebClient wc, string address) => wc.OpenWriteTaskAsync(address);
+    }
+}

--- a/src/System.Net.WebClient/tests/project.json
+++ b/src/System.Net.WebClient/tests/project.json
@@ -1,0 +1,52 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.2-beta-24516-03",
+    "System.Collections": "4.3.0-beta-24516-03",
+    "System.Collections.NonGeneric": "4.3.0-beta-24516-03",
+    "System.Collections.Specialized": "4.3.0-beta-24516-03",
+    "System.ComponentModel": "4.3.0-beta-24516-03",
+    "System.ComponentModel.EventBasedAsync": "4.3.0-beta-24516-03",
+    "System.Diagnostics.Debug": "4.3.0-beta-24516-03",
+    "System.Globalization": "4.3.0-beta-24516-03",
+    "System.IO": "4.3.0-beta-24516-03",
+    "System.ObjectModel": "4.3.0-beta-24516-03",
+    "System.Net.NetworkInformation": "4.3.0-beta-24516-03",
+    "System.Net.Primitives": "4.3.0-beta-24516-03",
+    "System.Net.Requests": "4.3.0-beta-24516-03",
+    "System.Net.Security": "4.3.0-beta-24516-03",
+    "System.Net.WebHeaderCollection": "4.3.0-beta-24516-03",
+    "System.Reflection": "4.3.0-beta-24516-03",
+    "System.Runtime": "4.3.0-beta-24516-03",
+    "System.Runtime.Extensions": "4.3.0-beta-24516-03",
+    "System.Runtime.Serialization.Primitives": "4.3.0-beta-24516-03",
+    "System.Threading.Tasks": "4.3.0-beta-24516-03",
+    "System.Text.Encoding": "4.3.0-beta-24516-03",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00807-03",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00807-03"
+  },
+  "frameworks": {
+    "netstandard1.7": {}
+  },
+  "supports": {
+    "coreFx.Test.netcoreapp1.1-ns17": {
+      "netstandard1.7": [
+        "win7-x86",
+        "win7-x64",
+        "win10-arm64",
+        "osx.10.10-x64",
+        "centos.7-x64",
+        "debian.8-x64",
+        "rhel.7-x64",
+        "ubuntu.14.04-x64",
+        "ubuntu.16.04-x64",
+        "fedora.23-x64",
+        "linux-x64",
+        "opensuse.13.2-x64"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR ports System.Net.WebClient to corefx.  The code is mostly taken from desktop and then cleaned up a bit stylistically.  The only major code rewrite was removing hundreds of lines of complicated APM callback-based code and replacing it with a few core async methods.  There's still plenty of more cleanup that can be done, but functionally this is sufficient.

I also wrote a bunch of tests for it (~85% coverage), and added a few members to {Http}WebRequest in support of the WebClient implementation.  I did not expose those {Http}WebRequest members in the contract, though; that will be done when dedicated time is put into finishing off the WebRequest surface area.

Note that a suggestion had been made to rewrite WebClient directly on top of HttpClient.  I declined to do so for several reasons, including because as-is it'll work with the other *WebRequest/Response objects as they're added to the implementation, and including because WebClient exposes several members that assume a WebRequest/Response-based implementation (e.g. GetWebRequest).  I've put WebClient into System.Net.Requests as it does tie in closely with these requests, analagous to TcpClient with Sockets.

Fixes https://github.com/dotnet/corefx/issues/11794
cc: @davidsh, @cipop, @ericeil, @karelz 