### PR TITLE
Add missing members to WebRequest/WebResponse

### DIFF
--- a/src/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/System.Net.Requests/ref/System.Net.Requests.cs
@@ -127,41 +127,62 @@ namespace System.Net
         TrustFailure = 9,
         UnknownError = 16
     }
-    public abstract partial class WebRequest
+    public abstract partial class WebRequest : System.Runtime.Serialization.ISerializable
     {
         protected WebRequest() { }
-        public abstract string ContentType { get; set; }
+        protected WebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public System.Net.Security.AuthenticationLevel AuthenticationLevel { get { throw null; } set { } }
+        public virtual long ContentLength { get { throw null; } set { } }
+        public virtual string ContentType { get { throw null; } set { } }
+        public virtual System.Net.Cache.RequestCachePolicy CachePolicy { get { throw null; } set { } }
+        public virtual string ConnectionGroupName { get { throw null; } set { } }
         public virtual System.Net.ICredentials Credentials { get { return default(System.Net.ICredentials); } set { } }
+        public static System.Net.Cache.RequestCachePolicy DefaultCachePolicy { get { throw null; } set { } }
         public static System.Net.IWebProxy DefaultWebProxy { get { return default(System.Net.IWebProxy); } set { } }
-        public abstract System.Net.WebHeaderCollection Headers { get; set; }
-        public abstract string Method { get; set; }
+        public virtual System.Net.WebHeaderCollection Headers { get { throw null; } set { } }
+        public System.Security.Principal.TokenImpersonationLevel ImpersonationLevel { get { throw null; } set { } }
+        public virtual string Method { get { throw null; } set { } }
+        public virtual bool PreAuthenticate { get { throw null; } set { } }
         public virtual System.Net.IWebProxy Proxy { get { return default(System.Net.IWebProxy); } set { } }
-        public abstract System.Uri RequestUri { get; }
+        public virtual System.Uri RequestUri { get { throw null; } }
+        public virtual int Timeout { get { throw null; } set { } }
         public virtual bool UseDefaultCredentials { get { return default(bool); } set { } }
-        public abstract void Abort();
-        public abstract System.IAsyncResult BeginGetRequestStream(System.AsyncCallback callback, object state);
-        public abstract System.IAsyncResult BeginGetResponse(System.AsyncCallback callback, object state);
+        public virtual void Abort() { throw null; }
+        public virtual System.IAsyncResult BeginGetRequestStream(System.AsyncCallback callback, object state) { throw null; }
+        public virtual System.IAsyncResult BeginGetResponse(System.AsyncCallback callback, object state) { throw null; }
         public static System.Net.WebRequest Create(string requestUriString) { return default(System.Net.WebRequest); }
         public static System.Net.WebRequest Create(System.Uri requestUri) { return default(System.Net.WebRequest); }
+        public static System.Net.WebRequest CreateDefault(Uri requestUri) { throw null; }
         public static System.Net.HttpWebRequest CreateHttp(string requestUriString) { return default(System.Net.HttpWebRequest); }
         public static System.Net.HttpWebRequest CreateHttp(System.Uri requestUri) { return default(System.Net.HttpWebRequest); }
-        public abstract System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult);
-        public abstract System.Net.WebResponse EndGetResponse(System.IAsyncResult asyncResult);
+        public virtual System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult) { throw null; }
+        public virtual System.Net.WebResponse EndGetResponse(System.IAsyncResult asyncResult) { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
+        protected virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
+        public virtual System.IO.Stream GetRequestStream() { throw null; }
         public virtual System.Threading.Tasks.Task<System.IO.Stream> GetRequestStreamAsync() { return default(System.Threading.Tasks.Task<System.IO.Stream>); }
+        public virtual System.Net.WebResponse GetResponse() { throw null; }
         public virtual System.Threading.Tasks.Task<System.Net.WebResponse> GetResponseAsync() { return default(System.Threading.Tasks.Task<System.Net.WebResponse>); }
+        public static System.Net.IWebProxy GetSystemWebProxy() { throw null; }
         public static bool RegisterPrefix(string prefix, System.Net.IWebRequestCreate creator) { return default(bool); }
     }
