### PR TITLE
Enable Encoding netstandard1.7 on Linux

### DIFF
--- a/src/System.Text.Encoding/tests/Decoder/Decoder.netstandard1.7.cs
+++ b/src/System.Text.Encoding/tests/Decoder/Decoder.netstandard1.7.cs
@@ -11,7 +11,6 @@ namespace System.Text.Encodings.Tests
     public class DecoderMiscTests
     {
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static unsafe void ConvertTest()
         {
             string s1 = "This is simple ascii string";
@@ -80,7 +79,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static unsafe void ConvertNegativeTest()
         {
             Decoder decoder = Encoding.UTF8.GetDecoder();
@@ -118,7 +116,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static unsafe void GetCharsTest()
         {
             string s1 = "This is simple ascii string";
@@ -165,7 +162,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static unsafe void GetCharsNegativeTest()
         {
             Decoder decoder = Encoding.UTF8.GetDecoder();
@@ -202,7 +198,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static void DecoderExceptionFallbackBufferTest()
         {
             Decoder decoder = Encoding.GetEncoding("us-ascii", new EncoderExceptionFallback(), new DecoderExceptionFallback()).GetDecoder();
@@ -229,7 +224,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static void DecoderReplacementFallbackBufferTest()
         {
             Decoder decoder = Encoding.GetEncoding("us-ascii", new EncoderReplacementFallback(), new DecoderReplacementFallback()).GetDecoder();

--- a/src/System.Text.Encoding/tests/Encoder/Encoder.netstandard1.7.cs
+++ b/src/System.Text.Encoding/tests/Encoder/Encoder.netstandard1.7.cs
@@ -11,7 +11,6 @@ namespace System.Text.Encodings.Tests
     public class EncoderMiscTests
     {
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static unsafe void ConvertTest()
         {
             string s1 = "This is simple ascii string";
@@ -76,7 +75,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static unsafe void ConvertNegativeTest()
         {
             Encoder encoder = Encoding.UTF8.GetEncoder();
@@ -115,7 +113,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static unsafe void GetBytesTest()
         {
             string s1 = "This is simple ascii string";
@@ -158,7 +155,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static unsafe void GetBytesNegativeTest()
         {
             Encoder encoder = Encoding.UTF8.GetEncoder();
@@ -195,7 +191,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static void EncoderExceptionFallbackBufferTest()
         {
             Encoder encoder = Encoding.GetEncoding("us-ascii", new EncoderExceptionFallback(), new DecoderExceptionFallback()).GetEncoder();
@@ -224,7 +219,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static void EncoderReplacementFallbackBufferTest()
         {
             Encoder encoder = Encoding.GetEncoding("us-ascii", new EncoderReplacementFallback(), new DecoderReplacementFallback()).GetEncoder();

--- a/src/System.Text.Encoding/tests/Encoding/Encoding.netstandard1.7.cs
+++ b/src/System.Text.Encoding/tests/Encoding/Encoding.netstandard1.7.cs
@@ -37,7 +37,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static void DefaultEncodingTest()
         {
             Encoding enc = (Encoding) Encoding.Default.Clone();
@@ -46,7 +45,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static void GetEncodingsTest()
         {
             EncodingInfo [] encodingList = Encoding.GetEncodings();
@@ -60,7 +58,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Theory]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         [MemberData(nameof(Encoding_TestData))]
         public static void NormalizationTest(int codepage, string name, string bodyName, string headerName, bool isBrowserDisplay, 
                                             bool isBrowserSave, bool isMailNewsDisplay, bool isMailNewsSave, int windowsCodePage)
@@ -77,7 +74,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Theory]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         [MemberData(nameof(Normalization_TestData))]
         public static void NormalizationTest(int codepage, bool normalized, bool normalizedC, bool normalizedD, bool normalizedKC, bool normalizedKD)
         {

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncoding.netstandard1.7.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncoding.netstandard1.7.cs
@@ -11,14 +11,12 @@ namespace System.Text.Encodings.Tests
     public class UnicodeEncodingMiscTests
     {
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static void CharSizeTest()
         {
             Assert.Equal(2, UnicodeEncoding.CharSize);
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static unsafe void GetCharAndBytesTest()
         {
             Encoding encoding = Encoding.Unicode;
@@ -46,7 +44,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static unsafe void GetBytesNegativeTest()
         {
             Encoding enc = Encoding.GetEncoding("utf-16", new EncoderExceptionFallback(), new DecoderExceptionFallback());
@@ -75,7 +72,6 @@ namespace System.Text.Encodings.Tests
         }
 
         [Fact]
-        [ActiveIssue(11858, Xunit.PlatformID.AnyUnix)]
         public static unsafe void GetCharsNegativeTest()
         {
             Encoding enc = Encoding.GetEncoding("utf-16", new EncoderExceptionFallback(), new DecoderExceptionFallback());


### PR DESCRIPTION
The full functionality now existed in coreclr package which allow us to enable the encoding tests on corefx