### PR TITLE
Optimize Enumerable.Cast calls followed by ToArray or ToList, refactor Count

### DIFF
--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -2,11 +2,54 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System.Collections.Generic
 {
     /// <summary>Internal helper functions for working with enumerables.</summary>
     internal static class EnumerableHelpers
     {
+        /// <summary>Gets the count of an enumerable.</summary>
+        /// <param name="source">The enumerable to count.</param>
+        /// <returns>The count of the enumerable.</returns>
+        internal static int GetCount<T>(IEnumerable<T> source)
+        {
+            Debug.Assert(source != null);
+
+            var genericCollection = source as ICollection<T>;
+            if (genericCollection != null)
+            {
+                return genericCollection.Count;
+            }
+
+            var collection = source as ICollection;
+            if (collection != null)
+            {
+                return collection.Count;
+            }
+
+            return FallbackGetCount(source);
+        }
+
+        private static int FallbackGetCount<T>(IEnumerable<T> source)
+        {
+            Debug.Assert(source != null);
+
+            int count = 0;
+            using (IEnumerator<T> e = source.GetEnumerator())
+            {
+                checked
+                {
+                    while (e.MoveNext())
+                    {
+                        count++;
+                    }
+                }
+            }
+
+            return count;
+        }
+
         /// <summary>Converts an enumerable to an array using the same logic as does List{T}.</summary>
         /// <param name="source">The enumerable to convert.</param>
         /// <returns>The resulting array.</returns>

--- a/src/System.Linq/src/System/Linq/Cast.cs
+++ b/src/System.Linq/src/System/Linq/Cast.cs
@@ -4,6 +4,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Linq
 {
@@ -42,15 +43,111 @@ namespace System.Linq
             {
                 throw Error.ArgumentNull(nameof(source));
             }
-
-            return CastIterator<TResult>(source);
+            
+            return new CastIterator<TResult>(source);
         }
 
-        private static IEnumerable<TResult> CastIterator<TResult>(IEnumerable source)
+        private sealed class CastIterator<TResult> : Iterator<TResult>, IIListProvider<TResult>
         {
-            foreach (object obj in source)
+            private readonly IEnumerable _source;
+            private IEnumerator _enumerator;
+
+            public CastIterator(IEnumerable source)
             {
-                yield return (TResult)obj;
+                Debug.Assert(source != null);
+
+                _source = source;
+            }
+
+            public override Iterator<TResult> Clone() => new CastIterator<TResult>(_source);
+            
+            public override void Dispose()
+            {
+                // Non-generic IEnumerators do not implement IDisposable up front.
+                // However, in a foreach loop with such enumerators the C# compiler will generate
+                // a type check to see if the enumerator implements IDisposable, and if so Dispose it.
+                // Since Cast was originally implemented using yield return and a foreach loop,
+                // let's try to preserve the original behavior.
+
+                var disposable = _enumerator as IDisposable;
+                disposable?.Dispose();
+                _enumerator = null;
+
+                base.Dispose();
+            }
+
+            public int GetCount(bool onlyIfCheap) => EnumerableHelpers.GetCount(this);
+
+            public override bool MoveNext()
+            {
+                switch (_state)
+                {
+                    case 1:
+                        _enumerator = _source.GetEnumerator();
+                        _state = 2;
+                        goto case 2;
+                    case 2:
+                        if (_enumerator.MoveNext())
+                        {
+                            _current = (TResult)_enumerator.Current;
+                            return true;
+                        }
+
+                        _state = 3;
+                        Dispose();
+                        break;
+                }
+
+                return false;
+            }
+
+            public TResult[] ToArray()
+            {
+                var collection = _source as ICollection;
+                if (collection == null)
+                {
+                    return EnumerableHelpers.ToArray(this);
+                }
+
+                int count = collection.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<TResult>();
+                }
+
+                int index = 0;
+                var array = new TResult[count];
+
+                foreach (object obj in collection)
+                {
+                    array[index++] = (TResult)obj;
+                }
+
+                Debug.Assert(index == array.Length);
+                return array;
+            }
+
+            public List<TResult> ToList()
+            {
+                var collection = _source as ICollection;
+                if (collection == null)
+                {
+                    return new List<TResult>(this);
+                }
+
+                int count = collection.Count;
+                var list = new List<TResult>(count);
+
+                if (count != 0) // Avoid the enumerator allocation
+                {
+                    foreach (object obj in collection)
+                    {
+                        list.Add((TResult)obj);
+                    }
+                }
+
+                Debug.Assert(list.Count == count);
+                return list;
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Count.cs
+++ b/src/System.Linq/src/System/Linq/Count.cs
@@ -16,37 +16,10 @@ namespace System.Linq
                 throw Error.ArgumentNull(nameof(source));
             }
 
-            ICollection<TSource> collectionoft = source as ICollection<TSource>;
-            if (collectionoft != null)
-            {
-                return collectionoft.Count;
-            }
-
-            IIListProvider<TSource> listProv = source as IIListProvider<TSource>;
-            if (listProv != null)
-            {
-                return listProv.GetCount(onlyIfCheap: false);
-            }
-
-            ICollection collection = source as ICollection;
-            if (collection != null)
-            {
-                return collection.Count;
-            }
-
-            int count = 0;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
-            {
-                checked
-                {
-                    while (e.MoveNext())
-                    {
-                        count++;
-                    }
-                }
-            }
-
-            return count;
+            var listProvider = source as IIListProvider<TSource>;
+            return listProvider != null ?
+                listProvider.GetCount(onlyIfCheap: false) :
+                EnumerableHelpers.GetCount(source);
         }
 
         public static int Count<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)

