### PR TITLE
Enable CharUnicodeInfo & StringInfo tests for Linux

### DIFF
--- a/src/System.Globalization/tests/CharUnicodeInfo/CharUnicodeInfoTests.netstandard1.7.cs
+++ b/src/System.Globalization/tests/CharUnicodeInfo/CharUnicodeInfoTests.netstandard1.7.cs
@@ -71,7 +71,6 @@ namespace System.Globalization.Tests
         };
 
         [Fact]
-        [ActiveIssue(11606, Xunit.PlatformID.AnyUnix)]
         public static void DigitsDecimalTest()
         {
             Assert.Equal(s_numericsCodepoints.Length % 10, 0);
@@ -86,7 +85,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(11606, Xunit.PlatformID.AnyUnix)]
         public static void NegativeDigitsTest()
         {
             for (int i=0; i < s_nonNumericsCodepoints.Length; i++)
@@ -97,7 +95,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(11606, Xunit.PlatformID.AnyUnix)]
         public static void DigitsTest()
         {
             Assert.Equal(s_numericNonDecimalCodepoints.Length, s_numericNonDecimalValues.Length);

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -12,7 +12,6 @@ namespace System.Globalization.Tests
     public class CurrentCultureTests : RemoteExecutorTestBase
     {
         [Fact]
-        [ActiveIssue(11381, Xunit.PlatformID.AnyUnix)]
         public void CurrentCulture()
         {
             RemoteInvoke(() =>
@@ -39,7 +38,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(11381, Xunit.PlatformID.AnyUnix)]
         public void CurrentUICulture()
         {
             RemoteInvoke(() =>

--- a/src/System.Globalization/tests/StringInfo/StringInfoTests.netstandard1.7.cs
+++ b/src/System.Globalization/tests/StringInfo/StringInfoTests.netstandard1.7.cs
@@ -20,7 +20,6 @@ namespace System.Globalization.Tests
         }
 
         [Theory]
-        [ActiveIssue(11615, Xunit.PlatformID.AnyUnix)]
         [MemberData(nameof(StringInfo_TestData))]
         public void SubstringTest(string source, int index, string expected, int length, string expectedWithLength)
         {
@@ -30,7 +29,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(11615, Xunit.PlatformID.AnyUnix)]
         public void NegativeTest()
         {
             string s = "Some String";


### PR DESCRIPTION
We have added the needed functionality to coreclr for Linux platforms. This change contains enabling the test for CurrentCulture tests on Linux as we have fixed a bug with the collation names