### PR TITLE
Avoid allocations in Registry.GetBaseKeyFromKeyName

### DIFF
--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
@@ -77,50 +77,18 @@ namespace Microsoft.Win32
             int i = keyName.IndexOf('\\');
             int length = i != -1 ? i : keyName.Length;
 
-            // Determine the potential base key from the length. Note that
-            // HKEY_CLASSES_ROOT and HKEY_CURRENT_USER are the same length,
-            // so for that case, switch on a char at a position with a
-            // unique char to determine the potential base key.
+            // Determine the potential base key from the length.
             RegistryKey baseKey = null;
             switch (length)
             {
-                case 10:
-                    baseKey = Users; // HKEY_USERS
-                    break;
-
-                case 17:
-                    const int UniqueCharIndex = 6;
-                    switch (keyName[UniqueCharIndex])
-                    {
-                        case 'l':
-                        case 'L':
-                            Debug.Assert(ClassesRoot.Name[UniqueCharIndex] == 'L');
-                            baseKey = ClassesRoot; // HKEY_C[L]ASSES_ROOT
-                            break;
-
-                        case 'u':
-                        case 'U':
-                            Debug.Assert(CurrentUser.Name[UniqueCharIndex] == 'U');
-                            baseKey = CurrentUser; // HKEY_C[U]RRENT_USER
-                            break;
-                    }
-                    break;
-
-                case 18:
-                    baseKey = LocalMachine; // HKEY_LOCAL_MACHINE
-                    break;
-
-                case 19:
-                    baseKey = CurrentConfig; // HKEY_CURRENT_CONFIG
-                    break;
-
-                case 21:
-                    baseKey = PerformanceData; // HKEY_PERFORMANCE_DATA
-                    break;
+                case 10: baseKey = Users; break; // HKEY_USERS
+                case 17: baseKey = char.ToUpperInvariant(keyName[6]) == 'L' ? ClassesRoot : CurrentUser; break; // HKEY_C[L]ASSES_ROOT, otherwise HKEY_CURRENT_USER
+                case 18: baseKey = LocalMachine; break; // HKEY_LOCAL_MACHINE
+                case 19: baseKey = CurrentConfig; break; // HKEY_CURRENT_CONFIG
+                case 21: baseKey = PerformanceData; break; // HKEY_PERFORMANCE_DATA
             }
 
