### PR TITLE
Updating the 'System.Runtime.Extensions' contracts to include the new single-precision Math APIs.

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -1251,6 +1251,7 @@
     "Description": "Provides commonly-used classes for performing mathematical functions, conversions, string comparisons and querying environment information.",
     "CommonTypes": [
       "System.Math",
+      "System.MathF",
       "System.Environment",
       "System.Random",
       "System.Progress<T>",

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.Manual.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.Manual.cs
@@ -14,4 +14,11 @@ namespace System
         public const double PI = 3.14159265358979323846;
         public const double E = 2.7182818284590452354;
     }
+#if netcoreapp11
+    public static partial class MathF
+    {
+        public const float PI = 3.14159265f;
+        public const float E = 2.71828183f;
+    }
+#endif
 }

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -120,7 +120,13 @@ namespace System
         public static byte[] GetBytes(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static byte[] GetBytes(ulong value) { throw null; }
+#if netcoreapp11
+        public static float Int32BitsToSingle(int value) { throw null; }
+#endif
         public static double Int64BitsToDouble(long value) { throw null; }
+#if netcoreapp11
+        public static int SingleToInt32Bits(float value) { throw null; }
+#endif
         public static bool ToBoolean(byte[] value, int startIndex) { throw null; }
         public static char ToChar(byte[] value, int startIndex) { throw null; }
         public static double ToDouble(byte[] value, int startIndex) { throw null; }
@@ -776,6 +782,39 @@ namespace System
         public static decimal Truncate(decimal d) { throw null; }
         public static double Truncate(double d) { throw null; }
     }
+#if netcoreapp11
+    public static partial class MathF
+    {
+        public static float Abs(float x) { throw null; }
+        public static float Acos(float x) { throw null; }
+        public static float Asin(float x) { throw null; }
+        public static float Atan(float x) { throw null; }
+        public static float Atan2(float y, float x) { throw null; }
+        public static float Ceiling(float x) { throw null; }
+        public static float Cos(float x) { throw null; }
+        public static float Cosh(float x) { throw null; }
+        public static float Exp(float x) { throw null; }
+        public static float Floor(float x) { throw null; }
+        public static float IEEERemainder(float x, float y) { throw null; }
+        public static float Log(float x) { throw null; }
+        public static float Log(float x, float y) { throw null; }
+        public static float Log10(float x) { throw null; }        
+        public static float Max(float x, float y) { throw null; }
+        public static float Min(float x, float y) { throw null; }
+        public static float Pow(float x, float y) { throw null; }
+        public static float Round(float x) { throw null; }
+        public static float Round(float x, int digits) { throw null; }
+        public static float Round(float x, int digits, System.MidpointRounding mode) { throw null; }
+        public static float Round(float x, System.MidpointRounding mode) { throw null; }
+        public static int Sign(float x) { return default(int); }
+        public static float Sin(float x) { throw null; }
+        public static float Sinh(float x) { throw null; }
+        public static float Sqrt(float x) { throw null; }
+        public static float Tan(float x) { throw null; }
+        public static float Tanh(float x) { throw null; }
+        public static float Truncate(float x) { throw null; }
+    }
+#endif
     public sealed class OperatingSystem : System.ICloneable, System.Runtime.Serialization.ISerializable
     {
         private OperatingSystem() { }

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -44,6 +44,7 @@
     <Compile Include="System\Environment.SpecialFolder.cs" />
     <Compile Include="System\Environment.SpecialFolderOption.cs" />
     <Compile Include="System\EnvironmentVariableTarget.cs" />
+    <Compile Include="System\MathF.cs" /> <!-- https://github.com/dotnet/buildtools/issues/1041 -->
     <Compile Include="System\OperatingSystem.cs" />
     <Compile Include="System\PlatformID.cs" />
     <Compile Include="System\IO\Path.cs" />

--- a/src/System.Runtime.Extensions/src/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/src/System/BitConverter.cs
@@ -453,6 +453,18 @@ namespace System
             return *((double*)&value);
         }
 
