### PR TITLE
Remove ref assm workarounds

### DIFF
--- a/src/System.IO.FileSystem/ref/project.json
+++ b/src/System.IO.FileSystem/ref/project.json
@@ -3,7 +3,7 @@
     "System.Runtime": "4.3.0-beta-24521-07",
     "System.Runtime.Handles": "4.3.0-beta-24521-07",
     "System.IO": "4.3.0-beta-24521-07",
-    "System.IO.FileSystem.Primitives": "4.0.1",
+    "System.IO.FileSystem.Primitives": "4.3.0-beta-24521-07",
     "System.Text.Encoding": "4.3.0-beta-24521-07",
     "System.Threading.Tasks": "4.3.0-beta-24521-07"
   },

--- a/src/System.IO.IsolatedStorage/ref/System.IO.IsolatedStorage.csproj
+++ b/src/System.IO.IsolatedStorage/ref/System.IO.IsolatedStorage.csproj
@@ -20,9 +20,6 @@
     <Compile Include="System.IO.IsolatedStorage.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.IO.FileSystem\ref\System.IO.FileSystem.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="4.0\project.json" />
     <None Include="4.0\System.IO.IsolatedStorage.depproj" />
     <None Include="project.json" />

--- a/src/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -45,14 +45,6 @@
   <ItemGroup Condition="'$(TargetGroup)' != 'net463' and '$(EnableWinRT)' == 'true'">
     <Compile Include="System\IO\IsolatedStorage\Helper.WinRT.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
-    <ProjectReference Include="..\..\System.IO.FileSystem\ref\System.IO.FileSystem.csproj">
-      <UndefineProperties>OSGroup</UndefineProperties>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\ref\System.Security.Cryptography.Algorithms.csproj">
-      <UndefineProperties>OSGroup</UndefineProperties>
-    </ProjectReference>
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
   </ItemGroup>

--- a/src/System.Net.WebClient/src/System.Net.WebClient.csproj
+++ b/src/System.Net.WebClient/src/System.Net.WebClient.csproj
@@ -33,9 +33,5 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup>
-    <!-- ToDo: Remove this P2P reference once we update corefx package versions -->
-    <ProjectReference Include="..\..\System.IO.FileSystem\ref\System.IO.FileSystem.csproj" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Algorithms/ref/project.json
+++ b/src/System.Security.Cryptography.Algorithms/ref/project.json
@@ -2,8 +2,8 @@
   "dependencies": {
     "System.Runtime": "4.3.0-beta-24521-07",
     "System.IO": "4.3.0-beta-24521-07",
-    "System.Security.Cryptography.Encoding": "4.0.0",
-    "System.Security.Cryptography.Primitives": "4.0.0"
+    "System.Security.Cryptography.Encoding": "4.3.0-beta-24521-07",
+    "System.Security.Cryptography.Primitives": "4.3.0-beta-24521-07"
   },
   "frameworks": {
     "netstandard1.7": {

--- a/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.csproj
@@ -9,9 +9,6 @@
     <Compile Include="System.Security.Cryptography.Cng.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\ref\System.Security.Cryptography.Algorithms.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.Cryptography.Cng/ref/project.json
+++ b/src/System.Security.Cryptography.Cng/ref/project.json
@@ -4,7 +4,7 @@
     "System.IO": "4.3.0-beta-24521-07",
     "System.Runtime.Handles": "4.3.0-beta-24521-07",
     "System.Security.Cryptography.Algorithms": "4.3.0-beta-24521-07",
-    "System.Security.Cryptography.Primitives": "4.0.0"
+    "System.Security.Cryptography.Primitives": "4.3.0-beta-24521-07"
   },
   "frameworks": {
     "netstandard1.7": {

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -254,11 +254,6 @@
       <Link>Common\System\Security\Cryptography\RSACng.SignVerify.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
-    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\ref\System.Security.Cryptography.Algorithms.csproj">
-      <UndefineProperties>OSGroup</UndefineProperties>
-    </ProjectReference>
-  </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System.Core" />

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -20,7 +20,6 @@
       <Project>{4c1bd451-6a99-45e7-9339-79c77c42ee9e}</Project>
       <Name>System.Security.Cryptography.Cng</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\pkg\System.Security.Cryptography.Algorithms.pkgproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CreateTests.cs" />

--- a/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.csproj
@@ -9,9 +9,6 @@
     <Compile Include="System.Security.Cryptography.Csp.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\ref\System.Security.Cryptography.Algorithms.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.Cryptography.Csp/ref/project.json
+++ b/src/System.Security.Cryptography.Csp/ref/project.json
@@ -3,7 +3,7 @@
     "System.IO": "4.3.0-beta-24521-07",
     "System.Runtime": "4.3.0-beta-24521-07",
     "System.Security.Cryptography.Algorithms": "4.3.0-beta-24521-07",
-    "System.Security.Cryptography.Primitives": "4.0.0"
+    "System.Security.Cryptography.Primitives": "4.3.0-beta-24521-07"
   },
   "frameworks": {
     "netstandard1.7": {

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -42,11 +42,6 @@
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
-    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\ref\System.Security.Cryptography.Algorithms.csproj">
-      <UndefineProperties>OSGroup</UndefineProperties>
-    </ProjectReference>
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
   </ItemGroup>

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -21,7 +21,6 @@
       <Project>{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}</Project>
       <Name>System.Security.Cryptography.Csp</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\pkg\System.Security.Cryptography.Algorithms.pkgproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CspParametersTests.cs" />

--- a/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.csproj
@@ -9,9 +9,6 @@
     <Compile Include="System.Security.Cryptography.OpenSsl.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\ref\System.Security.Cryptography.Algorithms.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.Cryptography.OpenSsl/ref/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/ref/project.json
@@ -4,7 +4,7 @@
     "System.Runtime.Handles": "4.3.0-beta-24521-07",
     "System.IO": "4.3.0-beta-24521-07",
     "System.Security.Cryptography.Algorithms": "4.3.0-beta-24521-07",
-    "System.Security.Cryptography.Primitives": "4.0.0"
+    "System.Security.Cryptography.Primitives": "4.3.0-beta-24521-07"
   },
   "frameworks": {
     "netstandard1.7": {

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -111,11 +111,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\ref\System.Security.Cryptography.Algorithms.csproj">
-      <UndefineProperties>OSGroup</UndefineProperties>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -105,7 +105,6 @@
       <Project>{78452f3e-ba91-47e7-bb0f-02e8a5c116c4}</Project>
       <Name>System.Security.Cryptography.OpenSsl</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\pkg\System.Security.Cryptography.Algorithms.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Undo the workarounds that were added to deal with downgraded ref assembly versions.

/cc @weshaggard @joperezr @stephentoub @steveharter 