### PR TITLE
Add negative tests for FileStream Begin/End

### DIFF
--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -87,7 +87,7 @@
     </Compile>
   </ItemGroup>
   <!-- .NET Standard 1.7 -->
-  <ItemGroup Condition="'$(PackageTargetFramework)' == 'netstandard1.7' and '$(TargetGroup)' != 'net46' and '$(TargetGroup)' != 'net463'" >
+  <ItemGroup Condition="'$(TargetGroup)' == ''" >
     <Compile Include="System\IO\FileStreamBase.NetStandard17.cs" />
     <Compile Include="System\IO\FileStream.NetStandard17.cs" />
   </ItemGroup>

--- a/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
@@ -11,19 +11,12 @@ namespace System.IO
     {
         public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, FileAccess access, int bufferSize)
         {
-            this._innerStream = new Win32FileStream(handle, access, bufferSize, this);
+            _innerStream = new Win32FileStream(handle, access, bufferSize, this);
         }
 
         public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
         {
-            this._innerStream = new Win32FileStream(handle, access, bufferSize, isAsync, this);
-        }
-
-        static partial void ValidatePath(string fullPath, string paramName)
-        {
-            // Prevent access to your disk drives as raw block devices.
-            if (fullPath.StartsWith("\\\\.\\", StringComparison.Ordinal))
-                throw new ArgumentException(SR.Arg_DevicesNotSupported, paramName);
+            _innerStream = new Win32FileStream(handle, access, bufferSize, isAsync, this);
         }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.cs
@@ -97,15 +97,11 @@ namespace System.IO
 
             string fullPath = Path.GetFullPath(path);
 
-            ValidatePath(fullPath, "path");
-
             if ((access & FileAccess.Read) != 0 && mode == FileMode.Append)
                 throw new ArgumentException(SR.Argument_InvalidAppendMode, nameof(access));
 
             this._innerStream = FileSystem.Current.Open(fullPath, mode, access, share, bufferSize, options, this);
         }
-
-        static partial void ValidatePath(string fullPath, string paramName);
 
         // InternalOpen, InternalCreate, and InternalAppend:
         // Factory methods for FileStream used by File, FileInfo, and ReadLinesIterator

--- a/src/System.IO.FileSystem/tests/FileStream/BeginRead.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/BeginRead.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class FileStream_BeginRead : FileSystemTest
+    {
+        [Fact]
+        public void BeginReadThrowsForNullArray()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+                Assert.Throws<ArgumentNullException>("array", () => fs.BeginRead(null, 0, 0, null, null));
+            }
+        }
+
+        [Fact]
+        public void BeginReadThrowsForNegativeOffset()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => fs.BeginRead(new byte[0], -1, 0, null, null));
+            }
+        }
+
+        [Fact]
+        public void BeginReadThrowsForNegativeNumBytes()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("numBytes", () => fs.BeginRead(new byte[0], 0, -1, null, null));
+            }
+        }
+
+        [Theory
+            InlineData(0, 0, 1)
+            InlineData(0, 1, 0)
+            InlineData(1, 0, 2)
+            InlineData(1, 1, 1)
+            ]
+        public void BeginReadThrowsForBadOffset(int arraySize, int offset, int numBytes)
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+                Assert.Throws<ArgumentException>(() => fs.BeginRead(new byte[arraySize], offset, numBytes, null, null));
+            }
+        }
+
+        [Fact]
+        public void BeginReadThrowsForClosed()
+        {
+            FileStream fs;
+            using (fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+            }
+
+            Assert.Throws<ObjectDisposedException>(() => fs.BeginRead(new byte[0], 0, 0, null, null));
+        }
+
+        [Fact]
+        public void BeginReadThrowsForWriteOnly()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+                Assert.Throws<NotSupportedException>(() => fs.BeginRead(new byte[0], 0, 0, null, null));
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileStream/BeginWrite.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/BeginWrite.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class FileStream_BeginWrite : FileSystemTest
+    {
+        [Fact]
+        public void BeginWriteThrowsForNullArray()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+                Assert.Throws<ArgumentNullException>("array", () => fs.BeginWrite(null, 0, 0, null, null));
+            }
+        }
+
+        [Fact]
+        public void BeginWriteThrowsForNegativeOffset()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => fs.BeginWrite(new byte[0], -1, 0, null, null));
+            }
+        }
+
+        [Fact]
+        public void BeginWriteThrowsForNegativeNumBytes()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("numBytes", () => fs.BeginWrite(new byte[0], 0, -1, null, null));
+            }
+        }
+
+        [Theory
+            InlineData(0, 0, 1)
+            InlineData(0, 1, 0)
+            InlineData(1, 0, 2)
+            InlineData(1, 1, 1)
+            ]
+        public void BeginWriteThrowsForBadOffset(int arraySize, int offset, int numBytes)
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+                Assert.Throws<ArgumentException>(() => fs.BeginWrite(new byte[arraySize], offset, numBytes, null, null));
+            }
+        }
+
+        [Fact]
+        public void BeginWriteThrowsForClosed()
+        {
+            FileStream fs;
+            using (fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+            }
+
+            Assert.Throws<ObjectDisposedException>(() => fs.BeginWrite(new byte[0], 0, 0, null, null));
+        }
+
+        [Fact]
+        public void BeginWriteThrowsForReadOnly()
+        {
+            string testPath = GetTestFilePath();
+            using (FileStream fs = new FileStream(testPath, FileMode.Create, FileAccess.Write))
+            {
+            }
+
+            using (FileStream fs = new FileStream(testPath, FileMode.Open, FileAccess.Read))
+            {
+                Assert.Throws<NotSupportedException>(() => fs.BeginWrite(new byte[0], 0, 0, null, null));
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileStream/EndRead.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/EndRead.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class FileStream_EndRead : FileSystemTest
+    {
+        [Fact]
+        public void EndReadThrowsForNullAsyncResult()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite))
+            {
+                Assert.Throws<ArgumentNullException>("asyncResult", () => fs.EndRead(null));
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileStream/EndWrite.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/EndWrite.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class FileStream_EndWrite : FileSystemTest
+    {
+        [Fact]
+        public void EndWriteThrowsForNullAsyncResult()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite))
+            {
+                Assert.Throws<ArgumentNullException>("asyncResult", () => fs.EndWrite(null));
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
@@ -197,12 +197,5 @@ namespace System.IO.Tests
                 Assert.Throws<NotSupportedException>(() => fs.ReadByte());
             }
         }
