### PR TITLE
Fix NumberFormatInfo.GetInstance test

### DIFF
--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoGetInstance.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoGetInstance.cs
@@ -24,7 +24,33 @@ namespace System.Globalization.Tests
         [MemberData(nameof(GetInstance_TestData))]
         public void GetInstance(IFormatProvider formatProvider, NumberFormatInfo expected)
         {
-            Assert.Equal(expected, NumberFormatInfo.GetInstance(formatProvider));
+            NumberFormatInfo nfi = NumberFormatInfo.GetInstance(formatProvider);
+
+            Assert.Equal(expected.CurrencyDecimalDigits, nfi.CurrencyDecimalDigits);
+            Assert.Equal(expected.CurrencyDecimalSeparator, nfi.CurrencyDecimalSeparator);
+            Assert.Equal(expected.CurrencyGroupSeparator, nfi.CurrencyGroupSeparator);
+            Assert.Equal(expected.CurrencyGroupSizes, nfi.CurrencyGroupSizes);
+            Assert.Equal(expected.CurrencyNegativePattern, nfi.CurrencyNegativePattern);
+            Assert.Equal(expected.CurrencyPositivePattern, nfi.CurrencyPositivePattern);
+            Assert.Equal(expected.CurrencySymbol, nfi.CurrencySymbol);
+            Assert.Equal(expected.NaNSymbol, nfi.NaNSymbol);
+            Assert.Equal(expected.NegativeInfinitySymbol, nfi.NegativeInfinitySymbol);
+            Assert.Equal(expected.NegativeSign, nfi.NegativeSign);
+            Assert.Equal(expected.NumberDecimalDigits, nfi.NumberDecimalDigits);
+            Assert.Equal(expected.NumberDecimalSeparator, nfi.NumberDecimalSeparator);
+            Assert.Equal(expected.NumberGroupSeparator, nfi.NumberGroupSeparator);
+            Assert.Equal(expected.NumberGroupSizes, nfi.NumberGroupSizes);
+            Assert.Equal(expected.NumberNegativePattern, nfi.NumberNegativePattern);
+            Assert.Equal(expected.PercentDecimalDigits, nfi.PercentDecimalDigits);
+            Assert.Equal(expected.PercentDecimalSeparator, nfi.PercentDecimalSeparator);
+            Assert.Equal(expected.PercentGroupSeparator, nfi.PercentGroupSeparator);
+            Assert.Equal(expected.PercentGroupSizes, nfi.PercentGroupSizes);
+            Assert.Equal(expected.PercentNegativePattern, nfi.PercentNegativePattern);
+            Assert.Equal(expected.PercentPositivePattern, nfi.PercentPositivePattern);
+            Assert.Equal(expected.PercentSymbol, nfi.PercentSymbol);
+            Assert.Equal(expected.PositiveInfinitySymbol, nfi.PositiveInfinitySymbol);
+            Assert.Equal(expected.PerMilleSymbol, nfi.PerMilleSymbol);
+            Assert.Equal(expected.PositiveSign, nfi.PositiveSign);
         }
 
         private class CustomFormatProvider : IFormatProvider


### PR DESCRIPTION
in this test we used to do Assert.Equal with the objects which eventually calls NumberFormatInfo.Equals which is really Object.Equals.
this means the equality was reference equality. this is can be true in most of the cases but it is not really guarnteed because the returned objects depends on other cached objects like CurrentThread.CurrentCulture, CultureInfo.numInfo...etc.
The change here is, if we don't have reference equality, we'll test the contents equality