### PR TITLE
Ensure tests reference all of NETStandard.Library

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -1,14 +1,10 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.2-beta-24520-06",
-    "Microsoft.NETCore.Targets": "1.0.3-beta-24520-06",
+    "NETStandard.Library": "1.6.1-beta-24520-06",
     "Microsoft.NETCore.TestHost": "1.1.0-beta-24520-03",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-beta-24520-03",
     "System.Diagnostics.Contracts": "4.3.0-beta-24520-06",
-    "System.IO.Compression": "4.3.0-beta-24520-06",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.3.0-beta-24520-06",
     "System.Linq.Parallel": "4.3.0-beta-24520-06",
-    "System.Xml.XDocument": "4.3.0-beta-24520-06",
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.3",


### PR DESCRIPTION
A recent change transitioned System.Reflection.Extensions from a split
package to a fat package.
https://github.com/dotnet/corefx/commit/7bdbc6fb3a187afc44037a3b1e44707a65d695cb

This was done because all of the types from S.R.E were pushed down to
System.Runtime, thus this assembly no longer needed to be runtime
specific.

The problem is that all of the runtime-specific package information
(aka runtime.json or lineup) comes from a single package:
Microsoft.NETCore.Targets.  If a package moves from being split to fat
then it will no longer have entries in Microsoft.NETCore.Targets.

This causes a problem if someone references an old version of the
package that changed (in this case System.Reflection.Extensions) but a
new version of the lineup (Microsoft.NETCore.Targets).  This was the
case for most of our tests: they reference the framework piece-meal and
have an indirect reference to the old System.Reflection.Extensions but
bring in the new Microsoft.NETCore.Targets.

The fix here is to always bring in split packages as a set so that we
never end up in a scenario where we have a new Microsoft.NETCore.Targets
and old split packages.  All split packages must be NETStandard.Library
(that's the criteria for being split: in NETStandard.Library and runtime
sepecific impls) so simply referencing the latest NETStandard.Library
instead of it's constituent packages is the best simple fix.

/cc @weshaggard @SedarG 

FYI @dotnet/corefx-contrib: This change will be required for picking up new packages from builds of CoreFx with @SedarG's change: beta-24522-03 or later.