### PR TITLE
Fix GetFolderPath test on Unix to avoid looking for LocalApplicationData

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -214,7 +214,7 @@ namespace System.Tests
         [InlineData(Environment.SpecialFolder.CommonApplicationData, Environment.SpecialFolderOption.None)]
         [InlineData(Environment.SpecialFolder.CommonTemplates, Environment.SpecialFolderOption.DoNotVerify)]
         [InlineData(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify)]
-        [InlineData(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.None)]
+        [InlineData(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify)]
         [InlineData(Environment.SpecialFolder.Desktop, Environment.SpecialFolderOption.DoNotVerify)]
         [InlineData(Environment.SpecialFolder.DesktopDirectory, Environment.SpecialFolderOption.DoNotVerify)]
         [InlineData(Environment.SpecialFolder.Templates, Environment.SpecialFolderOption.DoNotVerify)]


### PR DESCRIPTION
Some of the helix machines don't have this directory.  When GetFolderPath tries to verify that it exists (via the None special folder option) and doesn't find it, by design it returns a null string instead of returning the desired path, but the test isn't expecting that.  The fix is just to change the test to use DoNotVerify for this entry.

Fixes https://github.com/dotnet/corefx/issues/11960
cc: @JeremyKuhne