--- a/src/System.Linq/tests/CastTests.cs
+++ b/src/System.Linq/tests/CastTests.cs
@@ -3,13 +3,28 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Linq.Tests
 {
     public class CastTests : EnumerableTests
     {
+        private static List<Func<IEnumerable<T>, IEnumerable<T>>> IdentityTransforms<T>()
+        {
+            return new List<Func<IEnumerable<T>, IEnumerable<T>>>
+            {
+                e => e,
+                e => e.ToArray(), // well-known ICollection
+                e => e.ToList(), // well-known ICollection
+                e => new Queue<T>(e), // not-well-known ICollection
+                e => e.Select(i => i), // IPartition
+                e => !e.Any() ? e : e.Skip(1).Prepend(e.First()) // IIListProvider, non-IPartition
+            };
+        }
+
         [Fact]
         public void CastIntToLongThrows()
         {
@@ -216,6 +231,164 @@ namespace System.Linq.Tests
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<string>;
             Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
+        public void CastDisposeWorksForDisposableAndNonDisposableNonGenericIEnumerators()
+        {
+            int state1 = 0;
+            var disposable = new DisposableDelegateBasedNonGenericEnumerator
+            {
+                MoveNextWorker = () => false, // Enumerator represents a collection w/ 0 elements.
+                DisposeWorker = () => state1++
+            };
+
+            var nonDisposable = new DelegateBasedNonGenericEnumerator();
+
+            var enumerable = new DelegateBasedNonGenericEnumerable { GetEnumeratorWorker = () => disposable };
+
+            using (var e = enumerable.Cast<object>().GetEnumerator())
+            {
+                Assert.Equal(0, state1);
+
+                // Once we reach the end of the sequence, we should call Dispose if
+                // the non-generic IEnumerator implements IDisposable.
+                e.MoveNext();
+                Assert.Equal(1, state1);
+
+                // We shouldn't call it twice.
+                e.MoveNext();
+                Assert.Equal(1, state1);
+            }
+
+            enumerable.GetEnumeratorWorker = () => nonDisposable;
+
+            using (var e = enumerable.Cast<object>().GetEnumerator())
+            {
+                // If the IEnumerator does not implement IDisposable, things should still work correctly.
+                e.MoveNext();
+                e.MoveNext();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidCastOptimizationWithAtLeastOneNonStringData))]
+        public void CountIsNotInvalidlyOptimized(IEnumerable source)
+        {
+            // If not all of the items in a collection are of type T, then
+            // optimizing collection.Cast<T>().Count() would be invalid.
+
+            Assert.Throws<InvalidCastException>(() => source.Cast<string>().Count());
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidCastOptimizationWithAtLeastOneNonStringData))]
+        public void SkipIsNotInvalidlyOptimized(IEnumerable source)
+        {
+            // Can't skip over non-Ts.
+
+            object[] sourceArray = source.Cast<object>().ToArray();
+            int lastNonStringIndex = Array.FindLastIndex(sourceArray, obj => !(obj is string));
+
+            Assert.Throws<InvalidCastException>(() =>
+            {
+                foreach (string item in source.Cast<string>().Skip(lastNonStringIndex + 1)) { }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidCastOptimizationWithAtLeastOneNonStringData))]
+        public void ElementAtIsNotInvalidlyOptimized(IEnumerable source)
+        {
+            object[] sourceArray = source.Cast<object>().ToArray();
+            int lastNonStringIndex = Array.FindLastIndex(sourceArray, obj => !(obj is string));
+            
+            if (lastNonStringIndex == source.Cast<object>().Count() - 1)
+            {
+                // Add a string at the end.
+                source = source.Cast<object>().Append(string.Empty);
+            }
+
+            Assert.Throws<InvalidCastException>(() => source.Cast<string>().ElementAt(lastNonStringIndex + 1));
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidCastOptimizationWithAtLeastOneNonStringData))]
+        public void LastIsNotInvalidlyOptimized(IEnumerable source)
+        {
+            if (source.Cast<object>().Last() is string)
+            {
+                Assert.Throws<InvalidCastException>(() => source.Cast<string>().Last());
+            }
+            else
+            {
+                source = source.Cast<object>().Prepend(3).Append(string.Empty);
+
+                Assert.Throws<InvalidCastException>(() => source.Cast<string>().Last());
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidCastOptimizationWithAtLeastOneNonStringData))]
+        public void InvalidCastToArrayToList(IEnumerable source)
+        {
+            Assert.Throws<InvalidCastException>(() => source.Cast<string>().ToArray());
+            Assert.Throws<InvalidCastException>(() => source.Cast<string>().ToList());
+        }
+
+        public static IEnumerable<object[]> InvalidCastOptimizationWithAtLeastOneNonStringData()
+        {
+            var sources = new List<IEnumerable<object>>
+            {
+                new object[] { 3, "foo", new object() },
+                Enumerable.Repeat<object>("foo", 37).Append(3),
+                Enumerable.Range(1, 3).Cast<object>(),
+                Enumerable.Repeat(new object(), 1010),
+                Enumerable.Repeat<object>(1, 1).Append("foo").Append("foo"),
+                new object[] { 3, null, null, "foo" },
+                new object[] { null, 3 },
+                new object[] { null, 3, null, 3 }.Reverse()
+            };
+
+            foreach (var equivalentSource in IdentityTransforms<object>().SelectMany(t => sources.Select(s => t(s))))
+            {
+                yield return new object[] { equivalentSource };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(UntypedCollectionWithAllStringsData))]
+        public void CountToArrayAndToListShouldWorkAsExpected(IEnumerable source)
+        {
+            Assert.Equal(NaiveCast<string>(source).Count(), source.Cast<string>().Count());
+            Assert.Equal(NaiveCast<string>(source), source.Cast<string>().ToArray());
+            Assert.Equal(NaiveCast<string>(source), source.Cast<string>().ToList());
+        }
+
+        public static IEnumerable<object[]> UntypedCollectionWithAllStringsData()
+        {
+            var sources = new List<IEnumerable<object>>
+            {
+                Enumerable.Repeat<object>("foo", 37),
+                Enumerable.Repeat<object>(null, 123),
+                new object[] { null, "strstr", "bar" },
+                Array.Empty<object>()
+            };
+
+            foreach (var equivalentSource in IdentityTransforms<object>().SelectMany(t => sources.Select(s => t(s))))
+            {
+                yield return new object[] { equivalentSource };
+            }
+        }
+
+        private static IEnumerable<T> NaiveCast<T>(IEnumerable source)
+        {
+            Debug.Assert(source != null);
+
+            foreach (object obj in source)
+            {
+                yield return (T)obj;
+            }
         }
     }
 }

