### PR TITLE
Minor change to avoid an allocation in Uri

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -500,11 +500,10 @@ namespace System
                         // Hence anything like x:sdsd is a relative path and be added to the baseUri Path
                         break;
                     }
-                    string scheme = relativeStr.Substring(0, i);
-                    fixed (char* sptr = scheme)
+                    fixed (char* sptr = relativeStr) // relativeStr.Substring(0, i) represents the scheme
                     {
                         UriParser syntax = null;
-                        if (CheckSchemeSyntax(sptr, (ushort)scheme.Length, ref syntax) == ParsingError.None)
+                        if (CheckSchemeSyntax(sptr, (ushort)i, ref syntax) == ParsingError.None)
                         {
                             if (baseUri.Syntax == syntax)
                             {


### PR DESCRIPTION
We can avoid allocating a substring and just fix directly on `relativeStr`.

@CIPop @davidsh 