### PR TITLE
Ensure NameResolutionPal is initialized by every public entrypoint in System.Net.Dns

### DIFF
--- a/src/System.Net.NameResolution/src/System/Net/DNS.cs
+++ b/src/System.Net.NameResolution/src/System/Net/DNS.cs
@@ -24,12 +24,12 @@ namespace System.Net
         [Obsolete("GetHostByName is obsoleted for this type, please use GetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
         public static IPHostEntry GetHostByName(string hostName)
         {
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             if (hostName == null)
             {
                 throw new ArgumentNullException(nameof(hostName));
             }
-
-            NameResolutionPal.EnsureSocketsAreInitialized();
 
             // See if it's an IP Address.
             IPAddress address;
@@ -40,7 +40,7 @@ namespace System.Net
             return InternalGetHostByName(hostName, false);
         }
 
-        internal static IPHostEntry InternalGetHostByName(string hostName, bool includeIPv6)
+        private static IPHostEntry InternalGetHostByName(string hostName, bool includeIPv6)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "GetHostByName", hostName);
             IPHostEntry ipHostEntry = null;
@@ -99,6 +99,8 @@ namespace System.Net
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "GetHostByAddress", address);
 
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             if (address == null)
             {
                 throw new ArgumentNullException(nameof(address));
@@ -108,8 +110,6 @@ namespace System.Net
             {
                 GlobalLog.Print("Dns.GetHostByAddress: " + address);
             }
-
-            NameResolutionPal.EnsureSocketsAreInitialized();
 
             IPHostEntry ipHostEntry = InternalGetHostByAddress(IPAddress.Parse(address), false);
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "GetHostByAddress", ipHostEntry);
@@ -121,12 +121,12 @@ namespace System.Net
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "GetHostByAddress", "");
 
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             if (address == null)
             {
                 throw new ArgumentNullException(nameof(address));
             }
-
-            NameResolutionPal.EnsureSocketsAreInitialized();
 
             IPHostEntry ipHostEntry = InternalGetHostByAddress(address, false);
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "GetHostByAddress", ipHostEntry);
@@ -242,12 +242,12 @@ namespace System.Net
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "Resolve", hostName);
 
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             if (hostName == null)
             {
                 throw new ArgumentNullException(nameof(hostName));
             }
-
-            NameResolutionPal.EnsureSocketsAreInitialized();
 
             // See if it's an IP Address.
             IPAddress address;
@@ -485,12 +485,12 @@ namespace System.Net
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "GetHostEntry", hostNameOrAddress);
 
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             if (hostNameOrAddress == null)
             {
                 throw new ArgumentNullException(nameof(hostNameOrAddress));
             }
-
-            NameResolutionPal.EnsureSocketsAreInitialized();
 
             // See if it's an IP Address.
             IPAddress address;
@@ -518,6 +518,8 @@ namespace System.Net
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "GetHostEntry", "");
 
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             if (address == null)
             {
                 throw new ArgumentNullException(nameof(address));
@@ -528,8 +530,6 @@ namespace System.Net
                 throw new ArgumentException(SR.Format(SR.net_invalid_ip_addr, nameof(address)));
             }
 
-            NameResolutionPal.EnsureSocketsAreInitialized();
-
             IPHostEntry ipHostEntry = InternalGetHostByAddress(address, true);
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "GetHostEntry", ipHostEntry);
             return ipHostEntry;
@@ -539,12 +539,12 @@ namespace System.Net
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "GetHostAddresses", hostNameOrAddress);
 
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             if (hostNameOrAddress == null)
             {
                 throw new ArgumentNullException(nameof(hostNameOrAddress));
             }
-
-            NameResolutionPal.EnsureSocketsAreInitialized();
 
             // See if it's an IP Address.
             IPAddress address;

--- a/src/System.Net.NameResolution/src/System/Net/DNS.cs
+++ b/src/System.Net.NameResolution/src/System/Net/DNS.cs
@@ -109,6 +109,8 @@ namespace System.Net
                 GlobalLog.Print("Dns.GetHostByAddress: " + address);
             }
 
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             IPHostEntry ipHostEntry = InternalGetHostByAddress(IPAddress.Parse(address), false);
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "GetHostByAddress", ipHostEntry);
             return ipHostEntry;