-    public abstract partial class WebResponse : System.IDisposable
+    public abstract partial class WebResponse : System.Runtime.Serialization.ISerializable, System.IDisposable
     {
         protected WebResponse() { }
-        public abstract long ContentLength { get; }
-        public abstract string ContentType { get; }
+        protected WebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public virtual long ContentLength { get { throw null; } }
+        public virtual string ContentType { get { throw null; } }
         public virtual System.Net.WebHeaderCollection Headers { get { return default(System.Net.WebHeaderCollection); } }
-        public abstract System.Uri ResponseUri { get; }
+        public virtual bool IsFromCache { get { throw null; } }
+        public virtual bool IsMutuallyAuthenticated { get { throw null; } }
+        public virtual System.Uri ResponseUri { get { throw null; } }
         public virtual bool SupportsHeaders { get { return default(bool); } }
+        public virtual void Close() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        public abstract System.IO.Stream GetResponseStream();
+        public virtual System.IO.Stream GetResponseStream() { throw null; }
+        protected virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
 
     [Flags]

--- a/src/System.Net.Requests/ref/project.json
+++ b/src/System.Net.Requests/ref/project.json
@@ -7,6 +7,7 @@
     "System.Net.WebHeaderCollection": "4.3.0-beta-24522-03",
     "System.Runtime": "4.3.0-beta-24522-03",
     "System.Security.Cryptography.X509Certificates": "4.3.0-beta-24522-03",
+    "System.Security.Principal": "4.3.0-beta-24522-03",
     "System.Threading.Tasks": "4.3.0-beta-24522-03"
   },
   "frameworks": {

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -286,7 +286,7 @@ namespace System.Net
             }
         }
 
-        private Task<Stream> GetRequestStream()
+        private Task<Stream> GetRequestStreamTask()
         {
             CheckAbort();
 
@@ -320,7 +320,7 @@ namespace System.Net
             }
 
             _requestStreamCallback = callback;
-            _requestStreamOperation = GetRequestStream().ToApm(callback, state);
+            _requestStreamOperation = GetRequestStreamTask().ToApm(callback, state);
 
             return _requestStreamOperation.Task;
         }

--- a/src/System.Net.Requests/src/System/Net/WebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/WebRequest.cs
@@ -5,11 +5,16 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Net.Cache;
+using System.Net.Security;
+using System.Runtime.Serialization;
+using System.Security.Principal;
 using System.Threading.Tasks;
 
 namespace System.Net
 {
-    public abstract class WebRequest
+    [Serializable]
+    public abstract class WebRequest : ISerializable
     {
         internal class WebRequestPrefixElement
         {
@@ -25,6 +30,17 @@ namespace System.Net
 
         private static volatile List<WebRequestPrefixElement> s_prefixList;
         private static readonly object s_internalSyncObject = new object();
+
+        protected WebRequest() { }
+
+        protected WebRequest(SerializationInfo serializationInfo, StreamingContext streamingContext) { }
+
+        void ISerializable.GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            GetObjectData(serializationInfo, streamingContext);
+        }
+
+        protected virtual void GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext) { }
 
         // Create a WebRequest.
         //
@@ -173,7 +189,7 @@ namespace System.Net
         //
         // Returns:
         //     Newly created WebRequest.
-        internal static WebRequest CreateDefault(Uri requestUri)
+        public static WebRequest CreateDefault(Uri requestUri)
         {
             if (requestUri == null)
             {
@@ -375,34 +391,94 @@ namespace System.Net
             }
         }
 
-        protected WebRequest()
+        public static RequestCachePolicy DefaultCachePolicy { get; set; } = new RequestCachePolicy(RequestCacheLevel.BypassCache);
+
+        public virtual RequestCachePolicy CachePolicy { get; set; }
+
+        public AuthenticationLevel AuthenticationLevel { get; set; } = AuthenticationLevel.MutualAuthRequested;
+
+        public TokenImpersonationLevel ImpersonationLevel { get; set; } = TokenImpersonationLevel.Delegation;
+
+        public virtual string ConnectionGroupName
         {
+            get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
+            set
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
         }
 
-        public abstract string Method
+        public virtual string Method
         {
-            get;
-            set;
+            get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
+            set
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
         }
 
-        public abstract Uri RequestUri
+        public virtual Uri RequestUri
         {
-            get;
+            get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
         }
 
-        public abstract WebHeaderCollection Headers
+        public virtual WebHeaderCollection Headers
         {
-            get;
-            set;
+            get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
+            set
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
+        }
+        public virtual long ContentLength
+        {
+            get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
+            set
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
         }
 
-        public abstract string ContentType
+        public virtual string ContentType
         {
-            get;
-            set;
+            get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
+            set
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
         }
 
         public virtual ICredentials Credentials
+        {
+            get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
+            set
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
+        }
+
+        public virtual int Timeout
         {
             get
             {
@@ -426,13 +502,35 @@ namespace System.Net
             }
         }
 
-        public abstract IAsyncResult BeginGetResponse(AsyncCallback callback, object state);
+        public virtual Stream GetRequestStream()
+        {
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+        }
 
-        public abstract WebResponse EndGetResponse(IAsyncResult asyncResult);
+        public virtual WebResponse GetResponse()
+        {
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+        }
 
-        public abstract IAsyncResult BeginGetRequestStream(AsyncCallback callback, Object state);
+        public virtual IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
+        {
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+        }
 
-        public abstract Stream EndGetRequestStream(IAsyncResult asyncResult);
+        public virtual WebResponse EndGetResponse(IAsyncResult asyncResult)
+        {
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+        }
+
+        public virtual IAsyncResult BeginGetRequestStream(AsyncCallback callback, Object state)
+        {
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+        }
+
+        public virtual Stream EndGetRequestStream(IAsyncResult asyncResult)
+        {
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+        }
 
         public virtual Task<Stream> GetRequestStreamAsync()
         {
@@ -459,11 +557,16 @@ namespace System.Net
                     this));
         }
 
