### PR TITLE
Fix Vector3 hash code test on desktop

### DIFF
--- a/src/System.Numerics.Vectors/tests/Vector3Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector3Tests.cs
@@ -62,7 +62,6 @@ namespace System.Numerics.Tests
             Assert.NotEqual(v4.GetHashCode(), v8.GetHashCode());
             Assert.NotEqual(v7.GetHashCode(), v6.GetHashCode());
             Assert.NotEqual(v8.GetHashCode(), v6.GetHashCode());
-            Assert.NotEqual(v8.GetHashCode(), v7.GetHashCode());
             Assert.NotEqual(v8.GetHashCode(), v9.GetHashCode());
             Assert.NotEqual(v7.GetHashCode(), v9.GetHashCode());
         }


### PR DESCRIPTION
This test was changed in https://github.com/dotnet/corefx/commit/acb57bab3ebb30fc5ace58378a5fab561bcd06b0#diff-ea2105f2ec377b9d1f470d92d967a7eeL64 as part of updating the hash code corefx uses in vector.  But the test is now failing on desktop, as with the old hash function the two values are the same (hence the Assert.True in the original test before it was changed).  I'm simply deleting the assert.

```C#
Func<int, int, int> combineHashCodes = (h1, h2) => (((h1 << 5) + h1) ^ h2);
Console.WriteLine(combineHashCodes(combineHashCodes(1.0f.GetHashCode(), 1.0f.GetHashCode()), 1.0f.GetHashCode()));
Console.WriteLine(combineHashCodes(combineHashCodes(0.0f.GetHashCode(), 1.0f.GetHashCode()), 0.0f.GetHashCode()));
```

cc: @mellinoe