@@ -124,13 +126,15 @@ namespace System.Net
                 throw new ArgumentNullException(nameof(address));
             }
 
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             IPHostEntry ipHostEntry = InternalGetHostByAddress(address, false);
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "GetHostByAddress", ipHostEntry);
             return ipHostEntry;
         } // GetHostByAddress
         
         // Does internal IPAddress reverse and then forward lookups (for Legacy and current public methods).
-        internal static IPHostEntry InternalGetHostByAddress(IPAddress address, bool includeIPv6)
+        private static IPHostEntry InternalGetHostByAddress(IPAddress address, bool includeIPv6)
         {
             if (GlobalLog.IsEnabled)
             {
@@ -229,6 +233,7 @@ namespace System.Net
             }
 
             NameResolutionPal.EnsureSocketsAreInitialized();
+
             return NameResolutionPal.GetHostName();
         }
 
@@ -241,6 +246,8 @@ namespace System.Net
             {
                 throw new ArgumentNullException(nameof(hostName));
             }
+
+            NameResolutionPal.EnsureSocketsAreInitialized();
 
             // See if it's an IP Address.
             IPAddress address;
@@ -453,6 +460,8 @@ namespace System.Net
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostByName", hostName);
 
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             IAsyncResult asyncResult = HostResolutionBeginHelper(hostName, true, true, false, requestCallback, stateObject);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostByName", asyncResult);
@@ -463,6 +472,8 @@ namespace System.Net
         public static IPHostEntry EndGetHostByName(IAsyncResult asyncResult)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "EndGetHostByName", asyncResult);
+
+            NameResolutionPal.EnsureSocketsAreInitialized();
 
             IPHostEntry ipHostEntry = HostResolutionEndHelper(asyncResult);
 
@@ -478,6 +489,8 @@ namespace System.Net
             {
                 throw new ArgumentNullException(nameof(hostNameOrAddress));
             }
+
+            NameResolutionPal.EnsureSocketsAreInitialized();
 
             // See if it's an IP Address.
             IPAddress address;
@@ -515,6 +528,8 @@ namespace System.Net
                 throw new ArgumentException(SR.Format(SR.net_invalid_ip_addr, nameof(address)));
             }
 
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             IPHostEntry ipHostEntry = InternalGetHostByAddress(address, true);
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "GetHostEntry", ipHostEntry);
             return ipHostEntry;
@@ -528,6 +543,8 @@ namespace System.Net
             {
                 throw new ArgumentNullException(nameof(hostNameOrAddress));
             }
+
+            NameResolutionPal.EnsureSocketsAreInitialized();
 
             // See if it's an IP Address.
             IPAddress address;
@@ -554,6 +571,9 @@ namespace System.Net
         public static IAsyncResult BeginGetHostEntry(string hostNameOrAddress, AsyncCallback requestCallback, object stateObject)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostEntry", hostNameOrAddress);
+
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             IAsyncResult asyncResult = HostResolutionBeginHelper(hostNameOrAddress, false, true, true, requestCallback, stateObject);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostEntry", asyncResult);
@@ -563,6 +583,9 @@ namespace System.Net
         public static IAsyncResult BeginGetHostEntry(IPAddress address, AsyncCallback requestCallback, object stateObject)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostEntry", address);
+
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             IAsyncResult asyncResult = HostResolutionBeginHelper(address, true, true, requestCallback, stateObject);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostEntry", asyncResult);
@@ -581,6 +604,9 @@ namespace System.Net
         public static IAsyncResult BeginGetHostAddresses(string hostNameOrAddress, AsyncCallback requestCallback, object state)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostAddresses", hostNameOrAddress);
+
+            NameResolutionPal.EnsureSocketsAreInitialized();
+
             IAsyncResult asyncResult = HostResolutionBeginHelper(hostNameOrAddress, true, true, true, requestCallback, state);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostAddresses", asyncResult);
@@ -600,6 +626,8 @@ namespace System.Net
         public static IAsyncResult BeginResolve(string hostName, AsyncCallback requestCallback, object stateObject)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "BeginResolve", hostName);
+
+            NameResolutionPal.EnsureSocketsAreInitialized();
 
             IAsyncResult asyncResult = HostResolutionBeginHelper(hostName, false, false, false, requestCallback, stateObject);
 

--- a/src/System.Net.NameResolution/tests/UnitTests/InitializationTest.cs
+++ b/src/System.Net.NameResolution/tests/UnitTests/InitializationTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable 0618 // using obsolete methods
+
 using System.Threading.Tasks;
 
 using Xunit;
