### PR TITLE
Expose Begin/End methods on FileStream

### DIFF
--- a/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
+++ b/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
@@ -199,6 +199,8 @@ namespace System.IO
         public override bool CanRead { get { return default(bool); } }
         public override bool CanSeek { get { return default(bool); } }
         public override bool CanWrite { get { return default(bool); } }
+
+        [Obsolete("This property has been deprecated.  Please use FileStream's SafeFileHandle property instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
         public virtual System.IntPtr Handle { get { return default(System.IntPtr); } }
         public virtual bool IsAsync { get { return default(bool); } }
         public override long Length { get { return default(long); } }

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -89,6 +89,7 @@
   <!-- .NET Standard 1.7 -->
   <ItemGroup Condition="'$(PackageTargetFramework)' == 'netstandard1.7' and '$(TargetGroup)' != 'net46' and '$(TargetGroup)' != 'net463'" >
     <Compile Include="System\IO\FileStreamBase.NetStandard17.cs" />
+    <Compile Include="System\IO\FileStream.NetStandard17.cs" />
   </ItemGroup>
   <!-- Windows -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(TargetGroup)' != 'net46' and '$(TargetGroup)' != 'net463'">

--- a/src/System.IO.FileSystem/src/System/IO/FileStream.NetStandard17.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.NetStandard17.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Contracts;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO
+{
+    public partial class FileStream : Stream
+    {
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            return _innerStream.BeginRead(buffer, offset, count, callback, state);
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            return _innerStream.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            return _innerStream.EndRead(asyncResult);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            _innerStream.EndWrite(asyncResult);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileStream/Handle.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Handle.cs
@@ -13,7 +13,9 @@ namespace System.IO.Tests
         {
             using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create))
             {
+#pragma warning disable CS0618
                 Assert.Equal(fs.SafeFileHandle.DangerousGetHandle(), fs.Handle);
+#pragma warning restore CS0618
             }
         }
     }


### PR DESCRIPTION
Also add [Obsolete] to the Handle property

#11373, #11127

@stephentoub, @ericstj 