### PR TITLE
Fix for System.Xml.XPath.XmlDocument test failures

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2329,8 +2329,8 @@
       "BaselineVersion": "4.0.1",
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.0.1",
-        "4.0.2.0": "4.3.0",
-        "4.0.0.0": "4.0.0"
+        "4.0.0.0": "4.0.0",
+        "4.1.0.0": "4.3.0"
       }
     },
     "Microsoft.Private.PackageBaseline": {},

--- a/src/System.Private.Xml/tests/XPath/XmlDocument/System.Xml.XPath.XmlDocument.Tests.csproj
+++ b/src/System.Private.Xml/tests/XPath/XmlDocument/System.Xml.XPath.XmlDocument.Tests.csproj
@@ -20,6 +20,10 @@
     <CommonPathXPath>$(CommonPath)\System\Xml\XPath</CommonPathXPath>
   </PropertyGroup>
   <ItemGroup>
+    <!-- TODO: remove this P2P reference when new packages are produced and updated -->
+    <ProjectReference Include="..\..\..\..\System.Xml.XPath.XmlDocument\pkg\System.Xml.XPath.XmlDocument.pkgproj" />
+  </ItemGroup>
+  <ItemGroup>
     <!-- XPath.XmlDocument navigator -->
     <Compile Include="$(CommonPathXPath)\XmlDocument\CreateNavigatorFromXmlDocument.cs" />
     <Compile Include="XmlDocumentXPathTest.cs" />

--- a/src/System.Xml.XPath.XmlDocument/dir.props
+++ b/src/System.Xml.XPath.XmlDocument/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>
 

--- a/src/System.Xml.XPath.XmlDocument/pkg/System.Xml.XPath.XmlDocument.pkgproj
+++ b/src/System.Xml.XPath.XmlDocument/pkg/System.Xml.XPath.XmlDocument.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Xml.XPath.XmlDocument.csproj">
-      <SupportedFramework>net46;netcore50;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.XPath.XmlDocument.builds" />
     <!-- nothing special required for desktop - pure plib with no type conflicts. -->

--- a/src/System.Xml.XPath.XmlDocument/ref/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/ref/System.Xml.XPath.XmlDocument.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Xml.XPath.XmlDocument.Manual.cs" />

--- a/src/System.Xml.XPath.XmlDocument/ref/project.json
+++ b/src/System.Xml.XPath.XmlDocument/ref/project.json
@@ -6,9 +6,9 @@
     "System.Xml.ReaderWriter": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "imports": [
-        "dotnet5.4"
+        "dotnet5.8"
       ]
     }
   }

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.builds
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.Xml.XPath.XmlDocument.csproj" />
     <Project Include="System.Xml.XPath.XmlDocument.csproj">
-      <TargetGroup>net46</TargetGroup>
+      <TargetGroup>net463</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -5,20 +5,20 @@
     <ProjectGuid>{17CB2E3C-2904-4241-94DB-3894D24F35DA}</ProjectGuid>
     <AssemblyName>System.Xml.XPath.XmlDocument</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
     <ProjectReference Include="..\..\System.Private.Xml\src\System.Private.Xml.csproj" />
     <ProjectReference Include="..\..\System.Xml.XPath\src\System.Xml.XPath.csproj" />
     <ProjectReference Include="..\..\System.Xml.ReaderWriter\src\System.Xml.ReaderWriter.csproj" />
     <ProjectReference Include="..\..\System.Xml.XmlDocument\src\System.Xml.XmlDocument.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System.Xml" />
   </ItemGroup>

--- a/src/System.Xml.XPath.XmlDocument/src/project.json
+++ b/src/System.Xml.XPath.XmlDocument/src/project.json
@@ -1,6 +1,6 @@
 {
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.2-beta-24522-03",
         "System.Collections": "4.3.0-beta-24522-03",
@@ -25,12 +25,9 @@
         "System.Xml.ReaderWriter": "4.3.0-beta-24522-03",
         "System.Xml.XmlDocument": "4.3.0-beta-24522-03",
         "System.Xml.XPath": "4.3.0-beta-24522-03"
-      },
-      "imports": [
-        "dotnet5.4"
-      ]
+      }
     },
-    "net46": {
+    "net463": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }


### PR DESCRIPTION
This is a fix for Windows_NT failures at https://github.com/dotnet/corefx/pull/11997#issuecomment-250556212

cc: @weshaggard @joperezr 