+        [SecuritySafeCritical]
+        public static unsafe int SingleToInt32Bits(float value)
+        {
+            return *((int*)&value);
+        }
+
+        [SecuritySafeCritical]
+        public static unsafe float Int32BitsToSingle(int value)
+        {
+            return *((float*)&value);
+        }
+
         private static void ThrowValueArgumentNull()
         {
             throw new ArgumentNullException("value");

--- a/src/System.Runtime.Extensions/src/System/MathF.cs
+++ b/src/System.Runtime.Extensions/src/System/MathF.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// We normally shouldn't have to manually specify the
+// TypeForwardedToAttribute. The following bug is tracking
+// this: https://github.com/dotnet/buildtools/issues/1041
+[assembly: TypeForwardedTo(typeof(MathF))]

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="System\BitConverter.netcoreapp1.1.cs" />
     <Compile Include="System\IO\Path.GetRelativePath.cs" />
     <Compile Include="System\MathTests.netcoreapp1.1.cs" />
+    <Compile Include="System\MathF.netcoreapp1.1.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="System\Diagnostics\Stopwatch.cs" />

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -47,6 +47,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp1.1'">
+    <Compile Include="System\BitConverter.netcoreapp1.1.cs" />
     <Compile Include="System\IO\Path.GetRelativePath.cs" />
     <Compile Include="System\MathTests.netcoreapp1.1.cs" />
   </ItemGroup>

--- a/src/System.Runtime.Extensions/tests/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverter.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Tests
 {
-    public static class BitConverterTests
+    public static partial class BitConverterTests
     {
         [Fact]
         public static unsafe void IsLittleEndian()

--- a/src/System.Runtime.Extensions/tests/System/BitConverter.netcoreapp1.1.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverter.netcoreapp1.1.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Tests
+{
+    public static partial class BitConverterTests
+    {
+        [Fact]
+        public static void SingleToInt32Bits()
+        {
+            Single input = 12345.63f;
+            Int32 result = BitConverter.SingleToInt32Bits(input);
+            Assert.Equal(1178658437, result);
+            Single roundtripped = BitConverter.Int32BitsToSingle(result);
+            Assert.Equal(input, roundtripped);
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp1.1.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp1.1.cs
@@ -42,7 +42,7 @@ namespace System.Tests
 
             if (delta > allowedVariance)
             {
-                throw new EqualException($"{expected}", $"{actual}");
+                throw new EqualException($"{expected,10:G9}", $"{actual,10:G9}");
             }
         }
 
@@ -93,9 +93,9 @@ namespace System.Tests
         [Fact]
         public static void Atan2()
         {
-            Assert.Equal(-MathF.PI, MathF.Atan2(-0.0f, -0.0f));
+            AssertEqual(-MathF.PI, MathF.Atan2(-0.0f, -0.0f), CrossPlatformMachineEpsilon * 10);
             Assert.Equal(-0.0f, MathF.Atan2(-0.0f, 0.0f));
-            Assert.Equal(MathF.PI, MathF.Atan2(0.0f, -0.0f));
+            AssertEqual(MathF.PI, MathF.Atan2(0.0f, -0.0f), CrossPlatformMachineEpsilon * 10);
             Assert.Equal(0.0f, MathF.Atan2(0.0f, 0.0f));
             AssertEqual(MathF.PI / 2.0f, MathF.Atan2(1.0f, 0.0f), CrossPlatformMachineEpsilon * 10);
             AssertEqual(0.588002604f, MathF.Atan2(2.0f, 3.0f), CrossPlatformMachineEpsilon);

--- a/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp1.1.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp1.1.cs
@@ -1,0 +1,379 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using Xunit;
+using Xunit.Sdk;
+
+namespace System.Tests
+{
+    public static partial class MathFTests
+    {
+       // binary32 (float) has a machine epsilon of 2^-23 (approx. 1.19e-07). However, this is
+       // slightly too accurate when writing tests meant to run against math library implementations
+       // for various platforms. 2^-21 (approx. 4.76e-07) seems to be as accurate as we can get for
+       // our current set of platforms.
+       //
+       // The tests themselves will take `CrossPlatformMachineEpsilon` and adjust it according to the
+       // expected result so that the delta used for comparison will compare the most significant digits
+       // and ignore any digits that are outside the single precision range (6-9 digits).
+       //
+       // For example, a test with an expect result in the format of 0.xxxxxxxxx will use CrossPlatformMachineEpsilon
+       // for the variance, while an expected result in the format of 0.0xxxxxxxxx will use
+       // CrossPlatformMachineEpsilon / 10 and and expected result in the format of x.xxxxxx will
+       // use CrossPlatformMachineEpsilon * 10.
+        public const float CrossPlatformMachineEpsilon = 4.76837158e-07f;
+
+        /// <summary>
+        /// Verifies that two <see cref="float"/> values are equal, within the <paramref name="allowedVariance"/>.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The value to be compared against</param>
+        /// <param name="allowedVariance">The total variance allowed between the expected and actual results.</param>
+        /// <exception cref="EqualException">Thrown when the values are not equal</exception>
+        public static void AssertEqual(float expected, float actual, float allowedVariance)
+        {
+            // This is essentially equivalent to the Xunit.Assert.Equal(double, double, int) implementation
+            // available here: https://github.com/xunit/xunit/blob/2.1/src/xunit.assert/Asserts/EqualityAsserts.cs#L46
+
+            var delta = MathF.Abs(actual - expected);
+
+            if (delta > allowedVariance)
+            {
+                throw new EqualException($"{expected}", $"{actual}");
+            }
+        }
+
+        [Fact]
+        public static void Abs()
+        {
+            Assert.Equal(MathF.PI, MathF.Abs(MathF.PI));
+            Assert.Equal(0.0f, MathF.Abs(0.0f));
+            Assert.Equal(MathF.PI, MathF.Abs(-MathF.PI));
+            Assert.Equal(float.NaN, MathF.Abs(float.NaN));
+            Assert.Equal(float.PositiveInfinity, MathF.Abs(float.PositiveInfinity));
+            Assert.Equal(float.PositiveInfinity, MathF.Abs(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Acos()
+        {
+            Assert.Equal(0.0f, MathF.Acos(1.0f));
+            AssertEqual(MathF.PI / 2.0f, MathF.Acos(0.0f), CrossPlatformMachineEpsilon * 10);
+            AssertEqual(MathF.PI, MathF.Acos(-1.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(float.NaN, MathF.Acos(float.NaN));
+            Assert.Equal(float.NaN, MathF.Acos(float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Acos(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Asin()
+        {
+            AssertEqual(MathF.PI / 2.0f, MathF.Asin(1.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(0.0f, MathF.Asin(0.0f));
+            AssertEqual(-MathF.PI / 2.0f, MathF.Asin(-1.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(float.NaN, MathF.Asin(float.NaN));
+            Assert.Equal(float.NaN, MathF.Asin(float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Asin(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Atan()
+        {
+            AssertEqual(MathF.PI / 4.0f, MathF.Atan(1.0f), CrossPlatformMachineEpsilon);
+            Assert.Equal(0.0f, MathF.Atan(0.0f));
+            AssertEqual(-MathF.PI / 4.0f, MathF.Atan(-1.0f), CrossPlatformMachineEpsilon);
+            Assert.Equal(float.NaN, MathF.Atan(float.NaN));
+            AssertEqual(MathF.PI / 2.0f, MathF.Atan(float.PositiveInfinity), CrossPlatformMachineEpsilon * 10);
+            AssertEqual(-MathF.PI / 2.0f, MathF.Atan(float.NegativeInfinity), CrossPlatformMachineEpsilon * 10);
+        }
+
+        [Fact]
+        public static void Atan2()
+        {
+            Assert.Equal(-MathF.PI, MathF.Atan2(-0.0f, -0.0f));
+            Assert.Equal(-0.0f, MathF.Atan2(-0.0f, 0.0f));
+            Assert.Equal(MathF.PI, MathF.Atan2(0.0f, -0.0f));
+            Assert.Equal(0.0f, MathF.Atan2(0.0f, 0.0f));
+            AssertEqual(MathF.PI / 2.0f, MathF.Atan2(1.0f, 0.0f), CrossPlatformMachineEpsilon * 10);
+            AssertEqual(0.588002604f, MathF.Atan2(2.0f, 3.0f), CrossPlatformMachineEpsilon);
+            Assert.Equal(0.0f, MathF.Atan2(0.0f, 3.0f));
+            AssertEqual(-0.588002604f, MathF.Atan2(-2.0f, 3.0f), CrossPlatformMachineEpsilon);
+            Assert.Equal(float.NaN, MathF.Atan2(float.NaN, 1.0f));
+            Assert.Equal(float.NaN, MathF.Atan2(1.0f, float.NaN));
+            AssertEqual(MathF.PI / 2.0f, MathF.Atan2(float.PositiveInfinity, 1.0f), CrossPlatformMachineEpsilon * 10);
+            AssertEqual(-MathF.PI / 2.0f, MathF.Atan2(float.NegativeInfinity, 1.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(0.0f, MathF.Atan2(1.0f, float.PositiveInfinity));
+            AssertEqual(MathF.PI, MathF.Atan2(1.0f, float.NegativeInfinity), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(float.NaN, MathF.Atan2(float.NegativeInfinity, float.NegativeInfinity));
+            Assert.Equal(float.NaN, MathF.Atan2(float.NegativeInfinity, float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Atan2(float.PositiveInfinity, float.NegativeInfinity));
+            Assert.Equal(float.NaN, MathF.Atan2(float.PositiveInfinity, float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void Ceiling()
+        {
+            Assert.Equal(2.0f, MathF.Ceiling(1.1f));
+            Assert.Equal(2.0f, MathF.Ceiling(1.9f));
+            Assert.Equal(-1.0f, MathF.Ceiling(-1.1f));
+            Assert.Equal(float.NaN, MathF.Ceiling(float.NaN));
+            Assert.Equal(float.PositiveInfinity, MathF.Ceiling(float.PositiveInfinity));
+            Assert.Equal(float.NegativeInfinity, MathF.Ceiling(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Cos()
+        {
+            AssertEqual(0.540302306f, MathF.Cos(1.0f), CrossPlatformMachineEpsilon);
+            Assert.Equal(1.0f, MathF.Cos(0.0f));
+            AssertEqual(0.540302306f, MathF.Cos(-1.0f), CrossPlatformMachineEpsilon);
+            Assert.Equal(float.NaN, MathF.Cos(float.NaN));
+            Assert.Equal(float.NaN, MathF.Cos(float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Cos(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Cosh()
+        {
+            AssertEqual(1.54308063f, MathF.Cosh(1.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(1.0f, MathF.Cosh(0.0f));
+            AssertEqual(1.54308063f, MathF.Cosh(-1.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(float.NaN, MathF.Cosh(float.NaN));
+            Assert.Equal(float.PositiveInfinity, MathF.Cosh(float.PositiveInfinity));
+            Assert.Equal(float.PositiveInfinity, MathF.Cosh(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Exp()
+        {
+            AssertEqual(20.0855369f, MathF.Exp(3.0f), CrossPlatformMachineEpsilon * 100);
+            Assert.Equal(1.0f, MathF.Exp(0.0f));
+            Assert.Equal(MathF.E, MathF.Exp(1.0f));
+            AssertEqual(0.0497870684f, MathF.Exp(-3.0f), CrossPlatformMachineEpsilon / 10);
+            Assert.Equal(float.NaN, MathF.Exp(float.NaN));
+            Assert.Equal(float.PositiveInfinity, MathF.Exp(float.PositiveInfinity));
+            Assert.Equal(0.0f, MathF.Exp(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Floor()
+        {
+            Assert.Equal(1.0f, MathF.Floor(1.1f));
+            Assert.Equal(1.0f, MathF.Floor(1.9f));
+            Assert.Equal(-2.0f, MathF.Floor(-1.1f));
+            Assert.Equal(float.NaN, MathF.Floor(float.NaN));
+            Assert.Equal(float.PositiveInfinity, MathF.Floor(float.PositiveInfinity));
+            Assert.Equal(float.NegativeInfinity, MathF.Floor(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void IEEERemainder()
+        {
+            Assert.Equal(-1.0f, MathF.IEEERemainder(3.0f, 2.0f));
+            Assert.Equal(0.0f, MathF.IEEERemainder(4.0f, 2.0f));
+            Assert.Equal(1.0f, MathF.IEEERemainder(10.0f, 3.0f));
+            Assert.Equal(-1.0f, MathF.IEEERemainder(11.0f, 3.0f));
+            Assert.Equal(-2.0f, MathF.IEEERemainder(28.0f, 5.0f));
+            AssertEqual(1.8f, MathF.IEEERemainder(17.8f, 4.0f), CrossPlatformMachineEpsilon * 10);
+            AssertEqual(1.4f, MathF.IEEERemainder(17.8f, 4.1f), CrossPlatformMachineEpsilon * 10);
+            AssertEqual(0.1000004f, MathF.IEEERemainder(-16.3f, 4.1f), CrossPlatformMachineEpsilon / 10);
+            AssertEqual(1.4f, MathF.IEEERemainder(17.8f, -4.1f), CrossPlatformMachineEpsilon * 10);
+            AssertEqual(-1.4f, MathF.IEEERemainder(-17.8f, -4.1f), CrossPlatformMachineEpsilon * 10);
+        }
+
+        [Fact]
+        public static void Log()
+        {
+            AssertEqual(1.09861229f, MathF.Log(3.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(float.NegativeInfinity, MathF.Log(0.0f));
+            Assert.Equal(float.NaN, MathF.Log(-3.0f));
+            Assert.Equal(float.NaN, MathF.Log(float.NaN));
+            Assert.Equal(float.PositiveInfinity, MathF.Log(float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Log(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void LogWithBase()
+        {
+            Assert.Equal(1.0f, MathF.Log(3.0f, 3.0f));
+            AssertEqual(2.40217350f, MathF.Log(14.0f, 3.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(float.NegativeInfinity, MathF.Log(0.0f, 3.0f));
+            Assert.Equal(float.NaN, MathF.Log(-3.0f, 3.0f));
+            Assert.Equal(float.NaN, MathF.Log(float.NaN, 3.0f));
+            Assert.Equal(float.PositiveInfinity, MathF.Log(float.PositiveInfinity, 3.0f));
+            Assert.Equal(float.NaN, MathF.Log(float.NegativeInfinity, 3.0f));
+        }
+
+        [Fact]
+        public static void Log10()
+        {
+            AssertEqual(0.477121255f, MathF.Log10(3.0f), CrossPlatformMachineEpsilon);
+            Assert.Equal(float.NegativeInfinity, MathF.Log10(0.0f));
+            Assert.Equal(float.NaN, MathF.Log10(-3.0f));
+            Assert.Equal(float.NaN, MathF.Log10(float.NaN));
+            Assert.Equal(float.PositiveInfinity, MathF.Log10(float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Log10(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Max()
+        {
+            Assert.Equal(3.0f, MathF.Max(3.0f, -2.0f));
+            Assert.Equal(float.MaxValue, MathF.Max(float.MinValue, float.MaxValue));
+            Assert.Equal(float.PositiveInfinity, MathF.Max(float.NegativeInfinity, float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Max(float.PositiveInfinity, float.NaN));
+            Assert.Equal(float.NaN, MathF.Max(float.NaN, float.NaN));
+        }
+
+        [Fact]
+        public static void Min()
+        {
+            Assert.Equal(-2.0f, MathF.Min(3.0f, -2.0f));
+            Assert.Equal(float.MinValue, MathF.Min(float.MinValue, float.MaxValue));
+            Assert.Equal(float.NegativeInfinity, MathF.Min(float.NegativeInfinity, float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Min(float.NegativeInfinity, float.NaN));
+            Assert.Equal(float.NaN, MathF.Min(float.NaN, float.NaN));
+        }
+
+        [Fact]
+        public static void Pow()
+        {
+            Assert.Equal(1.0f, MathF.Pow(0.0f, 0.0f));
+            Assert.Equal(1.0f, MathF.Pow(1.0f, 0.0f));
+            Assert.Equal(8.0f, MathF.Pow(2.0f, 3.0f));
+            Assert.Equal(0.0f, MathF.Pow(0.0f, 3.0f));
+            Assert.Equal(-8.0f, MathF.Pow(-2.0f, 3.0f));
+            Assert.Equal(float.NaN, MathF.Pow(float.NaN, 1.0f));
+            Assert.Equal(float.NaN, MathF.Pow(1.0f, float.NaN));
+            Assert.Equal(float.PositiveInfinity, MathF.Pow(float.PositiveInfinity, 1.0f));
+            Assert.Equal(float.NegativeInfinity, MathF.Pow(float.NegativeInfinity, 1.0f));
+            Assert.Equal(1.0f, MathF.Pow(1.0f, float.PositiveInfinity));
+            Assert.Equal(1.0f, MathF.Pow(1.0f, float.NegativeInfinity));
+            Assert.Equal(0.0f, MathF.Pow(0.0f, float.PositiveInfinity));
+            Assert.Equal(float.PositiveInfinity, MathF.Pow(0.0f, -1.0f));
+            Assert.Equal(float.PositiveInfinity, MathF.Pow(0.0f, float.NegativeInfinity));
+            Assert.Equal(float.NaN, MathF.Pow(-1.0f, float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Pow(-1.0f, float.NegativeInfinity));
+            Assert.Equal(float.PositiveInfinity, MathF.Pow(1.1f, float.PositiveInfinity));
+            Assert.Equal(0.0f, MathF.Pow(1.1f, float.NegativeInfinity));
+            Assert.Equal(float.PositiveInfinity, MathF.Pow(-1.1f, float.PositiveInfinity));
+            Assert.Equal(0.0f, MathF.Pow(-1.1f, float.NegativeInfinity));
+            Assert.Equal(0.0f, MathF.Pow(1.1f, float.NegativeInfinity));
+            Assert.Equal(float.NaN, MathF.Pow(float.NaN, 0.0f));
+            Assert.Equal(1.0f, MathF.Pow(0.0f, -0.0f));
+            Assert.Equal(0.0f, MathF.Pow(0.0f, 1.0f));
+            Assert.Equal(float.PositiveInfinity, MathF.Pow(-0.0f, float.NegativeInfinity));
+            Assert.Equal(float.NegativeInfinity, MathF.Pow(-0.0f, -1.0f));
+            Assert.Equal(1.0f, MathF.Pow(-0.0f, -0.0f));
+            Assert.Equal(1.0f, MathF.Pow(-0.0f, 0.0f));
+            Assert.Equal(-0.0f, MathF.Pow(-0.0f, 1.0f));
+            Assert.Equal(0.0f, MathF.Pow(-0.0f, float.PositiveInfinity));
+            Assert.Equal(0.0f, MathF.Pow(float.NegativeInfinity, float.NegativeInfinity));
+            Assert.Equal(float.PositiveInfinity, MathF.Pow(float.NegativeInfinity, float.PositiveInfinity));
+            Assert.Equal(0.0f, MathF.Pow(float.PositiveInfinity, float.NegativeInfinity));
+            Assert.Equal(float.PositiveInfinity, MathF.Pow(float.PositiveInfinity, float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void Round()
+        {
+            Assert.Equal(0.0f, MathF.Round(0.0f));
+            Assert.Equal(1.0f, MathF.Round(1.4f));
+            Assert.Equal(2.0f, MathF.Round(1.5f));
+            Assert.Equal(2e7f, MathF.Round(2e7f));
+            Assert.Equal(0.0f, MathF.Round(-0.0f));
+            Assert.Equal(-1.0f, MathF.Round(-1.4f));
+            Assert.Equal(-2.0f, MathF.Round(-1.5f));
+            Assert.Equal(-2e7f, MathF.Round(-2e7f));
+        }
+
+        [Fact]
+        public static void Round_Digits()
+        {
+            AssertEqual(3.422f, MathF.Round(3.42156f, 3, MidpointRounding.AwayFromZero), CrossPlatformMachineEpsilon * 10);
+            AssertEqual(-3.422f, MathF.Round(-3.42156f, 3, MidpointRounding.AwayFromZero), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(0.0f, MathF.Round(0.0f, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(float.NaN, MathF.Round(float.NaN, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(float.PositiveInfinity, MathF.Round(float.PositiveInfinity, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(float.NegativeInfinity, MathF.Round(float.NegativeInfinity, 3, MidpointRounding.AwayFromZero));
+        }
+
+        [Fact]
+        public static void Sign()
+        {
+            Assert.Equal(0, MathF.Sign(0.0f));
+            Assert.Equal(0, MathF.Sign(-0.0f));
+            Assert.Equal(-1, MathF.Sign(-3.14f));
+            Assert.Equal(1, MathF.Sign(3.14f));
+            Assert.Equal(-1, MathF.Sign(float.NegativeInfinity));
+            Assert.Equal(1, MathF.Sign(float.PositiveInfinity));
+            Assert.Throws<ArithmeticException>(() => MathF.Sign(float.NaN));
+        }
+
+        [Fact]
+        public static void Sin()
+        {
+            AssertEqual(0.841470985f, MathF.Sin(1.0f), CrossPlatformMachineEpsilon);
+            Assert.Equal(0.0f, MathF.Sin(0.0f));
+            AssertEqual(-0.841470985f, MathF.Sin(-1.0f), CrossPlatformMachineEpsilon);
+            Assert.Equal(float.NaN, MathF.Sin(float.NaN));
+            Assert.Equal(float.NaN, MathF.Sin(float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Sin(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Sinh()
+        {
+            AssertEqual(1.17520119f, MathF.Sinh(1.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(0.0f, MathF.Sinh(0.0f));
+            AssertEqual(-1.17520119f, MathF.Sinh(-1.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(float.NaN, MathF.Sinh(float.NaN));
+            Assert.Equal(float.PositiveInfinity, MathF.Sinh(float.PositiveInfinity));
+            Assert.Equal(float.NegativeInfinity, MathF.Sinh(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Sqrt()
+        {
+            AssertEqual(1.73205081f, MathF.Sqrt(3.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(0.0f, MathF.Sqrt(0.0f));
+            Assert.Equal(float.NaN, MathF.Sqrt(-3.0f));
+            Assert.Equal(float.NaN, MathF.Sqrt(float.NaN));
+            Assert.Equal(float.PositiveInfinity, MathF.Sqrt(float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Sqrt(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Tan()
+        {
+            AssertEqual(1.55740772f, MathF.Tan(1.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(0.0f, MathF.Tan(0.0f));
+            AssertEqual(-1.55740772f, MathF.Tan(-1.0f), CrossPlatformMachineEpsilon * 10);
+            Assert.Equal(float.NaN, MathF.Tan(float.NaN));
+            Assert.Equal(float.NaN, MathF.Tan(float.PositiveInfinity));
+            Assert.Equal(float.NaN, MathF.Tan(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Tanh()
+        {
+            AssertEqual(0.761594156f, MathF.Tanh(1.0f), CrossPlatformMachineEpsilon);
+            Assert.Equal(0.0f, MathF.Tanh(0.0f));
+            AssertEqual(-0.761594156f, MathF.Tanh(-1.0f), CrossPlatformMachineEpsilon);
+            Assert.Equal(float.NaN, MathF.Tanh(float.NaN));
+            Assert.Equal(1.0f, MathF.Tanh(float.PositiveInfinity));
+            Assert.Equal(-1.0f, MathF.Tanh(float.NegativeInfinity));
+        }
+
+        [Fact]
+        public static void Truncate()
+        {
+            Assert.Equal(0.0f, MathF.Truncate(0.12345f));
+            Assert.Equal(3.0f, MathF.Truncate(3.14159f));
+            Assert.Equal(-3.0f, MathF.Truncate(-3.14159f));
+        }
+    }
+}


### PR DESCRIPTION
This updates the `System.Runtime.Extensions` contracts to include the new single-precision Math APIs approved in #1151 and implemented in CoreCLR in dotnet/coreclr#5492.