### PR TITLE
Expose path constructors for StreamReader/StreamWriter

### DIFF
--- a/src/System.IO/ref/System.IO.cs
+++ b/src/System.IO/ref/System.IO.cs
@@ -164,6 +164,11 @@ namespace System.IO
         public StreamReader(System.IO.Stream stream, System.Text.Encoding encoding, bool detectEncodingFromByteOrderMarks) { }
         public StreamReader(System.IO.Stream stream, System.Text.Encoding encoding, bool detectEncodingFromByteOrderMarks, int bufferSize) { }
         public StreamReader(System.IO.Stream stream, System.Text.Encoding encoding, bool detectEncodingFromByteOrderMarks, int bufferSize, bool leaveOpen) { }
+        public StreamReader(string path) { }
+        public StreamReader(string path, bool detectEncodingFromByteOrderMarks) { }
+        public StreamReader(string path, System.Text.Encoding encoding) { }
+        public StreamReader(string path, System.Text.Encoding encoding, bool detectEncodingFromByteOrderMarks) { }
+        public StreamReader(string path, System.Text.Encoding encoding, bool detectEncodingFromByteOrderMarks, int bufferSize) { }
         public virtual System.IO.Stream BaseStream { get { return default(System.IO.Stream); } }
         public virtual System.Text.Encoding CurrentEncoding { get { return default(System.Text.Encoding); } }
         public bool EndOfStream { get { return default(bool); } }
@@ -188,6 +193,10 @@ namespace System.IO
         public StreamWriter(System.IO.Stream stream, System.Text.Encoding encoding) { }
         public StreamWriter(System.IO.Stream stream, System.Text.Encoding encoding, int bufferSize) { }
         public StreamWriter(System.IO.Stream stream, System.Text.Encoding encoding, int bufferSize, bool leaveOpen) { }
+        public StreamWriter(string path) { }
+        public StreamWriter(string path, bool append) { }
+        public StreamWriter(string path, bool append, System.Text.Encoding encoding) { }
+        public StreamWriter(string path, bool append, System.Text.Encoding encoding, int bufferSize) { }
         public virtual bool AutoFlush { get { return default(bool); } set { } }
         public virtual System.IO.Stream BaseStream { get { return default(System.IO.Stream); } }
         public override System.Text.Encoding Encoding { get { return default(System.Text.Encoding); } }

--- a/src/System.IO/src/ApiCompatBaseline.uap101aot.txt
+++ b/src/System.IO/src/ApiCompatBaseline.uap101aot.txt
@@ -1,2 +1,9 @@
 MembersMustExist : Member 'System.IO.FileNotFoundException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.IO.IOException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamReader..ctor(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamReader..ctor(System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamReader..ctor(System.String, System.Text.Encoding)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamReader..ctor(System.String, System.Text.Encoding, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamWriter..ctor(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamWriter..ctor(System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.StreamWriter..ctor(System.String, System.Boolean, System.Text.Encoding)' does not exist in the implementation but it does exist in the contract.

--- a/src/System.IO/tests/StreamReader/StreamReader.StringCtorTests.cs
+++ b/src/System.IO/tests/StreamReader/StreamReader.StringCtorTests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class StreamReader_StringCtorTests
+    {
+        [Fact]
+        public static void NullArgs_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("path", () => new StreamReader((string)null));
+            Assert.Throws<ArgumentNullException>("encoding", () => new StreamReader("path", null, true));
+        }
+
+        [Fact]
+        public static void EmptyPath_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new StreamReader(""));
+        }
+
+        [Fact]
+        public static void NegativeBufferSize_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => new StreamReader("path", Encoding.UTF8, true, -1));
+        }
+
+        [Fact]
+        public static void ReadToEnd_False_detectEncodingFromByteOrderMarks()
+        {
+            string testfile = Path.GetTempFileName();
+            File.WriteAllBytes(testfile, new byte[] { 65, 66, 67, 68 });
+            using (var sr2 = new StreamReader(testfile, false))
+            {
+                Assert.Equal("ABCD", sr2.ReadToEnd());
+            }
+            File.Delete(testfile);
+        }
+
+        [Fact]
+        public static void ReadToEnd_True_detectEncodingFromByteOrderMarks()
+        {
+            string testfile = Path.GetTempFileName();
+            File.WriteAllBytes(testfile, new byte[] { 65, 66, 67, 68 });
+            using (var sr2 = new StreamReader(testfile, true))
+            {
+                Assert.Equal("ABCD", sr2.ReadToEnd());
+            }
+            File.Delete(testfile);
+        }
+    }
+}

