### PR TITLE
Add baseline for native Crypto packages

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2375,8 +2375,12 @@
         "4.0.1.0": "4.3.0"
       }
     },
-    "runtime.native.System.Security.Cryptography.Apple": {},
-    "runtime.native.System.Security.Cryptography.OpenSsl": {}
+    "runtime.native.System.Security.Cryptography.Apple": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    }
   },
   "ModulesToPackages": {
     "System.Native": "runtime.native.System",


### PR DESCRIPTION
We can't determine package version for native libraries and rely on a
baseline to set the appropriate version.

/cc @bartonjs 