### PR TITLE
Fix UNC path normalization

### DIFF
--- a/src/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.cs
@@ -48,7 +48,12 @@ namespace System.IO
         internal const int MaxShortPath = 260;
         internal const int MaxShortDirectoryPath = 248;
         internal const int MaxLongPath = short.MaxValue;
+        // \\?\, \\.\, \??\
         internal const int DevicePrefixLength = 4;
+        // \\
+        internal const int UncPrefixLength = 2;
+        // \\?\UNC\, \\.\UNC\
+        internal const int UncExtendedPrefixLength = 8;
         internal static readonly int MaxComponentLength = 255;
 
         internal static char[] GetInvalidPathChars() => new char[]

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -601,19 +601,30 @@ namespace System.IO.Tests
 
         [PlatformSpecific(PlatformID.Windows)]
         [Theory]
-        [InlineData(@"\\server\share", @"\\server\share")]
-        [InlineData(@"\\server\share", @" \\server\share")]
-        [InlineData(@"\\server\share\dir", @"\\server\share\dir")]
-        [InlineData(@"\\server\share", @"\\server\share\.")]
-        [InlineData(@"\\server\share", @"\\server\share\..")]
-        [InlineData(@"\\server\share\", @"\\server\share\    ")]
-        [InlineData(@"\\server\  share\", @"\\server\  share\")]
-        [InlineData(@"\\?\UNC\server\share", @"\\?\UNC\server\share")]
-        [InlineData(@"\\?\UNC\server\share\dir", @"\\?\UNC\server\share\dir")]
-        [InlineData(@"\\?\UNC\server\share\. ", @"\\?\UNC\server\share\. ")]
-        [InlineData(@"\\?\UNC\server\share\.. ", @"\\?\UNC\server\share\.. ")]
-        [InlineData(@"\\?\UNC\server\share\    ", @"\\?\UNC\server\share\    ")]
-        [InlineData(@"\\?\UNC\server\  share\", @"\\?\UNC\server\  share\")]
+        // https://github.com/dotnet/corefx/issues/11965
+        [InlineData(@"\\LOCALHOST\share\test.txt.~SS", @"\\LOCALHOST\share\test.txt.~SS")]
+        [InlineData(@"\\LOCALHOST\share", @"\\LOCALHOST\share")]
+        [InlineData(@"\\LOCALHOST\share", @" \\LOCALHOST\share")]
+        [InlineData(@"\\LOCALHOST\share\dir", @"\\LOCALHOST\share\dir")]
+        [InlineData(@"\\LOCALHOST\share", @"\\LOCALHOST\share\.")]
+        [InlineData(@"\\LOCALHOST\share", @"\\LOCALHOST\share\..")]
+        [InlineData(@"\\LOCALHOST\share\", @"\\LOCALHOST\share\    ")]
+        [InlineData(@"\\LOCALHOST\  share\", @"\\LOCALHOST\  share\")]
+        [InlineData(@"\\?\UNC\LOCALHOST\share\test.txt.~SS", @"\\?\UNC\LOCALHOST\share\test.txt.~SS")]
+        [InlineData(@"\\?\UNC\LOCALHOST\share", @"\\?\UNC\LOCALHOST\share")]
+        [InlineData(@"\\?\UNC\LOCALHOST\share\dir", @"\\?\UNC\LOCALHOST\share\dir")]
+        [InlineData(@"\\?\UNC\LOCALHOST\share\. ", @"\\?\UNC\LOCALHOST\share\. ")]
+        [InlineData(@"\\?\UNC\LOCALHOST\share\.. ", @"\\?\UNC\LOCALHOST\share\.. ")]
+        [InlineData(@"\\?\UNC\LOCALHOST\share\    ", @"\\?\UNC\LOCALHOST\share\    ")]
+        [InlineData(@"\\.\UNC\LOCALHOST\  share\", @"\\.\UNC\LOCALHOST\  share\")]
+        [InlineData(@"\\.\UNC\LOCALHOST\share\test.txt.~SS", @"\\.\UNC\LOCALHOST\share\test.txt.~SS")]
+        [InlineData(@"\\.\UNC\LOCALHOST\share", @"\\.\UNC\LOCALHOST\share")]
+        [InlineData(@"\\.\UNC\LOCALHOST\share\dir", @"\\.\UNC\LOCALHOST\share\dir")]
+        [InlineData(@"\\.\UNC\LOCALHOST\share\", @"\\.\UNC\LOCALHOST\share\. ")]
+        [InlineData(@"\\.\UNC\LOCALHOST\share\", @"\\.\UNC\LOCALHOST\share\.. ")]
+        [InlineData(@"\\.\UNC\LOCALHOST\share\", @"\\.\UNC\LOCALHOST\share\    ")]
+        [InlineData(@"\\.\UNC\LOCALHOST\  share\", @"\\.\UNC\LOCALHOST\  share\")]
+
         public static void GetFullPath_Windows_UNC_Valid(string expected, string input)
         {
             Assert.Equal(expected, Path.GetFullPath(input));
@@ -622,10 +633,10 @@ namespace System.IO.Tests
         [PlatformSpecific(PlatformID.Windows)]
         [Theory]
         [InlineData(@"\\")]
-        [InlineData(@"\\server")]
-        [InlineData(@"\\server\")]
-        [InlineData(@"\\server\\")]
-        [InlineData(@"\\server\..")]
+        [InlineData(@"\\LOCALHOST")]
+        [InlineData(@"\\LOCALHOST\")]
+        [InlineData(@"\\LOCALHOST\\")]
+        [InlineData(@"\\LOCALHOST\..")]
         public static void GetFullPath_Windows_UNC_Invalid(string invalidPath)
         {
             Assert.Throws<ArgumentException>(() => Path.GetFullPath(invalidPath));


### PR DESCRIPTION
Handling of short name expansion was broken for UNCs. This fixes the
prefix handling and adds a number of tests.

This also changes tests from `\\Server` to `\\LOCALHOST` to avoid network
conflicts with servers named Server.

Port of #11984