### PR TITLE
Re-adding lost changes to System.Xml.XmlSerializer after merge from dev/api

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Schema/XmlSchemaType.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/XmlSchemaType.cs
@@ -8,7 +8,6 @@ using System.Xml.Serialization;
 
 namespace System.Xml.Schema
 {
-    /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
@@ -27,7 +26,6 @@ namespace System.Xml.Schema
         //compiled information
         private XmlSchemaContentType _contentType;
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.GetXsdSimpleType"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -40,7 +38,6 @@ namespace System.Xml.Schema
             return DatatypeImplementation.GetSimpleTypeFromXsdType(qualifiedName);
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.GetXsdSimpleType"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -49,7 +46,6 @@ namespace System.Xml.Schema
             return DatatypeImplementation.GetSimpleTypeFromTypeCode(typeCode);
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.GetXsdComplexType"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -62,7 +58,6 @@ namespace System.Xml.Schema
             return null;
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.GetXsdComplexType"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -83,7 +78,6 @@ namespace System.Xml.Schema
             return null;
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.Name"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -94,7 +88,6 @@ namespace System.Xml.Schema
             set { _name = value; }
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.Final"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -105,7 +98,6 @@ namespace System.Xml.Schema
             set { _final = value; }
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.QualifiedName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -115,7 +107,6 @@ namespace System.Xml.Schema
             get { return _qname; }
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.FinalResolved"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -125,7 +116,6 @@ namespace System.Xml.Schema
             get { return _finalResolved; }
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.BaseSchemaType"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -146,7 +136,6 @@ namespace System.Xml.Schema
             }
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.BaseSchemaType"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -156,7 +145,6 @@ namespace System.Xml.Schema
             get { return _baseSchemaType; }
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.DerivedBy"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -166,7 +154,6 @@ namespace System.Xml.Schema
             get { return _derivedBy; }
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.Datatype"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -176,7 +163,6 @@ namespace System.Xml.Schema
             get { return _datatype; }
         }
 
-        /// <include file='doc\XmlSchemaType.uex' path='docs/doc[@for="XmlSchemaType.IsMixed"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
@@ -16,7 +16,6 @@ using Microsoft.CSharp;
 
 namespace System.Xml.Serialization
 {
-    /// <include file='doc\CodeIdentifier.uex' path='docs/doc[@for="CodeIdentifier"]/*' />
     ///<internalonly/>
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
@@ -31,7 +30,6 @@ namespace System.Xml.Serialization
         {
         }
 
-        /// <include file='doc\CodeIdentifier.uex' path='docs/doc[@for="CodeIdentifier.MakePascal"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -46,7 +44,6 @@ namespace System.Xml.Serialization
                 return identifier;
         }
 
-        /// <include file='doc\CodeIdentifier.uex' path='docs/doc[@for="CodeIdentifier.MakeCamel"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -61,7 +58,6 @@ namespace System.Xml.Serialization
                 return identifier;
         }
 
-        /// <include file='doc\CodeIdentifier.uex' path='docs/doc[@for="CodeIdentifier.MakeValid"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifiers.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifiers.cs
@@ -30,7 +30,6 @@ namespace System.Xml.Serialization
         }
     }
 
-    /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers"]/*' />
     ///<internalonly/>
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
@@ -63,14 +62,12 @@ namespace System.Xml.Serialization
             _list = new ArrayList();
         }
 
-        /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers.Clear"]/*' />
         public void Clear()
         {
             _identifiers.Clear();
             _list.Clear();
         }
 
-        /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers.UseCamelCasing"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -80,7 +77,6 @@ namespace System.Xml.Serialization
             set { _camelCase = value; }
         }
 
-        /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers.MakeRightCase"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -92,7 +88,6 @@ namespace System.Xml.Serialization
                 return CodeIdentifier.MakePascal(identifier);
         }
 
-        /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers.MakeUnique"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -118,7 +113,6 @@ namespace System.Xml.Serialization
             return identifier;
         }
 
-        /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers.AddReserved"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -127,7 +121,6 @@ namespace System.Xml.Serialization
             _reservedIdentifiers.Add(identifier, identifier);
         }
 
-        /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers.RemoveReserved"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -136,7 +129,6 @@ namespace System.Xml.Serialization
             _reservedIdentifiers.Remove(identifier);
         }
 
-        /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers.AddUnique"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -147,7 +139,6 @@ namespace System.Xml.Serialization
             return identifier;
         }
 
-        /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers.IsInUse"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -156,7 +147,6 @@ namespace System.Xml.Serialization
             return _identifiers.Contains(identifier) || _reservedIdentifiers.Contains(identifier);
         }
 
-        /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers.Add"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -166,7 +156,6 @@ namespace System.Xml.Serialization
             _list.Add(value);
         }
 
-        /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers.Remove"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -176,7 +165,6 @@ namespace System.Xml.Serialization
             _identifiers.Remove(identifier);
         }
 
-        /// <include file='doc\CodeIdentifiers.uex' path='docs/doc[@for="CodeIdentifiers.ToArray"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlAnyElementAttributes.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlAnyElementAttributes.cs
@@ -9,13 +9,11 @@ namespace System.Xml.Serialization
     using System.Collections;
     using System.ComponentModel;
 
-    /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
     public class XmlAnyElementAttributes : CollectionBase
     {
-        /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.this"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -25,7 +23,6 @@ namespace System.Xml.Serialization
             set { List[index] = value; }
         }
 
-        /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.Add"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -34,7 +31,6 @@ namespace System.Xml.Serialization
             return List.Add(attribute);
         }
 
-        /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.Insert"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -43,7 +39,6 @@ namespace System.Xml.Serialization
             List.Insert(index, attribute);
         }
 
-        /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.IndexOf"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -52,7 +47,6 @@ namespace System.Xml.Serialization
             return List.IndexOf(attribute);
         }
 
-        /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.Contains"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -61,7 +55,6 @@ namespace System.Xml.Serialization
             return List.Contains(attribute);
         }
 
-        /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.Remove"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -70,7 +63,6 @@ namespace System.Xml.Serialization
             List.Remove(attribute);
         }
 
-        /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.CopyTo"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlArrayItemAttributes.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlArrayItemAttributes.cs
@@ -9,13 +9,11 @@ namespace System.Xml.Serialization
     using System.Collections;
     using System.ComponentModel;
 
-    /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
     public class XmlArrayItemAttributes : CollectionBase
     {
-        /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.this"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -25,7 +23,6 @@ namespace System.Xml.Serialization
             set { List[index] = value; }
         }
 
-        /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.Add"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -34,7 +31,6 @@ namespace System.Xml.Serialization
             return List.Add(attribute);
         }
 
-        /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.Insert"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -43,7 +39,6 @@ namespace System.Xml.Serialization
             List.Insert(index, attribute);
         }
 
-        /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.IndexOf"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -52,7 +47,6 @@ namespace System.Xml.Serialization
             return List.IndexOf(attribute);
         }
 
-        /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.Contains"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -61,7 +55,6 @@ namespace System.Xml.Serialization
             return List.Contains(attribute);
         }
 
-        /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.Remove"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -70,7 +63,6 @@ namespace System.Xml.Serialization
             List.Remove(attribute);
         }
 
-        /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.CopyTo"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlAttributes.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlAttributes.cs
@@ -27,7 +27,6 @@ namespace System.Xml.Serialization
         XmlnsDeclarations = 0x800,
     }
 
