### PR TITLE
Fix build break due to missing entry in project.json

### DIFF
--- a/src/System.Net.WebClient/src/project.json
+++ b/src/System.Net.WebClient/src/project.json
@@ -12,6 +12,7 @@
         "System.Diagnostics.Tracing": "4.3.0-beta-24520-06",
         "System.IO": "4.3.0-beta-24520-06",
         "System.IO.FileSystem": "4.3.0-beta-24520-06",
+        "System.IO.FileSystem.Primitives": "4.3.0-beta-24520-06",
         "System.Globalization": "4.3.0-beta-24520-06",
         "System.Globalization.Extensions": "4.3.0-beta-24520-06",
         "System.Net.Primitives": "4.3.0-beta-24520-06",


### PR DESCRIPTION
I'm still sync'ing locally so have yet to try this out, but hopefully it fixes the build break.