### PR TITLE
remove pointer from baseline

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -5079,6 +5079,7 @@ namespace System.Reflection
     [System.CLSCompliantAttribute(false)]
     public sealed class Pointer : System.Runtime.Serialization.ISerializable
     {
+        private Pointer() { }    
         [System.Security.SecurityCriticalAttribute]
         public static unsafe object Box(void* ptr, System.Type type) { return default(object); }
         [System.Security.SecurityCriticalAttribute]

--- a/src/System.Runtime/src/ApiCompatBaseline.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.txt
@@ -1,4 +1,5 @@
+Compat issues with assembly System.Runtime:
 MembersMustExist : Member 'System.Type.IsSecurityCritical.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Type.IsSecuritySafeCritical.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Type.IsSecurityTransparent.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Reflection.Pointer..ctor()' does not exist in the implementation but it does exist in the contract.
+Total Issues: 3


### PR DESCRIPTION
In bringing over reflection types, we accidentally exposed the default constructor on S.Reflection.Pointer.

@sepidehMS 