### PR TITLE
Fix GetAnyStaticMethodValidated to check all overloads of operators

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -17,7 +17,7 @@ namespace System.Dynamic.Utils
             string name,
             Type[] types)
         {
-            foreach (MethodInfo method in type.GetRuntimeMethods())
+            foreach (MethodInfo method in type.GetTypeInfo().DeclaredMethods)
             {
                 if (method.IsStatic && method.Name == name && method.MatchesArgumentTypes(types))
                 {

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -17,9 +17,14 @@ namespace System.Dynamic.Utils
             string name,
             Type[] types)
         {
-            var method = type.GetAnyStaticMethod(name);
-
-            return method.MatchesArgumentTypes(types) ? method : null;
+            foreach (var method in type.GetRuntimeMethods())
+            {
+                if (method.IsStatic && method.Name == name && method.MatchesArgumentTypes(types))
+                {
+                    return method;
+                }
+            }
+            return null;
         }
 
         /// <summary>
@@ -104,18 +109,6 @@ namespace System.Dynamic.Utils
                     yield return method;
                 }
             }
-        }
-
-        public static MethodInfo GetAnyStaticMethod(this Type type, string name)
-        {
-            foreach (var method in type.GetRuntimeMethods())
-            {
-                if (method.IsStatic && method.Name == name)
-                {
-                    return method;
-                }
-            }
-            return null;
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -17,7 +17,7 @@ namespace System.Dynamic.Utils
             string name,
             Type[] types)
         {
-            foreach (var method in type.GetRuntimeMethods())
+            foreach (MethodInfo method in type.GetRuntimeMethods())
             {
                 if (method.IsStatic && method.Name == name && method.MatchesArgumentTypes(types))
                 {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -492,26 +492,26 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(new DateTime(90), lambda());
         }
 
-		[Fact]
-		public static void Subtract_NoSuchOperatorDeclaredOnType_ThrowsInvalidOperationException()
-		{
-			Assert.Throws<InvalidOperationException>(() => Expression.Add(Expression.Constant(new SubClass(0)), Expression.Constant(new SubClass(1))));
-		}
+        [Fact]
+        public static void Subtract_NoSuchOperatorDeclaredOnType_ThrowsInvalidOperationException()
+        {
+            Assert.Throws<InvalidOperationException>(() => Expression.Add(Expression.Constant(new SubClass(0)), Expression.Constant(new SubClass(1))));
+        }
 
-		public class BaseClass
-		{
-			public BaseClass(int value) { Value = value; }
-			public int Value { get; }
+        public class BaseClass
+        {
+            public BaseClass(int value) { Value = value; }
+            public int Value { get; }
 
-			public static BaseClass operator -(BaseClass i1, BaseClass i2) => new BaseClass(i1.Value - i2.Value);
-		}
+            public static BaseClass operator -(BaseClass i1, BaseClass i2) => new BaseClass(i1.Value - i2.Value);
+        }
 
-		public class SubClass : BaseClass
-		{
-			public SubClass(int value) : base(value) { }
-		}
+        public class SubClass : BaseClass
+        {
+            public SubClass(int value) : base(value) { }
+        
 
-		[Fact]
+        [Fact]
         public static void CannotReduce()
         {
             Expression exp = Expression.Subtract(Expression.Constant(0), Expression.Constant(0));

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -492,7 +492,26 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(new DateTime(90), lambda());
         }
 
-        [Fact]
+		[Fact]
+		public static void Subtract_NoSuchOperatorDeclaredOnType_ThrowsInvalidOperationException()
+		{
+			Assert.Throws<InvalidOperationException>(() => Expression.Add(Expression.Constant(new SubClass(0)), Expression.Constant(new SubClass(1))));
+		}
+
+		public class BaseClass
+		{
+			public BaseClass(int value) { Value = value; }
+			public int Value { get; }
+
+			public static BaseClass operator -(BaseClass i1, BaseClass i2) => new BaseClass(i1.Value - i2.Value);
+		}
+
+		public class SubClass : BaseClass
+		{
+			public SubClass(int value) : base(value) { }
+		}
+
+		[Fact]
         public static void CannotReduce()
         {
             Expression exp = Expression.Subtract(Expression.Constant(0), Expression.Constant(0));

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -509,7 +509,7 @@ namespace System.Linq.Expressions.Tests
         public class SubClass : BaseClass
         {
             public SubClass(int value) : base(value) { }
-        
+        }
 
         [Fact]
         public static void CannotReduce()

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -476,11 +476,20 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [ClassData(typeof(CompilationTypes))]
-        public static void Subtract_MultipleOverloads_CorrectlyResolvesOperator(bool useInterpreter)
+        public static void Subtract_MultipleOverloads_CorrectlyResolvesOperator1(bool useInterpreter)
         {
             BinaryExpression subtract = Expression.Subtract(Expression.Constant(new DateTime(100)), Expression.Constant(new DateTime(10)));
             Func<TimeSpan> lambda = Expression.Lambda<Func<TimeSpan>>(subtract).Compile(useInterpreter);
             Assert.Equal(new TimeSpan(90), lambda());
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public static void Subtract_MultipleOverloads_CorrectlyResolvesOperator2(bool useInterpreter)
+        {
+            BinaryExpression subtract = Expression.Subtract(Expression.Constant(new DateTime(100)), Expression.Constant(new TimeSpan(10)));
+            Func<DateTime> lambda = Expression.Lambda<Func<DateTime>>(subtract).Compile(useInterpreter);
+            Assert.Equal(new DateTime(90), lambda());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -474,6 +474,15 @@ namespace System.Linq.Expressions.Tests
 
         #endregion
 
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public static void Subtract_MultipleOverloads_CorrectlyResolvesOperator(bool useInterpreter)
+        {
+            BinaryExpression subtract = Expression.Subtract(Expression.Constant(new DateTime(100)), Expression.Constant(new DateTime(10)));
+            Func<TimeSpan> lambda = Expression.Lambda<Func<TimeSpan>>(subtract).Compile(useInterpreter);
+            Assert.Equal(new TimeSpan(90), lambda());
+        }
+
         [Fact]
         public static void CannotReduce()
         {

--- a/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
@@ -67,7 +67,7 @@ namespace System.Linq.Expressions.Tests
             string name,
             Type[] types)
         {
-            foreach (MethodInfo method in type.GetRuntimeMethods())
+            foreach (MethodInfo method in type.GetTypeInfo().DeclaredMethods)
             {
                 if (method.IsStatic && method.Name == name && method.MatchesArgumentTypes(types))
                 {

--- a/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
@@ -67,7 +67,7 @@ namespace System.Linq.Expressions.Tests
             string name,
             Type[] types)
         {
-            foreach (var method in type.GetRuntimeMethods())
+            foreach (MethodInfo method in type.GetRuntimeMethods())
             {
                 if (method.IsStatic && method.Name == name && method.MatchesArgumentTypes(types))
                 {

--- a/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
@@ -67,9 +67,14 @@ namespace System.Linq.Expressions.Tests
             string name,
             Type[] types)
         {
-            var method = type.GetAnyStaticMethod(name);
-
-            return method.MatchesArgumentTypes(types) ? method : null;
+            foreach (var method in type.GetRuntimeMethods())
+            {
+                if (method.IsStatic && method.Name == name && method.MatchesArgumentTypes(types))
+                {
+                    return method;
+                }
+            }
+            return null;
         }
 
         /// <summary>
@@ -123,18 +128,6 @@ namespace System.Linq.Expressions.Tests
                 return true;
             }
             return false;
-        }
-
-        internal static MethodInfo GetAnyStaticMethod(this Type type, string name)
-        {
-            foreach (var method in type.GetTypeInfo().DeclaredMethods)
-            {
-                if (method.IsStatic && method.Name == name)
-                {
-                    return method;
-                }
-            }
-            return null;
         }
     }
 }


### PR DESCRIPTION
Fixes #11907

This should probably be ported to 1.1.0, as we have already one documented report preventing porting-to-core

/cc @Whathecode @VSadov @Bartdesmet @stephentoub @JonHanna 