### PR TITLE
Fix Uri handling of unknown schemes

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -4189,7 +4189,7 @@ namespace System
                             && StaticNotAny(flags, Flags.HostUnicodeNormalized))
                         {
                             // Normalize any other host
-                            string user = new string(pString, startOtherHost, startOtherHost - end);
+                            string user = new string(pString, startOtherHost, end - startOtherHost);
                             try
                             {
                                 newHost += user.Normalize(NormalizationForm.FormC);

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -66,13 +66,12 @@ namespace System.PrivateUri.Tests
             string root = "viewcode://./codeschema_class?";
             string uriDataFra = root + Uri.EscapeDataString("Type=\u00E9");
 
-            // TODO #8330 : Uri should not throw ArgumentOutOfRangeException. 
-            // This test is documenting current behavior.
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-           {
-               Uri u1 = new Uri(uriDataFra);
-               Assert.Equal(root + "Type=%C3%A9", u1.AbsoluteUri);
-           });
+            Uri u1 = new Uri(uriDataFra);
+
+            // TODO #8330 : Normalization should produce the same result for escaped/unescaped URIs.
+            // Assert.Equal(root + "Type=%C3%A9", u1.AbsoluteUri);
+
+            Assert.NotEqual(root + "Type=%C3%A9", u1.AbsoluteUri);
         }
 
         [Fact]


### PR DESCRIPTION
Somehow this expression got transposed in corefx; it should be ```end - startOtherHost``` rather than ```startOtherHost - end``` (as can be seen in the previous section of code, end will always be >= startOtherHost).  As it was, it was resulting in an ArgumentOutOfRangeException, which a test was then codifying, and that test was then failing on desktop which has the correct ordering.

Contributes to https://github.com/dotnet/corefx/issues/8330
cc: @cipop, @davidsh