### PR TITLE
Stub out System.Net.ServicePoint

### DIFF
--- a/src/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/System.Net.Requests/ref/System.Net.Requests.cs
@@ -8,6 +8,31 @@
 
 namespace System.Net
 {
+    public class AuthenticationManager
+    {
+        private AuthenticationManager() { }
+        public static System.Net.ICredentialPolicy CredentialPolicy { get { throw null; } set { } }
+        public static System.Collections.Specialized.StringDictionary CustomTargetNameDictionary { get { throw null; } }
+        public static Authorization Authenticate(string challenge, System.Net.WebRequest request, ICredentials credentials) { throw null; }
+        public static Authorization PreAuthenticate(System.Net.WebRequest request, ICredentials credentials) { throw null; }
+        public static void Register(IAuthenticationModule authenticationModule) { }
+        public static void Unregister(IAuthenticationModule authenticationModule) { }
+        public static void Unregister(string authenticationScheme) { }
+        public static System.Collections.IEnumerator RegisteredModules { get { throw null; } }
+    }
+    public class Authorization
+    {
+        public Authorization(string token) { }
+        public Authorization(string token, bool finished) { }
+        public Authorization(string token, bool finished, string connectionGroupId) { }
+
+        public string Message { get { throw null; } }
+        public string ConnectionGroupId { get { throw null; } }
+        public bool Complete { get { throw null; } }
+        public string[] ProtectionRealm { get { throw null; } set { } }
+        public bool MutuallyAuthenticated { get { throw null; } set { } }
+    }
+    public delegate System.Net.IPEndPoint BindIPEndPoint(System.Net.ServicePoint servicePoint, System.Net.IPEndPoint remoteEndPoint, int retryCount);
     public partial class HttpWebRequest : System.Net.WebRequest
     {
         internal HttpWebRequest() { }
@@ -43,6 +68,21 @@ namespace System.Net
         public override bool SupportsHeaders { get { return default(bool); } }
         protected override void Dispose(bool disposing) { }
         public override System.IO.Stream GetResponseStream() { return default(System.IO.Stream); }
+    }
+    public interface IAuthenticationModule
+    {
+        System.Net.Authorization Authenticate(string challenge, System.Net.WebRequest request, System.Net.ICredentials credentials);
+        System.Net.Authorization PreAuthenticate(System.Net.WebRequest request, System.Net.ICredentials credentials);
+        bool CanPreAuthenticate { get; }
+        string AuthenticationType { get; }
+    }
+    public interface ICertificatePolicy
+    {
+        bool CheckValidationResult(System.Net.ServicePoint srvPoint, System.Security.Cryptography.X509Certificates.X509Certificate certificate, System.Net.WebRequest request, int certificateProblem);
+    }
+    public interface ICredentialPolicy
+    {
+        bool ShouldSendCredential(System.Uri challengeUri, System.Net.WebRequest request, System.Net.NetworkCredential credential, System.Net.IAuthenticationModule authenticationModule);
     }
     public partial interface IWebRequestCreate
     {
@@ -122,6 +162,62 @@ namespace System.Net
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public abstract System.IO.Stream GetResponseStream();
+    }
+
+    [Flags]
+    public enum SecurityProtocolType
+    {
+#pragma warning disable CS0618
+        Ssl3 = System.Security.Authentication.SslProtocols.Ssl3,
+#pragma warning restore CS0618
+        Tls = System.Security.Authentication.SslProtocols.Tls,
+        Tls11 = System.Security.Authentication.SslProtocols.Tls11,
+        Tls12 = System.Security.Authentication.SslProtocols.Tls12,
+    }
+    public class ServicePoint
+    {
+        internal ServicePoint() { }
+        public System.Net.BindIPEndPoint BindIPEndPointDelegate { get { throw null; } set { } }
+        public int ConnectionLeaseTimeout { get { throw null; } set { } }
+        public System.Uri Address { get { throw null; } }
+        public int MaxIdleTime { get { throw null; } set { } }
+        public bool UseNagleAlgorithm { get { throw null; } set { } }
+        public int ReceiveBufferSize { get { throw null; } set { } }
+        public bool Expect100Continue { get { throw null; } set { } }
+        public System.DateTime IdleSince { get { throw null; } }
+        public virtual System.Version ProtocolVersion { get { throw null; } }
+        public string ConnectionName { get { throw null; } }
+        public bool CloseConnectionGroup(string connectionGroupName) { throw null; }
+        public int ConnectionLimit { get { throw null; } set { } }
+        public int CurrentConnections { get { throw null; } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { throw null; } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate ClientCertificate { get { throw null; } }
+        public bool SupportsPipelining { get { throw null; } }
+        public void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval) { throw null; }
+    }
+    public class ServicePointManager
+    {
+        public const int DefaultNonPersistentConnectionLimit = 4;
+        public const int DefaultPersistentConnectionLimit = 2;
+        private ServicePointManager() { }
+        public static System.Net.SecurityProtocolType SecurityProtocol { get { throw null; } set { } }
+        public static int MaxServicePoints { get { throw null; } set { } }
+        public static int DefaultConnectionLimit { get { throw null; } set { } }
+        public static int MaxServicePointIdleTime { get { throw null; } set { } }
+        public static bool UseNagleAlgorithm { get { throw null; } set { } }
+        public static bool Expect100Continue { get { throw null; } set { } }
+        public static bool EnableDnsRoundRobin { get { throw null; } set { } }
+        public static int DnsRefreshTimeout { get { throw null; } set { } }
+        [Obsolete("CertificatePolicy is obsoleted for this type, please use ServerCertificateValidationCallback instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static System.Net.ICertificatePolicy CertificatePolicy { get { throw null; } set { } }
+        public static System.Net.Security.RemoteCertificateValidationCallback ServerCertificateValidationCallback { get { throw null; } set { } }
+        public static bool ReusePort { get { throw null; } set { } }
+        public static bool CheckCertificateRevocationList { get { throw null; } set { } }
+        public static System.Net.Security.EncryptionPolicy EncryptionPolicy { get { throw null; } }
+        public static System.Net.ServicePoint FindServicePoint(System.Uri address) { throw null; }
+        public static System.Net.ServicePoint FindServicePoint(string uriString, System.Net.IWebProxy proxy) { throw null; }
+        public static System.Net.ServicePoint FindServicePoint(System.Uri address, System.Net.IWebProxy proxy) { throw null; }
+        public static void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval) { throw null; }
     }
 }
 namespace System.Net.Cache

--- a/src/System.Net.Requests/ref/project.json
+++ b/src/System.Net.Requests/ref/project.json
@@ -1,9 +1,12 @@
 {
   "dependencies": {
+    "System.Collections.Specialized": "4.0.0",
     "System.IO": "4.0.0",
     "System.Net.Primitives": "4.0.10",
+    "System.Net.Security": "4.0.0",
     "System.Net.WebHeaderCollection": "4.0.0",
     "System.Runtime": "4.0.0",
+    "System.Security.Cryptography.X509Certificates": "4.1.0",
     "System.Threading.Tasks": "4.0.0"
   },
   "frameworks": {

--- a/src/System.Net.Requests/src/Resources/Strings.resx
+++ b/src/System.Net.Requests/src/Resources/Strings.resx
@@ -171,4 +171,7 @@
   <data name="net_invalid_enum" xml:space="preserve">
     <value>The specified value is not valid in the '{0}' enumeration.</value>
   </data>
+  <data name="net_securityprotocolnotsupported" xml:space="preserve">
+    <value>The requested security protocol is not supported.</value>
+  </data>
 </root>

--- a/src/System.Net.Requests/src/System.Net.Requests.csproj
+++ b/src/System.Net.Requests/src/System.Net.Requests.csproj
@@ -21,12 +21,21 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+    <Compile Include="System\Net\AuthenticationManager.cs" />
+    <Compile Include="System\Net\Authorization.cs" />
+    <Compile Include="System\Net\BindIPEndPoint.cs" />
     <Compile Include="System\Net\HttpRequestHeader.cs" />
     <Compile Include="System\Net\HttpWebRequest.cs" />
     <Compile Include="System\Net\HttpWebResponse.cs" />
+    <Compile Include="System\Net\IAuthenticationModule.cs" />
+    <Compile Include="System\Net\ICertificatePolicy.cs" />
+    <Compile Include="System\Net\ICredentialPolicy.cs" />
     <Compile Include="System\Net\IWebRequestCreate.cs" />
     <Compile Include="System\Net\ProtocolViolationException.cs" />
     <Compile Include="System\Net\RequestStream.cs" />
+    <Compile Include="System\Net\SecurityProtocolType.cs" />
+    <Compile Include="System\Net\ServicePoint.cs" />
+    <Compile Include="System\Net\ServicePointManager.cs" />
     <Compile Include="System\Net\SystemWebProxy.cs" />
     <Compile Include="System\Net\TaskExtensions.cs" />
     <Compile Include="System\Net\WebException.cs" />

--- a/src/System.Net.Requests/src/System/Net/AuthenticationManager.cs
+++ b/src/System.Net.Requests/src/System/Net/AuthenticationManager.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Specialized;
+
+namespace System.Net
+{
+    public class AuthenticationManager
+    {
+        private AuthenticationManager() { }
+
+        public static ICredentialPolicy CredentialPolicy { get; set; }
+
+        public static StringDictionary CustomTargetNameDictionary { get; } = new StringDictionary();
+
+        public static Authorization Authenticate(string challenge, WebRequest request, ICredentials credentials)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public static Authorization PreAuthenticate(WebRequest request, ICredentials credentials)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public static void Register(IAuthenticationModule authenticationModule)
+        {
+        }
+
+        public static void Unregister(IAuthenticationModule authenticationModule)
+        {
+        }
+
+        public static void Unregister(string authenticationScheme)
+        {
+        }
+
+        public static IEnumerator RegisteredModules => Array.Empty<IAuthenticationModule>().GetEnumerator();
+    }
+}

--- a/src/System.Net.Requests/src/System/Net/Authorization.cs
+++ b/src/System.Net.Requests/src/System/Net/Authorization.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net
+{
+    public class Authorization
+    {
+        private string[] _protectionRealm;
+        private bool _mutualAuth;
+
+        public Authorization(string token) :
+            this(token, true) { }
+
+        public Authorization(string token, bool finished) :
+            this(token, finished, null) { }
+
+        public Authorization(string token, bool finished, string connectionGroupId) :
+            this(token, finished, connectionGroupId, false) { }
+
+        internal Authorization(string token, bool finished, string connectionGroupId, bool mutualAuth)
+        {
+            Message = string.IsNullOrEmpty(token) ? null : token;
+            ConnectionGroupId = string.IsNullOrEmpty(connectionGroupId) ? null : connectionGroupId;
+            Complete = finished;
+            _mutualAuth = mutualAuth;
+        }
+
+        public string Message { get; }
+
+        public string ConnectionGroupId { get; }
+
+        public bool Complete { get; internal set; }
+
+        public string[] ProtectionRealm
+        {
+            get { return _protectionRealm; }
+            set { _protectionRealm = value != null && value.Length != 0 ? value : null; }
+        }
+
+        public bool MutuallyAuthenticated
+        {
+            get { return Complete && _mutualAuth; }
+            set { _mutualAuth = value; }
+        }
+    }
+}

--- a/src/System.Net.Requests/src/System/Net/BindIPEndPoint.cs
+++ b/src/System.Net.Requests/src/System/Net/BindIPEndPoint.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net
+{
+    public delegate IPEndPoint BindIPEndPoint(ServicePoint servicePoint, IPEndPoint remoteEndPoint, int retryCount);
+}

--- a/src/System.Net.Requests/src/System/Net/IAuthenticationModule.cs
+++ b/src/System.Net.Requests/src/System/Net/IAuthenticationModule.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net
+{
+    public interface IAuthenticationModule
+    {
+        Authorization Authenticate(string challenge, WebRequest request, ICredentials credentials);
+        Authorization PreAuthenticate(WebRequest request, ICredentials credentials);
+        bool CanPreAuthenticate { get; }
+        string AuthenticationType { get; }
+    }
+}

--- a/src/System.Net.Requests/src/System/Net/ICertificatePolicy.cs
+++ b/src/System.Net.Requests/src/System/Net/ICertificatePolicy.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net
+{
+    public interface ICertificatePolicy
+    {
+        bool CheckValidationResult(ServicePoint srvPoint, X509Certificate certificate, WebRequest request, int certificateProblem);
+    }
+}

--- a/src/System.Net.Requests/src/System/Net/ICredentialPolicy.cs
+++ b/src/System.Net.Requests/src/System/Net/ICredentialPolicy.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net
+{
+    public interface ICredentialPolicy
+    {
+        bool ShouldSendCredential(Uri challengeUri, WebRequest request, NetworkCredential credential, IAuthenticationModule authenticationModule);
+    }
+}

--- a/src/System.Net.Requests/src/System/Net/SecurityProtocolType.cs
+++ b/src/System.Net.Requests/src/System/Net/SecurityProtocolType.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Authentication;
+
+namespace System.Net
+{
+    [Flags]
+    public enum SecurityProtocolType
+    {
+#pragma warning disable CS0618
+        Ssl3 = SslProtocols.Ssl3,
+#pragma warning restore CS0618
+        Tls = SslProtocols.Tls,
+        Tls11 = SslProtocols.Tls11,
+        Tls12 = SslProtocols.Tls12,
+    }
+}

--- a/src/System.Net.Requests/src/System/Net/ServicePoint.cs
+++ b/src/System.Net.Requests/src/System/Net/ServicePoint.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+
+namespace System.Net
+{
+    public class ServicePoint
+    {
+        private int _connectionLeaseTimeout;
+        private int _maxIdleTime;
+        private int _receiveBufferSize;
+        private int _connectionLimit;
+
+        internal ServicePoint() { }
+
+        public BindIPEndPoint BindIPEndPointDelegate { get; set; }
+
+        public int ConnectionLeaseTimeout
+        {
+            get { return _connectionLeaseTimeout; }
+            set
+            {
+                if (value < Timeout.Infinite)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+                _connectionLeaseTimeout = value;
+            }
+        }
+
+        public Uri Address { get; internal set; }
+
+        public int MaxIdleTime
+        {
+            get { return _maxIdleTime; }
+            set
+            {
+                if (value < Timeout.Infinite)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+                _maxIdleTime = value;
+            }
+        }
+
+        public bool UseNagleAlgorithm { get; set; }
+
+        public int ReceiveBufferSize
+        {
+            get { return _receiveBufferSize; }
+            set
+            {
+                if (value < -1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+                _receiveBufferSize = value;
+            }
+        }
+
+        public bool Expect100Continue { get; set; }
+
+        public DateTime IdleSince { get; internal set; }
+
+        public virtual Version ProtocolVersion { get; internal set; } = new Version(1, 1);
+
+        public string ConnectionName { get; internal set; }
+
+        public bool CloseConnectionGroup(string connectionGroupName) => false;
+
+        public int ConnectionLimit
+        {
+            get { return _connectionLimit; }
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+                _connectionLimit = value;
+            }
+        }
+
+        public int CurrentConnections { get; internal set; }
+
+        public X509Certificate Certificate { get; internal set; }
+
+        public X509Certificate ClientCertificate { get; internal set; }
+
+        public bool SupportsPipelining { get; internal set; }
+
+        public void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval)
+        {
+            if (enabled)
+            {
+                if (keepAliveTime <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(keepAliveTime));
+                }
+                if (keepAliveInterval <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(keepAliveInterval));
+                }
+            }
+        }
+    }
+}

