### PR TITLE
Fix CodeDom test failing on Unix

### DIFF
--- a/src/System.CodeDom/tests/CSharpCodeGenerationTests.cs
+++ b/src/System.CodeDom/tests/CSharpCodeGenerationTests.cs
@@ -71,7 +71,7 @@ namespace System.CodeDom.Tests
 
             var field = new CodeMemberField("System.String", "Microsoft");
             field.Attributes = MemberAttributes.Public | MemberAttributes.Static;
-            field.InitExpression = new CodePrimitiveExpression("hi" + Environment.NewLine);
+            field.InitExpression = new CodePrimitiveExpression("hi");
             cd.Members.Add(field);
 
             field = new CodeMemberField();
@@ -106,7 +106,7 @@ namespace System.CodeDom.Tests
 
             AssertEqual(cd,
                 @"public class ClassWithFields {
-                      public static string Microsoft = ""hi\r\n"";
+                      public static string Microsoft = ""hi"";
                       public static int StaticPublicField = 5;
                       public int NonStaticPublicField = 6;
                       private int PrivateField = 7;

--- a/src/System.CodeDom/tests/VBCodeGenerationTests.cs
+++ b/src/System.CodeDom/tests/VBCodeGenerationTests.cs
@@ -75,7 +75,7 @@ namespace System.CodeDom.Tests
 
             var field = new CodeMemberField("System.String", "Microsoft");
             field.Attributes = MemberAttributes.Public | MemberAttributes.Static;
-            field.InitExpression = new CodePrimitiveExpression("hi" + Environment.NewLine);
+            field.InitExpression = new CodePrimitiveExpression("hi");
             cd.Members.Add(field);
 
             field = new CodeMemberField();
@@ -110,7 +110,7 @@ namespace System.CodeDom.Tests
 
             AssertEqual(cd,
                 @"Public Class ClassWithFields
-                      Public Shared Microsoft As String = ""hi""&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)
+                      Public Shared Microsoft As String = ""hi""
                       Public Shared StaticPublicField As Integer = 5
                       Public NonStaticPublicField As Integer = 6
                       Private PrivateField As Integer = 7


### PR DESCRIPTION
The test is including a newline where it shouldn't, which is causing problems when a newline is \n rather than \r\n.  Simple fix: remove it.  It's not necessary for the test; special characters in strings are tested elsewhere.