### PR TITLE
Fixed capitalization in parameter

### DIFF
--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -181,7 +181,7 @@ namespace System.Net
         public static readonly System.Net.IPAddress Loopback;
         public static readonly System.Net.IPAddress None;
         public IPAddress(byte[] address) { }
-        public IPAddress(byte[] address, long scopeid) { }
+        public IPAddress(byte[] address, long scopeId) { }
         public IPAddress(long newAddress) { }
         public System.Net.Sockets.AddressFamily AddressFamily { get { return default(System.Net.Sockets.AddressFamily); } }
         public bool IsIPv4MappedToIPv6 { get { return default(bool); } }

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -121,7 +121,7 @@ namespace System.Net
         ///     Constructor for an IPv6 Address with a specified Scope.
         ///   </para>
         /// </devdoc>
-        public IPAddress(byte[] address, long scopeid)
+        public IPAddress(byte[] address, long scopeId)
         {
             if (address == null)
             {
@@ -142,20 +142,20 @@ namespace System.Net
 
             // Consider: Since scope is only valid for link-local and site-local
             //           addresses we could implement some more robust checking here
-            if (scopeid < 0 || scopeid > 0x00000000FFFFFFFF)
+            if (scopeId < 0 || scopeId > 0x00000000FFFFFFFF)
             {
-                throw new ArgumentOutOfRangeException(nameof(scopeid));
+                throw new ArgumentOutOfRangeException(nameof(scopeId));
             }
 
-            PrivateScopeId = (uint)scopeid;
+            PrivateScopeId = (uint)scopeId;
         }
 
-        private IPAddress(ushort[] numbers, uint scopeid)
+        private IPAddress(ushort[] numbers, uint scopeId)
         {
             Debug.Assert(numbers != null);
 
             _numbers = numbers;
-            PrivateScopeId = scopeid;
+            PrivateScopeId = scopeId;
         }
 
         /// <devdoc>
@@ -531,6 +531,7 @@ namespace System.Net
             labels[5] = 0xFFFF;
             labels[6] = (ushort)(((address & 0x0000FF00) >> 8) | ((address & 0x000000FF) << 8));
             labels[7] = (ushort)(((address & 0xFF000000) >> 24) | ((address & 0x00FF0000) >> 8));
+            
             return new IPAddress(labels, 0);
         }
 


### PR DESCRIPTION
Fixed capitalization of `scopeid` parameter to camelCase in order to adhere to the .NET naming convention.