### PR TITLE
Enable netstandard1.7 char test for Linux

### DIFF
--- a/src/System.Runtime/tests/System/CharTests.netstandard1.7.cs
+++ b/src/System.Runtime/tests/System/CharTests.netstandard1.7.cs
@@ -61,7 +61,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(11724, Xunit.PlatformID.AnyUnix)]
         public static void LatinRangeTest()
         {
             StringBuilder sb = new StringBuilder(256);
@@ -75,7 +74,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(11724, Xunit.PlatformID.AnyUnix)]
         public static void NonLatinRangeTest()
         {
             for (int i=256; i <= 0xFFFF; i++)
@@ -93,7 +91,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(UpperLowerCasing_TestData))]
-        [ActiveIssue(11724, Xunit.PlatformID.AnyUnix)]
         public static void CasingTest(char lowerForm, char upperForm, string cultureName)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);


### PR DESCRIPTION
We got the updated coreclr package which will make the functionality work and the tests should pass