### PR TITLE
Reduce code size of Stack.Peek

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -12,6 +12,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
@@ -193,10 +194,11 @@ namespace System.Collections.Generic
 
         // Returns the top object on the stack without removing it.  If the stack
         // is empty, Peek throws an InvalidOperationException.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T Peek()
         {
             if (_size == 0)
-                throw new InvalidOperationException(SR.InvalidOperation_EmptyStack);
+                ThrowInvalidOperationEmptyStack();
             return _array[_size - 1];
         }
 
@@ -205,7 +207,7 @@ namespace System.Collections.Generic
         public T Pop()
         {
             if (_size == 0)
-                throw new InvalidOperationException(SR.InvalidOperation_EmptyStack);
+                ThrowInvalidOperationEmptyStack();
             _version++;
             T item = _array[--_size];
             _array[_size] = default(T);     // Free memory quicker.
@@ -237,6 +239,12 @@ namespace System.Collections.Generic
                 i++;
             }
             return objArray;
+        }
+
+        private void ThrowInvalidOperationEmptyStack()
+        {
+            Debug.Assert(_size == 0);
+            throw new InvalidOperationException(SR.InvalidOperation_EmptyStack);
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "not an expected scenario")]

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -12,7 +12,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
@@ -194,11 +193,13 @@ namespace System.Collections.Generic
 
         // Returns the top object on the stack without removing it.  If the stack
         // is empty, Peek throws an InvalidOperationException.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T Peek()
         {
             if (_size == 0)
-                ThrowInvalidOperationEmptyStack();
+            {
+                ThrowForEmptyStack();
+            }
+            
             return _array[_size - 1];
         }
 
@@ -207,7 +208,10 @@ namespace System.Collections.Generic
         public T Pop()
         {
             if (_size == 0)
-                ThrowInvalidOperationEmptyStack();
+            {
+                ThrowForEmptyStack();
+            }
+            
             _version++;
             T item = _array[--_size];
             _array[_size] = default(T);     // Free memory quicker.
@@ -241,7 +245,7 @@ namespace System.Collections.Generic
             return objArray;
         }
 
-        private void ThrowInvalidOperationEmptyStack()
+        private void ThrowForEmptyStack()
         {
             Debug.Assert(_size == 0);
             throw new InvalidOperationException(SR.InvalidOperation_EmptyStack);


### PR DESCRIPTION
Same as #12062, but for Stack. I had to add AggressiveInlining to get it to work, since it seems like the 1 extra byte from the `dec` in `_size - 1` was making it ineligible for inlining.

[Test code, before/after asm](https://gist.github.com/jamesqo/e3246abda58d7c0a51c4bd87f3a00cba) is available at the link. You can see inlining `Stack.Peek` increases the code size of `Main` by 31 bytes, while inlining `Queue.Peek` (asm is in the previous PR) increases it by 30.

cc @stephentoub, @ianhays 