### PR TITLE
Fix incremental restore when building against packages

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -95,6 +95,7 @@
   <PropertyGroup Condition="'$(BuildTestsAgainstPackages)' == 'true'">
     <GeneratedProjectJsonDir>$(ObjDir)generated</GeneratedProjectJsonDir>
     <BuildTestsAgainstPackagesIdentityRegex>$(CoreFxVersionsIdentityRegex)</BuildTestsAgainstPackagesIdentityRegex>
+    <SkipVerifyPackageVersions>true</SkipVerifyPackageVersions>
   </PropertyGroup>
 
   <!-- list of directories to perform batch restore -->
@@ -127,6 +128,7 @@
   <ItemGroup>
     <ProjectJsonFiles Include="$(SourceDir)**/project.json" />
     <ProjectJsonFiles Include="$(MSBuildThisFileDirectory)pkg/**/project.json" />
+    <ProjectJsonFiles Condition="'$(BuildTestsAgainstPackages)' == 'true'" Include="$(GeneratedProjectJsonDir)/**/project.json" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(BuildAllProjects)'=='true'">


### PR DESCRIPTION
While building against packages we weren't considering the
genreated project.json files when checking whether or not to
restore so restore was getting skipped in some cases.

The adds the generated project.json files to the list to check
as well as disables package validation because we are mostly
using new packages that aren't the ones we are validating against.

cc @chcosta @ericstj 