--- a/src/System.Net.Requests/src/System/Net/ServicePointManager.cs
+++ b/src/System.Net.Requests/src/System/Net/ServicePointManager.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+
+namespace System.Net
+{
+    public class ServicePointManager
+    {
+        public const int DefaultNonPersistentConnectionLimit = 4;
+        public const int DefaultPersistentConnectionLimit = 2;
+
+        private static SecurityProtocolType s_securityProtocolType = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+        private static int s_connectionLimit = 10;
+        private static int s_maxServicePoints = 0;
+        private static int s_maxServicePointIdleTime = 100000;
+        private static int s_dnsRefreshTimeout = 120000;
+
+        private ServicePointManager() { }
+
+        public static SecurityProtocolType SecurityProtocol
+        {
+            get { return s_securityProtocolType; }
+            set
+            {
+                ValidateSecurityProtocol(value);
+                s_securityProtocolType = value;
+            }
+        }
+
+        private static void ValidateSecurityProtocol(SecurityProtocolType value)
+        {
+            SecurityProtocolType allowed = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+            if ((value & ~allowed) != 0)
+            {
+                throw new NotSupportedException(SR.net_securityprotocolnotsupported);
+            }
+        }
+
+        public static int MaxServicePoints
+        {
+            get { return s_maxServicePoints; }
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+                s_maxServicePoints = value;
+            }
+        }
+
+        public static int DefaultConnectionLimit
+        {
+            get { return s_connectionLimit; }
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+                s_connectionLimit = value;
+            }
+        }
+
+        public static int MaxServicePointIdleTime
+        {
+            get { return s_maxServicePointIdleTime; }
+            set
+            {
+                if (value < Timeout.Infinite)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+                s_maxServicePointIdleTime = value;
+            }
+        }
+
+        public static bool UseNagleAlgorithm { get; set; } = true;
+
+        public static bool Expect100Continue { get; set; } = true;
+
+        public static bool EnableDnsRoundRobin { get; set; }
+
+        public static int DnsRefreshTimeout
+        {
+            get { return s_dnsRefreshTimeout; }
+            set { s_dnsRefreshTimeout = Math.Max(-1, value); }
+        }
+
+        [Obsolete("CertificatePolicy is obsoleted for this type, please use ServerCertificateValidationCallback instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static ICertificatePolicy CertificatePolicy { get; set; } = new DefaultCertPolicy();
+
+        private sealed class DefaultCertPolicy : ICertificatePolicy
+        {
+            public bool CheckValidationResult(ServicePoint srvPoint, X509Certificate certificate, WebRequest request, int certificateProblem) =>
+                certificateProblem == 0;
+        }
+
+        public static RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
+
+        public static bool ReusePort { get; set; }
+
+        public static bool CheckCertificateRevocationList { get; set; }
+
+        public static EncryptionPolicy EncryptionPolicy { get; } = EncryptionPolicy.RequireEncryption;
+
+        public static ServicePoint FindServicePoint(Uri address) => FindServicePoint(address, null);
+
+        public static ServicePoint FindServicePoint(string uriString, IWebProxy proxy) => FindServicePoint(new Uri(uriString), proxy);
+
+        public static ServicePoint FindServicePoint(Uri address, IWebProxy proxy)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public static void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval)
+        {
+            if (enabled)
+            {
+                if (keepAliveTime <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(keepAliveTime));
+                }
+                if (keepAliveInterval <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(keepAliveInterval));
+                }
+            }
+        }
+    }
+}