-    /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
@@ -50,7 +49,6 @@ namespace System.Xml.Serialization
         private static volatile Type s_ignoreAttributeType;
 
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlAttributes"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -95,7 +93,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlAttributes1"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -203,7 +200,6 @@ namespace System.Xml.Serialization
             return attrs.First();
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlElements"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -212,7 +208,6 @@ namespace System.Xml.Serialization
             get { return _xmlElements; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlAttribute"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -222,7 +217,6 @@ namespace System.Xml.Serialization
             set { _xmlAttribute = value; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlEnum"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -232,7 +226,6 @@ namespace System.Xml.Serialization
             set { _xmlEnum = value; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlText"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -242,7 +235,6 @@ namespace System.Xml.Serialization
             set { _xmlText = value; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlArray"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -252,7 +244,6 @@ namespace System.Xml.Serialization
             set { _xmlArray = value; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlArrayItems"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -261,7 +252,6 @@ namespace System.Xml.Serialization
             get { return _xmlArrayItems; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlDefaultValue"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -271,7 +261,6 @@ namespace System.Xml.Serialization
             set { _xmlDefaultValue = value; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlIgnore"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -281,7 +270,6 @@ namespace System.Xml.Serialization
             set { _xmlIgnore = value; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlType"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -291,7 +279,6 @@ namespace System.Xml.Serialization
             set { _xmlType = value; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlRoot"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -301,7 +288,6 @@ namespace System.Xml.Serialization
             set { _xmlRoot = value; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlAnyElement"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -310,7 +296,6 @@ namespace System.Xml.Serialization
             get { return _xmlAnyElements; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlAnyAttribute"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -320,13 +305,11 @@ namespace System.Xml.Serialization
             set { _xmlAnyAttribute = value; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.XmlChoiceIdentifier"]/*' />
         public XmlChoiceIdentifierAttribute XmlChoiceIdentifier
         {
             get { return _xmlChoiceIdentifier; }
         }
 
-        /// <include file='doc\XmlAttributes.uex' path='docs/doc[@for="XmlAttributes.Xmlns"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlElementAttributes.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlElementAttributes.cs
@@ -9,13 +9,11 @@ namespace System.Xml.Serialization
     using System.Collections;
     using System.ComponentModel;
 
-    /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
     public class XmlElementAttributes : CollectionBase
     {
-        /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.this"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -25,7 +23,6 @@ namespace System.Xml.Serialization
             set { List[index] = value; }
         }
 
-        /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.Add"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -34,7 +31,6 @@ namespace System.Xml.Serialization
             return List.Add(attribute);
         }
 
-        /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.Insert"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -43,7 +39,6 @@ namespace System.Xml.Serialization
             List.Insert(index, attribute);
         }
 
-        /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.IndexOf"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -52,7 +47,6 @@ namespace System.Xml.Serialization
             return List.IndexOf(attribute);
         }
 
-        /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.Contains"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -61,7 +55,6 @@ namespace System.Xml.Serialization
             return List.Contains(attribute);
         }
 
-        /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.Remove"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -70,7 +63,6 @@ namespace System.Xml.Serialization
             List.Remove(attribute);
         }
 
-        /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.CopyTo"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlMapping.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlMapping.cs
@@ -18,7 +18,6 @@ namespace System.Xml.Serialization
         Write = 0x02,
     }
 
-    /// <include file='doc\XmlMapping.uex' path='docs/doc[@for="XmlMapping"]/*' />
     ///<internalonly/>
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
@@ -55,7 +54,6 @@ namespace System.Xml.Serialization
             get { return _scope; }
         }
 
-        /// <include file='doc\XmlMapping.uex' path='docs/doc[@for="XmlMapping.ElementName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -64,7 +62,6 @@ namespace System.Xml.Serialization
             get { return System.Xml.Serialization.Accessor.UnescapeName(Accessor.Name); }
         }
 
-        /// <include file='doc\XmlMapping.uex' path='docs/doc[@for="XmlMapping.XsdElementName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -73,7 +70,6 @@ namespace System.Xml.Serialization
             get { return Accessor.Name; }
         }
 
-        /// <include file='doc\XmlMapping.uex' path='docs/doc[@for="XmlMapping.Namespace"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -104,14 +100,12 @@ namespace System.Xml.Serialization
             set { _isSoap = value; }
         }
 
-        /// <include file='doc\XmlMapping.uex' path='docs/doc[@for="XmlMapping.SetKey"]/*' />
         ///<internalonly/>
         public void SetKey(string key)
         {
             SetKeyInternal(key);
         }
 
-        /// <include file='doc\XmlMapping.uex' path='docs/doc[@for="XmlMapping.SetKeyInternal"]/*' />
         ///<internalonly/>
         internal void SetKeyInternal(string key)
         {

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlMemberMapping.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlMemberMapping.cs
@@ -10,7 +10,6 @@ using System.CodeDom.Compiler;
 
 namespace System.Xml.Serialization
 {
-    /// <include file='doc\XmlMemberMapping.uex' path='docs/doc[@for="XmlMemberMapping"]/*' />
     /// <internalonly/>
     public class XmlMemberMapping
     {
@@ -31,13 +30,11 @@ namespace System.Xml.Serialization
             get { return _mapping.Accessor; }
         }
 
-        /// <include file='doc\XmlMemberMapping.uex' path='docs/doc[@for="XmlMemberMapping.Any"]/*' />
         public bool Any
         {
             get { return Accessor.Any; }
         }
 
-        /// <include file='doc\XmlMemberMapping.uex' path='docs/doc[@for="XmlMemberMapping.ElementName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -46,7 +43,6 @@ namespace System.Xml.Serialization
             get { return Accessor.UnescapeName(Accessor.Name); }
         }
 
-        /// <include file='doc\XmlMemberMapping.uex' path='docs/doc[@for="XmlMemberMapping.XsdElementName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -55,7 +51,6 @@ namespace System.Xml.Serialization
             get { return Accessor.Name; }
         }
 
-        /// <include file='doc\XmlMemberMapping.uex' path='docs/doc[@for="XmlMemberMapping.Namespace"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -64,7 +59,6 @@ namespace System.Xml.Serialization
             get { return Accessor.Namespace; }
         }
 
-        /// <include file='doc\XmlMemberMapping.uex' path='docs/doc[@for="XmlMemberMapping.MemberName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -73,7 +67,6 @@ namespace System.Xml.Serialization
             get { return _mapping.Name; }
         }
 
-        /// <include file='doc\XmlMemberMapping.uex' path='docs/doc[@for="XmlMemberMapping.TypeName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -82,7 +75,6 @@ namespace System.Xml.Serialization
             get { return Accessor.Mapping != null ? Accessor.Mapping.TypeName : String.Empty; }
         }
 
-        /// <include file='doc\XmlMemberMapping.uex' path='docs/doc[@for="XmlMemberMapping.TypeNamespace"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -91,7 +83,6 @@ namespace System.Xml.Serialization
             get { return Accessor.Mapping != null ? Accessor.Mapping.Namespace : null; }
         }
 
-        /// <include file='doc\XmlMemberMapping.uex' path='docs/doc[@for="XmlMemberMapping.TypeFullName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -100,7 +91,6 @@ namespace System.Xml.Serialization
             get { return _mapping.TypeDesc.FullName; }
         }
 
-        /// <include file='doc\XmlMemberMapping.uex' path='docs/doc[@for="XmlMemberMapping.CheckSpecified"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlReflectionImporter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlReflectionImporter.cs
@@ -17,7 +17,6 @@ namespace System.Xml.Serialization
     using System.Collections.Generic;
     using System.Xml.Extensions;
 
