### PR TITLE
Reapply changes made to XmlSerializer

### DIFF
--- a/src/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/System.Private.Xml/src/System.Private.Xml.csproj
@@ -415,11 +415,8 @@
     <Compile Include="System\Xml\Serialization\Mappings.cs" />
     <Compile Include="System\Xml\Serialization\Models.cs" />
     <Compile Include="System\Xml\Serialization\NameTable.cs" />
-    <!-- Temporarily removing since after the merge from dev/api there is some work required on these files
-         in order to have them compile again. Issue tracking this is: https://github.com/dotnet/corefx/issues/11686
     <Compile Include="System\Xml\Serialization\ReflectionXmlSerializationReader.cs" />
     <Compile Include="System\Xml\Serialization\ReflectionXmlSerializationWriter.cs" />
-    -->
     <Compile Include="System\Xml\Serialization\SchemaImporter.cs" />
     <Compile Include="System\Xml\Serialization\SchemaObjectWriter.cs" />
     <Compile Include="System\Xml\Serialization\SoapAttributeAttribute.cs" />

--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -717,7 +717,7 @@ namespace System.Xml.Serialization
 
             if (mapping.IsFlags)
             {
-                Dictionary<string, long> table = WriteHashtable(mapping, mapping.TypeDesc.Name);
+                Hashtable table = WriteHashtable(mapping, mapping.TypeDesc.Name);
                 return Enum.ToObject(mapping.TypeDesc.Type, ToEnum(source, table, mapping.TypeDesc.Name));
             }
             else
@@ -726,9 +726,9 @@ namespace System.Xml.Serialization
             }
         }
 
