### PR TITLE
Add AndAlso and OrElse tests

### DIFF
--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -4,6 +4,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace System.Linq.Expressions.Tests
 {
@@ -286,6 +287,40 @@ namespace System.Linq.Expressions.Tests
 
         public void GenericMethod<T>() { }
         public static void StaticMethod() { }
+    }
+
+    public class UnreadableExpressionsData : IEnumerable<object[]>
+    {
+        private static readonly object[] Property = new object[] { Expression.Property(null, typeof(Unreadable<bool>), nameof(Unreadable<bool>.WriteOnly)) };
+        private static readonly object[] Indexer = new object[] { Expression.Property(null, typeof(Unreadable<bool>).GetProperty(nameof(Unreadable<bool>.WriteOnly)), new Expression[0]) };
+
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return Property;
+            yield return Indexer;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+    public class OpenGenericMethodsData : IEnumerable<object[]>
+    {
+        private static readonly object[] GenericClass = new object[] { typeof(GenericClass<>).GetMethod(nameof(GenericClass<string>.Method)) };
+        private static readonly object[] GenericMethod = new object[] { typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.GenericMethod)) };
+
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return GenericClass;
+            yield return GenericMethod;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 
     public enum ByteEnum : byte { A = Byte.MaxValue }


### PR DESCRIPTION
- Without method
- With method
- Semantics (e.g. does AndAlso short-circuit)
- Invalid operator

Also increases CC by ~1.5%, contributing to #1198
And removes some dead code from VerifyOpTrueFalse

/cc @VSadov