-    /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter"]/*' />
     ///<internalonly/>
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
@@ -49,7 +48,6 @@ namespace System.Xml.Serialization
             Element
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.XmlReflectionImporter"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -57,7 +55,6 @@ namespace System.Xml.Serialization
         {
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.XmlReflectionImporter1"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -65,7 +62,6 @@ namespace System.Xml.Serialization
         {
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.XmlReflectionImporter2"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -73,7 +69,6 @@ namespace System.Xml.Serialization
         {
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.XmlReflectionImporter3"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -89,7 +84,6 @@ namespace System.Xml.Serialization
             _modelScope = new ModelScope(_typeScope);
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.IncludeTypes"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -107,7 +101,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.IncludeType"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -136,7 +129,6 @@ namespace System.Xml.Serialization
             _savedArrayNamespace = previousArrayNamespace;
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.ImportTypeMapping"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -145,7 +137,6 @@ namespace System.Xml.Serialization
             return ImportTypeMapping(type, null, null);
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.ImportTypeMapping1"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -154,7 +145,6 @@ namespace System.Xml.Serialization
             return ImportTypeMapping(type, null, defaultNamespace);
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.ImportTypeMapping2"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -163,7 +153,6 @@ namespace System.Xml.Serialization
             return ImportTypeMapping(type, root, null);
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.ImportTypeMapping3"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -177,7 +166,6 @@ namespace System.Xml.Serialization
             return xmlMapping;
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.ImportMembersMapping"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -186,7 +174,6 @@ namespace System.Xml.Serialization
             return ImportMembersMapping(elementName, ns, members, hasWrapperElement, false);
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.ImportMembersMapping1"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -195,7 +182,6 @@ namespace System.Xml.Serialization
             return ImportMembersMapping(elementName, ns, members, hasWrapperElement, rpc, false);
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.ImportMembersMapping2"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -205,7 +191,6 @@ namespace System.Xml.Serialization
             return ImportMembersMapping(elementName, ns, members, hasWrapperElement, rpc, openModel, XmlMappingAccess.Read | XmlMappingAccess.Write);
         }
 
-        /// <include file='doc\XmlReflectionImporter.uex' path='docs/doc[@for="XmlReflectionImporter.ImportMembersMapping3"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlReflectionMember.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlReflectionMember.cs
@@ -7,7 +7,6 @@ using System;
 
 namespace System.Xml.Serialization
 {
-    /// <include file='doc\XmlReflectionMember.uex' path='docs/doc[@for="XmlReflectionMember"]/*' />
     ///<internalonly/>
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
@@ -21,7 +20,6 @@ namespace System.Xml.Serialization
         private bool _isReturnValue;
         private bool _overrideIsNullable;
 
-        /// <include file='doc\XmlReflectionMember.uex' path='docs/doc[@for="XmlReflectionMember.MemberType"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -31,7 +29,6 @@ namespace System.Xml.Serialization
             set { _type = value; }
         }
 
-        /// <include file='doc\XmlReflectionMember.uex' path='docs/doc[@for="XmlReflectionMember.XmlAttributes"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -41,7 +38,6 @@ namespace System.Xml.Serialization
             set { _xmlAttributes = value; }
         }
 
-        /// <include file='doc\XmlReflectionMember.uex' path='docs/doc[@for="XmlReflectionMember.SoapAttributes"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -51,7 +47,6 @@ namespace System.Xml.Serialization
             set { _soapAttributes = value; }
         }
 
-        /// <include file='doc\XmlReflectionMember.uex' path='docs/doc[@for="XmlReflectionMember.MemberName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -61,7 +56,6 @@ namespace System.Xml.Serialization
             set { _memberName = value; }
         }
 
-        /// <include file='doc\XmlReflectionMember.uex' path='docs/doc[@for="XmlReflectionMember.IsReturnValue"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -71,7 +65,6 @@ namespace System.Xml.Serialization
             set { _isReturnValue = value; }
         }
 
-        /// <include file='doc\XmlReflectionMember.uex' path='docs/doc[@for="XmlReflectionMember.OverrideIsNullable"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationGeneratedCode.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationGeneratedCode.cs
@@ -13,7 +13,6 @@ namespace System.Xml.Serialization
     using System.Security;
     using System.Globalization;
 
