### PR TITLE
Add FileWebRequest/Response to corefx

### DIFF
--- a/src/Common/src/System/Threading/Tasks/TaskToApm.cs
+++ b/src/Common/src/System/Threading/Tasks/TaskToApm.cs
@@ -45,10 +45,7 @@ namespace System.Threading.Tasks
             {
                 // Synchronous completion.
                 asyncResult = new TaskWrapperAsyncResult(task, state, completedSynchronously: true);
-                if (callback != null)
-                {
-                    callback(asyncResult);
-                }
+                callback?.Invoke(asyncResult);
             }
             else
             {

--- a/src/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/System.Net.Requests/ref/System.Net.Requests.cs
@@ -33,6 +33,47 @@ namespace System.Net
         public bool MutuallyAuthenticated { get { throw null; } set { } }
     }
     public delegate System.Net.IPEndPoint BindIPEndPoint(System.Net.ServicePoint servicePoint, System.Net.IPEndPoint remoteEndPoint, int retryCount);
+    public class FileWebRequest : WebRequest, System.Runtime.Serialization.ISerializable
+    {
+        internal FileWebRequest() { }
+        [Obsolete("Serialization is obsoleted for this type. http://go.microsoft.com/fwlink/?linkid=14202")]
+        protected FileWebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
+        public override string ConnectionGroupName { get { throw null; } set { } }
+        public override long ContentLength { get { throw null; } set { } }
+        public override string ContentType { get { throw null; } set { } }
+        public override System.Net.ICredentials Credentials { get { throw null; } set { } }
+        public override System.Net.WebHeaderCollection Headers { get { throw null; } }
+        public override string Method { get { throw null; } set { } }
+        public override bool PreAuthenticate { get { throw null; } set { } }
+        public override System.Net.IWebProxy Proxy { get { throw null; } set { } }
+        public override int Timeout { get { throw null; } set { } }
+        public override System.Uri RequestUri { get { throw null; } }
+        public override bool UseDefaultCredentials { get { throw null; } set { } }
+        public override void Abort() { throw null; }
+        public override System.IAsyncResult BeginGetRequestStream(System.AsyncCallback callback, object state) { throw null; }
+        public override System.IAsyncResult BeginGetResponse(System.AsyncCallback callback, object state) { throw null; }
+        public override System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult) { throw null; }
+        public override System.Net.WebResponse EndGetResponse(System.IAsyncResult asyncResult) { throw null; }
+        public override System.IO.Stream GetRequestStream() { throw null; }
+        public override System.Net.WebResponse GetResponse() { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+    }
+    public class FileWebResponse : WebResponse, System.Runtime.Serialization.ISerializable
+    {
+        internal FileWebResponse() { }
+        [Obsolete("Serialization is obsoleted for this type. http://go.microsoft.com/fwlink/?linkid=14202")]
+        protected FileWebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
+        public override long ContentLength { get { throw null; } }
+        public override string ContentType { get { throw null; } }
+        public override WebHeaderCollection Headers { get { throw null; } }
+        public override bool SupportsHeaders { get { throw null; } }
+        public override Uri ResponseUri { get { throw null; } }
+        public override void Close() { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public override System.IO.Stream GetResponseStream() { throw null; }
+    }
     public partial class HttpWebRequest : System.Net.WebRequest
     {
         internal HttpWebRequest() { }
@@ -165,6 +206,39 @@ namespace System.Net
         public virtual System.Threading.Tasks.Task<System.Net.WebResponse> GetResponseAsync() { return default(System.Threading.Tasks.Task<System.Net.WebResponse>); }
         public static System.Net.IWebProxy GetSystemWebProxy() { throw null; }
         public static bool RegisterPrefix(string prefix, System.Net.IWebRequestCreate creator) { return default(bool); }
+    }
+    public static class WebRequestMethods
+    {
+        public static class Ftp
+        {
+            public const string DownloadFile = "RETR";
+            public const string ListDirectory = "NLST";
+            public const string UploadFile = "STOR";
+            public const string DeleteFile = "DELE";
+            public const string AppendFile = "APPE";
+            public const string GetFileSize = "SIZE";
+            public const string UploadFileWithUniqueName = "STOU";
+            public const string MakeDirectory = "MKD";
+            public const string RemoveDirectory = "RMD";
+            public const string ListDirectoryDetails = "LIST";
+            public const string GetDateTimestamp = "MDTM";
+            public const string PrintWorkingDirectory = "PWD";
+            public const string Rename = "RENAME";
+        }
+        public static class Http
+        {
+            public const string Get = "GET";
+            public const string Connect = "CONNECT";
+            public const string Head = "HEAD";
+            public const string Put = "PUT";
+            public const string Post = "POST";
+            public const string MkCol = "MKCOL";
+        }
+        public static class File
+        {
+            public const string DownloadFile = "GET";
+            public const string UploadFile = "PUT";
+        }
     }
     public abstract partial class WebResponse : System.Runtime.Serialization.ISerializable, System.IDisposable
     {

--- a/src/System.Net.Requests/src/Resources/Strings.resx
+++ b/src/System.Net.Requests/src/Resources/Strings.resx
@@ -174,4 +174,13 @@
   <data name="net_securityprotocolnotsupported" xml:space="preserve">
     <value>The requested security protocol is not supported.</value>
   </data>
+  <data name="net_requestaborted" xml:space="preserve">
+    <value>The request was aborted: {0}.</value>
+  </data>
+  <data name="net_clsmall" xml:space="preserve">
+    <value>The Content-Length value must be greater than or equal to zero.</value>
+  </data>
+  <data name="net_webstatus_Timeout" xml:space="preserve">
+    <value>The operation has timed out.</value>
+  </data>
 </root>

--- a/src/System.Net.Requests/src/System.Net.Requests.csproj
+++ b/src/System.Net.Requests/src/System.Net.Requests.csproj
@@ -24,6 +24,8 @@
     <Compile Include="System\Net\AuthenticationManager.cs" />
     <Compile Include="System\Net\Authorization.cs" />
     <Compile Include="System\Net\BindIPEndPoint.cs" />
+    <Compile Include="System\Net\FileWebRequest.cs" />
+    <Compile Include="System\Net\FileWebResponse.cs" />
     <Compile Include="System\Net\HttpRequestHeader.cs" />
     <Compile Include="System\Net\HttpWebRequest.cs" />
     <Compile Include="System\Net\HttpWebResponse.cs" />
@@ -42,6 +44,7 @@
     <Compile Include="System\Net\WebExceptionStatus.cs" />
     <Compile Include="System\Net\WebHeaderCollection.cs" />
     <Compile Include="System\Net\WebRequest.cs" />
+    <Compile Include="System\Net\WebRequestMethods.cs" />
     <Compile Include="System\Net\WebResponse.cs" />
     <Compile Include="System\Net\Cache\HttpCacheAgeControl.cs" />
     <Compile Include="System\Net\Cache\HttpRequestCacheLevel.cs" />
@@ -62,6 +65,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
+      <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'net463' ">

--- a/src/System.Net.Requests/src/System/Net/FileWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/FileWebRequest.cs
@@ -1,0 +1,453 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Threading;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+
+namespace System.Net
+{
+    [Serializable]
+    public class FileWebRequest : WebRequest, ISerializable
+    {
+        private readonly WebHeaderCollection _headers = new WebHeaderCollection();
+        private string _method = WebRequestMethods.File.DownloadFile;
+        private FileAccess _fileAccess = FileAccess.Read;
+        private ManualResetEventSlim _blockReaderUntilRequestStreamDisposed;
+        private WebResponse _response;
+        private WebFileStream _stream;
+        private Uri _uri;
+        private long _contentLength;
+        private int _timeout = DefaultTimeoutMilliseconds;
+        private bool _readPending;
+        private bool _writePending;
+        private bool _writing;
+        private bool _syncHint;
+        private int _aborted;
+
+        internal FileWebRequest(Uri uri)
+        {
+            if (uri.Scheme != (object)Uri.UriSchemeFile)
+            {
+                throw new ArgumentOutOfRangeException(nameof(uri));
+            }
+
+            _uri = uri;
+        }
+
+        [Obsolete("Serialization is obsoleted for this type. http://go.microsoft.com/fwlink/?linkid=14202")]
+        protected FileWebRequest(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
+        {
+            _headers = (WebHeaderCollection)serializationInfo.GetValue("headers", typeof(WebHeaderCollection));
+            Proxy = (IWebProxy)serializationInfo.GetValue("proxy", typeof(IWebProxy));
+            _uri = (Uri)serializationInfo.GetValue("uri", typeof(Uri));
+            ConnectionGroupName = serializationInfo.GetString("connectionGroupName");
+            _method = serializationInfo.GetString("method");
+            _contentLength = serializationInfo.GetInt64("contentLength");
+            _timeout = serializationInfo.GetInt32("timeout");
+            _fileAccess = (FileAccess)serializationInfo.GetInt32("fileAccess");
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext) =>
+            GetObjectData(serializationInfo, streamingContext);
+
+        protected override void GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            serializationInfo.AddValue("headers", _headers, typeof(WebHeaderCollection));
+            serializationInfo.AddValue("proxy", Proxy, typeof(IWebProxy));
+            serializationInfo.AddValue("uri", _uri, typeof(Uri));
+            serializationInfo.AddValue("connectionGroupName", ConnectionGroupName);
+            serializationInfo.AddValue("method", _method);
+            serializationInfo.AddValue("contentLength", _contentLength);
+            serializationInfo.AddValue("timeout", _timeout);
+            serializationInfo.AddValue("fileAccess", _fileAccess);
+            serializationInfo.AddValue("preauthenticate", false);
+            base.GetObjectData(serializationInfo, streamingContext);
+        }
+
+        internal bool Aborted => _aborted != 0;
+
+        public override string ConnectionGroupName { get; set; }
+
+        public override long ContentLength
+        {
+            get { return _contentLength; }
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentException(SR.net_clsmall, nameof(value));
+                }
+                _contentLength = value;
+            }
+        }
+
+        public override string ContentType
+        {
+            get { return _headers["Content-Type"]; }
+            set { _headers["Content-Type"] = value; }
+        }
+
+        public override ICredentials Credentials { get; set; }
+
+        public override WebHeaderCollection Headers => _headers;
+
+        public override string Method
+        {
+            get { return _method; }
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new ArgumentException(SR.net_badmethod, nameof(value));
+                }
+                _method = value;
+            }
+        }
+
+        public override bool PreAuthenticate { get; set; }
+
+        public override IWebProxy Proxy { get; set; }
+
+        public override int Timeout
+        {
+            get { return _timeout; }
+            set
+            {
+                if (value < 0 && value != System.Threading.Timeout.Infinite)
+                {
+                    throw new ArgumentOutOfRangeException("value", SR.net_io_timeout_use_ge_zero);
+                }
+                _timeout = value;
+            }
+        }
+
+        public override Uri RequestUri => _uri;
+
+        private static Exception CreateRequestAbortedException() =>
+            new WebException(SR.Format(SR.net_requestaborted, WebExceptionStatus.RequestCanceled), WebExceptionStatus.RequestCanceled);
+
+        public override IAsyncResult BeginGetRequestStream(AsyncCallback callback, object state)
+        {
+            if (Aborted)
+            {
+                throw CreateRequestAbortedException();
+            }
+
+            if (string.Equals(_method, "GET", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(_method, "HEAD", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ProtocolViolationException(SR.net_nouploadonget);
+            }
+
+            if (_response != null)
+            {
+                throw new InvalidOperationException(SR.net_reqsubmitted);
+            }
+
+            lock (this)
+            {
+                if (_writePending)
+                {
+                    throw new InvalidOperationException(SR.net_repcall);
+                }
+                _writePending = true;
+            }
+
+            return TaskToApm.Begin(Task.Factory.StartNew<Stream>(s =>
+            {
+                FileWebRequest thisRef = (FileWebRequest)s;
+                try
+                {
+                    if (thisRef._stream == null)
+                    {
+                        thisRef._stream = new WebFileStream(thisRef, thisRef._uri.LocalPath, FileMode.Create, FileAccess.Write, FileShare.Read);
+                        thisRef._fileAccess = FileAccess.Write;
+                        thisRef._writing = true;
+                    }
+                    return thisRef._stream;
+                }
+                catch (Exception e) { throw new WebException(e.Message, e); }
+            }, this, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default), callback, state);
+        }
+
+        public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
+        {
+            if (Aborted)
+            {
+                throw CreateRequestAbortedException();
+            }
+
+            lock (this)
+            {
+                if (_readPending)
+                {
+                    throw new InvalidOperationException(SR.net_repcall);
+                }
+                _readPending = true;
+            }
+
+            return TaskToApm.Begin(Task.Factory.StartNew<WebResponse>(s =>
+            {
+                FileWebRequest thisRef = (FileWebRequest)s;
+
+                if (thisRef._writePending || thisRef._writing)
+                {
+                    lock (thisRef)
+                    {
+                        if (thisRef._writePending || thisRef._writing)
+                        {
+                            thisRef._blockReaderUntilRequestStreamDisposed = new ManualResetEventSlim();
+                        }
+                    }
+                }
+                thisRef._blockReaderUntilRequestStreamDisposed?.Wait();
+
+                try
+                {
+                    return thisRef._response ?? (thisRef._response = new FileWebResponse(thisRef, thisRef._uri, thisRef._fileAccess, !thisRef._syncHint));
+                }
+                catch (Exception e)
+                {
+                    throw new WebException(e.Message, e);
+                }
+            }, this, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default), callback, state);
+        }
+
+        public override Stream EndGetRequestStream(IAsyncResult asyncResult)
+        {
+            Stream stream = TaskToApm.End<Stream>(asyncResult);
+            _writePending = false;
+            return stream;
+        }
+
+        public override WebResponse EndGetResponse(IAsyncResult asyncResult)
+        {
+            WebResponse response = TaskToApm.End<WebResponse>(asyncResult);
+            _readPending = false;
+            return response;
+        }
+
+        public override Stream GetRequestStream()
+        {
+            IAsyncResult result = BeginGetRequestStream(null, null);
+
+            if (Timeout != Threading.Timeout.Infinite &&
+                !result.IsCompleted &&
+                (!result.AsyncWaitHandle.WaitOne(Timeout, false) || !result.IsCompleted))
+            {
+                _stream?.Close();
+                throw new WebException(SR.net_webstatus_Timeout, WebExceptionStatus.Timeout);
+            }
+
+            return EndGetRequestStream(result);
+        }
+
+        public override WebResponse GetResponse()
+        {
+            _syncHint = true;
+            IAsyncResult result = BeginGetResponse(null, null);
+
+            if (Timeout != Threading.Timeout.Infinite &&
+                !result.IsCompleted &&
+                (!result.AsyncWaitHandle.WaitOne(Timeout, false) || !result.IsCompleted))
+            {
+                _response?.Close();
+                throw new WebException(SR.net_webstatus_Timeout, WebExceptionStatus.Timeout);
+            }
+
+            return EndGetResponse(result);
+        }
+
+        internal void UnblockReader()
+        {
+            lock (this) { _blockReaderUntilRequestStreamDisposed?.Set(); }
+            _writing = false;
+        }
+
+        public override bool UseDefaultCredentials
+        {
+            get { throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException); }
+            set { throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException); }
+        }
+
+        public override void Abort()
+        {
+            if (Interlocked.Increment(ref _aborted) == 1)
+            {
+                _stream?.Abort();
+                _response?.Close();
+            }
+        }
+    }
+
+    internal sealed class FileWebRequestCreator : IWebRequestCreate
+    {
+        public WebRequest Create(Uri uri) => new FileWebRequest(uri);
+    }
+
+    internal sealed class WebFileStream : FileStream
+    {
+        private readonly FileWebRequest _request;
+
+        public WebFileStream(FileWebRequest request, string path, FileMode mode, FileAccess access, FileShare sharing) :
+            base(path, mode, access, sharing)
+        {
+            _request = request;
+        }
+
+        public WebFileStream(FileWebRequest request, string path, FileMode mode, FileAccess access, FileShare sharing, int length, bool async) :
+            base(path, mode, access, sharing, length, async)
+        {
+            _request = request;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                if (disposing)
+                {
+                    _request?.UnblockReader();
+                }
+            }
+            finally { base.Dispose(disposing); }
+        }
+
+        internal void Abort() => SafeFileHandle.Close();
+
+        public override int Read(byte[] buffer, int offset, int size)
+        {
+            CheckAborted();
+            try
+            {
+                return base.Read(buffer, offset, size);
+            }
+            catch
+            {
+                CheckAborted();
+                throw;
+            }
+        }
+
+        public override void Write(byte[] buffer, int offset, int size)
+        {
+            CheckAborted();
+            try
+            {
+                base.Write(buffer, offset, size);
+            }
+            catch
+            {
+                CheckAborted();
+                throw;
+            }
+        }
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
+        {
+            CheckAborted();
+            try
+            {
+                return base.BeginRead(buffer, offset, size, callback, state);
+            }
+            catch
+            {
+                CheckAborted();
+                throw;
+            }
+        }
+
+        public override int EndRead(IAsyncResult ar)
+        {
+            try
+            {
+                return base.EndRead(ar);
+            }
+            catch
+            {
+                CheckAborted();
+                throw;
+            }
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
+        {
+            CheckAborted();
+            try
+            {
+                return base.BeginWrite(buffer, offset, size, callback, state);
+            }
+            catch
+            {
+                CheckAborted();
+                throw;
+            }
+        }
+
+        public override void EndWrite(IAsyncResult ar)
+        {
+            try
+            {
+                base.EndWrite(ar);
+            }
+            catch
+            {
+                CheckAborted();
+                throw;
+            }
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            CheckAborted();
+            try
+            {
+                return base.ReadAsync(buffer, offset, count, cancellationToken);
+            }
+            catch
+            {
+                CheckAborted();
+                throw;
+            }
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            CheckAborted();
+            try
+            {
+                return base.WriteAsync(buffer, offset, count, cancellationToken);
+            }
+            catch
+            {
+                CheckAborted();
+                throw;
+            }
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            CheckAborted();
+            try
+            {
+                return base.CopyToAsync(destination, bufferSize, cancellationToken);
+            }
+            catch
+            {
+                CheckAborted();
+                throw;
+            }
+        }
+
+        private void CheckAborted()
+        {
+            if (_request.Aborted)
+            {
+                throw new WebException(SR.Format(SR.net_requestaborted, WebExceptionStatus.RequestCanceled), WebExceptionStatus.RequestCanceled);
+            }
+        }
+    }
+}

