### PR TITLE
Improved Tests for Debugging Helix Run

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
@@ -9,5 +9,12 @@
     <ProjectJson>../project.json</ProjectJson>
     <ProjectLockJson>../project.lock.json</ProjectLockJson>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\Utils.cs" />
+    <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
+    <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.CoreCLR.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractJsonSerializer.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractJsonSerializer.CoreCLR.cs" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), System.Runtime.Serialization.Json.Tests.settings.targets))\System.Runtime.Serialization.Json.Tests.settings.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
@@ -6,5 +6,12 @@
     <AssemblyName>System.Runtime.Serialization.Json.Tests</AssemblyName>
     <ProjectGuid>{701CB3BC-00DC-435D-BDE4-C5FC29A708A7}</ProjectGuid>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\Utils.cs" />
+    <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
+    <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.CoreCLR.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractJsonSerializer.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractJsonSerializer.CoreCLR.cs" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), System.Runtime.Serialization.Json.Tests.settings.targets))\System.Runtime.Serialization.Json.Tests.settings.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.settings.targets
+++ b/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.settings.targets
@@ -10,13 +10,6 @@
     <TestSourceFolder>$(MSBuildThisFileDirectory)\</TestSourceFolder>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\Utils.cs" />
-    <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
-    <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.CoreCLR.cs" />
-    <Compile Include="$(TestSourceFolder)DataContractJsonSerializer.cs" />
-    <Compile Include="$(TestSourceFolder)DataContractJsonSerializer.CoreCLR.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="$(TestSourceFolder)..\..\System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj">
       <Project>{6B4C1660-D158-4820-BE1C-D7A29CEBEC9B}</Project>
       <Name>System.Private.DataContractSerialization</Name>

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1942,10 +1942,30 @@ public static partial class DataContractSerializerTests
     public static void DCS_DeserializeEmptyString()
     {
         var serializer = new DataContractSerializer(typeof(object));
-        Assert.Throws<XmlException>(() =>
+        bool exceptionThrown = false;
+        try
         {
             serializer.ReadObject(new MemoryStream());
-        });
+        }
+        catch (Exception e)
+        {
+            Type expectedExceptionType = typeof(XmlException);
+            Type actualExceptionType = e.GetType();
+            if (!actualExceptionType.Equals(expectedExceptionType))
+            {
+                var messageBuilder = new StringBuilder();
+                messageBuilder.AppendLine("The actual exception was not of the expected type.");
+                messageBuilder.AppendLine($"Expected exception type: {expectedExceptionType.FullName}, {expectedExceptionType.GetTypeInfo().Assembly.FullName}");
+                messageBuilder.AppendLine($"Actual exception type: {actualExceptionType.FullName}, {actualExceptionType.GetTypeInfo().Assembly.FullName}");
+                messageBuilder.AppendLine($"The type of {nameof(expectedExceptionType)} was: {expectedExceptionType.GetType()}");
+                messageBuilder.AppendLine($"The type of {nameof(actualExceptionType)} was: {actualExceptionType.GetType()}");
+                Assert.True(false, messageBuilder.ToString());
+            }
+
+            exceptionThrown = true;
+        }
+
+        Assert.True(exceptionThrown, "An expected exception was not thrown.");
     }
 
     [Fact]

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
@@ -9,5 +9,17 @@
     <ProjectJson>../project.json</ProjectJson>
     <ProjectLockJson>../project.lock.json</ProjectLockJson>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(TestSourceFolder)Utils.cs" />
+    <Compile Include="$(TestSourceFolder)SerializationTypes.cs" />
+    <Compile Include="$(TestSourceFolder)SerializationTypes.CoreCLR.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractSerializer.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractSerializer.CoreCLR.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractSerializerStressTests.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractSerializerTestData.cs" />
+    <Compile Include="$(TestSourceFolder)MyResolver.cs" />
+    <Compile Include="$(TestSourceFolder)XmlDictionaryReaderTests.cs" />
+    <Compile Include="$(TestSourceFolder)XmlDictionaryWriterTest.cs" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), System.Runtime.Serialization.Xml.Tests.settings.targets))\System.Runtime.Serialization.Xml.Tests.settings.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -7,5 +7,17 @@
     <ProjectGuid>{30CAB353-089E-4294-B23B-F2DD1D945654}</ProjectGuid>
     <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(TestSourceFolder)Utils.cs" />
+    <Compile Include="$(TestSourceFolder)SerializationTypes.cs" />
+    <Compile Include="$(TestSourceFolder)SerializationTypes.CoreCLR.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractSerializer.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractSerializer.CoreCLR.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractSerializerStressTests.cs" />
+    <Compile Include="$(TestSourceFolder)DataContractSerializerTestData.cs" />
+    <Compile Include="$(TestSourceFolder)MyResolver.cs" />
+    <Compile Include="$(TestSourceFolder)XmlDictionaryReaderTests.cs" />
+    <Compile Include="$(TestSourceFolder)XmlDictionaryWriterTest.cs" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), System.Runtime.Serialization.Xml.Tests.settings.targets))\System.Runtime.Serialization.Xml.Tests.settings.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.settings.targets
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.settings.targets
@@ -10,18 +10,6 @@
     <TestSourceFolder>$(MSBuildThisFileDirectory)\</TestSourceFolder>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(TestSourceFolder)Utils.cs" />
-    <Compile Include="$(TestSourceFolder)SerializationTypes.cs" />
-    <Compile Include="$(TestSourceFolder)SerializationTypes.CoreCLR.cs" />
-    <Compile Include="$(TestSourceFolder)DataContractSerializer.cs" />
-    <Compile Include="$(TestSourceFolder)DataContractSerializer.CoreCLR.cs" />
-    <Compile Include="$(TestSourceFolder)DataContractSerializerStressTests.cs" />
-    <Compile Include="$(TestSourceFolder)DataContractSerializerTestData.cs" />
-    <Compile Include="$(TestSourceFolder)MyResolver.cs" />
-    <Compile Include="$(TestSourceFolder)XmlDictionaryReaderTests.cs" />
-    <Compile Include="$(TestSourceFolder)XmlDictionaryWriterTest.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="$(TestSourceFolder)..\..\System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj">
       <Project>{6B4C1660-D158-4820-BE1C-D7A29CEBEC9B}</Project>
       <Name>System.Private.DataContractSerialization</Name>


### PR DESCRIPTION
Improved the test for #10843. The issue reproduces in helix run only, which make it hard to root cause the issue. Adding more debug info in the test so that we can get more info regarding to the helix test failure.

Improved the test for #10848. Added more debug info in the test.

Fixed an issue with System.Runtime.Serialization.* tests. PR #11480  extracted settings into settings.targets. The issue is that VS couldn't find source code files included in settings.targets.