-            Debug.Assert(baseKey == null || baseKey.Name.Length == length);
-
+            // If a potential base key was found, see if keyName actually starts with the potential base key's name.
             if (baseKey != null && keyName.StartsWith(baseKey.Name, StringComparison.OrdinalIgnoreCase))
             {
                 subKeyName = (i == -1 || i == keyName.Length) ?

--- a/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -25,6 +25,7 @@
     </Compile>
     <Compile Include="Helpers.cs" />
     <Compile Include="RegistryKey\RegistryKey_GetValue_CorruptData.cs" />
+    <Compile Include="Registry\Registry_Fields.cs" />
     <Compile Include="Registry\Registry_Getvalue_str_str_obj.cs" />
     <Compile Include="Registry\Registry_SetValue_str_str_obj.cs" />
     <Compile Include="Registry\Registry_SetValue_str_str_obj_valuekind.cs" />

--- a/src/Microsoft.Win32.Registry/tests/Registry/Registry_Fields.cs
+++ b/src/Microsoft.Win32.Registry/tests/Registry/Registry_Fields.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.Win32.RegistryTests
+{
+    public class Registry_Fields
+    {
+        public static readonly object[][] BaseKeyNameTestData =
+        {
+            new object[] { Registry.CurrentUser, "HKEY_CURRENT_USER" },
+            new object[] { Registry.LocalMachine, "HKEY_LOCAL_MACHINE" },
+            new object[] { Registry.ClassesRoot, "HKEY_CLASSES_ROOT" },
+            new object[] { Registry.Users, "HKEY_USERS" },
+            new object[] { Registry.PerformanceData, "HKEY_PERFORMANCE_DATA" },
+            new object[] { Registry.CurrentConfig, "HKEY_CURRENT_CONFIG" }
+        };
+
+        [Theory]
+        [MemberData(nameof(BaseKeyNameTestData))]
+        public void BaseKeyName_ExpectedName(RegistryKey baseKey, string expectedName)
+        {
+            Assert.Equal(expectedName, baseKey.Name);
+        }
+    }
+}

--- a/src/Microsoft.Win32.Registry/tests/Registry/Registry_Getvalue_str_str_obj.cs
+++ b/src/Microsoft.Win32.Registry/tests/Registry/Registry_Getvalue_str_str_obj.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Win32.RegistryTests
         {
             new object[] { string.Empty }, // Not a valid base key name.
             new object[] { "HHHH_MMMM" }, // Not a valid base key name.
+            new object[] { "HHHH_CURRENT_USER" }, // Not a valid base key name.
             new object[] { "HKEY_CURRENT_USER_FOOBAR" }, // Starts with one of the valid base key names but isn't valid.
             new object[] { new string('a', 10) }, // String of length 10 that isn't HKEY_USERS.
             new object[] { new string('a', 17) }, // String of length 17 that isn't HKEY_CURRENT_USER or HKEY_CLASSES_ROOT.

--- a/src/Microsoft.Win32.Registry/tests/Registry/Registry_Getvalue_str_str_obj.cs
+++ b/src/Microsoft.Win32.Registry/tests/Registry/Registry_Getvalue_str_str_obj.cs
@@ -12,17 +12,28 @@ namespace Microsoft.Win32.RegistryTests
     public class Registry_GetValue_str_str_obj : RegistryTestsBase
     {
         [Fact]
-        public static void NegativeTests()
+        public static void NullKeyName_ThrowsArgumentNullException()
         {
-            // Should throw if passed keyName is null
-            Assert.Throws<ArgumentNullException>(
-                () => Registry.GetValue(keyName: null,valueName: null, defaultValue: null));
+            Assert.Throws<ArgumentNullException>("keyName", () => Registry.GetValue(null, null, null));
+        }
 
-            // Passing a string which does NOT start with one of the valid base key names, that should throw ArgumentException.
-            Assert.Throws<ArgumentException>(() => Registry.GetValue("HHHH_MMMM", null, null));
+        public static readonly object[][] ArgumentExceptionTestData =
+        {
+            new object[] { string.Empty }, // Not a valid base key name.
+            new object[] { "HHHH_MMMM" }, // Not a valid base key name.
+            new object[] { "HKEY_CURRENT_USER_FOOBAR" }, // Starts with one of the valid base key names but isn't valid.
+            new object[] { new string('a', 10) }, // String of length 10 that isn't HKEY_USERS.
+            new object[] { new string('a', 17) }, // String of length 17 that isn't HKEY_CURRENT_USER or HKEY_CLASSES_ROOT.
+            new object[] { new string('a', 18) }, // String of length 18 that isn't HKEY_LOCAL_MACHINE.
+            new object[] { new string('a', 19) }, // String of length 19 that isn't HKEY_CURRENT_CONFIG.
+            new object[] { new string('a', 21) } // String of length 21 that isn't HKEY_PERFORMANCE_DATA.
+        };
 
-            // Should throw if passed string which only starts with one of the valid base key names but actually it isn't valid.
-            Assert.Throws<ArgumentException>(() => Registry.GetValue("HKEY_CURRENT_USER_FOOBAR", null, null));
+        [Theory]
+        [MemberData(nameof(ArgumentExceptionTestData))]
+        public static void InvalidKeyName_ThrowsArgumentException(string keyName)
+        {
+            Assert.Throws<ArgumentException>(() => Registry.GetValue(keyName, null, null));
         }
 
         [Fact]


### PR DESCRIPTION
Avoid allocations in `Registry.GetBaseKeyFromKeyName` for improved perf.

<details>
<summary>10,000,000 iteration microbenchmark results:</summary>
```c#
using System;
using System.Diagnostics;
using Microsoft.Win32;

class Program
{
    private static void Main()
    {
        TimeAction("HKEY_USERS");
        TimeAction("HKEY_CLASSES_ROOT");
        TimeAction("HKEY_CURRENT_USER");
        TimeAction("HKEY_LOCAL_MACHINE");
        TimeAction("HKEY_CURRENT_CONFIG");
        TimeAction("HKEY_PERFORMANCE_DATA");
    }

    private static void TimeAction(string keyName)
    {
        string subKeyName;

        Console.WriteLine("Looking for: {0}", keyName);
        TimeAction("Old", () => GetBaseKeyFromKeyNameOld(keyName, out subKeyName));
        TimeAction("New", () => GetBaseKeyFromKeyNameNew(keyName, out subKeyName));
        Console.WriteLine();
    }

    private static void TimeAction(string prefix, Action action, int times = 5, int iterations = 10000000)
    {
        var sw = new Stopwatch();
        for (int i = 0; i < times; i++)
        {
            int gen0 = GC.CollectionCount(0);
            sw.Restart();
            for (int iter = 0; iter < iterations; iter++)
            {
                action();
            }
            sw.Stop();
            Console.WriteLine($"{prefix}: Time: {sw.Elapsed.TotalSeconds}\tGC0: {GC.CollectionCount(0) - gen0}");
        }
    }

    private static RegistryKey GetBaseKeyFromKeyNameOld(string keyName, out string subKeyName)
    {
        if (keyName == null)
        {
            throw new ArgumentNullException(nameof(keyName));
        }

        int i = keyName.IndexOf('\\');
        string basekeyName = i != -1 ?
            keyName.Substring(0, i).ToUpperInvariant() :
            keyName.ToUpperInvariant();

        RegistryKey basekey = null;
        switch (basekeyName)
        {
            case "HKEY_CURRENT_USER":
                basekey = CurrentUser;
                break;
            case "HKEY_LOCAL_MACHINE":
                basekey = LocalMachine;
                break;
            case "HKEY_CLASSES_ROOT":
                basekey = ClassesRoot;
                break;
            case "HKEY_USERS":
                basekey = Users;
                break;
            case "HKEY_PERFORMANCE_DATA":
                basekey = PerformanceData;
                break;
            case "HKEY_CURRENT_CONFIG":
                basekey = CurrentConfig;
                break;
            default:
                throw new ArgumentException(SR.Format(SR.Arg_RegInvalidKeyName, nameof(keyName)), nameof(keyName));
        }

        subKeyName = (i == -1 || i == keyName.Length) ?
            string.Empty :
            keyName.Substring(i + 1, keyName.Length - i - 1);

        return basekey;
    }

    private static RegistryKey GetBaseKeyFromKeyNameNew(string keyName, out string subKeyName)
    {
        if (keyName == null)
        {
            throw new ArgumentNullException(nameof(keyName));
        }

        int i = keyName.IndexOf('\\');
        int length = i != -1 ? i : keyName.Length;

        // Determine the potential base key from the length. Note that
        // HKEY_CLASSES_ROOT and HKEY_CURRENT_USER are the same length,
        // so for that case, switch on a char at a position with a
        // unique char to determine the potential base key.
        RegistryKey baseKey = null;
        switch (length)
        {
            case 10:
                baseKey = Users; // HKEY_USERS
                break;

            case 17:
                const int UniqueCharIndex = 6;
                switch (keyName[UniqueCharIndex])
                {
                    case 'l':
                    case 'L':
                        Debug.Assert(ClassesRoot.Name[UniqueCharIndex] == 'L');
                        baseKey = ClassesRoot; // HKEY_C[L]ASSES_ROOT
                        break;

                    case 'u':
                    case 'U':
                        Debug.Assert(CurrentUser.Name[UniqueCharIndex] == 'U');
                        baseKey = CurrentUser; // HKEY_C[U]RRENT_USER
                        break;
                }
                break;

            case 18:
                baseKey = LocalMachine; // HKEY_LOCAL_MACHINE
                break;

            case 19:
                baseKey = CurrentConfig; // HKEY_CURRENT_CONFIG
                break;

            case 21:
                baseKey = PerformanceData; // HKEY_PERFORMANCE_DATA
                break;
        }

        Debug.Assert(baseKey == null || baseKey.Name.Length == length);

        if (baseKey != null && keyName.StartsWith(baseKey.Name, StringComparison.OrdinalIgnoreCase))
        {
            subKeyName = (i == -1 || i == keyName.Length) ?
                string.Empty :
                keyName.Substring(i + 1, keyName.Length - i - 1);

            return baseKey;
        }

        throw new ArgumentException(SR.Format(SR.Arg_RegInvalidKeyName, nameof(keyName)), nameof(keyName));
    }

    private static readonly RegistryKey CurrentUser = Registry.CurrentUser;
    private static readonly RegistryKey LocalMachine = Registry.LocalMachine;
    private static readonly RegistryKey ClassesRoot = Registry.ClassesRoot;
    private static readonly RegistryKey Users = Registry.Users;
    private static readonly RegistryKey PerformanceData = Registry.PerformanceData;
    private static readonly RegistryKey CurrentConfig = Registry.CurrentConfig;

    private static class SR
    {
        public static readonly string Arg_RegInvalidKeyName = "";
        public static string Format(string format, params object[] args) => "";
    }
}
```
</details>

```
Looking for: HKEY_USERS
Old: Time: 0.8788987    GC0: 114
Old: Time: 0.8631488    GC0: 114
Old: Time: 0.8632139    GC0: 115
Old: Time: 0.8610054    GC0: 114
Old: Time: 0.8777991    GC0: 115
New: Time: 0.1460478    GC0: 0
New: Time: 0.1435679    GC0: 0
New: Time: 0.1483825    GC0: 0
New: Time: 0.1460772    GC0: 0
New: Time: 0.1466389    GC0: 0

Looking for: HKEY_CLASSES_ROOT
Old: Time: 1.0584964    GC0: 152
Old: Time: 1.0440053    GC0: 153
Old: Time: 1.0485327    GC0: 152
Old: Time: 1.0397064    GC0: 153
Old: Time: 1.0480944    GC0: 153
New: Time: 0.1783978    GC0: 0
New: Time: 0.1783887    GC0: 0
New: Time: 0.1766059    GC0: 0
New: Time: 0.1766773    GC0: 0
New: Time: 0.1754843    GC0: 0

Looking for: HKEY_CURRENT_USER
Old: Time: 1.0171277    GC0: 152
Old: Time: 1.0149935    GC0: 153
Old: Time: 0.9913258    GC0: 152
Old: Time: 0.9867099    GC0: 153
Old: Time: 0.9848178    GC0: 153
New: Time: 0.1799622    GC0: 0
New: Time: 0.1788742    GC0: 0
New: Time: 0.1795678    GC0: 0
New: Time: 0.1801555    GC0: 0
New: Time: 0.1844545    GC0: 0

Looking for: HKEY_LOCAL_MACHINE
Old: Time: 1.012618     GC0: 152
Old: Time: 1.010238     GC0: 153
Old: Time: 1.0330128    GC0: 152
Old: Time: 1.0363928    GC0: 153
Old: Time: 0.9934053    GC0: 153
New: Time: 0.1783099    GC0: 0
New: Time: 0.176293     GC0: 0
New: Time: 0.178086     GC0: 0
New: Time: 0.1771917    GC0: 0
New: Time: 0.176571     GC0: 0

Looking for: HKEY_CURRENT_CONFIG
Old: Time: 1.0658348    GC0: 152
Old: Time: 1.0611163    GC0: 153
Old: Time: 1.0657168    GC0: 152
Old: Time: 1.0883544    GC0: 153
Old: Time: 1.0980891    GC0: 152
New: Time: 0.1878427    GC0: 0
New: Time: 0.1887987    GC0: 0
New: Time: 0.1885428    GC0: 0
New: Time: 0.1877254    GC0: 0
New: Time: 0.1892498    GC0: 0

Looking for: HKEY_PERFORMANCE_DATA
Old: Time: 1.1319487    GC0: 172
Old: Time: 1.128515     GC0: 172
Old: Time: 1.1219242    GC0: 171
Old: Time: 1.1288843    GC0: 172
Old: Time: 1.1625333    GC0: 172
New: Time: 0.2075691    GC0: 0
New: Time: 0.2024885    GC0: 0
New: Time: 0.1991121    GC0: 0
New: Time: 0.1958105    GC0: 0
New: Time: 0.1894965    GC0: 0
```

cc: @stephentoub