### PR TITLE
Fix HandleCollector test on desktop

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/HandleCollectorTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/HandleCollectorTests.cs
@@ -75,7 +75,10 @@ namespace System.Runtime.InteropServices
             const int ToAdd = 10; // int.MaxValue
             {
                 // Jump HandleCollector instance forward until it almost overflows
-                FieldInfo handleCount = typeof(HandleCollector).GetTypeInfo().GetDeclaredField("_handleCount");
+                TypeInfo type = typeof(HandleCollector).GetTypeInfo();
+                FieldInfo handleCount =
+                    type.GetDeclaredField("_handleCount") ?? // corefx
+                    type.GetDeclaredField("handleCount");    // desktop
                 Assert.NotNull(handleCount);
                 handleCount.SetValue(collector, int.MaxValue - ToAdd);
             }


### PR DESCRIPTION
This test uses reflection to access a field in the HandleCollector type in order to make the test run a lot faster, but the field name is different in desktop and corefx.

cc: @mellinoe