### PR TITLE
Don't raise Exited events when Process.EnableRaisingEvents is false

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -187,7 +187,7 @@ namespace System.Diagnostics
                 {
                     EnsureState(State.Associated);
                     UpdateHasExited();
-                    if (_exited)
+                    if (_exited && _watchForExit)
                     {
                         RaiseOnExited();
                     }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -104,7 +104,7 @@ namespace System.Diagnostics.Tests
         [InlineData(true)]
         [InlineData(false)]
         [InlineData(null)]
-        public void TestEnableRaiseEvents(bool? enable)
+        public void TestEnableRaiseEventsWaitForExit(bool? enable)
         {
             bool exitedInvoked = false;
 
@@ -125,6 +125,37 @@ namespace System.Diagnostics.Tests
                 // at which point it returns to the caller even if the callback hasn't
                 // entirely completed. As such, we spin until the value is set.
                 Assert.True(SpinWait.SpinUntil(() => exitedInvoked, WaitInMS));
+            }
+            else
+            {
+                Assert.False(exitedInvoked);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [InlineData(null)]
+        public void TestEnableRaiseEventsHasExited(bool? enable)
+        {
+            bool exitedInvoked = false;
+
+            Process p = CreateProcess();
+            if (enable.HasValue)
+            {
+                p.EnableRaisingEvents = enable.Value;
+            }
+            p.Exited += delegate { exitedInvoked = true; };
+
+            p.Start();
+            p.Kill();
+
+            // HasExited can raise Exited events too
+            Assert.True(p.HasExited);
+
+            if (enable.GetValueOrDefault())
+            {
+                Assert.True(exitedInvoked);
             }
             else
             {

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -104,7 +104,7 @@ namespace System.Diagnostics.Tests
         [InlineData(true)]
         [InlineData(false)]
         [InlineData(null)]
-        public void TestEnableRaiseEventsWaitForExit(bool? enable)
+        public void TestEnableRaiseEvents(bool? enable)
         {
             bool exitedInvoked = false;
 
@@ -130,25 +130,6 @@ namespace System.Diagnostics.Tests
             {
                 Assert.False(exitedInvoked);
             }
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        [InlineData(null)]
-        public void TestEnableRaiseEventsHasExited(bool? enable)
-        {
-            bool exitedInvoked = false;
-
-            Process p = CreateProcess();
-            if (enable.HasValue)
-            {
-                p.EnableRaisingEvents = enable.Value;
-            }
-            p.Exited += delegate { exitedInvoked = true; };
-
-            p.Start();
-            p.Kill();
 
             // HasExited can raise Exited events too
             Assert.True(p.HasExited);


### PR DESCRIPTION
`Process.HasExited` raises Exited events even when `EnableRaisingEvents` is false.

Added a `_watchForExit` check before raising the event, which is the same as in `WaitForExit`.

Also added separate EnableRaisingEvents test for `HasExited` based on existing TestEnableRaiseEvents test.