### PR TITLE
Adding back lost changes that were done in System.Xml.XmlReaderWriter before dev/api merge

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/IXmlLineInfo.cs
+++ b/src/System.Private.Xml/src/System/Xml/IXmlLineInfo.cs
@@ -4,14 +4,10 @@
 
 namespace System.Xml
 {
-    /// <include file='doc\IXmlLineInfo.uex' path='docs/doc[@for="IXmlLineInfo"]/*' />
     public interface IXmlLineInfo
     {
-        /// <include file='doc\IXmlLineInfo.uex' path='docs/doc[@for="IXmlLineInfo.HasLineInfo"]/*' />
         bool HasLineInfo();
-        /// <include file='doc\IXmlLineInfo.uex' path='docs/doc[@for="IXmlLineInfo.LineNumber"]/*' />
         int LineNumber { get; }
-        /// <include file='doc\IXmlLineInfo.uex' path='docs/doc[@for="IXmlLineInfo.LinePosition"]/*' />
         int LinePosition { get; }
     }
 

--- a/src/System.Private.Xml/src/System/Xml/Schema/XmlSchemaForm.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/XmlSchemaForm.cs
@@ -7,25 +7,21 @@ namespace System.Xml.Schema
     using System.Xml.Serialization;
 
     // if change the enum, have to change xsdbuilder as well.
-    /// <include file='doc\XmlSchemaForm.uex' path='docs/doc[@for="XmlSchemaForm"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
     public enum XmlSchemaForm
     {
-        /// <include file='doc\XmlSchemaForm.uex' path='docs/doc[@for="XmlSchemaForm.XmlEnum"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
         [XmlIgnore]
         None,
-        /// <include file='doc\XmlSchemaForm.uex' path='docs/doc[@for="XmlSchemaForm.XmlEnum1"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
         [XmlEnum("qualified")]
         Qualified,
-        /// <include file='doc\XmlSchemaForm.uex' path='docs/doc[@for="XmlSchemaForm.XmlEnum2"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/IXmlSerializable.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/IXmlSerializable.cs
@@ -6,18 +6,14 @@ namespace System.Xml.Serialization
 {
     using System.Xml.Schema;
 
-    /// <include file='doc\IXmlSerializable.uex' path='docs/doc[@for="IXmlSerializable"]/*' />
     ///<internalonly/>
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
     public interface IXmlSerializable
     {
-        /// <include file='doc\IXmlSerializable.uex' path='docs/doc[@for="IXmlSerializable.GetSchema"]/*' />
         XmlSchema GetSchema();
-        /// <include file='doc\IXmlSerializable.uex' path='docs/doc[@for="IXmlSerializable.ReadXml"]/*' />
         void ReadXml(XmlReader reader);
-        /// <include file='doc\IXmlSerializable.uex' path='docs/doc[@for="IXmlSerializable.WriteXml"]/*' />
         void WriteXml(XmlWriter writer);
     }
 }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSchemaProviderAttribute.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSchemaProviderAttribute.cs
@@ -7,7 +7,6 @@ namespace System.Xml.Serialization
     using System;
     using System.Xml.Schema;
 
-    /// <include file='doc\XmlSchemaProviderAttribute.uex' path='docs/doc[@for="XmlSchemaProviderAttribute"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
@@ -17,7 +16,6 @@ namespace System.Xml.Serialization
         private string _methodName;
         private bool _any;
 
-        /// <include file='doc\XmlSchemaProviderAttribute.uex' path='docs/doc[@for="XmlSchemaProviderAttribute.XmlSchemaProviderAttribute"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -26,7 +24,6 @@ namespace System.Xml.Serialization
             _methodName = methodName;
         }
 
-        /// <include file='doc\XmlSchemaProviderAttribute.uex' path='docs/doc[@for="XmlSchemaProviderAttribute.MethodName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -35,7 +32,6 @@ namespace System.Xml.Serialization
             get { return _methodName; }
         }
 
-        /// <include file='doc\XmlSchemaProviderAttribute.uex' path='docs/doc[@for="XmlSchemaProviderAttribute.IsAny"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -27,7 +27,6 @@ namespace System.Xml
         RoundtripKind,
     }
 
-    /// <include file='doc\XmlConvert.uex' path='docs/doc[@for="XmlConvert"]/*' />
     /// <devdoc>
     ///    Encodes and decodes XML names according to
     ///    the "Encoding of arbitrary Unicode Characters in XML Names" specification.
@@ -41,7 +40,6 @@ namespace System.Xml
 
         internal static char[] crt = new char[] { '\n', '\r', '\t' };
 
-        /// <include file='doc\XmlConvert.uex' path='docs/doc[@for="XmlConvert.EncodeName"]/*' />
         /// <devdoc>
         ///    <para>
         ///       Converts names, such
@@ -54,7 +52,6 @@ namespace System.Xml
             return EncodeName(name, true/*Name_not_NmToken*/, false/*Local?*/);
         }
 
-        /// <include file='doc\XmlConvert.uex' path='docs/doc[@for="XmlConvert.EncodeNmToken"]/*' />
         /// <devdoc>
         ///    <para> Verifies the name is valid
         ///       according to production [7] in the XML spec.</para>
@@ -64,7 +61,6 @@ namespace System.Xml
             return EncodeName(name, false/*Name_not_NmToken*/, false/*Local?*/);
         }
 