--- a/src/System.Net.Requests/src/project.json
+++ b/src/System.Net.Requests/src/project.json
@@ -4,15 +4,18 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
         "System.Collections": "4.0.10",
+        "System.Collections.Specialized": "4.0.0",
         "System.Diagnostics.Debug": "4.0.0",
         "System.Diagnostics.Tracing": "4.0.0",
         "System.IO": "4.0.10",
         "System.IO.Compression": "4.1.0",
         "System.Net.Http": "4.0.0",
         "System.Net.Primitives": "4.0.10",
+        "System.Net.Security": "4.0.0",
         "System.Net.WebHeaderCollection": "4.0.0",
         "System.Resources.ResourceManager": "4.0.0",
         "System.Runtime": "4.0.20",
+        "System.Security.Cryptography.X509Certificates": "4.1.0",
         "System.Threading": "4.0.10",
         "System.Threading.Tasks": "4.0.10"
       },

--- a/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
+++ b/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Net.Security;
+using Xunit;
+
+#pragma warning disable CS0618 // obsolete warnings
+
+namespace System.Net.Tests
+{
+    public class AuthenticationManagerTest
+    {
+        [Fact]
+        public static void Authenticate_NotSupported()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => AuthenticationManager.Authenticate(null, null, null));
+            Assert.Throws<PlatformNotSupportedException>(() => AuthenticationManager.PreAuthenticate(null, null));
+        }
+
+        [Fact]
+        public static void Register_Unregister_Nop()
+        {
+            AuthenticationManager.Register(null);
+
+            int count = 0;
+            IEnumerator modules = AuthenticationManager.RegisteredModules;
+            while (modules.MoveNext()) count++;
+            Assert.Equal(0, count);
+
+            AuthenticationManager.Unregister((IAuthenticationModule)null);
+            AuthenticationManager.Unregister((string)null);
+        }
+
+        [Fact]
+        public static void CredentialPolicy_Roundtrip()
+        {
+            Assert.Null(AuthenticationManager.CredentialPolicy);
+
+            ICredentialPolicy cp = new DummyCredentialPolicy();
+            AuthenticationManager.CredentialPolicy = cp;
+            Assert.Same(cp, AuthenticationManager.CredentialPolicy);
+
+            AuthenticationManager.CredentialPolicy = null;
+            Assert.Null(AuthenticationManager.CredentialPolicy);
+        }
+
+        [Fact]
+        public static void CustomTargetNameDictionary_ValidCollection()
+        {
+            Assert.NotNull(AuthenticationManager.CustomTargetNameDictionary);
+            Assert.Empty(AuthenticationManager.CustomTargetNameDictionary);
+            Assert.Same(AuthenticationManager.CustomTargetNameDictionary, AuthenticationManager.CustomTargetNameDictionary);
+
+            AuthenticationManager.CustomTargetNameDictionary.Add("some key", "some value");
+            Assert.Equal("some value", AuthenticationManager.CustomTargetNameDictionary["some key"]);
+
+            AuthenticationManager.CustomTargetNameDictionary.Clear();
+            Assert.Equal(0, AuthenticationManager.CustomTargetNameDictionary.Count);
+        }
+
+        private sealed class DummyCredentialPolicy : ICredentialPolicy
+        {
+            public bool ShouldSendCredential(Uri challengeUri, WebRequest request, NetworkCredential credential, IAuthenticationModule authenticationModule) => true;
+        }
+    }
+}