--- a/src/System.Net.Requests/src/System/Net/FileWebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/FileWebResponse.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.Serialization;
+using System.Globalization;
+
+namespace System.Net
+{
+    [Serializable]
+    public class FileWebResponse : WebResponse, ISerializable
+    {
+        private const int DefaultFileStreamBufferSize = 8192;
+        private const string DefaultFileContentType = "application/octet-stream";
+
+        private readonly long _contentLength;
+        private readonly FileAccess _fileAccess;
+        private readonly WebHeaderCollection _headers;
+        private readonly Uri _uri;
+
+        private Stream _stream;
+        private bool _closed;
+
+        internal FileWebResponse(FileWebRequest request, Uri uri, FileAccess access, bool useAsync)
+        {
+            try
+            {
+                _fileAccess = access;
+                if (access == FileAccess.Write)
+                {
+                    _stream = Stream.Null;
+                }
+                else
+                {
+                    _stream = new WebFileStream(request, uri.LocalPath, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultFileStreamBufferSize, useAsync);
+                    _contentLength = _stream.Length;
+                }
+                _headers = new WebHeaderCollection();
+                _headers[HttpKnownHeaderNames.ContentLength] = _contentLength.ToString(NumberFormatInfo.InvariantInfo);
+                _headers[HttpKnownHeaderNames.ContentType] = DefaultFileContentType;
+                _uri = uri;
+            }
+            catch (Exception e)
+            {
+                throw new WebException(e.Message, e, WebExceptionStatus.ConnectFailure, null);
+            }
+        }
+
+        [Obsolete("Serialization is obsoleted for this type. http://go.microsoft.com/fwlink/?linkid=14202")]
+        protected FileWebResponse(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
+        {
+            _headers = (WebHeaderCollection)serializationInfo.GetValue("headers", typeof(WebHeaderCollection));
+            _uri = (Uri)serializationInfo.GetValue("uri", typeof(Uri));
+            _contentLength = serializationInfo.GetInt64("contentLength");
+            _fileAccess = (FileAccess)serializationInfo.GetInt32("fileAccess");
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            GetObjectData(serializationInfo, streamingContext);
+        }
+
+        protected override void GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            serializationInfo.AddValue("headers", _headers, typeof(WebHeaderCollection));
+            serializationInfo.AddValue("uri", _uri, typeof(Uri));
+            serializationInfo.AddValue("contentLength", _contentLength);
+            serializationInfo.AddValue("fileAccess", _fileAccess);
+            base.GetObjectData(serializationInfo, streamingContext);
+        }
+
+        public override long ContentLength
+        {
+            get
+            {
+                CheckDisposed();
+                return _contentLength;
+            }
+        }
+
+        public override string ContentType
+        {
+            get
+            {
+                CheckDisposed();
+                return DefaultFileContentType;
+            }
+        }
+
+        public override WebHeaderCollection Headers
+        {
+            get
+            {
+                CheckDisposed();
+                return _headers;
+            }
+        }
+
+        public override bool SupportsHeaders => true;
+
+        public override Uri ResponseUri
+        {
+            get
+            {
+                CheckDisposed();
+                return _uri;
+            }
+        }
+
+        private void CheckDisposed()
+        {
+            if (_closed)
+            {
+                throw new ObjectDisposedException(this.GetType().FullName);
+            }
+        }
+
+        public override void Close()
+        {
+            if (!_closed)
+            {
+                _closed = true;
+
+                Stream chkStream = _stream;
+                if (chkStream != null)
+                {
+                    chkStream.Close();
+                    _stream = null;
+                }
+            }
+        }
+
+        public override Stream GetResponseStream()
+        {
+            CheckDisposed();
+            return _stream;
+        }
+    }
+}

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -310,7 +310,7 @@ namespace System.Net
             return Task.FromResult((Stream)_requestStream);
         }
 
