### PR TITLE
Update version of MS.NETCore.Platforms and Targets

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -16,9 +16,8 @@
     <XmlDocFileRoot>$(PackagesDir)Microsoft.Private.Intellisense/1.0.0-rc4-24206-00/xmldocs</XmlDocFileRoot>
     <!-- We're currently not building a "live" baseline, instead we're using .NETCore 1.0 RTM stable versions as the baseline -->
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
-    <!-- temporary change until buildtools can be updated https://github.com/dotnet/buildtools/issues/831 -->
-    <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.0.3</LineupPackageVersion>
-    <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.0.2</PlatformPackageVersion>
+    <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.1.0</LineupPackageVersion>
+    <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.1.0</PlatformPackageVersion>
 
     <!-- by default all packages will use the same version which revs with respect to product version -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">4.3.0</PackageVersion>

--- a/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
+++ b/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <PackageVersion>1.0.2</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
   

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <PackageVersion>1.0.3</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <IsLineupPackage>true</IsLineupPackage>
     <RuntimeFileSource>runtime.json</RuntimeFileSource>
     <SkipValidatePackage>true</SkipValidatePackage>


### PR DESCRIPTION
We need to give space for these for LTS servicing, just like all the
other packages.

/cc @weshaggard @Petermarcu 