### PR TITLE
Add OnDownload/UploadProgressChanged to WebClient

### DIFF
--- a/src/System.Net.WebClient/ref/System.Net.WebClient.cs
+++ b/src/System.Net.WebClient/ref/System.Net.WebClient.cs
@@ -128,11 +128,13 @@ namespace System.Net
         protected virtual System.Net.WebResponse GetWebResponse(System.Net.WebRequest request, System.IAsyncResult result) { throw null; }
         protected virtual void OnDownloadDataCompleted(System.Net.DownloadDataCompletedEventArgs e) { }
         protected virtual void OnDownloadFileCompleted(System.ComponentModel.AsyncCompletedEventArgs e) { }
+        protected virtual void OnDownloadProgressChanged(System.Net.DownloadProgressChangedEventArgs e) { }
         protected virtual void OnDownloadStringCompleted(System.Net.DownloadStringCompletedEventArgs e) { }
         protected virtual void OnOpenReadCompleted(System.Net.OpenReadCompletedEventArgs e) { }
         protected virtual void OnOpenWriteCompleted(System.Net.OpenWriteCompletedEventArgs e) { }
         protected virtual void OnUploadDataCompleted(System.Net.UploadDataCompletedEventArgs e) { }
         protected virtual void OnUploadFileCompleted(System.Net.UploadFileCompletedEventArgs e) { }
+        protected virtual void OnUploadProgressChanged(System.Net.UploadProgressChangedEventArgs e) { }
         protected virtual void OnUploadStringCompleted(System.Net.UploadStringCompletedEventArgs e) { }
         protected virtual void OnUploadValuesCompleted(System.Net.UploadValuesCompletedEventArgs e) { }
         [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]

--- a/src/System.Net.WebClient/src/System/Net/WebClient.cs
+++ b/src/System.Net.WebClient/src/System/Net/WebClient.cs
@@ -77,10 +77,12 @@ namespace System.Net
         protected virtual void OnDownloadStringCompleted(DownloadStringCompletedEventArgs e) => DownloadStringCompleted?.Invoke(this, e);
         protected virtual void OnDownloadDataCompleted(DownloadDataCompletedEventArgs e) => DownloadDataCompleted?.Invoke(this, e);
         protected virtual void OnDownloadFileCompleted(AsyncCompletedEventArgs e) => DownloadFileCompleted?.Invoke(this, e);
+        protected virtual void OnDownloadProgressChanged(DownloadProgressChangedEventArgs e) => DownloadProgressChanged?.Invoke(this, e);
         protected virtual void OnUploadStringCompleted(UploadStringCompletedEventArgs e) => UploadStringCompleted?.Invoke(this, e);
         protected virtual void OnUploadDataCompleted(UploadDataCompletedEventArgs e) => UploadDataCompleted?.Invoke(this, e);
         protected virtual void OnUploadFileCompleted(UploadFileCompletedEventArgs e) => UploadFileCompleted?.Invoke(this, e);
         protected virtual void OnUploadValuesCompleted(UploadValuesCompletedEventArgs e) => UploadValuesCompleted?.Invoke(this, e);
+        protected virtual void OnUploadProgressChanged(UploadProgressChangedEventArgs e) => UploadProgressChanged?.Invoke(this, e);
         protected virtual void OnOpenReadCompleted(OpenReadCompletedEventArgs e) => OpenReadCompleted?.Invoke(this, e);
         protected virtual void OnOpenWriteCompleted(OpenWriteCompletedEventArgs e) => OpenWriteCompleted?.Invoke(this, e);
 
@@ -106,18 +108,21 @@ namespace System.Net
             if (!_initWebClientAsync)
             {
                 // Set up the async delegates
+
                 _openReadOperationCompleted = arg => OnOpenReadCompleted((OpenReadCompletedEventArgs)arg);
                 _openWriteOperationCompleted = arg => OnOpenWriteCompleted((OpenWriteCompletedEventArgs)arg);
+
                 _downloadStringOperationCompleted = arg => OnDownloadStringCompleted((DownloadStringCompletedEventArgs)arg);
                 _downloadDataOperationCompleted = arg => OnDownloadDataCompleted((DownloadDataCompletedEventArgs)arg);
                 _downloadFileOperationCompleted = arg => OnDownloadFileCompleted((AsyncCompletedEventArgs)arg);
+
                 _uploadStringOperationCompleted = arg => OnUploadStringCompleted((UploadStringCompletedEventArgs)arg);
                 _uploadDataOperationCompleted = arg => OnUploadDataCompleted((UploadDataCompletedEventArgs)arg);
                 _uploadFileOperationCompleted = arg => OnUploadFileCompleted((UploadFileCompletedEventArgs)arg);
                 _uploadValuesOperationCompleted = arg => OnUploadValuesCompleted((UploadValuesCompletedEventArgs)arg);
 
-                _reportDownloadProgressChanged = arg => DownloadProgressChanged?.Invoke(this, (DownloadProgressChangedEventArgs)arg);
-                _reportUploadProgressChanged = arg => UploadProgressChanged?.Invoke(this, (UploadProgressChangedEventArgs)arg);
+                _reportDownloadProgressChanged = arg => OnDownloadProgressChanged((DownloadProgressChangedEventArgs)arg);
+                _reportUploadProgressChanged = arg => OnUploadProgressChanged((UploadProgressChangedEventArgs)arg);
 
                 _progress = new ProgressData();
                 _initWebClientAsync = true;


### PR DESCRIPTION
Somehow I missed these.  Simple to put back.  The only remaining missing member (beyond missing the Component base type) is CachePolicy, which is commented out until the packages in corefx are updated so that we can reference the cache types that were already added in System.Net.Requests.

cc: @ericeil
https://github.com/dotnet/corefx/issues/12137