### PR TITLE
Delete unnecessary [In, Out] annotations on Stream Read method overloads

### DIFF
--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -1139,7 +1139,7 @@ namespace System
                 base.Dispose(disposing);
             }
 
-            public override int Read([In, Out] byte[] buffer, int offset, int count)
+            public override int Read(byte[] buffer, int offset, int count)
             {
                 ValidateRead(buffer, offset, count);
 

--- a/src/System.Console/src/System/IO/SyncTextReader.cs
+++ b/src/System.Console/src/System/IO/SyncTextReader.cs
@@ -56,7 +56,7 @@ namespace System.IO
             }
         }
 
-        public override int Read([In, Out] char[] buffer, int index, int count)
+        public override int Read(char[] buffer, int index, int count)
         {
             lock (this)
             {
@@ -64,7 +64,7 @@ namespace System.IO
             }
         }
 
-        public override int ReadBlock([In, Out] char[] buffer, int index, int count)
+        public override int ReadBlock(char[] buffer, int index, int count)
         {
             lock (this)
             {

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -671,7 +671,7 @@ namespace System.IO
         /// The total number of bytes read into the buffer. This might be less than the number of bytes requested 
         /// if that number of bytes are not currently available, or zero if the end of the stream is reached.
         /// </returns>
-        public override int Read([In, Out] byte[] array, int offset, int count)
+        public override int Read(byte[] array, int offset, int count)
         {
             ValidateReadWriteArgs(array, offset, count);
 

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
@@ -663,7 +663,7 @@ namespace System.IO
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override int Read([In, Out] byte[] array, int offset, int count)
+        public override int Read(byte[] array, int offset, int count)
         {
             if (array == null)
                 throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Buffer);

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -117,7 +117,7 @@ namespace System.IO.Pipes
         }
 
         [SecurityCritical]
-        public override int Read([In, Out] byte[] buffer, int offset, int count)
+        public override int Read(byte[] buffer, int offset, int count)
         {
             if (_isAsync)
             {

--- a/src/System.IO.UnmanagedMemoryStream/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/System.IO.UnmanagedMemoryStream/src/System/IO/UnmanagedMemoryStream.cs
@@ -443,7 +443,7 @@ namespace System.IO
         /// <param name="count">Maximum number of bytes to read.</param>
         /// <returns>Number of bytes actually read.</returns>
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override int Read([In, Out] byte[] buffer, int offset, int count)
+        public override int Read(byte[] buffer, int offset, int count)
         {
             if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer), SR.ArgumentNull_Buffer);

--- a/src/System.IO/src/System/IO/BufferedStream.cs
+++ b/src/System.IO/src/System/IO/BufferedStream.cs
@@ -436,7 +436,7 @@ namespace System.IO
             }
         }
 
-        public override int Read([In, Out] byte[] array, int offset, int count)
+        public override int Read(byte[] array, int offset, int count)
         {
             if (array == null)
                 throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Buffer);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -385,7 +385,7 @@ namespace System.Net.Sockets
         // Returns:
         // 
         //     Number of bytes we read, or 0 if the socket is closed.
-        public override int Read([In, Out] byte[] buffer, int offset, int size)
+        public override int Read(byte[] buffer, int offset, int size)
         {
 #if DEBUG
             using (GlobalLog.SetThreadKind(ThreadKinds.User | ThreadKinds.Sync))

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/BufferedStream.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/BufferedStream.cs
@@ -507,7 +507,7 @@ namespace System.IO
         }
 
 
-        public override int Read([In, Out] Byte[] array, Int32 offset, Int32 count)
+        public override int Read(Byte[] array, Int32 offset, Int32 count)
         {
             if (array == null)
                 throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Buffer);

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
@@ -556,7 +556,7 @@ namespace System.IO
         }
 
 
-        public override Int32 Read([In, Out] Byte[] buffer, Int32 offset, Int32 count)
+        public override Int32 Read(Byte[] buffer, Int32 offset, Int32 count)
         {
             // Arguments validation and not-disposed validation are done in BeginRead.
 


### PR DESCRIPTION
This annotation has no effect, the base Stream class does not have it, and most stream implementations in corefx do not have it either.

Fixes #11971.