### PR TITLE
Add ubuntu.16.10-x64 and opensuse.42.1-x64 to IsolatedStorage test project.json

### DIFF
--- a/src/System.IO.IsolatedStorage/tests/project.json
+++ b/src/System.IO.IsolatedStorage/tests/project.json
@@ -46,9 +46,11 @@
         "rhel.7-x64",
         "ubuntu.14.04-x64",
         "ubuntu.16.04-x64",
+        "ubuntu.16.10-x64",
         "fedora.23-x64",
         "linux-x64",
-        "opensuse.13.2-x64"
+        "opensuse.13.2-x64",
+        "opensuse.42.1-x64"
       ]
     }
   }


### PR DESCRIPTION
This adds two missing test RIDs to the IsolatedStorage test project.