### PR TITLE
Fix NoSocketsReuseUnicastPortSupport tests

### DIFF
--- a/src/Common/tests/System/Net/Capability.Sockets.cs
+++ b/src/Common/tests/System/Net/Capability.Sockets.cs
@@ -25,7 +25,7 @@ namespace System.Net.Test.Common
             internal char[] szCSDVersion;
         }
 
-        public static bool SocketsReuseUnicastPortSupport()
+        public static bool? SocketsReuseUnicastPortSupport()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -33,7 +33,21 @@ namespace System.Net.Test.Common
                 v.dwOSVersionInfoSize = (uint)Marshal.SizeOf<RTL_OSVERSIONINFOW>();
                 RtlGetVersion(ref v);
 
-                return (v.dwMajorVersion == 10);
+                if (v.dwMajorVersion == 10)
+                {
+                    return true;
+                }
+                else if (v.dwMajorVersion == 6 && (v.dwMinorVersion == 2 || v.dwMinorVersion == 3))
+                {
+                    // On Windows 8/Windows Server 2012 (major=6, minor=2) or Windows 8.1/Windows Server 2012 R2
+                    // (major=6, minor=3), this feature is not present unless a servicing patch is installed.
+                    // So, we return null to indicate that it is indeterminate whether the feature is active.
+                    return null;
+                }
+                else
+                {
+                    return false;
+                }
             }
 
             return false;

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -18,7 +18,8 @@ namespace System.Net.Sockets.Tests
         {
             get
             {
-                return Capability.SocketsReuseUnicastPortSupport();
+                return Capability.SocketsReuseUnicastPortSupport().HasValue &&
+                    Capability.SocketsReuseUnicastPortSupport().Value;
             }
         }
 
@@ -26,12 +27,12 @@ namespace System.Net.Sockets.Tests
         {
             get
             {
-                return !Capability.SocketsReuseUnicastPortSupport();
+                return Capability.SocketsReuseUnicastPortSupport().HasValue &&
+                    !Capability.SocketsReuseUnicastPortSupport().Value;
             }
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(11088, PlatformID.Windows)]
         [ConditionalFact(nameof(NoSocketsReuseUnicastPortSupport))]
         public void ReuseUnicastPort_CreateSocketGetOption_NoSocketsReuseUnicastPortSupport_Throws()
         {
@@ -52,7 +53,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(11088, PlatformID.Windows)]
         [ConditionalFact(nameof(NoSocketsReuseUnicastPortSupport))]
         public void ReuseUnicastPort_CreateSocketSetOption_NoSocketsReuseUnicastPortSupport_Throws()
         {


### PR DESCRIPTION
The NoSocketsReuseUnicastPortSupport tests were failing on Windows Server 2012 R2 in the CI runs because we thought the feature was not present. It was only introduced in Windows 10. However, it was later backported as a serving fix to both Windows 8.1 (Windows Server 2012 R2) and Windows 8 (Windows Server 2012). It is not possible to detect in the CI tests if a servicing patch is installed. So, this PR adjusts the capability detection to return a null value (instead of true or false) to indicate this uncertainty and thus the tests are skipped in that case.

Fixes #11088