### PR TITLE
Fixed JsonDataContract.GetGeneratedReadWriteDelegates.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
@@ -85,7 +85,7 @@ namespace System.Runtime.Serialization.Json
 #if NET_NATIVE
                             else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                             {
-                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalClassDataContract).ClassWriterDelegate;
+                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalClassDataContract)?.ClassWriterDelegate;
                                 tempDelegate = tempDelegate ?? new ReflectionJsonFormatWriter().ReflectionWriteClass;
 
                                 if (tempDelegate == null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonDataContract.cs
@@ -63,8 +63,10 @@ namespace System.Runtime.Serialization.Json
 #if NET_NATIVE
             // The c passed in could be a clone which is different from the original key,
             // We'll need to get the original key data contract from generated assembly.
-            DataContract keyDc = DataContract.GetDataContractFromGeneratedAssembly(c.UnderlyingType);
-            return JsonReadWriteDelegates.GetJsonDelegates().TryGetValue(keyDc, out result) ? result : null;
+            DataContract keyDc = (c != null && c.UnderlyingType != null) ?
+                DataContract.GetDataContractFromGeneratedAssembly(c.UnderlyingType)
+                : null;
+            return (keyDc != null && JsonReadWriteDelegates.GetJsonDelegates().TryGetValue(keyDc, out result)) ? result : null;
 #else
             return JsonReadWriteDelegates.GetJsonDelegates().TryGetValue(c, out result) ? result : null;
 #endif


### PR DESCRIPTION
Fixed the issue that JsonDataContract.GetGeneratedReadWriteDelegates may throw ArgumentNullException in NetNative.

Fix #12176