-        public override IAsyncResult BeginGetRequestStream(AsyncCallback callback, Object state)
+        public override IAsyncResult BeginGetRequestStream(AsyncCallback callback, object state)
         {
             CheckAbort();
 

--- a/src/System.Net.Requests/src/System/Net/WebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/WebRequest.cs
@@ -31,6 +31,8 @@ namespace System.Net
         private static volatile List<WebRequestPrefixElement> s_prefixList;
         private static readonly object s_internalSyncObject = new object();
 
+        internal const int DefaultTimeoutMilliseconds = 100 * 1000;
+
         protected WebRequest() { }
 
         protected WebRequest(SerializationInfo serializationInfo, StreamingContext streamingContext) { }
@@ -350,8 +352,8 @@ namespace System.Net
         //
         //
         // This is the method that initializes the prefix list. We create
-        // an List for the PrefixList, then an HttpRequestCreator object,
-        // and then we register the HTTP and HTTPS prefixes.
+        // an List for the PrefixList, then each of the request creators,
+        // and then we register them with the associated prefixes.
         //
         // Returns:
         //     true
@@ -369,14 +371,16 @@ namespace System.Net
                         if (s_prefixList == null)
                         {
                             var httpRequestCreator = new HttpRequestCreator();
+                            var fileRequestCreator = new FileWebRequestCreator();
 
-                            const int Count = 2;
+                            const int Count = 3;
                             var prefixList = new List<WebRequestPrefixElement>(Count)
                             {
                                 new WebRequestPrefixElement("http:", httpRequestCreator),
-                                new WebRequestPrefixElement("https:", httpRequestCreator)
+                                new WebRequestPrefixElement("https:", httpRequestCreator),
+                                new WebRequestPrefixElement("file:", fileRequestCreator),
                             };
-                            Debug.Assert(prefixList.Count == Count);
+                            Debug.Assert(prefixList.Count == Count, $"Expected {Count}, got {prefixList.Count}");
 
                             s_prefixList = prefixList;
                         }
@@ -522,7 +526,7 @@ namespace System.Net
             throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }
 