--- a/src/System.Net.Requests/tests/AuthorizationTest.cs
+++ b/src/System.Net.Requests/tests/AuthorizationTest.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Net.Security;
+using Xunit;
+
+#pragma warning disable CS0618 // obsolete warnings
+
+namespace System.Net.Tests
+{
+    public class AuthorizationTest
+    {
+        [Fact]
+        public static void Ctor()
+        {
+            var a = new Authorization("token");
+            Assert.Equal("token", a.Message);
+            Assert.True(a.Complete);
+            Assert.Null(a.ConnectionGroupId);
+            Assert.Null(a.ProtectionRealm);
+            Assert.False(a.MutuallyAuthenticated);
+        }
+    }
+}

--- a/src/System.Net.Requests/tests/ServicePointManagerTest.cs
+++ b/src/System.Net.Requests/tests/ServicePointManagerTest.cs
@@ -1,0 +1,190 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Security;
+using Xunit;
+
+#pragma warning disable CS0618 // obsolete warnings
+
+namespace System.Net.Tests
+{
+    public class ServicePointManagerTest
+    {
+        [Fact]
+        public static void RequireEncryption_ExpectedDefault()
+        {
+            Assert.Equal(EncryptionPolicy.RequireEncryption, ServicePointManager.EncryptionPolicy);
+        }
+
+        [Fact]
+        public static void CertificatePolicy_Roundtrips()
+        {
+            ICertificatePolicy cp = ServicePointManager.CertificatePolicy;
+            Assert.NotNull(cp);
+
+            Assert.True(cp.CheckValidationResult(null, null, null, 0));
+            Assert.False(cp.CheckValidationResult(null, null, null, 1));
+
+            ServicePointManager.CertificatePolicy = null;
+            Assert.Null(ServicePointManager.CertificatePolicy);
+
+            ServicePointManager.CertificatePolicy = cp;
+            Assert.Same(cp, ServicePointManager.CertificatePolicy);
+        }
+
+        [Fact]
+        public static void CheckCertificateRevocationList_Roundtrips()
+        {
+            Assert.False(ServicePointManager.CheckCertificateRevocationList);
+
+            ServicePointManager.CheckCertificateRevocationList = true;
+            Assert.True(ServicePointManager.CheckCertificateRevocationList);
+
+            ServicePointManager.CheckCertificateRevocationList = false;
+            Assert.False(ServicePointManager.CheckCertificateRevocationList);
+        }
+
+        [Fact]
+        public static void DefaultConnectionLimit_Roundtrips()
+        {
+            Assert.Equal(10, ServicePointManager.DefaultConnectionLimit);
+
+            ServicePointManager.DefaultConnectionLimit = 20;
+            Assert.Equal(20, ServicePointManager.DefaultConnectionLimit);
+
+            ServicePointManager.DefaultConnectionLimit = 10;
+            Assert.Equal(10, ServicePointManager.DefaultConnectionLimit);
+        }
+
+        [Fact]
+        public static void DnsRefreshTimeout_Roundtrips()
+        {
+            Assert.Equal(120000, ServicePointManager.DnsRefreshTimeout);
+
+            ServicePointManager.DnsRefreshTimeout = 42;
+            Assert.Equal(42, ServicePointManager.DnsRefreshTimeout);
+
+            ServicePointManager.DnsRefreshTimeout = 120000;
+            Assert.Equal(120000, ServicePointManager.DnsRefreshTimeout);
+        }
+
+        [Fact]
+        public static void EnableDnsRoundRobin_Roundtrips()
+        {
+            Assert.False(ServicePointManager.EnableDnsRoundRobin);
+
+            ServicePointManager.EnableDnsRoundRobin = true;
+            Assert.True(ServicePointManager.EnableDnsRoundRobin);
+
+            ServicePointManager.EnableDnsRoundRobin = false;
+            Assert.False(ServicePointManager.EnableDnsRoundRobin);
+        }
+
+        [Fact]
+        public static void Expect100Continue_Roundtrips()
+        {
+            Assert.True(ServicePointManager.Expect100Continue);
+
+            ServicePointManager.Expect100Continue = false;
+            Assert.False(ServicePointManager.Expect100Continue);
+
+            ServicePointManager.Expect100Continue = true;
+            Assert.True(ServicePointManager.Expect100Continue);
+        }
+
+        [Fact]
+        public static void MaxServicePointIdleTime_Roundtrips()
+        {
+            Assert.Equal(100000, ServicePointManager.MaxServicePointIdleTime);
+
+            ServicePointManager.MaxServicePointIdleTime = 42;
+            Assert.Equal(42, ServicePointManager.MaxServicePointIdleTime);
+
+            ServicePointManager.MaxServicePointIdleTime = 100000;
+            Assert.Equal(100000, ServicePointManager.MaxServicePointIdleTime);
+        }
+
+        [Fact]
+        public static void MaxServicePoints_Roundtrips()
+        {
+            Assert.Equal(0, ServicePointManager.MaxServicePoints);
+
+            ServicePointManager.MaxServicePoints = 42;
+            Assert.Equal(42, ServicePointManager.MaxServicePoints);
+
+            ServicePointManager.MaxServicePoints = 0;
+            Assert.Equal(0, ServicePointManager.MaxServicePoints);
+        }
+
+        [Fact]
+        public static void ReusePort_Roundtrips()
+        {
+            Assert.False(ServicePointManager.ReusePort);
+
+            ServicePointManager.ReusePort = true;
+            Assert.True(ServicePointManager.ReusePort);
+
+            ServicePointManager.ReusePort = false;
+            Assert.False(ServicePointManager.ReusePort);
+        }
+
+        [Fact]
+        public static void SecurityProtocol_Roundtrips()
+        {
+            var orig = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+            Assert.Equal(orig, ServicePointManager.SecurityProtocol);
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11;
+            Assert.Equal(SecurityProtocolType.Tls11, ServicePointManager.SecurityProtocol);
+
+            ServicePointManager.SecurityProtocol = orig;
+            Assert.Equal(orig, ServicePointManager.SecurityProtocol);
+        }
+
+        [Fact]
+        public static void ServerCertificateValidationCallback_Roundtrips()
+        {
+            Assert.Null(ServicePointManager.ServerCertificateValidationCallback);
+
+            RemoteCertificateValidationCallback callback = delegate { return true; };
+            ServicePointManager.ServerCertificateValidationCallback = callback;
+            Assert.Same(callback, ServicePointManager.ServerCertificateValidationCallback);
+
+            ServicePointManager.ServerCertificateValidationCallback = null;
+            Assert.Null(ServicePointManager.ServerCertificateValidationCallback);
+        }
+
+        [Fact]
+        public static void UseNagleAlgorithm_Roundtrips()
+        {
+            Assert.True(ServicePointManager.UseNagleAlgorithm);
+
+            ServicePointManager.UseNagleAlgorithm = false;
+            Assert.False(ServicePointManager.UseNagleAlgorithm);
+
+            ServicePointManager.UseNagleAlgorithm = true;
+            Assert.True(ServicePointManager.UseNagleAlgorithm);
+        }
+
+        [Fact]
+        public static void UnsupportedOperations_Throw()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => ServicePointManager.FindServicePoint(null));
+            Assert.Throws<PlatformNotSupportedException>(() => ServicePointManager.FindServicePoint("http://localhost", null));
+            Assert.Throws<PlatformNotSupportedException>(() => ServicePointManager.FindServicePoint(new Uri("http://localhost"), null));
+        }
+
+        [Fact]
+        public static void InvalidArguments_Throw()
+        {
+            Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3);
+            Assert.Throws<ArgumentNullException>("uriString", () => ServicePointManager.FindServicePoint((string)null, null));
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.MaxServicePoints = -1);
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.DefaultConnectionLimit = 0);
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.MaxServicePointIdleTime = -2);
+            Assert.Throws<ArgumentOutOfRangeException>("keepAliveTime", () => ServicePointManager.SetTcpKeepAlive(true, -1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("keepAliveInterval", () => ServicePointManager.SetTcpKeepAlive(true, 1, -1));
+        }
+    }
+}

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -20,11 +20,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />  
   
   <ItemGroup>