-        /// <include file='doc\XmlConvert.uex' path='docs/doc[@for="XmlConvert.EncodeLocalName"]/*' />
         /// <devdoc>
         ///    <para>Converts names, such as DataTable or DataColumn names, that contain
         ///       characters that are not permitted in XML names to valid names.</para>
@@ -74,7 +70,6 @@ namespace System.Xml
             return EncodeName(name, true/*Name_not_NmToken*/, true/*Local?*/);
         }
 
-        /// <include file='doc\XmlConvert.uex' path='docs/doc[@for="XmlConvert.DecodeName"]/*' />
         /// <devdoc>
         ///    <para>
         ///       Transforms an XML name into an object name (such as DataTable or DataColumn).</para>
@@ -342,8 +337,6 @@ namespace System.Xml
 
         //
         // Verification methods for strings
-        // 
-        /// <include file='doc\XmlConvert.uex' path='docs/doc[@for="XmlConvert.VerifyName"]/*' />
         /// <devdoc>
         ///    <para>
         ///    </para>
@@ -408,7 +401,6 @@ namespace System.Xml
             return name;
         }
 
-        /// <include file='doc\XmlConvert.uex' path='docs/doc[@for="XmlConvert.VerifyNCName"]/*' />
         /// <devdoc>
         ///    <para>
         ///    </para>
@@ -451,7 +443,6 @@ namespace System.Xml
             return null;
         }
 
-        /// <include file='doc\XmlConvert.uex' path='docs/doc[@for="XmlConvert.VerifyTOKEN"]/*' />
         /// <devdoc>
         ///    <para>
         ///    </para>
@@ -482,7 +473,6 @@ namespace System.Xml
             return null;
         }
 
-        /// <include file='doc\XmlConvert.uex' path='docs/doc[@for="XmlConvert.VerifyNMTOKEN"]/*' />
         /// <devdoc>
         ///    <para>
         ///    </para>

--- a/src/System.Private.Xml/src/System/Xml/XmlQualifiedName.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlQualifiedName.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 
 namespace System.Xml
 {
-    /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
@@ -18,25 +17,21 @@ namespace System.Xml
 
         private Int32 _hash;
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.Empty"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
         public static readonly XmlQualifiedName Empty = new XmlQualifiedName(string.Empty);
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.XmlQualifiedName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
         public XmlQualifiedName() : this(string.Empty, string.Empty) { }
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.XmlQualifiedName1"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
         public XmlQualifiedName(string name) : this(name, string.Empty) { }
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.XmlQualifiedName2"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -46,7 +41,6 @@ namespace System.Xml
             _name = name == null ? string.Empty : name;
         }
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.Namespace"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -55,7 +49,6 @@ namespace System.Xml
             get { return _ns; }
         }
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.Name"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -64,7 +57,6 @@ namespace System.Xml
             get { return _name; }
         }
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.GetHashCode"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -78,7 +70,6 @@ namespace System.Xml
             return _hash;
         }
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.IsEmpty"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -87,7 +78,6 @@ namespace System.Xml
             get { return Name.Length == 0 && Namespace.Length == 0; }
         }
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.ToString"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -96,7 +86,6 @@ namespace System.Xml
             return Namespace.Length == 0 ? Name : string.Concat(Namespace, ":", Name);
         }
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.Equals"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -117,7 +106,6 @@ namespace System.Xml
             return false;
         }
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.operator=="]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -132,7 +120,6 @@ namespace System.Xml
             return (a.Name == b.Name && a.Namespace == b.Namespace);
         }
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.operator!="]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -141,7 +128,6 @@ namespace System.Xml
             return !(a == b);
         }
 
-        /// <include file='doc\XmlQualifiedName.uex' path='docs/doc[@for="XmlQualifiedName.ToString1"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/XmlResolver.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlResolver.cs
@@ -12,7 +12,6 @@ namespace System.Xml
     using System.Threading.Tasks;
     using System.Runtime.Versioning;
 
-    /// <include file='doc\XmlResolver.uex' path='docs/doc[@for="XmlResolver"]/*' />
     /// <devdoc>
     ///    <para>Resolves external XML resources named by a Uniform
     ///       Resource Identifier (URI). This class is <see langword='abstract'/>
@@ -20,7 +19,6 @@ namespace System.Xml
     /// </devdoc>
     public abstract partial class XmlResolver
     {
-        /// <include file='doc\XmlResolver.uex' path='docs/doc[@for="XmlResolver.GetEntity1"]/*' />
         /// <devdoc>
         ///    <para>Maps a
         ///       URI to an Object containing the actual resource.</para>
@@ -32,7 +30,6 @@ namespace System.Xml
 
 
 
-        /// <include file='doc\XmlResolver.uex' path='docs/doc[@for="XmlResolver.ResolveUri"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -80,7 +77,6 @@ namespace System.Xml
         }
 
         //UE attension
-        /// <include file='doc\XmlResolver.uex' path='docs/doc[@for="XmlResolver.Credentials"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>


### PR DESCRIPTION
related: #11806 

cc: @weshaggard @danmosemsft 

This PR is readding the changes that were lost when we merged dev/api branch for the System.Xml.XmlReaderWriter library. For this library, essentially the only changes that were lost were the ones from PR #11336 which is basically just removing obsolete include comments to some files.