### PR TITLE
Updating System.Runtime.Handles to target uap10.1

### DIFF
--- a/src/System.Runtime.Handles/pkg/System.Runtime.Handles.pkgproj
+++ b/src/System.Runtime.Handles/pkg/System.Runtime.Handles.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.Handles.csproj">
-      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;uap10.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Handles.csproj">
       <TargetGroup>net463</TargetGroup>

--- a/src/System.Runtime.Handles/pkg/aot/System.Runtime.Handles.pkgproj
+++ b/src/System.Runtime.Handles/pkg/aot/System.Runtime.Handles.pkgproj
@@ -7,5 +7,11 @@
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Runtime.Handles.csproj">
+      <TargetGroup>uap101aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Handles/ref/System.Runtime.Handles.csproj
+++ b/src/System.Runtime.Handles/ref/System.Runtime.Handles.csproj
@@ -5,6 +5,7 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.7;uap10.1</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.Handles.cs" />

--- a/src/System.Runtime.Handles/src/System.Runtime.Handles.builds
+++ b/src/System.Runtime.Handles/src/System.Runtime.Handles.builds
@@ -10,6 +10,9 @@
     <Project Include="System.Runtime.Handles.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project> -->
+    <Project Include="System.Runtime.Handles.csproj">
+      <TargetGroup>uap101aot</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.Handles/src/System.Runtime.Handles.csproj
+++ b/src/System.Runtime.Handles/src/System.Runtime.Handles.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>System.Runtime.Handles</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <PackageTargetFramework Condition="'$(TargetGroup)'==''">netstandard1.7;uap10.1</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -18,10 +19,8 @@
     <Compile Include="System\IO\HandleInheritability.cs" />
     <Compile Include="System\Threading\WaitHandleExtensions.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
-    <TargetingPackReference Include="System.Private.CoreLib" />
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap101aot'">
     <TargetingPackReference Include="System.Private.Interop" />
-    <ProjectReference Include="../../System.Runtime/src/redist/System.Runtime.depproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />

--- a/src/System.Runtime.Handles/src/project.json
+++ b/src/System.Runtime.Handles/src/project.json
@@ -12,6 +12,12 @@
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
+    },
+    "uap10.1": {
+      "dependencies": {
+        "System.Runtime": "4.3.0-beta-24522-03",
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24522-01"
+      }
     }
   }
 }


### PR DESCRIPTION
SafeHandle and SafeWaitHandle was recently moved to System.Runtime (ref d4192921201403cdc9b5ad01dcd690b742eb12d3) 
But S.R.Handles doesn't explicitly target uap10.1, so restoring for uap10.1 results in picking netcore50 asset, which has the duplicate type definition. This causes an issue in .Net Native toolchain. 
With this change I'm making S.R.handles explicitly target uap10.1, with the right binaries, preventing the duplication issue that I mentioned earlier.

/cc @kouvel, @dotnet/corert-contrib, 