-        public abstract void Abort();
+        public virtual void Abort()
+        {
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+        }
 
         // Default Web Proxy implementation.
         private static IWebProxy s_DefaultWebProxy;
         private static bool s_DefaultWebProxyInitialized;
+
+        public static IWebProxy GetSystemWebProxy() => SystemWebProxy.Get();
 
         public static IWebProxy DefaultWebProxy
         {
@@ -488,6 +591,18 @@ namespace System.Net
                     s_DefaultWebProxy = value;
                     s_DefaultWebProxyInitialized = true;
                 }
+            }
+        }
+
+        public virtual bool PreAuthenticate
+        {
+            get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
+            set
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
             }
         }
 

--- a/src/System.Net.Requests/src/System/Net/WebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/WebResponse.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Runtime.Serialization;
 
 namespace System.Net
 {
@@ -12,7 +13,7 @@ namespace System.Net
     ///       response from a Uniform Resource Identifier (Uri). This is an abstract class.
     ///    </para>
     /// </devdoc>
-    public abstract class WebResponse : IDisposable
+    public abstract class WebResponse : ISerializable, IDisposable
     {
         /// <devdoc>
         ///    <para>Initializes a new
@@ -20,6 +21,23 @@ namespace System.Net
         ///       class.</para>
         /// </devdoc>
         protected WebResponse()
+        {
+        }
+
+        protected WebResponse(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            GetObjectData(serializationInfo, streamingContext);
+        }
+
+        protected virtual void GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+        }
+
+        public virtual void Close()
         {
         }
 
@@ -31,17 +49,27 @@ namespace System.Net
 
         protected virtual void Dispose(bool disposing)
         {
+            if (disposing)
+            {
+                try
+                {
+                    Close();
+                }
+                catch { }
+            }
         }
-
 
         /// <devdoc>
         ///    <para>When overridden in a derived class, gets or
         ///       sets
         ///       the content length of data being received.</para>
         /// </devdoc>
-        public abstract long ContentLength
+        public virtual long ContentLength
         {
-            get;
+            get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
         }
 
 
@@ -50,26 +78,38 @@ namespace System.Net
         ///       gets
         ///       or sets the content type of the data being received.</para>
         /// </devdoc>
-        public abstract string ContentType
+        public virtual string ContentType
         {
-            get;
+            get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
         }
+
+        public virtual bool IsFromCache => false;
+
+        public virtual bool IsMutuallyAuthenticated => false;
 
         /// <devdoc>
         /// <para>When overridden in a derived class, returns the <see cref='System.IO.Stream'/> object used
         ///    for reading data from the resource referenced in the <see cref='System.Net.WebRequest'/>
         ///    object.</para>
         /// </devdoc>
-        public abstract Stream GetResponseStream();
-
+        public virtual Stream GetResponseStream()
+        {
+             throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+        }
 
         /// <devdoc>
         ///    <para>When overridden in a derived class, gets the Uri that
         ///       actually responded to the request.</para>
         /// </devdoc>
-        public abstract Uri ResponseUri
+        public virtual Uri ResponseUri
         {
-            get;
+            get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
         }
 
         /// <devdoc>

--- a/src/System.Net.Requests/src/project.json
+++ b/src/System.Net.Requests/src/project.json
@@ -17,6 +17,7 @@
         "System.Resources.ResourceManager": "4.3.0-beta-24522-03",
         "System.Runtime": "4.3.0-beta-24522-03",
         "System.Runtime.Extensions": "4.3.0-beta-24522-03",
+        "System.Security.Principal": "4.3.0-beta-24522-03",
         "System.Security.Cryptography.X509Certificates": "4.3.0-beta-24522-03",
         "System.Threading": "4.3.0-beta-24522-03",
         "System.Threading.Tasks": "4.3.0-beta-24522-03"


### PR DESCRIPTION
Adds the missing members to WebRequest/WebResponse, and switches some that were abstract to instead be virtual, to match desktop.

(I believe @tijoytom was adding some of these as part of his updates to HttpWebRequest/Response, but I'm adding them all now to unblock @geoffkizer's work on FtpWebRequest/Response and mine on FileWebRequest/Response.)

cc: @davidsh, @cipop, @ericeil, @geoffkizer, @tijoytom, @karelz 