### PR TITLE
Disable newly added proxyauth test on *Nix

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -37,6 +37,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendSupportsCustomCertificateHandling))]
+        [ActiveIssue(12015, PlatformID.AnyUnix)]
         public void UseCallback_HaveNoCredsAndUseAuthenticatedCustomProxyAndPostToSecureServer_ProxyAuthenticationRequiredStatusCode()
         {
             int port;


### PR DESCRIPTION
PR #11985 added a new test which is failing on *Nix (part of OuterLoop):

System.Net.Http.Functional.Tests.HttpClientHandler_ServerCertificates_Test.UseCallback_HaveNoCredsAndUseAuthenticatedCustomProxyAndPostToSecureServer_ProxyAuthenticationRequiredStatusCode

System.Net.Http.CurlException : Failure when receiving data from the peer

Disabling this outerloop test for *Nix in [master]. Tracking this as #12015 