### PR TITLE
Add basic ServicePointManager implementation

### DIFF
--- a/src/System.Net.Requests/src/Resources/Strings.resx
+++ b/src/System.Net.Requests/src/Resources/Strings.resx
@@ -183,4 +183,7 @@
   <data name="net_webstatus_Timeout" xml:space="preserve">
     <value>The operation has timed out.</value>
   </data>
+  <data name="net_proxyschemenotsupported" xml:space="preserve">
+    <value>The ServicePointManager does not support proxies with the {0} scheme.</value>
+  </data>
 </root>

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
+using System.Net.Security;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -394,6 +395,15 @@ namespace System.Net
                 else
                 {
                     handler.Proxy = _proxy;
+                }
+
+                // Set relevant properties from ServicePointManager
+                handler.CheckCertificateRevocationList = ServicePointManager.CheckCertificateRevocationList;
+                RemoteCertificateValidationCallback rcvc = ServicePointManager.ServerCertificateValidationCallback; // TODO #11881: When HttpWebRequest.ServerCertificateValidationCallback added, check that first
+                if (rcvc != null)
+                {
+                    RemoteCertificateValidationCallback localRcvc = rcvc;
+                    handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => localRcvc(this, cert, chain, errors);
                 }
 
                 // Copy the HttpWebRequest request headers from the WebHeaderCollection into HttpRequestMessage.Headers and

--- a/src/System.Net.Requests/src/System/Net/ServicePoint.cs
+++ b/src/System.Net.Requests/src/System/Net/ServicePoint.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 
@@ -9,12 +10,17 @@ namespace System.Net
 {
     public class ServicePoint
     {
-        private int _connectionLeaseTimeout;
-        private int _maxIdleTime;
-        private int _receiveBufferSize;
+        private int _connectionLeaseTimeout = -1;
+        private int _maxIdleTime = 100 * 1000;
+        private int _receiveBufferSize = -1;
         private int _connectionLimit;
 
-        internal ServicePoint() { }
+        internal ServicePoint(Uri address)
+        {
+            Debug.Assert(address != null);
+            Address = address;
+            ConnectionName = address.Scheme;
+        }
 
         public BindIPEndPoint BindIPEndPointDelegate { get; set; }
 
@@ -31,7 +37,7 @@ namespace System.Net
             }
         }
 
-        public Uri Address { get; internal set; }
+        public Uri Address { get; }
 
         public int MaxIdleTime
         {
@@ -67,9 +73,9 @@ namespace System.Net
 
         public virtual Version ProtocolVersion { get; internal set; } = new Version(1, 1);
 
-        public string ConnectionName { get; internal set; }
+        public string ConnectionName { get; }
 
-        public bool CloseConnectionGroup(string connectionGroupName) => false;
+        public bool CloseConnectionGroup(string connectionGroupName) => true;
 
         public int ConnectionLimit
         {
@@ -84,13 +90,13 @@ namespace System.Net
             }
         }
 
-        public int CurrentConnections { get; internal set; }
+        public int CurrentConnections => 0;
 
         public X509Certificate Certificate { get; internal set; }
 
         public X509Certificate ClientCertificate { get; internal set; }
 
