### PR TITLE
Enable System.Net.WebSockets.Client tests for UWP

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.builds
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.builds
@@ -6,7 +6,7 @@
       <OSGroup>Unix</OSGroup>
     </Project>
     <Project Include="System.Net.WebSockets.Client.Tests.csproj">
-      <TestTFMs>netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcore50;netcoreapp1.0;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Net.WebSockets.Client/tests/project.json
+++ b/src/System.Net.WebSockets.Client/tests/project.json
@@ -2,8 +2,6 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.2-beta-24522-03",
     "System.Linq.Expressions": "4.3.0-beta-24522-03",
-    "System.Net.Sockets": "4.3.0-beta-24522-03",
-    "System.Net.Security": "4.3.0-beta-24522-03",
     "System.Net.WebSockets": "4.3.0-beta-24522-03",
     "System.Net.WebSockets.Client": "4.3.0-beta-24522-03",
     "System.ObjectModel": "4.3.0-beta-24522-03",
@@ -22,6 +20,7 @@
     "netstandard1.3": {}
   },
   "supports": {
+    "coreFx.Test.netcore50": {},
     "coreFx.Test.netcoreapp1.0": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},


### PR DESCRIPTION
These changes allow the WebSockets.Client tests to run for netcore50 (UWP) target.
I removed unneeded packages from project.json which prevented the tests from working on UWP. UWP doesn't have System.Net.Security, for example. But it doesn't need that package in the tests project anyways.

There are failures in the tests (ClientWebSocketOptions) when they run but I will follow up separately with that.