### PR TITLE
Fixed performance of Min/Max in SortedSet.

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -1850,7 +1850,7 @@ namespace System.Collections.Generic
                     return default(T);
                 }
 
-                var current = _root;
+                Node current = _root;
                 while (current.Left != null)
                 {
                     current = current.Left;
@@ -1869,7 +1869,7 @@ namespace System.Collections.Generic
                     return default(T);
                 }
 
-                var current = _root;
+                Node current = _root;
                 while (current.Right != null)
                 {
                     current = current.Right;

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -1845,9 +1845,18 @@ namespace System.Collections.Generic
         {
             get
             {
-                T ret = default(T);
-                InOrderTreeWalk(delegate (SortedSet<T>.Node n) { ret = n.Item; return false; });
-                return ret;
+                if (_root == null)
+                {
+                    return default(T);
+                }
+
+                var current = _root;
+                while (current.Left != null)
+                {
+                    current = current.Left;
+                }
+
+                return current.Item;
             }
         }
 
@@ -1855,9 +1864,18 @@ namespace System.Collections.Generic
         {
             get
             {
-                T ret = default(T);
-                InOrderTreeWalk(delegate (SortedSet<T>.Node n) { ret = n.Item; return false; }, true);
-                return ret;
+                if (_root == null)
+                {
+                    return default(T);
+                }
+
+                var current = _root;
+                while (current.Right != null)
+                {
+                    current = current.Right;
+                }
+
+                return current.Item;
             }
         }
 


### PR DESCRIPTION
The existing implementation of Min/Max calls InOrderTreeWalk,
which perform an allocation of a stack for traversing the tree.
But when you are finding the smallest or largest element in a
tree there is no need to perform this allocation.  This is an
optimised version that directly finds the smallest or largest
element.

This is an important use case for using a sorted set as a priority 
queue.  In microbenchmarking, with the following code I 
found a 30-40% speed up:
```csharp
        for(int j=0; j < 10; j++) {
            var s = new SortedSet<object>();
            for(int n = 0; n < 100000; n++) {
                s.Add(n);
            }

            int i = 0;
            while(s.Min != null) 
            {
                var o = s.Min;
                s.Remove(o);
                i++;
                if(i%2 == 0) {
                    s.Add((int)o * 2);
                }
            }
        }
```