### PR TITLE
Port to 1.1: Fix WinHttpHandler to deal with custom HTTP auth responses

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -93,7 +93,9 @@ namespace System.Net.Http
                         out firstSchemeIgnored,
                         out authTarget))
                     {
-                        WinHttpException.ThrowExceptionUsingLastError();
+                        // WinHTTP returns an error for schemes it doesn't handle.
+                        // So, we need to ignore the error and just let it stay at 401.
+                        break;
                     }
 
                     // WinHTTP returns the proper authTarget based on the status code (401, 407).
@@ -144,7 +146,9 @@ namespace System.Net.Http
                         out firstSchemeIgnored,
                         out authTarget))
                     {
-                        WinHttpException.ThrowExceptionUsingLastError();
+                        // WinHTTP returns an error for schemes it doesn't handle.
+                        // So, we need to ignore the error and just let it stay at 401.
+                        break;
                     }
 
                     // WinHTTP returns the proper authTarget based on the status code (401, 407).


### PR DESCRIPTION
Port PR #11481

WinHTTP returns an error from WinHttpQueryAuthSchemes if a server sends back a response with a scheme that isn't handled by WinHTTP. Many servers use custom auth schemes. A few don't even send a `WWW-Authenticate` header in the response at all (technically against RFC7235). To handle these cases and to match Desktop behavior, we ignore the error from WinHttpQueryAuthSchemes.

Fixes #11452 and #11456.