### PR TITLE
fixing Crypto test AddReadOnlyThrowsWhenCertificateExists

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -88,11 +88,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                             break;
                         }
                     }
-                }
 
-                if (toAdd != null)
-                {
-                    Assert.ThrowsAny<CryptographicException>(() => store.Add(toAdd));
+                    if (toAdd != null)
+                    {
+                        Assert.ThrowsAny<CryptographicException>(() => store.Add(toAdd));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Ensuring that if a certificate that matches the "HasPrivateKey" criteria is found it isn't disposed before we try to add it to the certificate store. I must be one of the only people that has a certificate in their store that actually causes this test to get all the way through.