-
-        [Fact]
-        [PlatformSpecific(Xunit.PlatformID.Windows)]
-        public void RawLongPathAccess_ThrowsArgumentException()
-        {
-            Assert.Throws<ArgumentException>(() => CreateFileStream("\\\\.\\disk\\access\\", FileMode.Open));
-        }
     }
 }

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -34,6 +34,18 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+    <Compile Include="FileStream\Handle.cs"/>
+    <Compile Include="Directory\GetLogicalDrives.cs" />
+    <Compile Include="FileStream\BeginRead.cs" />
+    <Compile Include="FileStream\EndRead.cs" />
+    <Compile Include="FileStream\BeginWrite.cs" />
+    <Compile Include="FileStream\EndWrite.cs" />
+    <Compile Include="FileStream\LockUnlock.cs" />
+    <Compile Include="File\EncryptDecrypt.cs" />
+    <Compile Include="File\Replace.cs" />
+    <Compile Include="File\ReadWriteAllLines.netstandard1.7.cs" />
+  </ItemGroup>
   <ItemGroup>
     <!-- Rewritten -->
     <Compile Include="DirectoryInfo\GetSetAttributes.cs" />
@@ -44,14 +56,12 @@
     <Compile Include="DirectoryInfo\Root.cs" />
     <Compile Include="Directory\EnumerableAPIs.cs" />
     <Compile Include="Directory\GetFileSystemEntries_str_str_so.cs" />
-    <Compile Include="Directory\GetLogicalDrives.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="Directory\GetParent.cs" />
     <Compile Include="FileInfo\GetSetAttributes.cs" />
     <Compile Include="FileInfo\Length.cs" />
     <Compile Include="FileInfo\Open.cs" />
     <Compile Include="FileStream\FlushAsync.cs" />
     <Compile Include="FileStream\Pipes.cs" />
-    <Compile Include="FileStream\Handle.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="FileStream\SafeFileHandle.cs" />
     <Compile Include="FileStream\IsAsync.cs" />
     <Compile Include="FileStream\CanTimeout.cs" />
@@ -72,7 +82,6 @@
     <Compile Include="FileStream\ReadByte.cs" />
     <Compile Include="FileStream\SetLength.cs" />
     <Compile Include="FileStream\Length.cs" />
-    <Compile Include="FileStream\LockUnlock.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="FileStream\Position.cs" />
     <Compile Include="FileStream\Seek.cs" />
     <Compile Include="FileStream\ctor_sfh_fa_buffer_async.cs" />
@@ -88,13 +97,10 @@
     <Compile Include="FileStream\ctor_str_fm_fa.cs" />
     <Compile Include="FileStream\ctor_str_fm.cs" />
     <Compile Include="File\Append.cs" />
-    <Compile Include="File\EncryptDecrypt.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
-    <Compile Include="File\Replace.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="File\Create.cs" />
     <Compile Include="File\Delete.cs" />
     <Compile Include="File\GetSetAttributes.cs" />
     <Compile Include="File\Move.cs" />
-    <Compile Include="File\ReadWriteAllLines.netstandard1.7.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="File\ReadWriteAllText.cs" />
     <Compile Include="File\ReadWriteAllLines.cs" />
     <Compile Include="UnseekableFileStream.cs" />


### PR DESCRIPTION
Adds negative tests for Begin/End, removes unnecessary block for `\\.\`
paths.

(The block for `\\.\` paths fulfills a need that predates our supported
Windows OSes. You cannot inadvertently mess up "raw" drives. In addition
we currently allow `\\?\` which is another form of device path access.)