-        public bool SupportsPipelining { get; internal set; }
+        public bool SupportsPipelining { get; internal set; } = true;
 
         public void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval)
         {

--- a/src/System.Net.Requests/src/System/Net/ServicePointManager.cs
+++ b/src/System.Net.Requests/src/System/Net/ServicePointManager.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -13,11 +15,12 @@ namespace System.Net
         public const int DefaultNonPersistentConnectionLimit = 4;
         public const int DefaultPersistentConnectionLimit = 2;
 
+        private static readonly ConcurrentDictionary<string, WeakReference<ServicePoint>> s_servicePointTable = new ConcurrentDictionary<string, WeakReference<ServicePoint>>();
         private static SecurityProtocolType s_securityProtocolType = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
         private static int s_connectionLimit = 10;
         private static int s_maxServicePoints = 0;
-        private static int s_maxServicePointIdleTime = 100000;
-        private static int s_dnsRefreshTimeout = 120000;
+        private static int s_maxServicePointIdleTime = 100 * 1000;
+        private static int s_dnsRefreshTimeout = 2 * 60 * 1000;
 
         private ServicePointManager() { }
 
@@ -114,7 +117,98 @@ namespace System.Net
 
         public static ServicePoint FindServicePoint(Uri address, IWebProxy proxy)
         {
-            throw new PlatformNotSupportedException();
+            if (address == null)
+            {
+                throw new ArgumentNullException(nameof(address));
+            }
+
+            // If there's a proxy for this address, get the "real" address.
+            bool isProxyServicePoint = ProxyAddressIfNecessary(ref address, proxy);
+
+            // Create a lookup key to find the service point
+            string tableKey = MakeQueryString(address, isProxyServicePoint);
+
+            // Get an existing service point or create a new one
+            ServicePoint sp; // outside of loop to keep references alive from one iteration to the next
+            while (true)
+            {
+                // The table maps lookup key to a weak reference to a service point.  If the table
+                // contains a weak ref for the key and that weak ref points to a valid ServicePoint,
+                // simply return it (after updating its last used time).
+                WeakReference<ServicePoint> wr;
+                if (s_servicePointTable.TryGetValue(tableKey, out wr) && wr.TryGetTarget(out sp))
+                {
+                    sp.IdleSince = DateTime.Now;
+                    return sp;
+                }
+
+                // Any time we don't find what we're looking for in the table, take that as an opportunity
+                // to scavenge the table looking for entries that have lost their service point and removing them.
+                foreach (KeyValuePair<string, WeakReference<ServicePoint>> entry in s_servicePointTable)
+                {
+                    ServicePoint ignored;
+                    if (!entry.Value.TryGetTarget(out ignored))
+                    {
+                        // We use the IDictionary.Remove method rather than TryRemove as it will only
+                        // remove the entry from the table if both the key/value in the pair match.
+                        // This avoids a race condition where another thread concurrently sets a new
+                        // weak reference value for the same key, and is why when adding the new
+                        // service point below, we don't use any weak reference object we may already
+                        // have from the initial retrieval above.
+                        ((IDictionary<string, WeakReference<ServicePoint>>)s_servicePointTable).Remove(entry);
+                    }
+                }
+
+                // There wasn't a service point in the table.  Create a new one, and then store
+                // it back into the table.  We create a new weak reference object even if we were
+                // able to get one above so that when we scavenge the table, we can rely on 
+                // weak reference reference equality to know whether we're removing the same
+                // weak reference we saw when we enumerated.
+                sp = new ServicePoint(address)
+                {
+                    ConnectionLimit = DefaultConnectionLimit,
+                    IdleSince = DateTime.Now,
+                    Expect100Continue = Expect100Continue,
+                    UseNagleAlgorithm = UseNagleAlgorithm
+                };
+                s_servicePointTable[tableKey] = new WeakReference<ServicePoint>(sp);
+
+                // It's possible there's a race between two threads both updating the table
+                // at the same time.  We don't want to just use GetOrAdd, as with the weak
+                // reference we may end up getting back a weak ref that no longer has a target.
+                // So we simply loop around again; in all but the most severe of circumstances, the
+                // next iteration will find it in the table and return it.
+            }
+        }
+
+        private static bool ProxyAddressIfNecessary(ref Uri address, IWebProxy proxy)
+        {
+            if (proxy != null && !address.IsLoopback)
+            {
+                Uri proxyAddress = proxy.GetProxy(address);
+                if (proxyAddress != null)
+                {
+                    if (proxyAddress.Scheme != Uri.UriSchemeHttp)
+                    {
+                        throw new NotSupportedException(SR.Format(SR.net_proxyschemenotsupported, address.Scheme));
+                    }
+
+                    address = proxyAddress;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string MakeQueryString(Uri address) => address.IsDefaultPort ?
+            address.Scheme + "://" + address.DnsSafeHost :
+            address.Scheme + "://" + address.DnsSafeHost + ":" + address.Port.ToString();
+
+        private static string MakeQueryString(Uri address, bool isProxy)
+        {
+            string queryString = MakeQueryString(address);
+            return isProxy ? queryString + "://proxy" : queryString;
         }
 
         public static void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval)

--- a/src/System.Net.Requests/src/project.json
+++ b/src/System.Net.Requests/src/project.json
@@ -4,6 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
         "System.Collections": "4.3.0-beta-24522-03",
+        "System.Collections.Concurrent": "4.3.0-beta-24522-03",
         "System.Collections.Specialized": "4.3.0-beta-24522-03",
         "System.Diagnostics.Debug": "4.3.0-beta-24522-03",
         "System.Diagnostics.Tracing": "4.3.0-beta-24522-03",
@@ -20,8 +21,7 @@
         "System.Runtime.Extensions": "4.3.0-beta-24522-03",
         "System.Security.Principal": "4.3.0-beta-24522-03",
         "System.Security.Cryptography.X509Certificates": "4.3.0-beta-24522-03",
-        "System.Threading": "4.3.0-beta-24522-03",
-        "System.Threading.Tasks": "4.3.0-beta-24522-03"
+        "System.Threading": "4.3.0-beta-24522-03"
       }
     },
     "net463": {

--- a/src/System.Net.Requests/tests/ServicePointManagerTest.cs
+++ b/src/System.Net.Requests/tests/ServicePointManagerTest.cs
@@ -3,9 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using Xunit;
-
-#pragma warning disable CS0618 // obsolete warnings
 
 namespace System.Net.Tests
 {
@@ -20,6 +19,7 @@ namespace System.Net.Tests
         [Fact]
         public static void CertificatePolicy_Roundtrips()
         {
+#pragma warning disable CS0618 // obsolete warnings
             ICertificatePolicy cp = ServicePointManager.CertificatePolicy;
             Assert.NotNull(cp);
 
@@ -31,6 +31,7 @@ namespace System.Net.Tests
 
             ServicePointManager.CertificatePolicy = cp;
             Assert.Same(cp, ServicePointManager.CertificatePolicy);
+#pragma warning restore CS0619
         }
 
         [Fact]
@@ -168,14 +169,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        public static void UnsupportedOperations_Throw()
-        {
-            Assert.Throws<PlatformNotSupportedException>(() => ServicePointManager.FindServicePoint(null));
-            Assert.Throws<PlatformNotSupportedException>(() => ServicePointManager.FindServicePoint("http://localhost", null));
-            Assert.Throws<PlatformNotSupportedException>(() => ServicePointManager.FindServicePoint(new Uri("http://localhost"), null));
-        }
-
-        [Fact]
         public static void InvalidArguments_Throw()
         {
             Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3);
@@ -185,6 +178,164 @@ namespace System.Net.Tests
             Assert.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.MaxServicePointIdleTime = -2);
             Assert.Throws<ArgumentOutOfRangeException>("keepAliveTime", () => ServicePointManager.SetTcpKeepAlive(true, -1, 1));
             Assert.Throws<ArgumentOutOfRangeException>("keepAliveInterval", () => ServicePointManager.SetTcpKeepAlive(true, 1, -1));
+            Assert.Throws<ArgumentNullException>("address", () => ServicePointManager.FindServicePoint(null));
+            Assert.Throws<ArgumentNullException>("uriString", () => ServicePointManager.FindServicePoint((string)null, null));
+            Assert.Throws<ArgumentNullException>("address", () => ServicePointManager.FindServicePoint((Uri)null, null));
+            Assert.Throws<NotSupportedException>(() => ServicePointManager.FindServicePoint("http://anything", new FixedWebProxy("https://anything")));
+
+            ServicePoint sp = ServicePointManager.FindServicePoint("http://" + Guid.NewGuid().ToString("N"), null);
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => sp.ConnectionLeaseTimeout = -2);
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => sp.ConnectionLimit = 0);
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => sp.MaxIdleTime = -2);
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => sp.ReceiveBufferSize = -2);
+            Assert.Throws<ArgumentOutOfRangeException>("keepAliveTime", () => sp.SetTcpKeepAlive(true, -1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("keepAliveInterval", () => sp.SetTcpKeepAlive(true, 1, -1));
+        }
+
+        [Fact]
+        public static void FindServicePoint_ReturnsCachedServicePoint()
+        {
+            const string Localhost = "http://localhost";
+            string address1 = "http://" + Guid.NewGuid().ToString("N");
+            string address2 = "http://" + Guid.NewGuid().ToString("N");
+
+            Assert.NotNull(ServicePointManager.FindServicePoint(new Uri(address1)));
+
+            Assert.Same(
+                ServicePointManager.FindServicePoint(address1, null),
+                ServicePointManager.FindServicePoint(address1, null));
+            Assert.Same(
+                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)),
+                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)));
+            Assert.Same(
+                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)),
+                ServicePointManager.FindServicePoint(address2, new FixedWebProxy(address1)));
+            Assert.Same(
+                ServicePointManager.FindServicePoint(Localhost, new FixedWebProxy(address1)),
+                ServicePointManager.FindServicePoint(Localhost, new FixedWebProxy(address2)));
+
+            Assert.NotSame(
+                ServicePointManager.FindServicePoint(address1, null),
+                ServicePointManager.FindServicePoint(address2, null));
+            Assert.NotSame(
+                ServicePointManager.FindServicePoint(address1, null),
+                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)));
+            Assert.NotSame(
+                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address1)),
+                ServicePointManager.FindServicePoint(address1, new FixedWebProxy(address2)));
+        }
+
+        [Fact]
+        public static void FindServicePoint_Collectible()
+        {
+            string address = "http://" + Guid.NewGuid().ToString("N");
+
+            bool initial = GetExpect100Continue(address);
+            SetExpect100Continue(address, !initial);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.Equal(initial, GetExpect100Continue(address));
+        }
+
+        [Fact]
+        public static void FindServicePoint_ReturnedServicePointMatchesExpectedValues()
+        {
+            string address = "http://" + Guid.NewGuid().ToString("N");
+
+            DateTime start = DateTime.Now;
+            ServicePoint sp = ServicePointManager.FindServicePoint(address, null);
+
+            Assert.InRange(sp.IdleSince, start, DateTime.MaxValue);
+            Assert.Equal(new Uri(address), sp.Address);
+            Assert.Null(sp.BindIPEndPointDelegate);
+            Assert.Null(sp.Certificate);
+            Assert.Null(sp.ClientCertificate);
+            Assert.Equal(-1, sp.ConnectionLeaseTimeout);
+            Assert.Equal("http", sp.ConnectionName);
+            Assert.Equal(0, sp.CurrentConnections);
+            Assert.Equal(true, sp.Expect100Continue);
+            Assert.Equal(100000, sp.MaxIdleTime);
+            Assert.Equal(new Version(1, 1), sp.ProtocolVersion);
+            Assert.Equal(-1, sp.ReceiveBufferSize);
+            Assert.True(sp.SupportsPipelining, "SupportsPipelining");
+            Assert.True(sp.UseNagleAlgorithm, "UseNagleAlgorithm");
+        }
+
+        [Fact]
+        public static void FindServicePoint_PropertiesRoundtrip()
+        {
+            string address = "http://" + Guid.NewGuid().ToString("N");
+
+            BindIPEndPoint expectedBindIPEndPointDelegate = delegate { return null; };
+            int expectedConnectionLeaseTimeout = 42;
+            int expectedConnectionLimit = 84;
+            bool expected100Continue = false;
+            int expectedMaxIdleTime = 200000;
+            int expectedReceiveBufferSize = 123;
+            bool expectedUseNagleAlgorithm = false;
+
+            ServicePoint sp1 = ServicePointManager.FindServicePoint(address, null);
+            sp1.BindIPEndPointDelegate = expectedBindIPEndPointDelegate;
+            sp1.ConnectionLeaseTimeout = expectedConnectionLeaseTimeout;
+            sp1.ConnectionLimit = expectedConnectionLimit;
+            sp1.Expect100Continue = expected100Continue;
+            sp1.MaxIdleTime = expectedMaxIdleTime;
+            sp1.ReceiveBufferSize = expectedReceiveBufferSize;
+            sp1.UseNagleAlgorithm = expectedUseNagleAlgorithm;
+
+            ServicePoint sp2 = ServicePointManager.FindServicePoint(address, null);
+            Assert.Same(expectedBindIPEndPointDelegate, sp2.BindIPEndPointDelegate);
+            Assert.Equal(expectedConnectionLeaseTimeout, sp2.ConnectionLeaseTimeout);
+            Assert.Equal(expectedConnectionLimit, sp2.ConnectionLimit);
+            Assert.Equal(expected100Continue, sp2.Expect100Continue);
+            Assert.Equal(expectedMaxIdleTime, sp2.MaxIdleTime);
+            Assert.Equal(expectedReceiveBufferSize, sp2.ReceiveBufferSize);
+            Assert.Equal(expectedUseNagleAlgorithm, sp2.UseNagleAlgorithm);
+        }
+
+        [Fact]
+        public static void FindServicePoint_NewServicePointsInheritCurrentValues()
+        {
+            string address1 = "http://" + Guid.NewGuid().ToString("N");
+            string address2 = "http://" + Guid.NewGuid().ToString("N");
+
+            bool orig100Continue = ServicePointManager.Expect100Continue;
+            bool origNagle = ServicePointManager.UseNagleAlgorithm;
+
+            ServicePointManager.Expect100Continue = false;
+            ServicePointManager.UseNagleAlgorithm = false;
+            ServicePoint sp1 = ServicePointManager.FindServicePoint(address1, null);
+            Assert.False(sp1.Expect100Continue);
+            Assert.False(sp1.UseNagleAlgorithm);
+
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.UseNagleAlgorithm = true;
+            ServicePoint sp2 = ServicePointManager.FindServicePoint(address2, null);
+            Assert.True(sp2.Expect100Continue);
+            Assert.True(sp2.UseNagleAlgorithm);
+            Assert.False(sp1.Expect100Continue);
+            Assert.False(sp1.UseNagleAlgorithm);
+
+            ServicePointManager.Expect100Continue = orig100Continue;
+            ServicePointManager.UseNagleAlgorithm = origNagle;
+        }
+
+        // Separated out to avoid the JIT in debug builds interfering with object lifetimes
+        private static bool GetExpect100Continue(string address) =>
+            ServicePointManager.FindServicePoint(address, null).Expect100Continue;
+        private static void SetExpect100Continue(string address, bool value) =>
+            ServicePointManager.FindServicePoint(address, null).Expect100Continue = value;
+
+        private sealed class FixedWebProxy : IWebProxy
+        {
+            private readonly Uri _proxyAddress;
+            public FixedWebProxy(string proxyAddress) { _proxyAddress = new Uri(proxyAddress); }
+            public Uri GetProxy(Uri destination) => _proxyAddress;
+            public bool IsBypassed(Uri host) => false;
+            public ICredentials Credentials { get; set; }
         }
     }
 }


### PR DESCRIPTION
I'd previously stubbed out ServicePointManager with FindServicePoint throwing exceptions.  This commit revises it:
- FindServicePoint now behaves similarly to desktop, at least in terms of observable behavior.  A table maps addresses to service points wrapped in weak references; calls to FindServicePoint return the object found in the table if there is one, or else creates/stores/returns a new one.
- HttpWebRequest now respects several properties set on ServicePointManager, in particular those related to certs.
- Several stubbed out members are fixed with the right default values.

cc: @ericeil, @davidsh, @cipop, @karelz, @tijoytom 
Fixes https://github.com/dotnet/corefx/issues/11885