--- a/src/System.IO/tests/StreamWriter/StreamWriter.StringCtorTests.cs
+++ b/src/System.IO/tests/StreamWriter/StreamWriter.StringCtorTests.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class StreamWriter_StringCtorTests
+    {
+        [Fact]
+        public static void NullArgs_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("path", () => new StreamWriter((string)null));
+            Assert.Throws<ArgumentNullException>("encoding", () => new StreamWriter("path", false, null));
+        }
+
+        [Fact]
+        public static void EmptyPath_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new StreamWriter(""));
+        }
+
+        [Fact]
+        public static void NegativeBufferSize_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => new StreamWriter("path", false, Encoding.UTF8, -1));
+        }
+
+        [Fact]
+        public static void CreateStreamWriter()
+        {
+            string testfile = Path.GetTempFileName();
+            string testString = "Hello World!";
+            using (StreamWriter writer = new StreamWriter(testfile))
+            {
+                writer.Write(testString);
+            }
+
+            using (StreamReader reader = new StreamReader(testfile))
+            {
+                Assert.Equal(testString, reader.ReadToEnd());
+            }
+            File.Delete(testfile);
+        }
+
+        public static IEnumerable<object[]> EncodingsToTestStreamWriter()
+        {
+            yield return new object[] { Encoding.UTF8, "This is UTF8\u00FF" };
+            yield return new object[] { Encoding.BigEndianUnicode, "This is BigEndianUnicode\u00FF" };
+            yield return new object[] { Encoding.Unicode, "This is Unicode\u00FF" };
+        }
+
+        [Theory]
+        [MemberData(nameof(EncodingsToTestStreamWriter))]
+        public static void TestEncoding(Encoding encoding, string testString)
+        {
+            string testfile = Path.GetTempFileName();
+            using (StreamWriter writer = new StreamWriter(testfile, false, encoding))
+            {
+                writer.Write(testString);
+            }
+
+            using (StreamReader reader = new StreamReader(testfile, encoding))
+            {
+                Assert.Equal(testString, reader.ReadToEnd());
+            }
+            File.Delete(testfile);
+        }
+    }
+}

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -26,9 +26,11 @@
     <Compile Include="MemoryStream\MemoryStream.TryGetBufferTests.cs" />
     <Compile Include="MemoryStream\MemoryStreamTests.cs" />
     <Compile Include="StreamReader\StreamReader.CtorTests.cs" />
+    <Compile Include="StreamReader\StreamReader.StringCtorTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="StreamReader\StreamReaderTests.cs" />
     <Compile Include="StreamWriter\StreamWriter.BaseStream.cs" />
     <Compile Include="StreamWriter\StreamWriter.CloseTests.cs" />
+    <Compile Include="StreamWriter\StreamWriter.StringCtorTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="StreamWriter\StreamWriter.CtorTests.cs" />
     <Compile Include="StreamWriter\StreamWriter.FlushTests.cs" />
     <Compile Include="StreamWriter\StreamWriter.WriteTests.cs" />


### PR DESCRIPTION
Exposes the members and adds new tests for them. System.IO is already updated to build for netstandard1.7 so no changes to be made there. These new constructors are not added for uap10.1 as that would require we merge the IO and IO.FileSystem assemblies to gain access to FileStream from the IO assembly.

Progress towards https://github.com/dotnet/corefx/issues/9465

@danmosemsft @joperezr @weshaggard 