### PR TITLE
Always initialize Targets* properties to false

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -230,6 +230,16 @@
     </Otherwise>
   </Choose>
 
+  <!-- initialize all the targets variables to false as they should only be set below -->
+  <PropertyGroup>
+    <TargetsWindows>false</TargetsWindows>
+    <TargetsUnix>false</TargetsUnix>
+    <TargetsLinux>false</TargetsLinux>
+    <TargetsOSX>false</TargetsOSX>
+    <TargetsFreeBSD>false</TargetsFreeBSD>
+    <TargetsNetBSD>false</TargetsNetBSD>
+  </PropertyGroup>
+
   <!-- Setup properties per OSGroup -->
   <Choose>
     <When Condition="'$(OSGroup)'=='AnyOS'">


### PR DESCRIPTION
We were hitting some cases where TargetsWindows was set as and
environment variable and caused some of our builds to start failing.

These should never be set outside of the Choose statement based on
OSGroup so we are always defaulting them to false to ensure the enviroment
doesn't end up overriding them.

cc @ericstj @chcosta 