### PR TITLE
Baseline 1.1

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -5,7 +5,7 @@
         "4.0.1",
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -15,21 +15,23 @@
       "StableVersions": [
         "1.0.0",
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "1.1.0"
     },
     "Microsoft.NETCore.Targets": {
       "StableVersions": [
         "1.0.0",
         "1.0.1",
         "1.0.2"
-      ]
+      ],
+      "BaselineVersion": "1.1.0"
     },
     "Microsoft.VisualBasic": {
       "StableVersions": [
         "10.0.1",
         "10.0.0"
       ],
-      "BaselineVersion": "10.0.1",
+      "BaselineVersion": "10.1.0",
       "AssemblyVersionInPackageVersion": {
         "10.0.0.0": "10.0.0",
         "10.0.1.0": "10.0.1"
@@ -40,7 +42,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -51,7 +53,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -61,7 +63,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -70,227 +72,272 @@
     "NETStandard.Library": {
       "StableVersions": [
         "1.6.0"
-      ]
+      ],
+      "BaselineVersion": "1.6.1"
     },
     "runtime.any.System.Collections": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Diagnostics.Tools": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Diagnostics.Tracing": {
       "StableVersions": [
         "4.1.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Globalization": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Globalization.Calendars": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.IO": {
       "StableVersions": [
         "4.1.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Reflection": {
       "StableVersions": [
         "4.1.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Reflection.Extensions": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Reflection.Primitives": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Resources.ResourceManager": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Runtime": {
       "StableVersions": [
         "4.1.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Runtime.Handles": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Runtime.InteropServices": {
       "StableVersions": [
         "4.1.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Text.Encoding": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Text.Encoding.Extensions": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Threading.Tasks": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.any.System.Threading.Timer": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Collections": {
       "StableVersions": [
         "4.0.10"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Diagnostics.Tools": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Diagnostics.Tracing": {
       "StableVersions": [
         "4.0.20"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Globalization": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Globalization.Calendars": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.IO": {
       "StableVersions": [
         "4.1.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Reflection": {
       "StableVersions": [
         "4.0.10"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Reflection.Extensions": {
       "StableVersions": [
         "4.0.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Reflection.Primitives": {
       "StableVersions": [
         "4.0.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Resources.ResourceManager": {
       "StableVersions": [
         "4.0.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Runtime": {
       "StableVersions": [
         "4.0.20"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Runtime.Handles": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Runtime.InteropServices": {
       "StableVersions": [
         "4.0.20"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Text.Encoding": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Text.Encoding.Extensions": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Threading.Tasks": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.aot.System.Threading.Timer": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.debian.8-x64.runtime.native.System": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.debian.8-x64.runtime.native.System.IO.Compression": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.debian.8-x64.runtime.native.System.Net.Http": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.debian.8-x64.runtime.native.System.Net.Security": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.debian.8-x64.runtime.native.System.Security.Cryptography": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.fedora.23-x64.runtime.native.System": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.fedora.23-x64.runtime.native.System.IO.Compression": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.fedora.23-x64.runtime.native.System.Net.Http": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.fedora.23-x64.runtime.native.System.Net.Security": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.native.System": {
       "StableVersions": [
@@ -331,202 +378,242 @@
     "runtime.opensuse.13.2-x64.runtime.native.System": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.osx.10.10-x64.runtime.native.System": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.osx.10.10-x64.runtime.native.System.Net.Http": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.osx.10.10-x64.runtime.native.System.Net.Security": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.rhel.7-x64.runtime.native.System": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.rhel.7-x64.runtime.native.System.IO.Compression": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.rhel.7-x64.runtime.native.System.Net.Http": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.rhel.7-x64.runtime.native.System.Net.Security": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.ubuntu.14.04-x64.runtime.native.System": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.ubuntu.16.04-x64.runtime.native.System": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography": {
       "StableVersions": [
         "1.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.unix.Microsoft.Win32.Primitives": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.unix.System.Console": {
       "StableVersions": [
         "4.0.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.unix.System.Diagnostics.Debug": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.unix.System.IO.FileSystem": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.unix.System.Net.Primitives": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.unix.System.Net.Sockets": {
       "StableVersions": [
         "4.1.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.unix.System.Private.Uri": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.unix.System.Runtime.Extensions": {
       "StableVersions": [
         "4.1.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.win.Microsoft.Win32.Primitives": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.win.System.Console": {
       "StableVersions": [
         "4.0.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.win.System.Diagnostics.Debug": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.win.System.IO.FileSystem": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.win.System.Net.Primitives": {
       "StableVersions": [
         "4.0.11"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.win.System.Net.Sockets": {
       "StableVersions": [
         "4.1.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.win.System.Runtime.Extensions": {
       "StableVersions": [
         "4.1.0"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.win10-x86-aot.runtime.native.System.IO.Compression": {
       "StableVersions": [
@@ -541,7 +628,8 @@
     "runtime.win7-x64.runtime.native.System.IO.Compression": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.win7-x86.runtime.native.System.Data.SqlClient.sni": {
       "StableVersions": [
@@ -551,25 +639,28 @@
     "runtime.win7-x86.runtime.native.System.IO.Compression": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.win7.System.Private.Uri": {
       "StableVersions": [
         "4.0.1",
         "4.0.2"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "runtime.win8-arm.runtime.native.System.IO.Compression": {
       "StableVersions": [
         "4.0.1"
-      ]
+      ],
+      "BaselineVersion": "4.3.0"
     },
     "System.AppContext": {
       "StableVersions": [
         "4.0.0",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
@@ -580,7 +671,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -592,7 +683,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -605,7 +696,7 @@
         "4.0.10",
         "4.0.12"
       ],
-      "BaselineVersion": "4.0.12",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -618,7 +709,7 @@
         "1.2.0",
         "1.1.36"
       ],
-      "BaselineVersion": "1.2.0",
+      "BaselineVersion": "1.3.0",
       "AssemblyVersionInPackageVersion": {
         "1.1.37.0": "1.1.37",
         "1.2.0.0": "1.2.0",
@@ -631,7 +722,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -643,7 +734,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -655,7 +746,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -667,7 +758,7 @@
         "4.0.10",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -681,7 +772,7 @@
         "4.0.11",
         "4.0.10"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -693,7 +784,7 @@
         "4.0.0",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
@@ -705,7 +796,7 @@
         "4.0.0",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
@@ -716,7 +807,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -727,7 +818,7 @@
         "4.0.0",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
@@ -738,7 +829,7 @@
       "StableVersions": [
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.1.0",
         "4.1.0.0": "4.1.0",
@@ -750,7 +841,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -762,7 +853,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -773,7 +864,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -783,7 +874,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -793,7 +884,7 @@
       "StableVersions": [
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.1.0",
         "4.1.0.0": "4.1.0",
@@ -806,7 +897,7 @@
         "4.0.0",
         "4.0.2"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.0.1",
         "4.0.3.0": "4.3.0",
@@ -818,7 +909,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -829,7 +920,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -839,7 +930,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -852,7 +943,7 @@
         "4.0.20",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -865,7 +956,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -877,7 +968,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -890,7 +981,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -902,7 +993,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -914,7 +1005,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -927,7 +1018,7 @@
         "4.0.10",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -941,7 +1032,7 @@
         "4.1.0",
         "4.1.1"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
@@ -954,7 +1045,7 @@
         "4.0.1",
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.0.1",
         "4.0.2.0": "4.3.0",
@@ -966,7 +1057,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -977,7 +1068,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -987,7 +1078,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -998,7 +1089,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -1009,7 +1100,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1020,7 +1111,7 @@
         "4.0.1",
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.0.1",
         "4.0.0.0": "4.0.0"
@@ -1030,7 +1121,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1040,7 +1131,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1050,7 +1141,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1061,7 +1152,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -1073,7 +1164,7 @@
         "4.0.0",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
@@ -1086,7 +1177,7 @@
         "4.0.10",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1099,7 +1190,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1110,7 +1201,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1121,7 +1212,7 @@
         "4.0.0",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
@@ -1133,7 +1224,7 @@
         "4.0.1",
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.0.1",
         "4.0.0.0": "4.0.0"
@@ -1143,7 +1234,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1153,7 +1244,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1164,7 +1255,7 @@
         "4.0.0",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
@@ -1175,7 +1266,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1188,7 +1279,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
         "4.0.0.0": "4.0.0",
@@ -1203,7 +1294,7 @@
         "4.0.11",
         "4.0.10"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
         "4.0.0.0": "4.0.0",
@@ -1215,7 +1306,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1226,7 +1317,7 @@
         "4.1.0",
         "4.0.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.1.0.0": "4.1.0",
         "4.1.1.0": "4.3.0",
@@ -1239,7 +1330,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1249,7 +1340,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1259,7 +1350,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1271,7 +1362,7 @@
         "4.1.0",
         "4.1.1"
       ],
-      "BaselineVersion": "4.1.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
@@ -1284,7 +1375,7 @@
         "4.0.1",
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.0.1",
         "4.0.2.0": "4.3.0",
@@ -1297,7 +1388,7 @@
         "4.0.10",
         "4.0.12"
       ],
-      "BaselineVersion": "4.0.12",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1328,7 +1419,7 @@
         "4.0.10",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1341,7 +1432,7 @@
         "4.0.1",
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0"
       }
@@ -1351,7 +1442,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -1363,7 +1454,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1374,7 +1465,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1385,7 +1476,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1396,7 +1487,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1409,7 +1500,7 @@
         "1.1.0",
         "1.2.0"
       ],
-      "BaselineVersion": "1.4.0",
+      "BaselineVersion": "1.4.1",
       "AssemblyVersionInPackageVersion": {
         "1.0.22.0": "1.0.22",
         "1.3.0.0": "1.3.0",
@@ -1423,7 +1514,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1434,7 +1525,7 @@
         "4.0.0",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
@@ -1445,7 +1536,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1456,7 +1547,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1466,7 +1557,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1479,7 +1570,7 @@
         "4.0.20",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1492,6 +1583,7 @@
       "StableVersions": [
         "4.0.0"
       ],
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.2.0": "4.3.0"
@@ -1501,7 +1593,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1513,7 +1605,7 @@
         "4.0.10",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1526,7 +1618,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1539,7 +1631,7 @@
         "4.0.20",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1552,7 +1644,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1563,7 +1655,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0"
       }
@@ -1572,7 +1664,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0"
       }
@@ -1582,7 +1674,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1594,7 +1686,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.2",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -1608,7 +1700,7 @@
         "4.0.10",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.1.0": "4.1.1",
@@ -1624,7 +1716,7 @@
         "4.0.10",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.1.0": "4.1.1",
@@ -1639,7 +1731,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1651,7 +1743,7 @@
         "4.0.1",
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.0.1",
         "4.0.0.0": "4.0.0"
@@ -1661,7 +1753,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1672,7 +1764,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -1683,7 +1775,7 @@
       "StableVersions": [
         "4.2.0"
       ],
-      "BaselineVersion": "4.2.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.2.0",
         "4.1.0.0": "4.2.0",
@@ -1695,7 +1787,7 @@
       "StableVersions": [
         "4.2.0"
       ],
-      "BaselineVersion": "4.2.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.2.0",
         "4.1.0.0": "4.2.0",
@@ -1707,7 +1799,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1717,7 +1809,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1727,7 +1819,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0"
       }
@@ -1736,6 +1828,7 @@
       "StableVersions": [
         "4.0.0"
       ],
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1745,7 +1838,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1755,7 +1848,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1765,7 +1858,7 @@
       "StableVersions": [
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.1.0",
         "4.1.0.0": "4.1.0",
@@ -1777,7 +1870,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1787,7 +1880,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1797,6 +1890,7 @@
       "StableVersions": [
         "4.0.0"
       ],
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1806,7 +1900,7 @@
       "StableVersions": [
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.1.0.0": "4.1.0",
         "4.1.1.0": "4.3.0"
@@ -1818,7 +1912,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1830,7 +1924,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -1843,7 +1937,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1854,7 +1948,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1866,7 +1960,7 @@
         "4.0.10",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1880,7 +1974,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1891,7 +1985,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1902,7 +1996,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -1915,7 +2009,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -1927,7 +2021,7 @@
         "4.6.0",
         "4.5.25"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "4.7.0",
       "AssemblyVersionInPackageVersion": {
         "4.6.0.0": "4.6.0",
         "4.6.1.0": "4.7.0",
@@ -1938,7 +2032,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.3.0"
@@ -1949,7 +2043,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1959,7 +2053,7 @@
       "StableVersions": [
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.3.0"
@@ -1969,7 +2063,7 @@
       "StableVersions": [
         "4.0.10"
       ],
-      "BaselineVersion": "4.0.10",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.10.0": "4.0.10",
         "4.0.11.0": "4.3.0"
@@ -1980,7 +2074,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1"
@@ -1992,7 +2086,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -2006,7 +2100,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -2018,7 +2112,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -2031,7 +2125,7 @@
         "4.0.10",
         "4.0.11"
       ],
-      "BaselineVersion": "4.0.11",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
@@ -2043,7 +2137,7 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -2055,7 +2149,7 @@
         "4.0.1",
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.0.1",
         "4.0.0.0": "4.0.0",
@@ -2067,14 +2161,16 @@
         "4.0.1",
         "4.0.0"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.0.1",
         "4.0.2.0": "4.3.0",
         "4.0.0.0": "4.0.0"
       }
     },
-    "Microsoft.Private.PackageBaseline": {},
+    "Microsoft.Private.PackageBaseline": {
+      "BaselineVersion": "1.0.1"
+    },
     "runtime.win10-arm-aot.runtime.native.System.IO.Compression": {
       "StableVersions": [
         "4.0.1"
@@ -2086,42 +2182,52 @@
       ]
     },
     "System.Composition.AttributedModel": {
+      "BaselineVersion": "1.0.31",
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31"
       }
     },
     "System.Composition.Convention": {
+      "BaselineVersion": "1.0.31",
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31"
       }
     },
     "System.Composition.Hosting": {
+      "BaselineVersion": "1.0.31",
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31"
       }
     },
     "System.Composition.Runtime": {
+      "BaselineVersion": "1.0.31",
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31"
       }
     },
     "System.Composition.TypedParts": {
+      "BaselineVersion": "1.0.31",
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31"
       }
     },
-    "System.Composition": {},
+    "System.Composition": {
+      "BaselineVersion": "1.0.31"
+    },
     "System.IO.Pipes.AccessControl": {
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.3.0"
       }
     },
     "System.Runtime.Serialization.Formatters": {
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.3.0"
       }
     },
     "System.ValueTuple": {
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.3.0"
       }
@@ -2130,6 +2236,90 @@
       "BaselineVersion": "4.3.0"
     },
     "runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.fedora.24-x64.runtime.native.System.Net.Http": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.fedora.24-x64.runtime.native.System.Net.Security": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.fedora.24-x64.runtime.native.System": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.opensuse.42.1-x64.runtime.native.System": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.16.10-x64.runtime.native.System": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.win10-arm64.runtime.native.System.Data.SqlClient.sni": {
+      "BaselineVersion": "4.3.0"
+    },
+    "runtime.win10-arm64.runtime.native.System.IO.Compression": {
       "BaselineVersion": "4.3.0"
     }
   },

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.builds
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.builds
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="runtime.native.System.Data.SqlClient.sni.pkgproj" />
+    <!-- The following packages are built in TFS 
     <Project Include="win\runtime.native.System.Data.SqlClient.sni.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>x86</Platform>
@@ -14,7 +15,7 @@
     <Project Include="win\runtime.native.System.Data.SqlClient.sni.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>arm64</Platform>
-    </Project>
+    </Project> -->
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -12,9 +12,10 @@
     <Dependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
       <Version>$(RuntimeWin7RuntimeNativeSystemDataSqlClientSniVersion)</Version>
     </Dependency>
+    <!-- The following package is not being built as part of the 1.1 release and will not have a stable version
     <Dependency Include="runtime.win10-arm64.runtime.native.System.Data.SqlClient.sni">
       <Version>$(RuntimeWin10Arm64RuntimeNativeSystemDataSqlClientSniVersion)</Version>
-    </Dependency>
+    </Dependency> -->
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
We want 1.1 packages to only depend on other 1.1 packages.  Previously this would only be the case of the libraries in the package actually required the update, but this would lead folks to a place where they would be on a mix of 1.0 and 1.1 references after "update all".
/cc @weshaggard 

In doing this I noticed some issues with the build of the SNI package and cleaned it up.  Without this fix we'd need to remove the sni ARM dependency when we moved the packages to stable.
/cc @saurabh500 @ianhays @dagood 