### PR TITLE
Fix WinHttpHandler when connecting thru authenticating proxy

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -254,6 +254,19 @@ namespace System.Net.Http
                     ref certHandleSize))
                 {
                     int lastError = Marshal.GetLastWin32Error();
+                    WinHttpTraceHelper.Trace(
+                        "OnRequestSendingRequest: Error getting WINHTTP_OPTION_SERVER_CERT_CONTEXT, {0}",
+                        lastError);
+
+                    if (lastError == Interop.WinHttp.ERROR_WINHTTP_INCORRECT_HANDLE_STATE)
+                    {
+                        // Not yet an SSL/TLS connection. This occurs while connecting thru a proxy where the
+                        // CONNECT verb hasn't yet been processed due to the proxy requiring authentication.
+                        // We need to ignore this notification. Another notification will be sent once the final
+                        // connection thru the proxy is completed.
+                        return;
+                    }
+
                     throw WinHttpException.CreateExceptionUsingError(lastError);
                 }
                 


### PR DESCRIPTION
WinHttpRequestCallback.OnRequestSendingRequest was throwing ERROR_WINHTTP_INCORRECT_HANDLE_STATE when trying to retrieve the WINHTTP_OPTION_SERVER_CERT_CONTEXT during custom server certificate validation. This problem would repro when POST'ing a request body to a secure (TLS/SSL) server thru an authenticating proxy.

The error was being returned because the request handle was not yet bound to a secure connection. This occurs while connecting thru a proxy where the CONNECT verb hasn't yet been processed due to the proxy requiring authentication. Discussions with the WinHTTP team confirmed this analysis and fix.

The fix is to ignore this notification when getting this error. Another notification will be sent once the final
secure connection thru the proxy is completed.

Fixes #11973