-        private Dictionary<string, long> WriteHashtable(EnumMapping mapping, string name)
+        private Hashtable WriteHashtable(EnumMapping mapping, string name)
         {
-            var h = new Dictionary<string, long>();
+            var h = new Hashtable();
 
             ConstantMapping[] constants = mapping.Constants;
 

--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
@@ -23,7 +23,7 @@ namespace System.Xml.Serialization
 
         public ReflectionXmlSerializationWriter(XmlMapping xmlMapping, XmlWriter xmlWriter, XmlSerializerNamespaces namespaces, string encodingStyle, string id)
         {
-            Init(xmlWriter, namespaces, encodingStyle, id);
+            Init(xmlWriter, namespaces, encodingStyle, id, null);
 
             if (!xmlMapping.IsWriteable || !xmlMapping.GenerateSerializer)
             {

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -358,32 +358,8 @@ namespace System.Xml.Serialization
             ilg = new CodeGenerator(this.typeBuilder);
             ilg.BeginMethod(typeof(void), "InitCallbacks", Array.Empty<Type>(), Array.Empty<string>(),
                 CodeGenerator.ProtectedOverrideMethodAttributes);
-
-            string dummyArrayMethodName = NextMethodName("Array");
-            bool needDummyArrayMethod = false;
             ilg.EndMethod();
-
-            if (needDummyArrayMethod)
-            {
-                ilg.BeginMethod(
-                    typeof(object),
-                    GetMethodBuilder(dummyArrayMethodName),
-                    Array.Empty<Type>(),
-                    Array.Empty<string>(),
-                    CodeGenerator.PrivateMethodAttributes);
-                MethodInfo XmlSerializationReader_UnknownNode1 = typeof(XmlSerializationReader).GetMethod(
-                      "UnknownNode",
-                      CodeGenerator.InstanceBindingFlags,
-                      new Type[] { typeof(object) }
-                      );
-                ilg.Ldarg(0);
-                ilg.Load(null);
-                ilg.Call(XmlSerializationReader_UnknownNode1);
-                ilg.Load(null);
-                ilg.EndMethod();
-            }
         }
-
 
         private string GenerateMembersElement(XmlMembersMapping xmlMembersMapping)
         {

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -279,7 +279,7 @@ namespace System.Xml.Serialization
             {
                 this.innerSerializer = contract.GetSerializer(type);
             }
-			else if (ReflectionMethodEnabled)
+            else if (ReflectionMethodEnabled)
             {
                 var importer = new XmlReflectionImporter(defaultNamespace);
                 _mapping = importer.ImportTypeMapping(type, null, defaultNamespace);
@@ -730,7 +730,7 @@ namespace System.Xml.Serialization
 
             return serializers;
 #else
-			XmlSerializerImplementation contract = null;
+            XmlSerializerImplementation contract = null;
             Assembly assembly = type == null ? null : TempAssembly.LoadGeneratedAssembly(type, null, out contract);
             TempAssembly tempAssembly = null;
             if (assembly == null)

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -115,16 +115,33 @@ namespace System.Xml.Serialization
     /// </devdoc>
     public class XmlSerializer
     {
+        private enum SerializationMode
+        {
+            CodeGenOnly,
+            ReflectionOnly,
+            ReflectionAsBackup
+        }
+
+        private SerializationMode Mode { get; set; } = SerializationMode.ReflectionAsBackup;
+
+        private bool ReflectionMethodEnabled
+        {
+            get
+            {
+                return Mode == SerializationMode.ReflectionOnly || Mode == SerializationMode.ReflectionAsBackup;
+            }
+        }
+
         private TempAssembly _tempAssembly;
         private bool _typedSerializer;
         private Type _primitiveType;
         private XmlMapping _mapping;
         private XmlDeserializationEvents _events = new XmlDeserializationEvents();
 #if NET_NATIVE
-        public string DefaultNamespace = null;
         private XmlSerializer innerSerializer;
-        private readonly Type rootType;
 #endif
+        public string DefaultNamespace = null;
+        private Type rootType;
 
         private static TempAssemblyCache s_cache = new TempAssemblyCache();
         private static volatile XmlSerializerNamespaces s_defaultNamespaces;
@@ -197,7 +214,12 @@ namespace System.Xml.Serialization
         /// </devdoc>
         public XmlSerializer(XmlTypeMapping xmlTypeMapping)
         {
+            if (xmlTypeMapping == null)
+                throw new ArgumentNullException(nameof(xmlTypeMapping));
+
+#if !NET_NATIVE
             _tempAssembly = GenerateTempAssembly(xmlTypeMapping);
+#endif
             _mapping = xmlTypeMapping;
         }
 
@@ -218,10 +240,9 @@ namespace System.Xml.Serialization
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
 
-#if NET_NATIVE
-            this.DefaultNamespace = defaultNamespace;
+            DefaultNamespace = defaultNamespace;
             rootType = type;
-#endif
+
             _mapping = GetKnownMapping(type, defaultNamespace);
             if (_mapping != null)
             {
@@ -258,6 +279,16 @@ namespace System.Xml.Serialization
             {
                 this.innerSerializer = contract.GetSerializer(type);
             }
+			else if (ReflectionMethodEnabled)
+            {
+                var importer = new XmlReflectionImporter(defaultNamespace);
+                _mapping = importer.ImportTypeMapping(type, null, defaultNamespace);
+
+                if (_mapping == null)
+                {
+                    _mapping = XmlReflectionImporter.GetTopLevelMapping(type, defaultNamespace);
+                }
+            }
 #endif
         }
 
@@ -274,12 +305,11 @@ namespace System.Xml.Serialization
         /// </devdoc>
         internal XmlSerializer(Type type, XmlAttributeOverrides overrides, Type[] extraTypes, XmlRootAttribute root, string defaultNamespace, string location, Evidence evidence)
         {
-#if NET_NATIVE
-            throw new PlatformNotSupportedException();
-#else
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
 
+            DefaultNamespace = defaultNamespace;
+            rootType = type;
             XmlReflectionImporter importer = new XmlReflectionImporter(overrides, defaultNamespace);
             if (extraTypes != null)
             {
@@ -291,6 +321,8 @@ namespace System.Xml.Serialization
             {
                 DemandForUserLocationOrEvidence();
             }
+
+#if !NET_NATIVE
             _tempAssembly = GenerateTempAssembly(_mapping, type, defaultNamespace, location, evidence);
 #endif
         }
@@ -396,8 +428,25 @@ namespace System.Xml.Serialization
                     SerializePrimitive(xmlWriter, o, namespaces);
                 }
 #if !NET_NATIVE
+                else if (Mode == SerializationMode.ReflectionOnly)
+                {
+                    XmlMapping mapping;
+                    if (_mapping != null && _mapping.GenerateSerializer)
+                    {
+                        mapping = _mapping;
+                    }
+                    else
+                    {
+                        XmlReflectionImporter importer = new XmlReflectionImporter(DefaultNamespace);
+                        mapping = importer.ImportTypeMapping(rootType, null, DefaultNamespace);
+                    }
+
+                    var writer = new ReflectionXmlSerializationWriter(mapping, xmlWriter, namespaces == null || namespaces.Count == 0 ? DefaultNamespaces : namespaces, encodingStyle, id);
+                    writer.WriteObject(o);
+                }
                 else if (_tempAssembly == null || _typedSerializer)
                 {
+                    // The contion for the block is never true, thus the block is never hit.
                     XmlSerializationWriter writer = CreateWriter();
                     writer.Init(xmlWriter, namespaces == null || namespaces.Count == 0 ? DefaultNamespaces : namespaces, encodingStyle, id, _tempAssembly);
                     try
@@ -414,25 +463,43 @@ namespace System.Xml.Serialization
 #else
                 else
                 {
-                    if (this.innerSerializer == null)
+                    if (this.innerSerializer != null)
+                    {
+                        if (!string.IsNullOrEmpty(this.DefaultNamespace))
+                        {
+                            this.innerSerializer.DefaultNamespace = this.DefaultNamespace;
+                        }
+
+                        XmlSerializationWriter writer = this.innerSerializer.CreateWriter();
+                        writer.Init(xmlWriter, namespaces == null || namespaces.Count == 0 ? DefaultNamespaces : namespaces, encodingStyle, id);
+                        try
+                        {
+                            this.innerSerializer.Serialize(o, writer);
+                        }
+                        finally
+                        {
+                            writer.Dispose();
+                        }
+                    }
+                    else if (ReflectionMethodEnabled)
+                    {
+                        XmlMapping mapping;
+                        if (_mapping != null && _mapping.GenerateSerializer)
+                        {
+                            mapping = _mapping;
+                        }
+                        else
+                        {
+                            XmlReflectionImporter importer = new XmlReflectionImporter(DefaultNamespace);
+                            mapping = importer.ImportTypeMapping(rootType, null, DefaultNamespace);
+                        }
+
+                        var writer = new ReflectionXmlSerializationWriter(mapping, xmlWriter, namespaces == null || namespaces.Count == 0 ? DefaultNamespaces : namespaces, encodingStyle, id);
+                        writer.WriteObject(o);
+                    }
+                    else
                     {
                         throw new InvalidOperationException(SR.Format(SR.Xml_MissingSerializationCodeException, this.rootType, typeof(XmlSerializer).Name));
-                    }
-
-                    if (!string.IsNullOrEmpty(this.DefaultNamespace))
-                    {
-                        this.innerSerializer.DefaultNamespace = this.DefaultNamespace; 
-                    }
-                    
-                    XmlSerializationWriter writer = this.innerSerializer.CreateWriter();
-                    writer.Init(xmlWriter, namespaces == null || namespaces.Count == 0 ? DefaultNamespaces : namespaces, encodingStyle, id);
-                    try
-                    {
-                        this.innerSerializer.Serialize(o, writer);
-                    }
-                    finally
-                    {
-                        writer.Dispose();
                     }
                 }
 #endif
@@ -508,6 +575,22 @@ namespace System.Xml.Serialization
                     return DeserializePrimitive(xmlReader, events);
                 }
 #if !NET_NATIVE
+                else if (Mode == SerializationMode.ReflectionOnly)
+                {
+                    XmlMapping mapping;
+                    if (_mapping != null && _mapping.GenerateSerializer)
+                    {
+                        mapping = _mapping;
+                    }
+                    else
+                    {
+                        XmlReflectionImporter importer = new XmlReflectionImporter(DefaultNamespace);
+                        mapping = importer.ImportTypeMapping(rootType, null, DefaultNamespace);
+                    }
+
+                    var reader = new ReflectionXmlSerializationReader(mapping, xmlReader, events, encodingStyle);
+                    return reader.ReadObject();
+                }
                 else if (_tempAssembly == null || _typedSerializer)
                 {
                     XmlSerializationReader reader = CreateReader();
@@ -528,25 +611,44 @@ namespace System.Xml.Serialization
 #else
                 else
                 {
-                    if (this.innerSerializer == null)
+                    if (this.innerSerializer != null)
                     {
+                        if (!string.IsNullOrEmpty(this.DefaultNamespace))
+                        {
+                            this.innerSerializer.DefaultNamespace = this.DefaultNamespace;
+                        }
+
+                        XmlSerializationReader reader = this.innerSerializer.CreateReader();
+                        reader.Init(xmlReader, encodingStyle);
+                        try
+                        {
+                            return this.innerSerializer.Deserialize(reader);
+                        }
+                        finally
+                        {
+                            reader.Dispose();
+                        }
+                    }
+                    else if (ReflectionMethodEnabled)
+                    {
+                        XmlMapping mapping;
+                        if (_mapping != null && _mapping.GenerateSerializer)
+                        {
+                            mapping = _mapping;
+                        }
+                        else
+                        {
+                            XmlReflectionImporter importer = new XmlReflectionImporter(DefaultNamespace);
+                            mapping = importer.ImportTypeMapping(rootType, null, DefaultNamespace);
+                        }
+
+                        var reader = new ReflectionXmlSerializationReader(mapping, xmlReader, events, encodingStyle);
+                        return reader.ReadObject();
+                    }
+                    else
+                    {
+
                         throw new InvalidOperationException(SR.Format(SR.Xml_MissingSerializationCodeException, this.rootType, typeof(XmlSerializer).Name));
-                    }
-
-                    if (!string.IsNullOrEmpty(this.DefaultNamespace))
-                    {
-                        this.innerSerializer.DefaultNamespace = this.DefaultNamespace; 
-                    }
-
-                    XmlSerializationReader reader = this.innerSerializer.CreateReader();
-                    reader.Init(xmlReader, encodingStyle);
-                    try
-                    {
-                        return this.innerSerializer.Deserialize(reader);
-                    }
-                    finally
-                    {
-                        reader.Dispose();
                     }
                 }
 #endif
@@ -589,12 +691,14 @@ namespace System.Xml.Serialization
                 return false;
             }
 #else
-            if (this.innerSerializer == null)
+            if (this.innerSerializer != null)
             {
-                return false;
+                return this.innerSerializer.CanDeserialize(xmlReader);
             }
-
-            return this.innerSerializer.CanDeserialize(xmlReader);
+            else
+            {
+                return ReflectionMethodEnabled;
+            }
 #endif
         }
 
@@ -614,7 +718,19 @@ namespace System.Xml.Serialization
         public static XmlSerializer[] FromMappings(XmlMapping[] mappings, Type type)
         {
             if (mappings == null || mappings.Length == 0) return Array.Empty<XmlSerializer>();
-            XmlSerializerImplementation contract = null;
+
+#if NET_NATIVE
+            var serializers = new XmlSerializer[mappings.Length];
+            for(int i=0;i<mappings.Length;i++)
+            {
+                serializers[i] = new XmlSerializer();
+                serializers[i].rootType = type;
+                serializers[i]._mapping = mappings[i];
+            }
+
+            return serializers;
+#else
+			XmlSerializerImplementation contract = null;
             Assembly assembly = type == null ? null : TempAssembly.LoadGeneratedAssembly(type, null, out contract);
             TempAssembly tempAssembly = null;
             if (assembly == null)
@@ -654,6 +770,7 @@ namespace System.Xml.Serialization
                     serializers[i] = (XmlSerializer)contract.TypedSerializers[mappings[i].Key];
                 return serializers;
             }
+#endif
         }
 
         private static XmlSerializer[] GetSerializersFromCache(XmlMapping[] mappings, Type type)


### PR DESCRIPTION
Reapply changes made to XmlSerializer since the move to System.Private.Xml since they got lost in merge from dev/api.

Fix #11768.

/cc: @mconnew @huanwu @zhenlan @joperezr 