### PR TITLE
Always define GeneratedProjectJsonDir property

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -48,6 +48,9 @@
     <ToolsDir Condition="'$(UseToolRuntimeForToolsDir)'=='true'">$(ToolRuntimePath)</ToolsDir>
     <ToolsDir Condition="'$(ToolsDir)'==''">$(ProjectDir)Tools/</ToolsDir>
     <ToolRuntimePath Condition="'$(ToolRuntimePath)'==''">$(ToolsDir)</ToolRuntimePath>
+
+    <!-- needs to be defined all the time to avoid indexing every file from the root -->
+    <GeneratedProjectJsonDir>$(ObjDir)generated</GeneratedProjectJsonDir>
   </PropertyGroup>
 
   <Import Project="$(ToolRuntimePath)BuildVersion.targets" Condition="Exists('$(ToolRuntimePath)BuildVersion.targets')" />
@@ -93,7 +96,6 @@
 
   <!-- This is the directory where we dynamically generate project.json's for our test build package dependencies -->
   <PropertyGroup Condition="'$(BuildTestsAgainstPackages)' == 'true'">
-    <GeneratedProjectJsonDir>$(ObjDir)generated</GeneratedProjectJsonDir>
     <BuildTestsAgainstPackagesIdentityRegex>$(CoreFxVersionsIdentityRegex)</BuildTestsAgainstPackagesIdentityRegex>
     <SkipVerifyPackageVersions>true</SkipVerifyPackageVersions>
   </PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/12001

Apparently msbuild will try to expand the wildcard item even
if the condition on it is false and in some cases that causes
GeneratedProjectJsonDir to be set to empty and causes msbuild
to try to find all project.json files on the entire drive. To ensure
we don't try indexing the entire drive we will always set
the property.

https://github.com/dotnet/corefx/commit/760104f2957978c475648923f744f0b709507559#diff-0b192804a6349e8c26d2b027afbd89a2R131