### PR TITLE
Make Queue.Peek inline

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -244,8 +244,10 @@ namespace System.Collections.Generic
         public T Peek()
         {
             if (_size == 0)
-                throw new InvalidOperationException(SR.InvalidOperation_EmptyQueue);
-
+            {
+                ThrowForEmptyQueue();
+            }
+            
             return _array[_head];
         }
 
@@ -326,6 +328,12 @@ namespace System.Collections.Generic
             // than a simple comparison and a rarely taken branch.   
             int tmp = index + 1;
             index = (tmp == _array.Length) ? 0 : tmp;
+        }
+
+        private void ThrowForEmptyQueue()
+        {
+            Debug.Assert(_size == 0);
+            throw new InvalidOperationException(SR.InvalidOperation_EmptyQueue);
         }
 
         public void TrimExcess()

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -228,7 +228,9 @@ namespace System.Collections.Generic
         public T Dequeue()
         {
             if (_size == 0)
-                throw new InvalidOperationException(SR.InvalidOperation_EmptyQueue);
+            {
+                ThrowForEmptyQueue();
+            }
 
             T removed = _array[_head];
             _array[_head] = default(T);


### PR DESCRIPTION
We can trivially make Queue.Peek inline by moving the throw code into a new method. JIT will not inline this as per dotnet/coreclr#6103.

[Test code, before/after asm](https://gist.github.com/jamesqo/6faf5c7c7a6237f74cbd97d485a3fcd1)

@ianhays 