-    /// <include file='doc\XmlSerializationGeneratedCode.uex' path='docs/doc[@for="XmlSerializationGeneratedCode"]/*' />
     ///<internalonly/>
     public abstract class XmlSerializationGeneratedCode
     {

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -20,7 +20,6 @@ namespace System.Xml.Serialization
     using System.Configuration;
     using System.Xml.Serialization.Configuration;
 
-    /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader"]/*' />
     ///<internalonly/>
     public abstract class XmlSerializationReader : XmlSerializationGeneratedCode
     {
@@ -115,7 +114,6 @@ namespace System.Xml.Serialization
 
         private static bool s_checkDeserializeAdvances;
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.InitIDs"]/*' />
         protected abstract void InitIDs();
 
         // this method must be called before any generated deserialization methods are called
@@ -185,7 +183,6 @@ namespace System.Xml.Serialization
             InitIDs();
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.DecodeName"]/*' />
         protected bool DecodeName
         {
             get
@@ -198,7 +195,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.Reader"]/*' />
         protected XmlReader Reader
         {
             get
@@ -207,7 +203,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReaderCount"]/*' />
         protected int ReaderCount
         {
             get
@@ -216,7 +211,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.Document"]/*' />
         protected XmlDocument Document
         {
             get
@@ -230,7 +224,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ResolveDynamicAssembly"]/*' />
         ///<internalonly/>
         protected static Assembly ResolveDynamicAssembly(string assemblyFullName)
         {
@@ -296,7 +289,6 @@ namespace System.Xml.Serialization
             _tokenID = _r.NameTable.Add("token");
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.GetXsiType"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -564,7 +556,6 @@ namespace System.Xml.Serialization
             return result;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadTypedPrimitive"]/*' />
         protected object ReadTypedPrimitive(XmlQualifiedName type)
         {
             return ReadTypedPrimitive(type, false);
@@ -730,7 +721,6 @@ namespace System.Xml.Serialization
             return value;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadTypedNull"]/*' />
         protected object ReadTypedNull(XmlQualifiedName type)
         {
             InitPrimitiveIDs();
@@ -828,7 +818,6 @@ namespace System.Xml.Serialization
             return value;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.IsXmlnsAttribute"]/*' />
         protected bool IsXmlnsAttribute(string name)
         {
             if (!name.StartsWith("xmlns", StringComparison.Ordinal)) return false;
@@ -836,7 +825,6 @@ namespace System.Xml.Serialization
             return name[5] == ':';
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.IsArrayTypeAttribute"]/*' />
         protected void ParseWsdlArrayType(XmlAttribute attr)
         {
             if ((object)attr.LocalName == (object)_wsdlArrayTypeID && (object)attr.NamespaceURI == (object)_wsdlNsID)
@@ -855,7 +843,6 @@ namespace System.Xml.Serialization
             return;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.IsReturnValue"]/*' />
         protected bool IsReturnValue
         {
             // value only valid for soap 1.1
@@ -863,7 +850,6 @@ namespace System.Xml.Serialization
             set { _isReturnValue = value; }
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadNull"]/*' />
         protected bool ReadNull()
         {
             if (!GetNullAttr()) return false;
@@ -884,7 +870,6 @@ namespace System.Xml.Serialization
             return true;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.GetNullAttr"]/*' />
         protected bool GetNullAttr()
         {
             string isNull = _r.GetAttribute(_nilID, _instanceNsID);
@@ -900,14 +885,12 @@ namespace System.Xml.Serialization
             return true;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadNullableString"]/*' />
         protected string ReadNullableString()
         {
             if (ReadNull()) return null;
             return _r.ReadElementString();
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadNullableQualifiedName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -917,7 +900,6 @@ namespace System.Xml.Serialization
             return ReadElementQualifiedName();
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadElementQualifiedName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -934,7 +916,6 @@ namespace System.Xml.Serialization
             return qname;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadXmlDocument"]/*' />
         protected XmlDocument ReadXmlDocument(bool wrapped)
         {
             XmlNode n = ReadXmlNode(wrapped);
@@ -945,7 +926,6 @@ namespace System.Xml.Serialization
             return doc;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CollapseWhitespace"]/*' />
         protected string CollapseWhitespace(string value)
         {
             if (value == null)
@@ -953,7 +933,6 @@ namespace System.Xml.Serialization
             return value.Trim();
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadXmlNode"]/*' />
         protected XmlNode ReadXmlNode(bool wrapped)
         {
             XmlNode node = null;
@@ -980,13 +959,11 @@ namespace System.Xml.Serialization
             return node;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToByteArrayBase64"]/*' />
         protected static byte[] ToByteArrayBase64(string value)
         {
             return XmlCustomFormatter.ToByteArrayBase64(value);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToByteArrayBase641"]/*' />
         protected byte[] ToByteArrayBase64(bool isNull)
         {
             if (isNull)
@@ -996,13 +973,11 @@ namespace System.Xml.Serialization
             return ReadByteArray(true); //means use Base64
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToByteArrayHex"]/*' />
         protected static byte[] ToByteArrayHex(string value)
         {
             return XmlCustomFormatter.ToByteArrayHex(value);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToByteArrayHex1"]/*' />
         protected byte[] ToByteArrayHex(bool isNull)
         {
             if (isNull)
@@ -1012,7 +987,6 @@ namespace System.Xml.Serialization
             return ReadByteArray(false); //means use BinHex
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.GetArrayLength"]/*' />
         protected int GetArrayLength(string name, string ns)
         {
             if (GetNullAttr()) return 0;
@@ -1027,11 +1001,8 @@ namespace System.Xml.Serialization
 
         private struct SoapArrayInfo
         {
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.qname;"]/*' />
             public string qname;
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.dimensions;"]/*' />
             public int dimensions;
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.length;"]/*' />
             public int length;
             public int jaggedDimensions;
         }
@@ -1169,61 +1140,51 @@ namespace System.Xml.Serialization
             return soapArrayInfo;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToDateTime"]/*' />
         protected static DateTime ToDateTime(string value)
         {
             return XmlCustomFormatter.ToDateTime(value);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToDate"]/*' />
         protected static DateTime ToDate(string value)
         {
             return XmlCustomFormatter.ToDate(value);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToTime"]/*' />
         protected static DateTime ToTime(string value)
         {
             return XmlCustomFormatter.ToTime(value);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToChar"]/*' />
         protected static char ToChar(string value)
         {
             return XmlCustomFormatter.ToChar(value);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToEnum"]/*' />
         protected static long ToEnum(string value, Hashtable h, string typeName)
         {
             return XmlCustomFormatter.ToEnum(value, h, typeName, true);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToXmlName"]/*' />
         protected static string ToXmlName(string value)
         {
             return XmlCustomFormatter.ToXmlName(value);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToXmlNCName"]/*' />
         protected static string ToXmlNCName(string value)
         {
             return XmlCustomFormatter.ToXmlNCName(value);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToXmlNmToken"]/*' />
         protected static string ToXmlNmToken(string value)
         {
             return XmlCustomFormatter.ToXmlNmToken(value);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToXmlNmTokens"]/*' />
         protected static string ToXmlNmTokens(string value)
         {
             return XmlCustomFormatter.ToXmlNmTokens(value);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToXmlQualifiedName"]/*' />
         protected XmlQualifiedName ToXmlQualifiedName(string value)
         {
             return ToXmlQualifiedName(value, DecodeName);
@@ -1255,14 +1216,11 @@ namespace System.Xml.Serialization
                 return new XmlQualifiedName(_r.NameTable.Add(localName), ns);
             }
         }
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.UnknownAttribute"]/*' />
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.UnknownAttribute"]/*' />
         protected void UnknownAttribute(object o, XmlAttribute attr)
         {
             UnknownAttribute(o, attr, null);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.UnknownAttribute1"]/*' />
         protected void UnknownAttribute(object o, XmlAttribute attr, string qnames)
         {
             if (_events.OnUnknownAttribute != null)
@@ -1274,13 +1232,11 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.UnknownAttribute"]/*' />
         protected void UnknownElement(object o, XmlElement elem)
         {
             UnknownElement(o, elem, null);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.UnknownElement1"]/*' />
         protected void UnknownElement(object o, XmlElement elem, string qnames)
         {
             if (_events.OnUnknownElement != null)
@@ -1292,13 +1248,11 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.UnknownNode"]/*' />
         protected void UnknownNode(object o)
         {
             UnknownNode(o, null);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.UnknownNode1"]/*' />
         protected void UnknownNode(object o, string qnames)
         {
             if (_r.NodeType == XmlNodeType.None || _r.NodeType == XmlNodeType.Whitespace)
@@ -1360,7 +1314,6 @@ namespace System.Xml.Serialization
                 lineNumber = linePosition = -1;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.UnreferencedObject"]/*' />
         protected void UnreferencedObject(string id, object o)
         {
             if (_events.OnUnreferencedObject != null)
@@ -1391,55 +1344,46 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CreateUnknownTypeException"]/*' />
         protected Exception CreateUnknownTypeException(XmlQualifiedName type)
         {
             return new InvalidOperationException(SR.Format(SR.XmlUnknownType, type.Name, type.Namespace, CurrentTag()));
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CreateReadOnlyCollectionException"]/*' />
         protected Exception CreateReadOnlyCollectionException(string name)
         {
             return new InvalidOperationException(SR.Format(SR.XmlReadOnlyCollection, name));
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CreateAbstractTypeException"]/*' />
         protected Exception CreateAbstractTypeException(string name, string ns)
         {
             return new InvalidOperationException(SR.Format(SR.XmlAbstractType, name, ns, CurrentTag()));
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CreateInaccessibleConstructorException"]/*' />
         protected Exception CreateInaccessibleConstructorException(string typeName)
         {
             return new InvalidOperationException(SR.Format(SR.XmlConstructorInaccessible, typeName));
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CreateCtorHasSecurityException"]/*' />
         protected Exception CreateCtorHasSecurityException(string typeName)
         {
             return new InvalidOperationException(SR.Format(SR.XmlConstructorHasSecurityAttributes, typeName));
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CreateUnknownNodeException"]/*' />
         protected Exception CreateUnknownNodeException()
         {
             return new InvalidOperationException(SR.Format(SR.XmlUnknownNode, CurrentTag()));
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CreateUnknownConstantException"]/*' />
         protected Exception CreateUnknownConstantException(string value, Type enumType)
         {
             return new InvalidOperationException(SR.Format(SR.XmlUnknownConstant, value, enumType.Name));
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CreateInvalidCastException"]/*' />
         protected Exception CreateInvalidCastException(Type type, object value)
         {
             return CreateInvalidCastException(type, value, null);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CreateInvalidCastException1"]/*' />
         protected Exception CreateInvalidCastException(Type type, object value, string id)
         {
             if (value == null)
@@ -1450,20 +1394,17 @@ namespace System.Xml.Serialization
                 return new InvalidCastException(SR.Format(SR.XmlInvalidCastWithId, value.GetType().FullName, type.FullName, id));
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CreateBadDerivationException"]/*' />
         protected Exception CreateBadDerivationException(string xsdDerived, string nsDerived, string xsdBase, string nsBase, string clrDerived, string clrBase)
         {
             return new InvalidOperationException(SR.Format(SR.XmlSerializableBadDerivation, xsdDerived, nsDerived, xsdBase, nsBase, clrDerived, clrBase));
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CreateMissingIXmlSerializableType"]/*' />
         protected Exception CreateMissingIXmlSerializableType(string name, string ns, string clrType)
         {
             return new InvalidOperationException(SR.Format(SR.XmlSerializableMissingClrType, name, ns, typeof(XmlIncludeAttribute).Name, clrType));
             //XmlSerializableMissingClrType= Type '{0}' from namespace '{1}' doesnot have corresponding IXmlSerializable type. Please consider adding {2} to '{3}'.
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.EnsureArrayIndex"]/*' />
         protected Array EnsureArrayIndex(Array a, int index, Type elementType)
         {
             if (a == null) return Array.CreateInstance(elementType, 32);
@@ -1473,7 +1414,6 @@ namespace System.Xml.Serialization
             return b;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ShrinkArray"]/*' />
         protected Array ShrinkArray(Array a, int length, Type elementType, bool isNullable)
         {
             if (a == null)
@@ -1529,13 +1469,11 @@ namespace System.Xml.Serialization
             return 0 != (s_isTextualNodeBitmap & (1 << (int)nodeType));
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadString"]/*' />
         protected string ReadString(string value)
         {
             return ReadString(value, false);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadString1"]/*' />
         protected string ReadString(string value, bool trim)
         {
             string str = _r.ReadString();
@@ -1546,13 +1484,11 @@ namespace System.Xml.Serialization
             return value + str;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadSerializable"]/*' />
         protected IXmlSerializable ReadSerializable(IXmlSerializable serializable)
         {
             return ReadSerializable(serializable, false);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadSerializable"]/*' />
         protected IXmlSerializable ReadSerializable(IXmlSerializable serializable, bool wrappedAny)
         {
             string name = null;
@@ -1579,7 +1515,6 @@ namespace System.Xml.Serialization
             return serializable;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadReference"]/*' />
         protected bool ReadReference(out string fixupReference)
         {
             string href = _soap12 ? _r.GetAttribute("ref", Soap12.Encoding) : _r.GetAttribute("href");
@@ -1609,7 +1544,6 @@ namespace System.Xml.Serialization
             return true;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.AddTarget"]/*' />
         protected void AddTarget(string id, object o)
         {
             if (id == null)
@@ -1629,21 +1563,18 @@ namespace System.Xml.Serialization
 
 
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.AddFixup"]/*' />
         protected void AddFixup(Fixup fixup)
         {
             if (_fixups == null) _fixups = new ArrayList();
             _fixups.Add(fixup);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.AddFixup2"]/*' />
         protected void AddFixup(CollectionFixup fixup)
         {
             if (_collectionFixups == null) _collectionFixups = new ArrayList();
             _collectionFixups.Add(fixup);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.GetTarget"]/*' />
         protected object GetTarget(string id)
         {
             object target = _targets != null ? _targets[id] : null;
@@ -1655,7 +1586,6 @@ namespace System.Xml.Serialization
             return target;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.Referenced"]/*' />
         protected void Referenced(object o)
         {
             if (o == null) return;
@@ -1704,7 +1634,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.FixupArrayRefs"]/*' />
         protected void FixupArrayRefs(object fixup)
         {
             Fixup f = (Fixup)fixup;
@@ -1930,10 +1859,8 @@ namespace System.Xml.Serialization
             return array;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.InitCallbacks"]/*' />
         protected abstract void InitCallbacks();
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadReferencedElements"]/*' />
         protected void ReadReferencedElements()
         {
             _r.MoveToContent();
@@ -1951,32 +1878,27 @@ namespace System.Xml.Serialization
             HandleUnreferencedObjects();
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadReferencedElement"]/*' />
         protected object ReadReferencedElement()
         {
             return ReadReferencedElement(null, null);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadReferencedElement1"]/*' />
         protected object ReadReferencedElement(string name, string ns)
         {
             string dummy;
             return ReadReferencingElement(name, ns, out dummy);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadReferencingElement"]/*' />
         protected object ReadReferencingElement(out string fixupReference)
         {
             return ReadReferencingElement(null, null, out fixupReference);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadReferencingElement1"]/*' />
         protected object ReadReferencingElement(string name, string ns, out string fixupReference)
         {
             return ReadReferencingElement(name, ns, false, out fixupReference);
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadReferencingElement2"]/*' />
         protected object ReadReferencingElement(string name, string ns, bool elementCanBeType, out string fixupReference)
         {
             object o = null;
@@ -2024,7 +1946,6 @@ namespace System.Xml.Serialization
             return o;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.AddReadCallback"]/*' />
         protected void AddReadCallback(string name, string ns, Type type, XmlSerializationReadCallback read)
         {
             XmlQualifiedName typeName = new XmlQualifiedName(_r.NameTable.Add(name), _r.NameTable.Add(ns));
@@ -2033,7 +1954,6 @@ namespace System.Xml.Serialization
             _typesReverse[type] = typeName;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadEndElement"]/*' />
         protected void ReadEndElement()
         {
             while (_r.NodeType == XmlNodeType.Whitespace) _r.Skip();
@@ -2136,7 +2056,6 @@ namespace System.Xml.Serialization
             return childNodes;
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CheckReaderCount"]/*' />
         protected void CheckReaderCount(ref int whileIterations, ref int readerCount)
         {
             if (s_checkDeserializeAdvances)
@@ -2151,7 +2070,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="Fixup"]/*' />
         ///<internalonly/>
         protected class Fixup
         {
@@ -2159,13 +2077,11 @@ namespace System.Xml.Serialization
             private object _source;
             private string[] _ids;
 
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="Fixup.Fixup1"]/*' />
             public Fixup(object o, XmlSerializationFixupCallback callback, int count)
                 : this(o, callback, new string[count])
             {
             }
 
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="Fixup.Fixup2"]/*' />
             public Fixup(object o, XmlSerializationFixupCallback callback, string[] ids)
             {
                 _callback = callback;
@@ -2173,34 +2089,29 @@ namespace System.Xml.Serialization
                 _ids = ids;
             }
 
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="Fixup.Callback"]/*' />
             public XmlSerializationFixupCallback Callback
             {
                 get { return _callback; }
             }
 
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="Fixup.Source"]/*' />
             public object Source
             {
                 get { return _source; }
                 set { _source = value; }
             }
 
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="Fixup.Ids"]/*' />
             public string[] Ids
             {
                 get { return _ids; }
             }
         }
 
-        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="CollectionFixup"]/*' />
         protected class CollectionFixup
         {
             private XmlSerializationCollectionFixupCallback _callback;
             private object _collection;
             private object _collectionItems;
 
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="CollectionFixup.CollectionFixup"]/*' />
             public CollectionFixup(object collection, XmlSerializationCollectionFixupCallback callback, object collectionItems)
             {
                 _callback = callback;
@@ -2208,19 +2119,16 @@ namespace System.Xml.Serialization
                 _collectionItems = collectionItems;
             }
 
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="CollectionFixup.Callback"]/*' />
             public XmlSerializationCollectionFixupCallback Callback
             {
                 get { return _callback; }
             }
 
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="CollectionFixup.Collection"]/*' />
             public object Collection
             {
                 get { return _collection; }
             }
 
-            /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="CollectionFixup.CollectionItems"]/*' />
             public object CollectionItems
             {
                 get { return _collectionItems; }
@@ -2228,16 +2136,13 @@ namespace System.Xml.Serialization
         }
     }
 
-    /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationFixupCallback"]/*' />
     ///<internalonly/>
     public delegate void XmlSerializationFixupCallback(object fixup);
 
 
-    /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationCollectionFixupCallback"]/*' />
     ///<internalonly/>
     public delegate void XmlSerializationCollectionFixupCallback(object collection, object collectionItems);
 
-    /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReadCallback"]/*' />
     ///<internalonly/>
     public delegate object XmlSerializationReadCallback();
 

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
@@ -19,7 +19,6 @@ namespace System.Xml.Serialization
     using System.Runtime.Versioning;
     using System.Collections.Generic;
 
-    /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter"]/*' />
     ///<internalonly/>
     public abstract class XmlSerializationWriter : XmlSerializationGeneratedCode
     {
@@ -54,7 +53,6 @@ namespace System.Xml.Serialization
             Init(tempAssembly);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.EscapeName"]/*' />
         protected bool EscapeName
         {
             get
@@ -67,7 +65,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.Writer"]/*' />
         protected XmlWriter Writer
         {
             get
@@ -80,7 +77,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.Namespaces"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -104,7 +100,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromByteArrayBase64"]/*' />
         protected static byte[] FromByteArrayBase64(byte[] value)
         {
             // Unlike other "From" functions that one is just a place holder for automatic code generation.
@@ -114,80 +109,67 @@ namespace System.Xml.Serialization
             return value;
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.ResolveDynamicAssembly"]/*' />
         ///<internalonly/>
         protected static Assembly ResolveDynamicAssembly(string assemblyFullName)
         {
             return DynamicAssemblies.Get(assemblyFullName);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromByteArrayHex"]/*' />
         protected static string FromByteArrayHex(byte[] value)
         {
             return XmlCustomFormatter.FromByteArrayHex(value);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromDateTime"]/*' />
         protected static string FromDateTime(DateTime value)
         {
             return XmlCustomFormatter.FromDateTime(value);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromDate"]/*' />
         protected static string FromDate(DateTime value)
         {
             return XmlCustomFormatter.FromDate(value);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromTime"]/*' />
         protected static string FromTime(DateTime value)
         {
             return XmlCustomFormatter.FromTime(value);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromChar"]/*' />
         protected static string FromChar(char value)
         {
             return XmlCustomFormatter.FromChar(value);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromEnum"]/*' />
         protected static string FromEnum(long value, string[] values, long[] ids)
         {
             return XmlCustomFormatter.FromEnum(value, values, ids, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromEnum1"]/*' />
         protected static string FromEnum(long value, string[] values, long[] ids, string typeName)
         {
             return XmlCustomFormatter.FromEnum(value, values, ids, typeName);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromXmlName"]/*' />
         protected static string FromXmlName(string name)
         {
             return XmlCustomFormatter.FromXmlName(name);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromXmlNCName"]/*' />
         protected static string FromXmlNCName(string ncName)
         {
             return XmlCustomFormatter.FromXmlNCName(ncName);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromXmlNmToken"]/*' />
         protected static string FromXmlNmToken(string nmToken)
         {
             return XmlCustomFormatter.FromXmlNmToken(nmToken);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromXmlNmTokens"]/*' />
         protected static string FromXmlNmTokens(string nmTokens)
         {
             return XmlCustomFormatter.FromXmlNmTokens(nmTokens);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteXsiType"]/*' />
         protected void WriteXsiType(string name, string ns)
         {
             WriteAttribute("type", XmlSchema.InstanceNamespace, GetQualifiedName(name, ns));
@@ -255,7 +237,6 @@ namespace System.Xml.Serialization
             return new XmlQualifiedName(typeName, typeNs);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteTypedPrimitive"]/*' />
         protected void WriteTypedPrimitive(string name, string ns, object o, bool xsiType)
         {
             string value = null;
@@ -434,13 +415,11 @@ namespace System.Xml.Serialization
             return prefix + ":" + name;
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromXmlQualifiedName"]/*' />
         protected string FromXmlQualifiedName(XmlQualifiedName xmlQualifiedName)
         {
             return FromXmlQualifiedName(xmlQualifiedName, true);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.FromXmlQualifiedName"]/*' />
         protected string FromXmlQualifiedName(XmlQualifiedName xmlQualifiedName, bool ignoreEmpty)
         {
             if (xmlQualifiedName == null) return null;
@@ -448,37 +427,31 @@ namespace System.Xml.Serialization
             return GetQualifiedName(EscapeName ? XmlConvert.EncodeLocalName(xmlQualifiedName.Name) : xmlQualifiedName.Name, xmlQualifiedName.Namespace);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteStartElement"]/*' />
         protected void WriteStartElement(string name)
         {
             WriteStartElement(name, null, null, false, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteStartElement1"]/*' />
         protected void WriteStartElement(string name, string ns)
         {
             WriteStartElement(name, ns, null, false, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteStartElement4"]/*' />
         protected void WriteStartElement(string name, string ns, bool writePrefixed)
         {
             WriteStartElement(name, ns, null, writePrefixed, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteStartElement2"]/*' />
         protected void WriteStartElement(string name, string ns, object o)
         {
             WriteStartElement(name, ns, o, false, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteStartElement3"]/*' />
         protected void WriteStartElement(string name, string ns, object o, bool writePrefixed)
         {
             WriteStartElement(name, ns, o, writePrefixed, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteStartElement5"]/*' />
         protected void WriteStartElement(string name, string ns, object o, bool writePrefixed, XmlSerializerNamespaces xmlns)
         {
             if (o != null && _objectsInUse != null)
@@ -591,13 +564,11 @@ namespace System.Xml.Serialization
             return null;
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullTagEncoded"]/*' />
         protected void WriteNullTagEncoded(string name)
         {
             WriteNullTagEncoded(name, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullTagEncoded1"]/*' />
         protected void WriteNullTagEncoded(string name, string ns)
         {
             if (name == null || name.Length == 0)
@@ -607,13 +578,11 @@ namespace System.Xml.Serialization
             _w.WriteEndElement();
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullTagLiteral"]/*' />
         protected void WriteNullTagLiteral(string name)
         {
             WriteNullTagLiteral(name, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullTag1"]/*' />
         protected void WriteNullTagLiteral(string name, string ns)
         {
             if (name == null || name.Length == 0)
@@ -623,13 +592,11 @@ namespace System.Xml.Serialization
             _w.WriteEndElement();
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteEmptyTag"]/*' />
         protected void WriteEmptyTag(string name)
         {
             WriteEmptyTag(name, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteEmptyTag1"]/*' />
         protected void WriteEmptyTag(string name, string ns)
         {
             if (name == null || name.Length == 0)
@@ -638,13 +605,11 @@ namespace System.Xml.Serialization
             _w.WriteEndElement();
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteEndElement"]/*' />
         protected void WriteEndElement()
         {
             _w.WriteEndElement();
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteEndElement1"]/*' />
         protected void WriteEndElement(object o)
         {
             _w.WriteEndElement();
@@ -660,13 +625,11 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteSerializable"]/*' />
         protected void WriteSerializable(IXmlSerializable serializable, string name, string ns, bool isNullable)
         {
             WriteSerializable(serializable, name, ns, isNullable, true);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteSerializable1"]/*' />
         protected void WriteSerializable(IXmlSerializable serializable, string name, string ns, bool isNullable, bool wrapped)
         {
             if (serializable == null)
@@ -685,7 +648,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullableStringEncoded"]/*' />
         protected void WriteNullableStringEncoded(string name, string ns, string value, XmlQualifiedName xsiType)
         {
             if (value == null)
@@ -694,7 +656,6 @@ namespace System.Xml.Serialization
                 WriteElementString(name, ns, value, xsiType);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullableStringLiteral"]/*' />
         protected void WriteNullableStringLiteral(string name, string ns, string value)
         {
             if (value == null)
@@ -704,7 +665,6 @@ namespace System.Xml.Serialization
         }
 
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullableStringEncodedRaw"]/*' />
         protected void WriteNullableStringEncodedRaw(string name, string ns, string value, XmlQualifiedName xsiType)
         {
             if (value == null)
@@ -713,7 +673,6 @@ namespace System.Xml.Serialization
                 WriteElementStringRaw(name, ns, value, xsiType);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullableStringEncodedRaw1"]/*' />
         protected void WriteNullableStringEncodedRaw(string name, string ns, byte[] value, XmlQualifiedName xsiType)
         {
             if (value == null)
@@ -722,7 +681,6 @@ namespace System.Xml.Serialization
                 WriteElementStringRaw(name, ns, value, xsiType);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullableStringLiteralRaw"]/*' />
         protected void WriteNullableStringLiteralRaw(string name, string ns, string value)
         {
             if (value == null)
@@ -731,7 +689,6 @@ namespace System.Xml.Serialization
                 WriteElementStringRaw(name, ns, value, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullableStringLiteralRaw1"]/*' />
         protected void WriteNullableStringLiteralRaw(string name, string ns, byte[] value)
         {
             if (value == null)
@@ -740,7 +697,6 @@ namespace System.Xml.Serialization
                 WriteElementStringRaw(name, ns, value, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullableQualifiedNameEncoded"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -752,7 +708,6 @@ namespace System.Xml.Serialization
                 WriteElementQualifiedName(name, ns, value, xsiType);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNullableQualifiedNameLiteral"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -765,7 +720,6 @@ namespace System.Xml.Serialization
         }
 
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementEncoded"]/*' />
         protected void WriteElementEncoded(XmlNode node, string name, string ns, bool isNullable, bool any)
         {
             if (node == null)
@@ -776,7 +730,6 @@ namespace System.Xml.Serialization
             WriteElement(node, name, ns, isNullable, any);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementLiteral"]/*' />
         protected void WriteElementLiteral(XmlNode node, string name, string ns, bool isNullable, bool any)
         {
             if (node == null)
@@ -818,13 +771,11 @@ namespace System.Xml.Serialization
                 _w.WriteEndElement();
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.CreateUnknownTypeException"]/*' />
         protected Exception CreateUnknownTypeException(object o)
         {
             return CreateUnknownTypeException(o.GetType());
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.CreateUnknownTypeException1"]/*' />
         protected Exception CreateUnknownTypeException(Type type)
         {
             if (typeof(IXmlSerializable).IsAssignableFrom(type)) return new InvalidOperationException(SR.Format(SR.XmlInvalidSerializable, type.FullName));
@@ -833,57 +784,48 @@ namespace System.Xml.Serialization
             return new InvalidOperationException(SR.Format(SR.XmlUnxpectedType, type.FullName));
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.CreateMismatchChoiceException"]/*' />
         protected Exception CreateMismatchChoiceException(string value, string elementName, string enumValue)
         {
             // Value of {0} mismatches the type of {1}, you need to set it to {2}.
             return new InvalidOperationException(SR.Format(SR.XmlChoiceMismatchChoiceException, elementName, value, enumValue));
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.CreateUnknownAnyElementException"]/*' />
         protected Exception CreateUnknownAnyElementException(string name, string ns)
         {
             return new InvalidOperationException(SR.Format(SR.XmlUnknownAnyElement, name, ns));
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.CreateInvalidChoiceIdentifierValueException"]/*' />
         protected Exception CreateInvalidChoiceIdentifierValueException(string type, string identifier)
         {
             return new InvalidOperationException(SR.Format(SR.XmlInvalidChoiceIdentifierValue, type, identifier));
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.CreateChoiceIdentifierValueException"]/*' />
         protected Exception CreateChoiceIdentifierValueException(string value, string identifier, string name, string ns)
         {
             // XmlChoiceIdentifierMismatch=Value '{0}' of the choice identifier '{1}' does not match element '{2}' from namespace '{3}'.
             return new InvalidOperationException(SR.Format(SR.XmlChoiceIdentifierMismatch, value, identifier, name, ns));
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.CreateInvalidEnumValueException"]/*' />
         protected Exception CreateInvalidEnumValueException(object value, string typeName)
         {
             return new InvalidOperationException(SR.Format(SR.XmlUnknownConstant, value, typeName));
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.CreateInvalidAnyTypeException"]/*' />
         protected Exception CreateInvalidAnyTypeException(object o)
         {
             return CreateInvalidAnyTypeException(o.GetType());
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.CreateInvalidAnyTypeException1"]/*' />
         protected Exception CreateInvalidAnyTypeException(Type type)
         {
             return new InvalidOperationException(SR.Format(SR.XmlIllegalAnyElement, type.FullName));
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteReferencingElement"]/*' />
         protected void WriteReferencingElement(string n, string ns, object o)
         {
             WriteReferencingElement(n, ns, o, false);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteReferencingElement1"]/*' />
         protected void WriteReferencingElement(string n, string ns, object o, bool isNullable)
         {
             if (o == null)
@@ -922,7 +864,6 @@ namespace System.Xml.Serialization
             return id;
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteId"]/*' />
         protected void WriteId(object o)
         {
             WriteId(o, true);
@@ -936,13 +877,11 @@ namespace System.Xml.Serialization
                 _w.WriteAttributeString("id", GetId(o, addToReferencesList));
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteXmlAttribute1"]/*' />
         protected void WriteXmlAttribute(XmlNode node)
         {
             WriteXmlAttribute(node, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteXmlAttribute2"]/*' />
         protected void WriteXmlAttribute(XmlNode node, object container)
         {
             XmlAttribute attr = node as XmlAttribute;
@@ -966,7 +905,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteAttribute"]/*' />
         protected void WriteAttribute(string localName, string ns, string value)
         {
             if (value == null) return;
@@ -999,7 +937,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteAttribute0"]/*' />
         protected void WriteAttribute(string localName, string ns, byte[] value)
         {
             if (value == null) return;
@@ -1034,14 +971,12 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteAttribute1"]/*' />
         protected void WriteAttribute(string localName, string value)
         {
             if (value == null) return;
             _w.WriteAttributeString(localName, null, value);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteAttribute01"]/*' />
         protected void WriteAttribute(string localName, byte[] value)
         {
             if (value == null) return;
@@ -1051,28 +986,24 @@ namespace System.Xml.Serialization
             _w.WriteEndAttribute();
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteAttribute2"]/*' />
         protected void WriteAttribute(string prefix, string localName, string ns, string value)
         {
             if (value == null) return;
             _w.WriteAttributeString(prefix, localName, null, value);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteValue"]/*' />
         protected void WriteValue(string value)
         {
             if (value == null) return;
             _w.WriteString(value);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteValue01"]/*' />
         protected void WriteValue(byte[] value)
         {
             if (value == null) return;
             XmlCustomFormatter.WriteArrayBase64(_w, value, 0, value.Length);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteStartDocument"]/*' />
         protected void WriteStartDocument()
         {
             if (_w.WriteState == WriteState.Start)
@@ -1081,25 +1012,21 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementString"]/*' />
         protected void WriteElementString(String localName, String value)
         {
             WriteElementString(localName, null, value, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementString1"]/*' />
         protected void WriteElementString(String localName, String ns, String value)
         {
             WriteElementString(localName, ns, value, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementString2"]/*' />
         protected void WriteElementString(String localName, String value, XmlQualifiedName xsiType)
         {
             WriteElementString(localName, null, value, xsiType);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementString3"]/*' />
         protected void WriteElementString(String localName, String ns, String value, XmlQualifiedName xsiType)
         {
             if (value == null) return;
@@ -1114,43 +1041,36 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementStringRaw"]/*' />
         protected void WriteElementStringRaw(String localName, String value)
         {
             WriteElementStringRaw(localName, null, value, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementStringRaw0"]/*' />
         protected void WriteElementStringRaw(String localName, byte[] value)
         {
             WriteElementStringRaw(localName, null, value, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementStringRaw1"]/*' />
         protected void WriteElementStringRaw(String localName, String ns, String value)
         {
             WriteElementStringRaw(localName, ns, value, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementStringRaw01"]/*' />
         protected void WriteElementStringRaw(String localName, String ns, byte[] value)
         {
             WriteElementStringRaw(localName, ns, value, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementStringRaw2"]/*' />
         protected void WriteElementStringRaw(String localName, String value, XmlQualifiedName xsiType)
         {
             WriteElementStringRaw(localName, null, value, xsiType);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementStringRaw02"]/*' />
         protected void WriteElementStringRaw(String localName, byte[] value, XmlQualifiedName xsiType)
         {
             WriteElementStringRaw(localName, null, value, xsiType);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementStringRaw3"]/*' />
         protected void WriteElementStringRaw(String localName, String ns, String value, XmlQualifiedName xsiType)
         {
             if (value == null) return;
@@ -1161,7 +1081,6 @@ namespace System.Xml.Serialization
             _w.WriteEndElement();
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementStringRaw03"]/*' />
         protected void WriteElementStringRaw(String localName, String ns, byte[] value, XmlQualifiedName xsiType)
         {
             if (value == null) return;
@@ -1172,14 +1091,12 @@ namespace System.Xml.Serialization
             _w.WriteEndElement();
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteRpcResult"]/*' />
         protected void WriteRpcResult(string name, string ns)
         {
             if (!_soap12) return;
             WriteElementQualifiedName(Soap12.RpcResult, Soap12.RpcNamespace, new XmlQualifiedName(name, ns), null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementQualifiedName"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -1188,13 +1105,11 @@ namespace System.Xml.Serialization
             WriteElementQualifiedName(localName, null, value, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementQualifiedName1"]/*' />
         protected void WriteElementQualifiedName(string localName, XmlQualifiedName value, XmlQualifiedName xsiType)
         {
             WriteElementQualifiedName(localName, null, value, xsiType);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementQualifiedName2"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -1203,7 +1118,6 @@ namespace System.Xml.Serialization
             WriteElementQualifiedName(localName, ns, value, null);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteElementQualifiedName3"]/*' />
         protected void WriteElementQualifiedName(string localName, string ns, XmlQualifiedName value, XmlQualifiedName xsiType)
         {
             if (value == null) return;
@@ -1220,7 +1134,6 @@ namespace System.Xml.Serialization
             _w.WriteEndElement();
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.AddWriteCallback"]/*' />
         protected void AddWriteCallback(Type type, string typeName, string typeNs, XmlSerializationWriteCallback callback)
         {
             TypeEntry entry = new TypeEntry();
@@ -1355,25 +1268,21 @@ namespace System.Xml.Serialization
             }
             _w.WriteEndElement();
         }
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WritePotentiallyReferencingElement"]/*' />
         protected void WritePotentiallyReferencingElement(string n, string ns, object o)
         {
             WritePotentiallyReferencingElement(n, ns, o, null, false, false);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WritePotentiallyReferencingElement1"]/*' />
         protected void WritePotentiallyReferencingElement(string n, string ns, object o, Type ambientType)
         {
             WritePotentiallyReferencingElement(n, ns, o, ambientType, false, false);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WritePotentiallyReferencingElement2"]/*' />
         protected void WritePotentiallyReferencingElement(string n, string ns, object o, Type ambientType, bool suppressReference)
         {
             WritePotentiallyReferencingElement(n, ns, o, ambientType, suppressReference, false);
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WritePotentiallyReferencingElement3"]/*' />
         protected void WritePotentiallyReferencingElement(string n, string ns, object o, Type ambientType, bool suppressReference, bool isNullable)
         {
             if (o == null)
@@ -1458,10 +1367,8 @@ namespace System.Xml.Serialization
             return (TypeEntry)_typeEntries[t];
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.InitCallbacks"]/*' />
         protected abstract void InitCallbacks();
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteReferencedElements"]/*' />
         protected void WriteReferencedElements()
         {
             if (_referencesToWrite == null) return;
@@ -1472,13 +1379,11 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.TopLevelElement"]/*' />
         protected void TopLevelElement()
         {
             _objectsInUse = new Hashtable();
         }
 
-        /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriter.WriteNamespaceDeclarations"]/*' />
         ///<internalonly/>
         protected void WriteNamespaceDeclarations(XmlSerializerNamespaces xmlns)
         {
@@ -1527,7 +1432,6 @@ namespace System.Xml.Serialization
     }
 
 
-    /// <include file='doc\XmlSerializationWriter.uex' path='docs/doc[@for="XmlSerializationWriteCallback"]/*' />
     ///<internalonly/>
     public delegate void XmlSerializationWriteCallback(object o);
 

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializerNamespaces.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializerNamespaces.cs
@@ -12,7 +12,6 @@ namespace System.Xml.Serialization
     using System.Collections.Generic;
     using System.Xml.Extensions;
 
-    /// <include file='doc\XmlSerializerNamespaces.uex' path='docs/doc[@for="XmlSerializerNamespaces"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
@@ -20,7 +19,6 @@ namespace System.Xml.Serialization
     {
         private Dictionary<string, string> _namespaces = null;
 
-        /// <include file='doc\XmlSerializerNamespaces.uex' path='docs/doc[@for="XmlSerializerNamespaces.XmlSerializerNamespaces"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -29,7 +27,6 @@ namespace System.Xml.Serialization
         }
 
 
-        /// <include file='doc\XmlSerializerNamespaces.uex' path='docs/doc[@for="XmlSerializerNamespaces.XmlSerializerNamespaces1"]/*' />
         /// <internalonly/>
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
@@ -39,7 +36,6 @@ namespace System.Xml.Serialization
             _namespaces = new Dictionary<string, string>(namespaces.Namespaces);
         }
 
-        /// <include file='doc\XmlSerializerNamespaces.uex' path='docs/doc[@for="XmlSerializerNamespaces.XmlSerializerNamespaces2"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -52,7 +48,6 @@ namespace System.Xml.Serialization
             }
         }
 
-        /// <include file='doc\XmlSerializerNamespaces.uex' path='docs/doc[@for="XmlSerializerNamespaces.Add"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -72,7 +67,6 @@ namespace System.Xml.Serialization
             Namespaces[prefix] = ns;
         }
 
-        /// <include file='doc\XmlSerializerNamespaces.uex' path='docs/doc[@for="XmlSerializerNamespaces.ToArray"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
@@ -83,7 +77,6 @@ namespace System.Xml.Serialization
             return (XmlQualifiedName[])NamespaceList.ToArray();
         }
 
-        /// <include file='doc\XmlSerializerNamespaces.uex' path='docs/doc[@for="XmlSerializerNamespaces.Count"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>


### PR DESCRIPTION
Fixes #11806 

cc: @weshaggard @danmosemsft @shmao @stephentoub 

Re-applying the last set of changes that were lost on the dev/api merge. Once this is in, all changes in master that were made before the fork to move them System.Private.Xml until right before the merge from dev/api will have been re-applied to the source files.