-        public virtual IAsyncResult BeginGetRequestStream(AsyncCallback callback, Object state)
+        public virtual IAsyncResult BeginGetRequestStream(AsyncCallback callback, object state)
         {
             throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }

--- a/src/System.Net.Requests/src/System/Net/WebRequestMethods.cs
+++ b/src/System.Net.Requests/src/System/Net/WebRequestMethods.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net
+{
+    public static class WebRequestMethods
+    {
+        public static class Ftp
+        {
+            public const string DownloadFile = "RETR";
+            public const string ListDirectory = "NLST";
+            public const string UploadFile = "STOR";
+            public const string DeleteFile = "DELE";
+            public const string AppendFile = "APPE";
+            public const string GetFileSize = "SIZE";
+            public const string UploadFileWithUniqueName = "STOU";
+            public const string MakeDirectory = "MKD";
+            public const string RemoveDirectory = "RMD";
+            public const string ListDirectoryDetails = "LIST";
+            public const string GetDateTimestamp = "MDTM";
+            public const string PrintWorkingDirectory = "PWD";
+            public const string Rename = "RENAME";
+        }
+
+        public static class Http
+        {
+            public const string Get = "GET";
+            public const string Connect = "CONNECT";
+            public const string Head = "HEAD";
+            public const string Put = "PUT";
+            public const string Post = "POST";
+            public const string MkCol = "MKCOL";
+        }
+
+        public static class File
+        {
+            public const string DownloadFile = "GET";
+            public const string UploadFile = "PUT";
+        }
+    }
+}

