### PR TITLE
fixing the leftover TODO in BufferedStream from uap10.1 targeting

### DIFF
--- a/src/System.IO/src/System/IO/BufferedStream.cs
+++ b/src/System.IO/src/System/IO/BufferedStream.cs
@@ -436,7 +436,7 @@ namespace System.IO
             }
         }
 
-        public override int Read(/*[TODO: Enable after System.Private.Interop is built against S.P.CoreLib and not S.Runtime] [In, Out]*/ byte[] array, int offset, int count)
+        public override int Read([In, Out] byte[] array, int offset, int count)
         {
             if (array == null)
                 throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Buffer);


### PR DESCRIPTION
While working on 671cf4c01ece51971f019409917bbb3e7f720ef9 there was a build break regarding the disabled section that I'm enabling now due to System.Private.Interop being built slightly differently. So back then I had disabled the [In,Out] parameters to work around that issue. This change is enabling it back. 

/cc @weshaggard, /cc @dotnet/corert-contrib 