### PR TITLE
Update layout package version for .NET Native targeting pack

### DIFF
--- a/layout/dir.proj
+++ b/layout/dir.proj
@@ -38,7 +38,7 @@
     <TargetFrameworkMonikers Include="uap10.1">
       <RID>win10-x64-aot</RID>
       <AdditionalBinaryPath>
-        $(PackagesDir)/Microsoft.TargetingPack.Private.NETNative/1.1.0-beta-24512-00/lib/uap10.1;
+        $(PackagesDir)/Microsoft.TargetingPack.Private.NETNative/1.1.0-beta-24519-00/lib/uap10.1;
         $(PackagesDir)/runtime.win7.System.Private.Uri\4.3.0-$(CoreFxExpectedPrerelease)\runtimes\aot\lib\netcore50;
         $(PackagesDir)/System.Private.DataContractSerialization\4.3.0-$(CoreFxExpectedPrerelease)\runtimes\aot\lib\netcore50;
         $(PackagesDir)/System.Private.Xml\4.3.0-$(CoreFxExpectedPrerelease)\lib\netstandard1.3;


### PR DESCRIPTION
@danmosemsft @SedarG 

@SedarG Are we at a point where we are auto-updating the .NET Native targeting pack yet? If so can we start validating it in the repo and share the version number with this layout project?