@@ -11,19 +13,107 @@ namespace System.Net.NameResolution.Tests
     public class InitializationTests
     {
         [Fact]
+        public void Dns_BeginGetHostAddresses_CallSocketInit_Ok()
+        {
+            NameResolutionPal.FakesReset();
+            Assert.ThrowsAny<Exception>(() => Dns.BeginGetHostAddresses(null, null, null));
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+        }
+
+        [Fact]
+        public void Dns_BeginGetHostByName_CallSocketInit_Ok()
+        {
+            NameResolutionPal.FakesReset();
+            Assert.ThrowsAny<Exception>(() => Dns.BeginGetHostByName(null, null, null));
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+        }
+
+        [Fact]
+        public void Dns_BeginGetHostEntry_String_CallSocketInit_Ok()
+        {
+            NameResolutionPal.FakesReset();
+            Assert.ThrowsAny<Exception>(() => Dns.BeginGetHostEntry((string)null, null, null));
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+        }
+
+        [Fact]
+        public void Dns_BeginGetHostEntry_IPAddress_CallSocketInit_Ok()
+        {
+            NameResolutionPal.FakesReset();
+            Assert.ThrowsAny<Exception>(() => Dns.BeginGetHostEntry((IPAddress)null, null, null));
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+        }
+
+        [Fact]
+        public void Dns_GetHostAddresses_CallSocketInit_Ok()
+        {
+            NameResolutionPal.FakesReset();
+            Assert.ThrowsAny<Exception>(() => Dns.GetHostAddresses(null));
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+        }
+
+        [Fact]
+        public void Dns_GetHostByAddress_String_CallSocketInit_Ok()
+        {
+            NameResolutionPal.FakesReset();
+            Assert.ThrowsAny<Exception>(() => Dns.GetHostByAddress((string)null));
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+        }
+
+        [Fact]
+        public void Dns_GetHostByAddress_IPAddress_CallSocketInit_Ok()
+        {
+            NameResolutionPal.FakesReset();
+            Assert.ThrowsAny<Exception>(() => Dns.GetHostByAddress((IPAddress)null));
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+        }
+
+        [Fact]
+        public void Dns_GetHostByName_CallSocketInit_Ok()
+        {
+            NameResolutionPal.FakesReset();
+            Assert.ThrowsAny<Exception>(() => Dns.GetHostByName(null));
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+        }
+
+        [Fact]
+        public void Dns_GetHostEntry_String_CallSocketInit_Ok()
+        {
+            NameResolutionPal.FakesReset();
+            Assert.ThrowsAny<Exception>(() => Dns.GetHostEntry((string)null));
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+        }
+
+        [Fact]
+        public void Dns_GetHostEntry_IPAddress_CallSocketInit_Ok()
+        {
+            NameResolutionPal.FakesReset();
+            Assert.ThrowsAny<Exception>(() => Dns.GetHostEntry((IPAddress)null));
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+        }
+
+        [Fact]
+        public void Dns_Resolve_CallSocketInit_Ok()
+        {
+            NameResolutionPal.FakesReset();
+            Assert.ThrowsAny<Exception>(() => Dns.Resolve(null));
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+        }
+
+        [Fact]
         public async Task Dns_GetHostAddressesAsync_CallsSocketInit_Ok()
         {
             NameResolutionPal.FakesReset();
             await Assert.ThrowsAnyAsync<Exception>(() => Dns.GetHostAddressesAsync(null));
-            Assert.Equal(1, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
         }
-        
+
         [Fact]
         public async Task Dns_GetHostEntryAsync_CallsSocketInit_Ok()
         {
             NameResolutionPal.FakesReset();
             await Assert.ThrowsAnyAsync<Exception>(() => Dns.GetHostEntryAsync((string)null));
-            Assert.Equal(1, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
         }
 
         [Fact]
@@ -31,7 +121,7 @@ namespace System.Net.NameResolution.Tests
         {
             NameResolutionPal.FakesReset();
             Assert.ThrowsAny<Exception>(() => Dns.GetHostName());
-            Assert.Equal(1, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
+            Assert.NotEqual(0, NameResolutionPal.FakesEnsureSocketsAreInitializedCallCount);
         }
     }
 }


### PR DESCRIPTION
Fixes #11987.

@CIPop @stephentoub 