--- a/src/System.Linq/tests/EnumerableTests.cs
+++ b/src/System.Linq/tests/EnumerableTests.cs
@@ -268,5 +268,47 @@ namespace System.Linq.Tests
             public IEnumerator<T> GetEnumerator() => GetEnumeratorWorker();
             IEnumerator IEnumerable.GetEnumerator() => NonGenericGetEnumeratorWorker();
         }
+
+        protected class DelegateBasedNonGenericEnumerator : IEnumerator
+        {
+            public Func<bool> MoveNextWorker { get; set; }
+            public Func<object> CurrentWorker { get; set; }
+            public Action ResetWorker { get; set; }
+
+            public DelegateBasedNonGenericEnumerator()
+            {
+                MoveNextWorker = () => false;
+                CurrentWorker = () => null;
+                ResetWorker = () => { };
+            }
+
+            public bool MoveNext() => MoveNextWorker();
+            public object Current => CurrentWorker();
+            public void Reset() => ResetWorker();
+        }
+
+        protected class DisposableDelegateBasedNonGenericEnumerator : DelegateBasedNonGenericEnumerator, IDisposable
+        {
+            public Action DisposeWorker { get; set; }
+
+            public DisposableDelegateBasedNonGenericEnumerator() : base()
+            {
+                DisposeWorker = () => { };
+            }
+
+            public void Dispose() => DisposeWorker();
+        }
+
+        protected class DelegateBasedNonGenericEnumerable : IEnumerable
+        {
+            public Func<IEnumerator> GetEnumeratorWorker { get; set; }
+
+            public DelegateBasedNonGenericEnumerable()
+            {
+                GetEnumeratorWorker = () => Array.Empty<object>().GetEnumerator();
+            }
+
+            public IEnumerator GetEnumerator() => GetEnumeratorWorker();
+        }
     }
 }


### PR DESCRIPTION
This PR contains 3 changes:

- Segregate parts of `Enumerable.Count` so it is possible to call `Count` from an IIListProvider w/o going into an infinite loop. This is useful for iterators (like this one) where we can optimize `ToArray` or `ToList` but not `Count`.

- Optimize the iterator returned by `Cast` for non-generic ICollections; in `ToArray` and `ToList` we can preallocate an array before enumerating the items. Common BCL containers such as List/Queue/Array/etc. implement the non-generic interface, so the optimizations should benefit a lot of code.
  - GetCount can't be optimized since just returning the `.Count` of the source collection wouldn't actually verify that all of the elements in it were of type TResult. This isn't a problem for `ToArray` / `ToList` however, since we have to go through the entire collection anyway.

- Add extensive testing for the changes, including regression tests to make sure that `Skip`, `ElementAt`, `Last`, etc. aren't optimized.

@stephentoub, @VSadov, @JonHanna 