### PR TITLE
Mark System.Collections HashCollisionScenario test as OuterLoop

### DIFF
--- a/src/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
@@ -20,6 +20,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [OuterLoop("Takes over 55% of System.Collections.Tests testing time")]
         public static void OutOfBoundsRegression()
         {
             var dictionary = new Dictionary<string, string>();


### PR DESCRIPTION
Takes a long time. Also, any changes to Dictionary's hashing algorithm are likely to be checked very very carefully anyway, as this would have the potential to cause breaking changes

Trims System.Collections test time by ~7s

/cc @stephentoub @ianhays