### PR TITLE
Fixing CI build by adding P2P reference to System.Net.WebClient

### DIFF
--- a/src/System.Net.WebClient/src/System.Net.WebClient.csproj
+++ b/src/System.Net.WebClient/src/System.Net.WebClient.csproj
@@ -33,5 +33,9 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- ToDo: Remove this P2P reference once we update corefx package versions -->
+    <ProjectReference Include="..\..\System.IO.FileSystem\ref\System.IO.FileSystem.csproj" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
FYI: @stephentoub @JeremyKuhne 

cc: @weshaggard @ericstj 

Fixing the CI build.