### PR TITLE
Fix test target group clash

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -486,7 +486,7 @@
     <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)$(OSPlatformConfig)/</IntermediateOutputRootPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)/$(TargetOutputRelPath)</IntermediateOutputPath>
 
-    <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)/$(MSBuildProjectName)/</TestPath>
+    <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)</TestPath>
 
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
     <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(ConfigurationGroup)/</PackageOutputPath>

--- a/dir.targets
+++ b/dir.targets
@@ -63,4 +63,23 @@
     </ItemGroup>
   </Target>
 
+  <!-- Copied from https://github.com/dotnet/buildtools/blob/6a703fe4d4dc3cd75414f5350fff939e5bc10c44/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets#L252-L266
+       to avoid forking buildtools for release/1.1.0 -->
+  <!-- archive the test binaries along with some supporting files -->
+  <Target Name="ArchiveTestBuild" Condition="'$(ArchiveTests)' == 'true'"  DependsOnTargets="RunTestsForProject">
+    <PropertyGroup>
+      <TestArchiveDir>$(TestWorkingDir)$(OSPlatformConfig)/archive/tests/</TestArchiveDir>
+      <TestArchiveDir Condition="'$(TestTFM)' != ''">$(TestArchiveDir)$(TestTFM)/</TestArchiveDir>
+      <ProjectJson Condition="!Exists('$(ProjectJson)')">$(OriginalProjectJson)</ProjectJson>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TestProjectName)'==''">
+      <TestProjectName>$(MSBuildProjectName)</TestProjectName>
+    </PropertyGroup>
+
+    <!-- the project json and runner script files need to be included in the archive -->
+    <Copy SourceFiles="$(ProjectJson);$(ProjectLockJson)" DestinationFolder="$(TestPath)%(TestNugetTargetMoniker.Folder)" />
+    <MakeDir Directories="$(TestArchiveDir)" />
+    <ZipFileCreateFromDirectory SourceDirectory="$(TestPath)%(TestNugetTargetMoniker.Folder)" DestinationArchive="$(TestArchiveDir)$(TestProjectName).zip" OverwriteDestination="true" />
+  </Target>
+
 </Project>

--- a/dir.targets
+++ b/dir.targets
@@ -68,7 +68,7 @@
   <!-- archive the test binaries along with some supporting files -->
   <Target Name="ArchiveTestBuild" Condition="'$(ArchiveTests)' == 'true'"  DependsOnTargets="RunTestsForProject">
     <PropertyGroup>
-      <TestArchiveDir>$(TestWorkingDir)$(OSPlatformConfig)/archive/tests/</TestArchiveDir>
+      <TestArchiveDir>$(TestWorkingDir)$(OSPlatformConfig)/archive/tests/$(TargetOutputRelPath)</TestArchiveDir>
       <TestArchiveDir Condition="'$(TestTFM)' != ''">$(TestArchiveDir)$(TestTFM)/</TestArchiveDir>
       <ProjectJson Condition="!Exists('$(ProjectJson)')">$(OriginalProjectJson)</ProjectJson>
     </PropertyGroup>


### PR DESCRIPTION
Tests were using paths that didn't account for targetgroup.

The result was that when cross-compiling tests the ArchiveTestBuild target and the CopyTestToTestDirectory were reusing the same directory.

For ArchiveTestBuild this caused a error when creating the zip.

For CopyTestToTestDirectory it looks like this was occasionally hitting files in use but would retry.  The result of that would be potentially loss of test coverage (eg: if the netstandard17 build was overwritten with netstandard13).  I suspect there were likely other places that were broken due to this clash.

I'm fixing it by copying the target to rel so that we can avoid forking buildtools.

/cc @weshaggard @MattGal @gkhanna79 