--- a/src/System.Net.Requests/src/project.json
+++ b/src/System.Net.Requests/src/project.json
@@ -10,6 +10,7 @@
         "System.Globalization": "4.3.0-beta-24522-03",
         "System.IO": "4.3.0-beta-24522-03",
         "System.IO.Compression": "4.3.0-beta-24522-03",
+        "System.IO.FileSystem": "4.3.0-beta-24522-03",
         "System.Net.Http": "4.3.0-beta-24522-03",
         "System.Net.Primitives": "4.3.0-beta-24522-03",
         "System.Net.Security": "4.3.0-beta-24522-03",

--- a/src/System.Net.Requests/tests/FileWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/FileWebRequestTest.cs
@@ -1,0 +1,274 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Net.Http;
+using System.Net.Test.Common;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Tests
+{
+    public class FileWebRequestTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public FileWebRequestTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Ctor_VerifyDefaults_Success()
+        {
+            Uri uri = new Uri("file://somefilepath");
+            FileWebRequest request = (FileWebRequest)WebRequest.Create(uri);
+            Assert.Null(request.ContentType);
+            Assert.Null(request.Credentials);
+            Assert.NotNull(request.Headers);
+            Assert.Equal(0, request.Headers.Count);
+            Assert.Equal("GET", request.Method);
+            Assert.Null(request.Proxy);
+            Assert.Equal(uri, request.RequestUri);
+        }
+
+        [Fact]
+        public void FileWebRequest_Properties_Roundtrips()
+        {
+            WebRequest request = WebRequest.Create("file://anything");
+
+            request.ContentLength = 42;
+            Assert.Equal(42, request.ContentLength);
+
+            request.ContentType = "anything";
+            Assert.Equal("anything", request.ContentType);
+
+            request.Timeout = 42000;
+            Assert.Equal(42000, request.Timeout);
+        }
+
+        [Fact]
+        public void InvalidArguments_Throws()
+        {
+            WebRequest request = WebRequest.Create("file://anything");
+            Assert.Throws<ArgumentException>("value", () => request.ContentLength = -1);
+            Assert.Throws<ArgumentException>("value", () => request.Method = null);
+            Assert.Throws<ArgumentException>("value", () => request.Method = "");
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => request.Timeout = -2);
+        }
+
+        [Fact]
+        public void GetRequestStream_MethodGet_ThrowsProtocolViolation()
+        {
+            WebRequest request = WebRequest.Create("file://anything");
+            Assert.Throws<ProtocolViolationException>(() => request.BeginGetRequestStream(null, null));
+        }
+
+        [Fact]
+        public void GetRequestResponseAfterAbort_Throws()
+        {
+            WebRequest request = WebRequest.Create("file://anything");
+            request.Abort();
+            Assert.Throws<WebException>(() => request.BeginGetRequestStream(null, null));
+            Assert.Throws<WebException>(() => request.BeginGetResponse(null, null));
+        }
+
+        [Fact]
+        public void NotImplementedMembers_Throws()
+        {
+            WebRequest request = WebRequest.Create("file://anything");
+            Assert.Throws<NotImplementedException>(() => request.UseDefaultCredentials);
+            Assert.Throws<NotImplementedException>(() => request.UseDefaultCredentials = true);
+        }
+    }
+
+    public abstract class FileWebRequestTestBase
+    {
+        public abstract Task<WebResponse> GetResponseAsync(WebRequest request);
+        public abstract Task<Stream> GetRequestStreamAsync(WebRequest request);
+
+        [Fact]
+        public async Task ReadFile_ContainsExpectedContent()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                var data = new byte[1024 * 10];
+                var random = new Random(42);
+                random.NextBytes(data);
+
+                File.WriteAllBytes(path, data);
+
+                WebRequest request = WebRequest.Create("file://" + path);
+                using (WebResponse response = await GetResponseAsync(request))
+                {
+                    Assert.Equal(data.Length, response.ContentLength);
+                    Assert.Equal(data.Length.ToString(), response.Headers[HttpRequestHeader.ContentLength]);
+
+                    Assert.Equal("application/octet-stream", response.ContentType);
+                    Assert.Equal("application/octet-stream", response.Headers[HttpRequestHeader.ContentType]);
+
+                    Assert.True(response.SupportsHeaders);
+                    Assert.NotNull(response.Headers);
+                    Assert.Equal(new Uri("file://" + path), response.ResponseUri);
+
+                    using (Stream s = response.GetResponseStream())
+                    {
+                        var target = new MemoryStream();
+                        await s.CopyToAsync(target);
+                        Assert.Equal(data, target.ToArray());
+                    }
+                }
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async Task WriteFile_ContainsExpectedContent()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                var data = new byte[1024 * 10];
+                var random = new Random(42);
+                random.NextBytes(data);
+
+                var request = WebRequest.Create("file://" + path);
+                request.Method = WebRequestMethods.File.UploadFile;
+
+                using (Stream s = await GetRequestStreamAsync(request))
+                {
+                    await s.WriteAsync(data, 0, data.Length);
+                }
+
+                Assert.Equal(data, File.ReadAllBytes(path));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async Task WriteThenReadFile_WriteAccessResultsInNullResponseStream()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                var data = new byte[1024 * 10];
+                var random = new Random(42);
+                random.NextBytes(data);
+
+                var request = WebRequest.Create("file://" + path);
+                request.Method = WebRequestMethods.File.UploadFile;
+
+                using (Stream s = await GetRequestStreamAsync(request))
+                {
+                    await s.WriteAsync(data, 0, data.Length);
+                }
+
+                using (WebResponse response = await GetResponseAsync(request))
+                using (Stream s = response.GetResponseStream()) // will hand back a null stream
+                {
+                    Assert.Equal(0, s.Length);
+                }
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async Task ConcurrentReadWrite_ResponseBlocksThenGetsNullStream()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                var data = new byte[1024 * 10];
+                var random = new Random(42);
+                random.NextBytes(data);
+
+                var request = WebRequest.Create("file://" + path);
+                request.Method = WebRequestMethods.File.UploadFile;
+
+                Task<Stream> requestStreamTask = GetRequestStreamAsync(request);
+                Task<WebResponse> responseTask = GetResponseAsync(request);
+
+                using (Stream s = await requestStreamTask)
+                {
+                    await s.WriteAsync(data, 0, data.Length);
+                }
+
+                using (WebResponse response = await responseTask)
+                using (Stream s = response.GetResponseStream()) // will hand back a null stream
+                {
+                    Assert.Equal(0, s.Length);
+                }
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async Task RequestAfterResponse_throws()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                var data = new byte[1024];
+                WebRequest request = WebRequest.Create("file://" + path);
+                request.Method = WebRequestMethods.File.UploadFile;
+                using (WebResponse response = await GetResponseAsync(request))
+                {
+                    await Assert.ThrowsAsync<InvalidOperationException>(() => GetRequestStreamAsync(request));
+                }
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task BeginGetResponse_OnNonexistentFile_ShouldNotCrashApplication(bool? abortWithDelay)
+        {
+            FileWebRequest request = (FileWebRequest)WebRequest.Create("file://" + Path.GetRandomFileName());
+            Task<WebResponse> responseTask = GetResponseAsync(request);
+            if (abortWithDelay.HasValue)
+            {
+                if (abortWithDelay.Value)
+                {
+                    await Task.Delay(1);
+                }
+                request.Abort();
+            }
+            await Assert.ThrowsAsync<WebException>(() => responseTask);
+        }
+    }
+
+    public sealed class SyncFileWebRequestTestBase : FileWebRequestTestBase
+    {
+        public override Task<WebResponse> GetResponseAsync(WebRequest request) => Task.Run(() => request.GetResponse());
+        public override Task<Stream> GetRequestStreamAsync(WebRequest request) => Task.Run(() => request.GetRequestStream());
+    }
+
+    public sealed class TaskFileWebRequestTestBase : FileWebRequestTestBase
+    {
+        public override Task<WebResponse> GetResponseAsync(WebRequest request) => request.GetResponseAsync();
+
+        public override Task<Stream> GetRequestStreamAsync(WebRequest request) => request.GetRequestStreamAsync();
+    }
+}

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -40,6 +40,7 @@
   <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
     <Compile Include="AuthorizationTest.cs" />
     <Compile Include="AuthenticationManagerTest.cs" />
+    <Compile Include="FileWebRequestTest.cs" />
     <Compile Include="HttpRequestCachePolicyTest.cs" />
     <Compile Include="RequestCachePolicyTest.cs" />
     <Compile Include="ServicePointManagerTest.cs" />

--- a/src/System.Net.Requests/tests/WebRequestTest.cs
+++ b/src/System.Net.Requests/tests/WebRequestTest.cs
@@ -75,7 +75,6 @@ namespace System.Net.Tests
         [Theory]
         [InlineData("ws")]
         [InlineData("wss")]
-        [InlineData("file")]
         [InlineData("ftp")]
         [InlineData("custom")]
         public void Create_InvalidWebRequestUriScheme_Throws(string scheme)


### PR DESCRIPTION
The semantics of these types are a bit strange in places (e.g. allowing a request stream and a response stream for the same file, but using a null stream for the response in that case), but I didn't mess with them.

cc: @davidsh, @cipop, @ericeil, @karelz, @geoffkizer