### PR TITLE
Fix DSACng default key size for win7

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DSACng.cs
+++ b/src/Common/src/System/Security/Cryptography/DSACng.cs
@@ -2,9 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
 using Internal.Cryptography;
-using static Interop.NCrypt;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace System.Security.Cryptography
 {
@@ -18,7 +19,7 @@ namespace System.Security.Cryptography
             ///     Create a DSACng algorithm with a random 2048 bit key pair.
             /// </summary>
             public DSACng()
-                : this(keySize: 2048)
+                : this(keySize: s_defaultKeySize)
             {
             }
 
@@ -69,7 +70,16 @@ namespace System.Security.Cryptography
                 KeySizeValue = newKeySize;
             }
 
+            private static bool Supports2048KeySize()
+            {
+                Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+                Version version = Environment.OSVersion.Version;
+                bool isAtLeastWindows8 = version.Major > 6 || (version.Major == 6 && version.Minor >= 2);
+                return isAtLeastWindows8;
+            }
+
             private static KeySizes[] s_legalKeySizes = new KeySizes[] { new KeySizes(minSize: 512, maxSize: 3072, skipSize: 64) };
+            private static readonly int s_defaultKeySize = Supports2048KeySize() ? 2048 : 1024;
         }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
@@ -6,8 +6,20 @@ using Xunit;
 
 namespace System.Security.Cryptography.Dsa.Tests
 {
-    public class DSAKeyGeneration
+    public partial class DSAKeyGeneration
     {
+        [Fact]
+        public static void VerifyDefaultKeySize_Fips186_2()
+        {
+            if (!DSAFactory.SupportsFips186_3)
+            {
+                using (DSA dsa = DSAFactory.Create())
+                {
+                    Assert.True(dsa.KeySize <= 1024); // KeySize must be <= 1024 for FIPS 186-2
+                }
+            }
+        }
+
         [Fact]
         public static void GenerateMinKey()
         {

--- a/src/System.Security.Cryptography.Algorithms/src/project.json
+++ b/src/System.Security.Cryptography.Algorithms/src/project.json
@@ -12,6 +12,7 @@
         "System.Text.Encoding": "4.3.0-beta-24522-03",
         "System.Runtime.Extensions": "4.3.0-beta-24522-03",
         "System.Runtime.InteropServices": "4.3.0-beta-24522-03",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0-beta-24522-03",
         "System.Runtime.Numerics": "4.3.0-beta-24522-03",
         "System.Security.Cryptography.Primitives": "4.3.0-beta-24522-03",
         "System.Security.Cryptography.Encoding": "4.3.0-beta-24522-03",

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
@@ -22,7 +22,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         {
             get
             {
-                return true;
+                return (!PlatformDetection.IsWindows7);
             }
         }
     }

--- a/src/System.Security.Cryptography.Cng/src/project.json
+++ b/src/System.Security.Cryptography.Cng/src/project.json
@@ -13,6 +13,7 @@
         "System.Runtime": "4.3.0-beta-24522-03",
         "System.Runtime.Extensions": "4.3.0-beta-24522-03",
         "System.Runtime.InteropServices": "4.3.0-beta-24522-03",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0-beta-24522-03",
         "System.Security.Cryptography.Algorithms": "4.3.0-beta-24522-03",
         "System.Security.Cryptography.Encoding": "4.3.0-beta-24522-03",
         "System.Security.Cryptography.Primitives": "4.3.0-beta-24522-03",

--- a/src/System.Security.Cryptography.Cng/tests/DSACngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/DSACngProvider.cs
@@ -20,7 +20,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         {
             get
             {
-                return true;
+                return (!PlatformDetection.IsWindows7);
             }
         }
     }

--- a/src/System.Security.Cryptography.Cng/tests/DSACngTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/DSACngTests.cs
@@ -19,7 +19,7 @@ namespace System.Security.Cryptography.Dsa.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsFips186_3))]
         public static void TestImportV2Key()
         {
             using (CngKey key = CngKey.Import(TestData.Key_DSA2048Key, CngKeyBlobFormat.GenericPrivateBlob))
@@ -57,6 +57,24 @@ namespace System.Security.Cryptography.Dsa.Tests
             {
                 byte[] reExported = key.Export(CngKeyBlobFormat.GenericPublicBlob);
                 Assert.Equal<byte>(TestData.Key_DSA1024PublicKey, reExported);
+            }
+        }
+
+        [Fact]
+        public static void VerifyDefaultKeySize_Cng()
+        {
+            using (DSA dsa = new DSACng())
+            {
+                // DSACng detects OS version and selects appropriate default key size
+                Assert.Equal(DSAFactory.SupportsFips186_3 ? 2048 : 1024, dsa.KeySize);
+            }
+        }
+
+        static internal bool SupportsFips186_3
+        {
+            get
+            {
+                return DSAFactory.SupportsFips186_3;
             }
         }
     }


### PR DESCRIPTION
For DSACng, change the default key size to 1024 when running on Windows 7.

Addresses issue https://github.com/dotnet/corefx/issues/12052

@bartonjs