### PR TITLE
Add parent handle tracking to SafeNCryptKeyHandle

### DIFF
--- a/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.cs
+++ b/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.cs
@@ -10,25 +10,25 @@ namespace Microsoft.Win32.SafeHandles
 {
     public abstract partial class SafeNCryptHandle : System.Runtime.InteropServices.SafeHandle
     {
-        protected SafeNCryptHandle() : base (default(System.IntPtr), default(bool)) { }
-        public override bool IsInvalid { get { return default(bool); } }
-        protected override bool ReleaseHandle() { return default(bool); }
+        protected SafeNCryptHandle() : base(default(System.IntPtr), default(bool)) { }
+        public override bool IsInvalid { get { throw null; } }
+        protected override bool ReleaseHandle() { throw null; }
         protected abstract bool ReleaseNativeHandle();
     }
     public sealed partial class SafeNCryptKeyHandle : Microsoft.Win32.SafeHandles.SafeNCryptHandle
     {
         public SafeNCryptKeyHandle() { }
-        protected override bool ReleaseNativeHandle() { return default(bool); }
+        protected override bool ReleaseNativeHandle() { throw null; }
     }
     public sealed partial class SafeNCryptProviderHandle : Microsoft.Win32.SafeHandles.SafeNCryptHandle
     {
         public SafeNCryptProviderHandle() { }
-        protected override bool ReleaseNativeHandle() { return default(bool); }
+        protected override bool ReleaseNativeHandle() { throw null; }
     }
     public sealed partial class SafeNCryptSecretHandle : Microsoft.Win32.SafeHandles.SafeNCryptHandle
     {
         public SafeNCryptSecretHandle() { }
-        protected override bool ReleaseNativeHandle() { return default(bool); }
+        protected override bool ReleaseNativeHandle() { throw null; }
     }
 }
 namespace System.Security.Cryptography
@@ -39,12 +39,12 @@ namespace System.Security.Cryptography
         public AesCng(string keyName) { }
         public AesCng(string keyName, System.Security.Cryptography.CngProvider provider) { }
         public AesCng(string keyName, System.Security.Cryptography.CngProvider provider, System.Security.Cryptography.CngKeyOpenOptions openOptions) { }
-        public override byte[] Key { get { return default(byte[]); } set { } }
-        public override int KeySize { get { return default(int); } set { } }
-        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor() { return default(System.Security.Cryptography.ICryptoTransform); }
-        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) { return default(System.Security.Cryptography.ICryptoTransform); }
-        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor() { return default(System.Security.Cryptography.ICryptoTransform); }
-        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) { return default(System.Security.Cryptography.ICryptoTransform); }
+        public override byte[] Key { get { throw null; } set { } }
+        public override int KeySize { get { throw null; } set { } }
+        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor() { throw null; }
+        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) { throw null; }
+        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor() { throw null; }
+        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) { throw null; }
         protected override void Dispose(bool disposing) { }
         public override void GenerateIV() { }
         public override void GenerateKey() { }
