### PR TITLE
Reduce rotations done in Sorted Set's IntersectWithEnumerable.

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -2199,13 +2199,13 @@ namespace System.Collections.Generic
                 return ret;
             }
 
+#if DEBUG
             internal override void IntersectWithEnumerable(IEnumerable<T> other)
             {
                 base.IntersectWithEnumerable(other);
-#if DEBUG
-                Debug.Assert(this.versionUpToDate() && _root == _underlying.FindRange(_min, _max));
-#endif
+                Debug.Assert(versionUpToDate() && _root == _underlying.FindRange(_min, _max));
             }
+#endif
 
             void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
             {

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -1347,7 +1347,7 @@ namespace System.Collections.Generic
                 }
             }
 
-            if (toSave.Count < this.Count)
+            if (toSave.Count < Count)
             {
                 Clear();
                 AddAllElements(toSave);
@@ -2201,21 +2201,7 @@ namespace System.Collections.Generic
 
             internal override void IntersectWithEnumerable(IEnumerable<T> other)
             {
-                List<T> toSave = new List<T>(this.Count);
-                foreach (T item in other)
-                {
-                    if (Contains(item))
-                    {
-                        toSave.Add(item);
-                    }
-                }
-
-                if (toSave.Count < Count)
-                {
-                    Clear();
-                    AddAllElements(toSave);
-                }
-
+                base.IntersectWithEnumerable(other);
 #if DEBUG
                 Debug.Assert(this.versionUpToDate() && _root == _underlying.FindRange(_min, _max));
 #endif

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -1344,11 +1344,14 @@ namespace System.Collections.Generic
                 if (Contains(item))
                 {
                     toSave.Add(item);
-                    Remove(item);
                 }
             }
-            Clear();
-            AddAllElements(toSave);
+
+            if (toSave.Count < this.Count)
+            {
+                Clear();
+                AddAllElements(toSave);
+            }
         }
 
         /// <summary>
@@ -2204,11 +2207,15 @@ namespace System.Collections.Generic
                     if (Contains(item))
                     {
                         toSave.Add(item);
-                        Remove(item);
                     }
                 }
-                Clear();
-                AddAllElements(toSave);
+
+                if (toSave.Count < Count)
+                {
+                    Clear();
+                    AddAllElements(toSave);
+                }
+
 #if DEBUG
                 Debug.Assert(this.versionUpToDate() && _root == _underlying.FindRange(_min, _max));
 #endif


### PR DESCRIPTION
Fixes issue [#6414](https://github.com/dotnet/corefx/issues/6414) with the fix described by @SunnyWar , reducing the rotations done in SortedSet's IntersectWithEnumerable.