+    <Compile Include="AuthorizationTest.cs" />
+    <Compile Include="AuthenticationManagerTest.cs" />
     <Compile Include="HttpRequestCachePolicyTest.cs" />
     <Compile Include="HttpWebRequestTest.cs" />
     <Compile Include="HttpWebResponseTest.cs" />
     <Compile Include="RequestCachePolicyTest.cs" />
     <Compile Include="RequestStreamTest.cs" />
+    <Compile Include="ServicePointManagerTest.cs" />
     <Compile Include="WebRequestTest.cs" />
 
     <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">

--- a/src/System.Net.Requests/tests/project.json
+++ b/src/System.Net.Requests/tests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24522-03",
+    "System.Collections.Specialized": "4.3.0-beta-24522-03",
     "System.IO.Compression": "4.3.0-beta-24522-03",
     "System.Linq.Expressions": "4.3.0-beta-24522-03",
     "System.Net.Http": "4.3.0-beta-24522-03",
@@ -12,6 +13,7 @@
     "System.ObjectModel": "4.3.0-beta-24522-03",
     "System.Text.RegularExpressions": "4.3.0-beta-24522-03",
     "System.Resources.ResourceManager": "4.3.0-beta-24522-03",
+    "System.Security.Cryptography.X509Certificates": "4.3.0-beta-24522-03",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"


### PR DESCRIPTION
cc: @davidsh, @cipop, @ericeil, @karelz

Adds a new contract System.Net.ServicePoint with stubbed out implementations of ServicePointManager, ServicePoint, AuthenticationManager, and friends.

However, unless we plan to ship with such functionality stubbed out, I don't think we're going to want to keep this as a separate contract.  The public surface area of ServicePointManager actually brings in / depends on WebRequest, which means that for WebRequest and friends to respect settings from ServicePointManager, ServicePointManager can't live in a contract above WebRequest.  Instead, I think we should push all of these types down into System.Net.Requests, recognizing that these types are part of that compat model and used only with/for that model.  We would be explicitly acknowledging that HttpClient would not respect any of the associated settings, as System.Net.Requests depends on System.Net.Http, not the other way around, and thus System.Net.Http wouldn't have access to ServicePointManager (other than through super hacky means like reflection).