@@ -52,43 +52,43 @@ namespace System.Security.Cryptography
     public sealed partial class CngAlgorithm : System.IEquatable<System.Security.Cryptography.CngAlgorithm>
     {
         public CngAlgorithm(string algorithm) { }
-        public string Algorithm { get { return default(string); } }
-        public static System.Security.Cryptography.CngAlgorithm ECDiffieHellman { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm ECDiffieHellmanP256 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm ECDiffieHellmanP384 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm ECDiffieHellmanP521 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm ECDsa { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm ECDsaP256 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm ECDsaP384 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm ECDsaP521 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm MD5 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm Rsa { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm Sha1 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm Sha256 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm Sha384 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public static System.Security.Cryptography.CngAlgorithm Sha512 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public override bool Equals(object obj) { return default(bool); }
-        public bool Equals(System.Security.Cryptography.CngAlgorithm other) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public static bool operator ==(System.Security.Cryptography.CngAlgorithm left, System.Security.Cryptography.CngAlgorithm right) { return default(bool); }
-        public static bool operator !=(System.Security.Cryptography.CngAlgorithm left, System.Security.Cryptography.CngAlgorithm right) { return default(bool); }
-        public override string ToString() { return default(string); }
+        public string Algorithm { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm ECDiffieHellman { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm ECDiffieHellmanP256 { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm ECDiffieHellmanP384 { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm ECDiffieHellmanP521 { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm ECDsa { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm ECDsaP256 { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm ECDsaP384 { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm ECDsaP521 { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm MD5 { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm Rsa { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm Sha1 { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm Sha256 { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm Sha384 { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithm Sha512 { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Security.Cryptography.CngAlgorithm other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.CngAlgorithm left, System.Security.Cryptography.CngAlgorithm right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.CngAlgorithm left, System.Security.Cryptography.CngAlgorithm right) { throw null; }
+        public override string ToString() { throw null; }
     }
     public sealed partial class CngAlgorithmGroup : System.IEquatable<System.Security.Cryptography.CngAlgorithmGroup>
     {
         public CngAlgorithmGroup(string algorithmGroup) { }
-        public string AlgorithmGroup { get { return default(string); } }
-        public static System.Security.Cryptography.CngAlgorithmGroup DiffieHellman { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
-        public static System.Security.Cryptography.CngAlgorithmGroup Dsa { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
-        public static System.Security.Cryptography.CngAlgorithmGroup ECDiffieHellman { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
-        public static System.Security.Cryptography.CngAlgorithmGroup ECDsa { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
-        public static System.Security.Cryptography.CngAlgorithmGroup Rsa { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
-        public override bool Equals(object obj) { return default(bool); }
-        public bool Equals(System.Security.Cryptography.CngAlgorithmGroup other) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public static bool operator ==(System.Security.Cryptography.CngAlgorithmGroup left, System.Security.Cryptography.CngAlgorithmGroup right) { return default(bool); }
-        public static bool operator !=(System.Security.Cryptography.CngAlgorithmGroup left, System.Security.Cryptography.CngAlgorithmGroup right) { return default(bool); }
-        public override string ToString() { return default(string); }
+        public string AlgorithmGroup { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithmGroup DiffieHellman { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithmGroup Dsa { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithmGroup ECDiffieHellman { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithmGroup ECDsa { get { throw null; } }
+        public static System.Security.Cryptography.CngAlgorithmGroup Rsa { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Security.Cryptography.CngAlgorithmGroup other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.CngAlgorithmGroup left, System.Security.Cryptography.CngAlgorithmGroup right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.CngAlgorithmGroup left, System.Security.Cryptography.CngAlgorithmGroup right) { throw null; }
+        public override string ToString() { throw null; }
     }
     [System.FlagsAttribute]
     public enum CngExportPolicies
@@ -102,57 +102,57 @@ namespace System.Security.Cryptography
     public sealed partial class CngKey : System.IDisposable
     {
         internal CngKey() { }
-        public System.Security.Cryptography.CngAlgorithm Algorithm { get { return default(System.Security.Cryptography.CngAlgorithm); } }
-        public System.Security.Cryptography.CngAlgorithmGroup AlgorithmGroup { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
-        public System.Security.Cryptography.CngExportPolicies ExportPolicy { get { return default(System.Security.Cryptography.CngExportPolicies); } }
-        public Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle Handle { get { return default(Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle); } }
-        public bool IsEphemeral { get { return default(bool); } }
-        public bool IsMachineKey { get { return default(bool); } }
-        public string KeyName { get { return default(string); } }
-        public int KeySize { get { return default(int); } }
-        public System.Security.Cryptography.CngKeyUsages KeyUsage { get { return default(System.Security.Cryptography.CngKeyUsages); } }
-        public System.IntPtr ParentWindowHandle { get { return default(System.IntPtr); } set { } }
-        public System.Security.Cryptography.CngProvider Provider { get { return default(System.Security.Cryptography.CngProvider); } }
-        public Microsoft.Win32.SafeHandles.SafeNCryptProviderHandle ProviderHandle { get { return default(Microsoft.Win32.SafeHandles.SafeNCryptProviderHandle); } }
-        public System.Security.Cryptography.CngUIPolicy UIPolicy { get { return default(System.Security.Cryptography.CngUIPolicy); } }
-        public string UniqueName { get { return default(string); } }
-        public static System.Security.Cryptography.CngKey Create(System.Security.Cryptography.CngAlgorithm algorithm) { return default(System.Security.Cryptography.CngKey); }
-        public static System.Security.Cryptography.CngKey Create(System.Security.Cryptography.CngAlgorithm algorithm, string keyName) { return default(System.Security.Cryptography.CngKey); }
-        public static System.Security.Cryptography.CngKey Create(System.Security.Cryptography.CngAlgorithm algorithm, string keyName, System.Security.Cryptography.CngKeyCreationParameters creationParameters) { return default(System.Security.Cryptography.CngKey); }
+        public System.Security.Cryptography.CngAlgorithm Algorithm { get { throw null; } }
+        public System.Security.Cryptography.CngAlgorithmGroup AlgorithmGroup { get { throw null; } }
+        public System.Security.Cryptography.CngExportPolicies ExportPolicy { get { throw null; } }
+        public Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle Handle { get { throw null; } }
+        public bool IsEphemeral { get { throw null; } }
+        public bool IsMachineKey { get { throw null; } }
+        public string KeyName { get { throw null; } }
+        public int KeySize { get { throw null; } }
+        public System.Security.Cryptography.CngKeyUsages KeyUsage { get { throw null; } }
+        public System.IntPtr ParentWindowHandle { get { throw null; } set { } }
+        public System.Security.Cryptography.CngProvider Provider { get { throw null; } }
+        public Microsoft.Win32.SafeHandles.SafeNCryptProviderHandle ProviderHandle { get { throw null; } }
+        public System.Security.Cryptography.CngUIPolicy UIPolicy { get { throw null; } }
+        public string UniqueName { get { throw null; } }
+        public static System.Security.Cryptography.CngKey Create(System.Security.Cryptography.CngAlgorithm algorithm) { throw null; }
+        public static System.Security.Cryptography.CngKey Create(System.Security.Cryptography.CngAlgorithm algorithm, string keyName) { throw null; }
+        public static System.Security.Cryptography.CngKey Create(System.Security.Cryptography.CngAlgorithm algorithm, string keyName, System.Security.Cryptography.CngKeyCreationParameters creationParameters) { throw null; }
         public void Delete() { }
         public void Dispose() { }
-        public static bool Exists(string keyName) { return default(bool); }
-        public static bool Exists(string keyName, System.Security.Cryptography.CngProvider provider) { return default(bool); }
-        public static bool Exists(string keyName, System.Security.Cryptography.CngProvider provider, System.Security.Cryptography.CngKeyOpenOptions options) { return default(bool); }
-        public byte[] Export(System.Security.Cryptography.CngKeyBlobFormat format) { return default(byte[]); }
-        public System.Security.Cryptography.CngProperty GetProperty(string name, System.Security.Cryptography.CngPropertyOptions options) { return default(System.Security.Cryptography.CngProperty); }
-        public bool HasProperty(string name, System.Security.Cryptography.CngPropertyOptions options) { return default(bool); }
-        public static System.Security.Cryptography.CngKey Import(byte[] keyBlob, System.Security.Cryptography.CngKeyBlobFormat format) { return default(System.Security.Cryptography.CngKey); }
-        public static System.Security.Cryptography.CngKey Import(byte[] keyBlob, System.Security.Cryptography.CngKeyBlobFormat format, System.Security.Cryptography.CngProvider provider) { return default(System.Security.Cryptography.CngKey); }
-        public static System.Security.Cryptography.CngKey Open(Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle keyHandle, System.Security.Cryptography.CngKeyHandleOpenOptions keyHandleOpenOptions) { return default(System.Security.Cryptography.CngKey); }
-        public static System.Security.Cryptography.CngKey Open(string keyName) { return default(System.Security.Cryptography.CngKey); }
-        public static System.Security.Cryptography.CngKey Open(string keyName, System.Security.Cryptography.CngProvider provider) { return default(System.Security.Cryptography.CngKey); }
-        public static System.Security.Cryptography.CngKey Open(string keyName, System.Security.Cryptography.CngProvider provider, System.Security.Cryptography.CngKeyOpenOptions openOptions) { return default(System.Security.Cryptography.CngKey); }
+        public static bool Exists(string keyName) { throw null; }
+        public static bool Exists(string keyName, System.Security.Cryptography.CngProvider provider) { throw null; }
+        public static bool Exists(string keyName, System.Security.Cryptography.CngProvider provider, System.Security.Cryptography.CngKeyOpenOptions options) { throw null; }
+        public byte[] Export(System.Security.Cryptography.CngKeyBlobFormat format) { throw null; }
+        public System.Security.Cryptography.CngProperty GetProperty(string name, System.Security.Cryptography.CngPropertyOptions options) { throw null; }
+        public bool HasProperty(string name, System.Security.Cryptography.CngPropertyOptions options) { throw null; }
+        public static System.Security.Cryptography.CngKey Import(byte[] keyBlob, System.Security.Cryptography.CngKeyBlobFormat format) { throw null; }
+        public static System.Security.Cryptography.CngKey Import(byte[] keyBlob, System.Security.Cryptography.CngKeyBlobFormat format, System.Security.Cryptography.CngProvider provider) { throw null; }
+        public static System.Security.Cryptography.CngKey Open(Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle keyHandle, System.Security.Cryptography.CngKeyHandleOpenOptions keyHandleOpenOptions) { throw null; }
+        public static System.Security.Cryptography.CngKey Open(string keyName) { throw null; }
+        public static System.Security.Cryptography.CngKey Open(string keyName, System.Security.Cryptography.CngProvider provider) { throw null; }
+        public static System.Security.Cryptography.CngKey Open(string keyName, System.Security.Cryptography.CngProvider provider, System.Security.Cryptography.CngKeyOpenOptions openOptions) { throw null; }
         public void SetProperty(System.Security.Cryptography.CngProperty property) { }
     }
     public sealed partial class CngKeyBlobFormat : System.IEquatable<System.Security.Cryptography.CngKeyBlobFormat>
     {
         public CngKeyBlobFormat(string format) { }
-        public static System.Security.Cryptography.CngKeyBlobFormat EccFullPrivateBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
-        public static System.Security.Cryptography.CngKeyBlobFormat EccFullPublicBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
-        public static System.Security.Cryptography.CngKeyBlobFormat EccPrivateBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
-        public static System.Security.Cryptography.CngKeyBlobFormat EccPublicBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
-        public string Format { get { return default(string); } }
-        public static System.Security.Cryptography.CngKeyBlobFormat GenericPrivateBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
-        public static System.Security.Cryptography.CngKeyBlobFormat GenericPublicBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
-        public static System.Security.Cryptography.CngKeyBlobFormat OpaqueTransportBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
-        public static System.Security.Cryptography.CngKeyBlobFormat Pkcs8PrivateBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
-        public override bool Equals(object obj) { return default(bool); }
-        public bool Equals(System.Security.Cryptography.CngKeyBlobFormat other) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public static bool operator ==(System.Security.Cryptography.CngKeyBlobFormat left, System.Security.Cryptography.CngKeyBlobFormat right) { return default(bool); }
-        public static bool operator !=(System.Security.Cryptography.CngKeyBlobFormat left, System.Security.Cryptography.CngKeyBlobFormat right) { return default(bool); }
-        public override string ToString() { return default(string); }
+        public static System.Security.Cryptography.CngKeyBlobFormat EccFullPrivateBlob { get { throw null; } }
+        public static System.Security.Cryptography.CngKeyBlobFormat EccFullPublicBlob { get { throw null; } }
+        public static System.Security.Cryptography.CngKeyBlobFormat EccPrivateBlob { get { throw null; } }
+        public static System.Security.Cryptography.CngKeyBlobFormat EccPublicBlob { get { throw null; } }
+        public string Format { get { throw null; } }
+        public static System.Security.Cryptography.CngKeyBlobFormat GenericPrivateBlob { get { throw null; } }
+        public static System.Security.Cryptography.CngKeyBlobFormat GenericPublicBlob { get { throw null; } }
+        public static System.Security.Cryptography.CngKeyBlobFormat OpaqueTransportBlob { get { throw null; } }
+        public static System.Security.Cryptography.CngKeyBlobFormat Pkcs8PrivateBlob { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Security.Cryptography.CngKeyBlobFormat other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.CngKeyBlobFormat left, System.Security.Cryptography.CngKeyBlobFormat right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.CngKeyBlobFormat left, System.Security.Cryptography.CngKeyBlobFormat right) { throw null; }
+        public override string ToString() { throw null; }
     }
     [System.FlagsAttribute]
     public enum CngKeyCreationOptions
@@ -164,13 +164,13 @@ namespace System.Security.Cryptography
     public sealed partial class CngKeyCreationParameters
     {
         public CngKeyCreationParameters() { }
-        public System.Nullable<System.Security.Cryptography.CngExportPolicies> ExportPolicy { get { return default(System.Nullable<System.Security.Cryptography.CngExportPolicies>); } set { } }
-        public System.Security.Cryptography.CngKeyCreationOptions KeyCreationOptions { get { return default(System.Security.Cryptography.CngKeyCreationOptions); } set { } }
-        public System.Nullable<System.Security.Cryptography.CngKeyUsages> KeyUsage { get { return default(System.Nullable<System.Security.Cryptography.CngKeyUsages>); } set { } }
-        public System.Security.Cryptography.CngPropertyCollection Parameters { get { return default(System.Security.Cryptography.CngPropertyCollection); } }
-        public System.IntPtr ParentWindowHandle { get { return default(System.IntPtr); } set { } }
-        public System.Security.Cryptography.CngProvider Provider { get { return default(System.Security.Cryptography.CngProvider); } set { } }
-        public System.Security.Cryptography.CngUIPolicy UIPolicy { get { return default(System.Security.Cryptography.CngUIPolicy); } set { } }
+        public System.Nullable<System.Security.Cryptography.CngExportPolicies> ExportPolicy { get { throw null; } set { } }
+        public System.Security.Cryptography.CngKeyCreationOptions KeyCreationOptions { get { throw null; } set { } }
+        public System.Nullable<System.Security.Cryptography.CngKeyUsages> KeyUsage { get { throw null; } set { } }
+        public System.Security.Cryptography.CngPropertyCollection Parameters { get { throw null; } }
+        public System.IntPtr ParentWindowHandle { get { throw null; } set { } }
+        public System.Security.Cryptography.CngProvider Provider { get { throw null; } set { } }
+        public System.Security.Cryptography.CngUIPolicy UIPolicy { get { throw null; } set { } }
     }
     [System.FlagsAttribute]
     public enum CngKeyHandleOpenOptions
@@ -198,15 +198,15 @@ namespace System.Security.Cryptography
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CngProperty : System.IEquatable<System.Security.Cryptography.CngProperty>
     {
-        public CngProperty(string name, byte[] value, System.Security.Cryptography.CngPropertyOptions options) { throw new System.NotImplementedException(); }
-        public string Name { get { return default(string); } }
-        public System.Security.Cryptography.CngPropertyOptions Options { get { return default(System.Security.Cryptography.CngPropertyOptions); } }
-        public override bool Equals(object obj) { return default(bool); }
-        public bool Equals(System.Security.Cryptography.CngProperty other) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public byte[] GetValue() { return default(byte[]); }
-        public static bool operator ==(System.Security.Cryptography.CngProperty left, System.Security.Cryptography.CngProperty right) { return default(bool); }
-        public static bool operator !=(System.Security.Cryptography.CngProperty left, System.Security.Cryptography.CngProperty right) { return default(bool); }
+        public CngProperty(string name, byte[] value, System.Security.Cryptography.CngPropertyOptions options) { throw null;}
+        public string Name { get { throw null; } }
+        public System.Security.Cryptography.CngPropertyOptions Options { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Security.Cryptography.CngProperty other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public byte[] GetValue() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.CngProperty left, System.Security.Cryptography.CngProperty right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.CngProperty left, System.Security.Cryptography.CngProperty right) { throw null; }
     }
     public sealed partial class CngPropertyCollection : System.Collections.ObjectModel.Collection<System.Security.Cryptography.CngProperty>
     {
@@ -222,15 +222,15 @@ namespace System.Security.Cryptography
     public sealed partial class CngProvider : System.IEquatable<System.Security.Cryptography.CngProvider>
     {
         public CngProvider(string provider) { }
-        public static System.Security.Cryptography.CngProvider MicrosoftSmartCardKeyStorageProvider { get { return default(System.Security.Cryptography.CngProvider); } }
-        public static System.Security.Cryptography.CngProvider MicrosoftSoftwareKeyStorageProvider { get { return default(System.Security.Cryptography.CngProvider); } }
-        public string Provider { get { return default(string); } }
-        public override bool Equals(object obj) { return default(bool); }
-        public bool Equals(System.Security.Cryptography.CngProvider other) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
-        public static bool operator ==(System.Security.Cryptography.CngProvider left, System.Security.Cryptography.CngProvider right) { return default(bool); }
-        public static bool operator !=(System.Security.Cryptography.CngProvider left, System.Security.Cryptography.CngProvider right) { return default(bool); }
-        public override string ToString() { return default(string); }
+        public static System.Security.Cryptography.CngProvider MicrosoftSmartCardKeyStorageProvider { get { throw null; } }
+        public static System.Security.Cryptography.CngProvider MicrosoftSoftwareKeyStorageProvider { get { throw null; } }
+        public string Provider { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Security.Cryptography.CngProvider other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.CngProvider left, System.Security.Cryptography.CngProvider right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.CngProvider left, System.Security.Cryptography.CngProvider right) { throw null; }
+        public override string ToString() { throw null; }
     }
     public sealed partial class CngUIPolicy
     {
@@ -239,11 +239,11 @@ namespace System.Security.Cryptography
         public CngUIPolicy(System.Security.Cryptography.CngUIProtectionLevels protectionLevel, string friendlyName, string description) { }
         public CngUIPolicy(System.Security.Cryptography.CngUIProtectionLevels protectionLevel, string friendlyName, string description, string useContext) { }
         public CngUIPolicy(System.Security.Cryptography.CngUIProtectionLevels protectionLevel, string friendlyName, string description, string useContext, string creationTitle) { }
-        public string CreationTitle { get { return default(string); } }
-        public string Description { get { return default(string); } }
-        public string FriendlyName { get { return default(string); } }
-        public System.Security.Cryptography.CngUIProtectionLevels ProtectionLevel { get { return default(System.Security.Cryptography.CngUIProtectionLevels); } }
-        public string UseContext { get { return default(string); } }
+        public string CreationTitle { get { throw null; } }
+        public string Description { get { throw null; } }
+        public string FriendlyName { get { throw null; } }
+        public System.Security.Cryptography.CngUIProtectionLevels ProtectionLevel { get { throw null; } }
+        public string UseContext { get { throw null; } }
     }
     [System.FlagsAttribute]
     public enum CngUIProtectionLevels
@@ -257,15 +257,15 @@ namespace System.Security.Cryptography
         public DSACng() { }
         public DSACng(int keySize) { }
         public DSACng(System.Security.Cryptography.CngKey key) { }
-        public System.Security.Cryptography.CngKey Key { get { return default(System.Security.Cryptography.CngKey); } }
-        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
-        public override byte[] CreateSignature(byte[] hash) { return default(byte[]); }
+        public System.Security.Cryptography.CngKey Key { get { throw null; } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public override byte[] CreateSignature(byte[] hash) { throw null; }
         protected override void Dispose(bool disposing) { }
-        public override System.Security.Cryptography.DSAParameters ExportParameters(bool includePrivateParameters) { return default(System.Security.Cryptography.DSAParameters); }
-        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
-        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
+        public override System.Security.Cryptography.DSAParameters ExportParameters(bool includePrivateParameters) { throw null; }
+        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public override void ImportParameters(System.Security.Cryptography.DSAParameters parameters) { }
-        public override bool VerifySignature(byte[] hash, byte[] signature) { return default(bool); }
+        public override bool VerifySignature(byte[] hash, byte[] signature) { throw null; }
     }
     public sealed partial class ECDsaCng : System.Security.Cryptography.ECDsa
     {
@@ -273,35 +273,35 @@ namespace System.Security.Cryptography
         public ECDsaCng(int keySize) { }
         public ECDsaCng(System.Security.Cryptography.CngKey key) { }
         public ECDsaCng(System.Security.Cryptography.ECCurve curve) { }
-        public System.Security.Cryptography.CngKey Key { get { return default(System.Security.Cryptography.CngKey); } }
-        public override int KeySize { get { return default(int); } set { } }
-        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
+        public System.Security.Cryptography.CngKey Key { get { throw null; } }
+        public override int KeySize { get { throw null; } set { } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
         protected override void Dispose(bool disposing) { }
-        public override System.Security.Cryptography.ECParameters ExportExplicitParameters(bool includePrivateParameters) { return default(System.Security.Cryptography.ECParameters); }
-        public override System.Security.Cryptography.ECParameters ExportParameters(bool includePrivateParameters) { return default(System.Security.Cryptography.ECParameters); }
+        public override System.Security.Cryptography.ECParameters ExportExplicitParameters(bool includePrivateParameters) { throw null; }
+        public override System.Security.Cryptography.ECParameters ExportParameters(bool includePrivateParameters) { throw null; }
         public override void GenerateKey(System.Security.Cryptography.ECCurve curve) { }
-        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
-        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
+        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public override void ImportParameters(System.Security.Cryptography.ECParameters parameters) { }
-        public override byte[] SignHash(byte[] hash) { return default(byte[]); }
-        public override bool VerifyHash(byte[] hash, byte[] signature) { return default(bool); }
+        public override byte[] SignHash(byte[] hash) { throw null; }
+        public override bool VerifyHash(byte[] hash, byte[] signature) { throw null; }
     }
     public sealed partial class RSACng : System.Security.Cryptography.RSA
     {
         public RSACng() { }
         public RSACng(int keySize) { }
         public RSACng(System.Security.Cryptography.CngKey key) { }
-        public System.Security.Cryptography.CngKey Key { get { return default(System.Security.Cryptography.CngKey); } }
-        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
-        public override byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { return default(byte[]); }
+        public System.Security.Cryptography.CngKey Key { get { throw null; } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public override byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }
         protected override void Dispose(bool disposing) { }
-        public override byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { return default(byte[]); }
-        public override System.Security.Cryptography.RSAParameters ExportParameters(bool includePrivateParameters) { return default(System.Security.Cryptography.RSAParameters); }
-        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
-        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
+        public override byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }
+        public override System.Security.Cryptography.RSAParameters ExportParameters(bool includePrivateParameters) { throw null; }
+        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public override void ImportParameters(System.Security.Cryptography.RSAParameters parameters) { }
-        public override byte[] SignHash(byte[] hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { return default(byte[]); }
-        public override bool VerifyHash(byte[] hash, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { return default(bool); }
+        public override byte[] SignHash(byte[] hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public override bool VerifyHash(byte[] hash, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
     }
     public sealed partial class TripleDESCng : System.Security.Cryptography.TripleDES
     {
@@ -309,13 +309,13 @@ namespace System.Security.Cryptography
         public TripleDESCng(string keyName) { }
         public TripleDESCng(string keyName, System.Security.Cryptography.CngProvider provider) { }
         public TripleDESCng(string keyName, System.Security.Cryptography.CngProvider provider, System.Security.Cryptography.CngKeyOpenOptions openOptions) { }
-        public override byte[] Key { get { return default(byte[]); } set { } }
-        public override int KeySize { get { return default(int); } set { } }
-        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
-        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor() { return default(System.Security.Cryptography.ICryptoTransform); }
-        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) { return default(System.Security.Cryptography.ICryptoTransform); }
-        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor() { return default(System.Security.Cryptography.ICryptoTransform); }
-        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) { return default(System.Security.Cryptography.ICryptoTransform); }
+        public override byte[] Key { get { throw null; } set { } }
+        public override int KeySize { get { throw null; } set { } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor() { throw null; }
+        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) { throw null; }
+        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor() { throw null; }
+        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) { throw null; }
         protected override void Dispose(bool disposing) { }
         public override void GenerateIV() { }
         public override void GenerateKey() { }

--- a/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.cs
+++ b/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Win32.SafeHandles
     public abstract partial class SafeNCryptHandle : System.Runtime.InteropServices.SafeHandle
     {
         protected SafeNCryptHandle() : base(default(System.IntPtr), default(bool)) { }
+        protected SafeNCryptHandle(System.IntPtr handle, System.Runtime.InteropServices.SafeHandle parentHandle) : base(default(System.IntPtr), default(bool)) { }
         public override bool IsInvalid { get { throw null; } }
         protected override bool ReleaseHandle() { throw null; }
         protected abstract bool ReleaseNativeHandle();
@@ -18,6 +19,7 @@ namespace Microsoft.Win32.SafeHandles
     public sealed partial class SafeNCryptKeyHandle : Microsoft.Win32.SafeHandles.SafeNCryptHandle
     {
         public SafeNCryptKeyHandle() { }
+        public SafeNCryptKeyHandle(System.IntPtr handle, System.Runtime.InteropServices.SafeHandle parentHandle) { }
         protected override bool ReleaseNativeHandle() { throw null; }
     }
     public sealed partial class SafeNCryptProviderHandle : Microsoft.Win32.SafeHandles.SafeNCryptHandle

--- a/src/System.Security.Cryptography.Cng/src/ApiCompatBaseLine.net463.txt
+++ b/src/System.Security.Cryptography.Cng/src/ApiCompatBaseLine.net463.txt
@@ -8,3 +8,5 @@ MembersMustExist : Member 'System.Security.Cryptography.ECDsaCng.ExportExplicitP
 MembersMustExist : Member 'System.Security.Cryptography.ECDsaCng.ExportParameters(System.Boolean)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Security.Cryptography.ECDsaCng.GenerateKey(System.Security.Cryptography.ECCurve)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Security.Cryptography.ECDsaCng.ImportParameters(System.Security.Cryptography.ECParameters)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.SafeHandles.SafeNCryptHandle..ctor(System.IntPtr, System.Runtime.InteropServices.SafeHandle)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle..ctor(System.IntPtr, System.Runtime.InteropServices.SafeHandle)' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Security.Cryptography.Cng/src/Microsoft/Win32/SafeHandles/NCryptSafeHandles.cs
+++ b/src/System.Security.Cryptography.Cng/src/Microsoft/Win32/SafeHandles/NCryptSafeHandles.cs
@@ -63,9 +63,36 @@ namespace Microsoft.Win32.SafeHandles
         /// </summary>
         private SafeNCryptHandle _holder;
 
+        private SafeHandle _parentHandle;
+
         protected SafeNCryptHandle() : base(IntPtr.Zero, true)
         {
             return;
+        }
+
+        protected SafeNCryptHandle(IntPtr handle, SafeHandle parentHandle)
+            : base(IntPtr.Zero, true)
+        {
+            if (parentHandle == null)
+                throw new ArgumentNullException(nameof(parentHandle));
+            if (parentHandle.IsClosed || parentHandle.IsInvalid)
+                throw new ArgumentException(SR.Argument_Invalid_SafeHandleInvalidOrClosed, nameof(parentHandle));
+
+            bool success = false;
+            parentHandle.DangerousAddRef(ref success);
+            _parentHandle = parentHandle;
+
+            // Don't set the handle value until after parentHandle has been validated and persisted to a field,
+            // otherwise Dispose will try to call the underlying Free function.
+            SetHandle(handle);
+
+            // But if this handle value IsInvalid then we'll never call ReleaseHandle, which leaves the parent open
+            // forever.  Instead, release such a parent now.
+            if (IsInvalid)
+            {
+                _parentHandle.DangerousRelease();
+                _parentHandle = null;
+            }
         }
 
         /// <summary>
@@ -110,7 +137,8 @@ namespace Microsoft.Win32.SafeHandles
                     case OwnershipState.Owner:
                         return Holder == null && !IsInvalid && !IsClosed;
 
-                    // Duplicate handles have valid open holders with the same raw handle value
+                    // Duplicate handles have valid open holders with the same raw handle value,
+                    // and should not be tracking a distinct parent.
                     case OwnershipState.Duplicate:
                         bool acquiredHolder = false;
 
@@ -129,7 +157,8 @@ namespace Microsoft.Win32.SafeHandles
                                                !Holder.IsInvalid &&
                                                !Holder.IsClosed &&
                                                holderRawHandle != IntPtr.Zero &&
-                                               holderRawHandle == handle;
+                                               holderRawHandle == handle &&
+                                               _parentHandle == null;
 
                             return holderValid && !IsInvalid && !IsClosed;
                         }
@@ -254,6 +283,14 @@ namespace Microsoft.Win32.SafeHandles
                 holder.SetHandle(DangerousGetHandle());
                 GC.SuppressFinalize(holder);
 
+
+                // Move the parent handle to the Holder
+                if (_parentHandle != null)
+                {
+                    holder._parentHandle = _parentHandle;
+                    _parentHandle = null;
+                }
+
                 // Transition into the duplicate state, referencing the holder. The initial reference count
                 // on the holder will refer to the original handle so there is no need to AddRef here.
                 Holder = holder;        // Transitions to OwnershipState.Duplicate
@@ -279,6 +316,9 @@ namespace Microsoft.Win32.SafeHandles
         ///     Similar to duplication, releasing a handle performs different operations based upon the state
         ///     of the handle.
         /// 
+        ///     An instance which was constructed with a parentHandle value will only call DangerousRelease on
+        ///     the parentHandle object. Otherwise the behavior is dictated by the ownership state.
+        /// 
         ///     * Owner     - Simply call the release P/Invoke method
         ///     * Duplicate - Decrement the reference count of the current holder
         ///     * Holder    - Call the release P/Invoke. Note that ReleaseHandle on a holder implies a reference
@@ -289,6 +329,11 @@ namespace Microsoft.Win32.SafeHandles
             if (_ownershipState == OwnershipState.Duplicate)
             {
                 Holder.DangerousRelease();
+                return true;
+            }
+            else if (_parentHandle != null)
+            {
+                _parentHandle.DangerousRelease();
                 return true;
             }
             else
@@ -319,6 +364,15 @@ namespace Microsoft.Win32.SafeHandles
     /// </summary>
     public sealed class SafeNCryptKeyHandle : SafeNCryptHandle
     {
+        public SafeNCryptKeyHandle()
+        {
+        }
+
+        public SafeNCryptKeyHandle(IntPtr handle, SafeHandle parentHandle)
+            : base(handle, parentHandle)
+        {
+        }
+
         internal SafeNCryptKeyHandle Duplicate()
         {
             return Duplicate<SafeNCryptKeyHandle>();

--- a/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
@@ -120,6 +120,9 @@
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
     <value>Non-negative number required.</value>
   </data>
+  <data name="Argument_Invalid_SafeHandleInvalidOrClosed" xml:space="preserve">
+    <value>The method cannot be called with an invalid or closed SafeHandle.</value>
+  </data>
   <data name="Argument_InvalidOffLen" xml:space="preserve">
     <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
   </data>

--- a/src/System.Security.Cryptography.Cng/tests/HandleTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/HandleTests.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
-using System.Security.Cryptography.EcDsa.Tests;
 using Xunit;
 
 namespace System.Security.Cryptography.Cng.Tests
@@ -36,6 +36,145 @@ namespace System.Security.Cryptography.Cng.Tests
                 Assert.Equal<byte>(propertyValue, actualValue);
             }
         }
+
+#if netstandard17
+        [Fact]
+        public static void SafeNCryptKeyHandle_ParentHandle_Invalid()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SafeNCryptKeyHandle(IntPtr.Zero, null));
+
+            using (SafeHandle openButInvalid = new StateInformingSafeHandle(false))
+            using (SafeHandle closedAndInvalid = new StateInformingSafeHandle())
+            using (SafeHandle closedButValid = new StateInformingSafeHandle(true, false))
+            {
+                closedAndInvalid.Dispose();
+                closedButValid.Dispose();
+
+                // Preconditions.
+                Assert.False(openButInvalid.IsClosed, "openButInvalid.IsClosed");
+                Assert.True(openButInvalid.IsInvalid, "openButInvalid.IsInvalid");
+                Assert.True(closedButValid.IsClosed, "closedButValid.IsClosed");
+                Assert.False(closedButValid.IsInvalid, "closedButValid.IsInvalid");
+                Assert.True(closedAndInvalid.IsClosed, "closedAndInvalid.IsClosed");
+                Assert.True(closedAndInvalid.IsInvalid, "closedAndInvalid.IsInvalid");
+
+                // Tests
+                Assert.Throws<ArgumentException>(() => new SafeNCryptKeyHandle(IntPtr.Zero, openButInvalid));
+                Assert.Throws<ArgumentException>(() => new SafeNCryptKeyHandle(IntPtr.Zero, closedButValid));
+                Assert.Throws<ArgumentException>(() => new SafeNCryptKeyHandle(IntPtr.Zero, closedAndInvalid));
+            }
+        }
+
+        [Fact]
+        public static void SafeNCryptKeyHandle_InvalidKey_ParentHandle_NotKeptAlive()
+        {
+            using (SafeHandle parentHandle = new StateInformingSafeHandle())
+            using (var keyHandle = new SafeNCryptKeyHandle(IntPtr.Zero, parentHandle))
+            {
+                Assert.False(parentHandle.IsInvalid, "After ctor, parentHandle.IsInvalid");
+                Assert.False(parentHandle.IsClosed, "After ctor, parentHandle.IsClosed");
+
+                parentHandle.Dispose();
+
+                Assert.True(parentHandle.IsInvalid, "After parentHandle.Dispose, parentHandle.IsInvalid");
+                Assert.True(parentHandle.IsClosed, "After parentHandle.Dispose, parentHandle.IsClosed");
+            }
+        }
+
+        [Fact]
+        public static void SafeNCryptKeyHandle_ValidKey_ParentHandle_KeptAlive()
+        {
+            // NCryptFreeObject will check dwMagic values to determine what kind of object
+            // it was given.  Since we don't really want to leak a key in this test we'll
+            // track a test-local buffer.
+            IntPtr fakeKeyPtr = Marshal.AllocHGlobal(512);
+            try
+            {
+                Marshal.WriteInt32(fakeKeyPtr, 0);
+
+                using (SafeHandle parentHandle = new StateInformingSafeHandle())
+                {
+                    using (var keyHandle = new SafeNCryptKeyHandle(fakeKeyPtr, parentHandle))
+                    {
+                        Assert.False(parentHandle.IsInvalid, "After ctor, parentHandle.IsInvalid");
+                        Assert.False(parentHandle.IsClosed, "After ctor, parentHandle.IsClosed");
+
+                        parentHandle.Dispose();
+
+                        Assert.False(parentHandle.IsInvalid, "After parentHandle.Dispose, parentHandle.IsInvalid");
+                        Assert.False(parentHandle.IsClosed, "After parentHandle.Dispose, parentHandle.IsClosed");
+                    }
+
+                    Assert.True(parentHandle.IsInvalid, "After keyHandle.Dispose, parentHandle.IsInvalid");
+                    Assert.True(parentHandle.IsClosed, "After keyHandle.Dispose, parentHandle.IsClosed");
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(fakeKeyPtr);
+            }
+        }
+
+        [Fact]
+        public static void SafeNCryptKeyHandle_ValidKey_ParentHandle_DoesNotForciblyClose()
+        {
+            // NCryptFreeObject will check dwMagic values to determine what kind of object
+            // it was given.  Since we don't really want to leak a key in this test we'll
+            // track a test-local buffer.
+            IntPtr fakeKeyPtr = Marshal.AllocHGlobal(512);
+            try
+            {
+                Marshal.WriteInt32(fakeKeyPtr, 0);
+
+                using (SafeHandle parentHandle = new StateInformingSafeHandle())
+                {
+                    using (var keyHandle = new SafeNCryptKeyHandle(fakeKeyPtr, parentHandle))
+                    {
+                    }
+
+                    Assert.False(parentHandle.IsInvalid, "After keyHandle.Dispose, parentHandle.IsInvalid");
+                    Assert.False(parentHandle.IsClosed, "After keyHandle.Dispose, parentHandle.IsClosed");
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(fakeKeyPtr);
+            }
+        }
+
+        private class StateInformingSafeHandle : SafeHandle
+        {
+            private bool _isOpen;
+            private readonly bool _invalidateOnClose;
+
+            public StateInformingSafeHandle()
+                : this(true)
+            {
+            }
+
+            public StateInformingSafeHandle(bool isOpen)
+                : this(isOpen, true)
+            {
+            }
+
+            public StateInformingSafeHandle(bool isOpen, bool invalidateOnClose)
+                : base(IntPtr.Zero, true)
+            {
+                _isOpen = isOpen;
+                _invalidateOnClose = invalidateOnClose;
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                if (_invalidateOnClose)
+                    _isOpen = false;
+
+                return true;
+            }
+
+            public override bool IsInvalid => !_isOpen;
+        }
+#endif
     }
 }
 

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -10,6 +10,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Cng.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Cng.Tests</RootNamespace>
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
     <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.6</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
This is a prerequisite for X509Certificates' ephemeral private key import, the
functionality is required to allow a key handle to track that it is owned by
a PCERT_CONTEXT and that a) the PCERT_CONTEXT needs to be kept alive,
and b) the key shouldn't be destroyed when this handle is freed (but the
reference count against the PCERT_CONTEXT needs to be decremented).

The System.Security.Cryptography.Cng ref.cs was also regenerated using the newest version of GenAPI (split across two commits).

Part 1 of 3 for #8186.
cc: @stephentoub 