### PR TITLE
Mark Ubuntu 16.10 as unreliable for X509Certificates outerloop CI tests

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class X509FilesystemTests
     {
         // #9293: Our Fedora23 CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
-        private static bool IsReliableInCI { get; } = !PlatformDetection.IsFedora23;
+        private static bool IsReliableInCI { get; } = !PlatformDetection.IsFedora23 && !PlatformDetection.IsUbuntu1610;
 
         [Fact]
         [OuterLoop]


### PR DESCRIPTION
We seem to be hitting the same "NTFS Volume" issue that we were hitting on Fedora 23, described here: https://github.com/dotnet/corefx/issues/9293. This is causing spurious failures in the X509Certificates tests. I've added the same workaround we are using for Fedora.

@bartonjs 