### PR TITLE
Add back missing WebRequest property setters

### DIFF
--- a/src/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/System.Net.Requests/ref/System.Net.Requests.cs
@@ -244,8 +244,8 @@ namespace System.Net
     {
         protected WebResponse() { }
         protected WebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
-        public virtual long ContentLength { get { throw null; } }
-        public virtual string ContentType { get { throw null; } }
+        public virtual long ContentLength { get { throw null; } set { } }
+        public virtual string ContentType { get { throw null; } set { } }
         public virtual System.Net.WebHeaderCollection Headers { get { return default(System.Net.WebHeaderCollection); } }
         public virtual bool IsFromCache { get { throw null; } }
         public virtual bool IsMutuallyAuthenticated { get { throw null; } }

--- a/src/System.Net.Requests/src/System/Net/WebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/WebResponse.cs
@@ -70,6 +70,10 @@ namespace System.Net
             {
                 throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
             }
+            set
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
         }
 
 
@@ -81,6 +85,10 @@ namespace System.Net
         public virtual string ContentType
         {
             get
+            {
+                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+            }
+            set
             {
                 throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
             }


### PR DESCRIPTION
Missed these when adding back the rest of the WebRequest/Response surface area.
cc: @ericeil, @davidsh, @cipop
Fixes https://github.com/dotnet/corefx/issues/12141
(The types still need to derive from MBRO, but that should be handled by a sweep across the whole repo.)