### PR TITLE
Fix concurrency problem in FileWebRequest resulting in sporadic test failures

### DIFF
--- a/src/System.Net.Requests/tests/FileWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/FileWebRequestTest.cs
@@ -186,9 +186,13 @@ namespace System.Net.Tests
             }
         }
 
+        protected virtual bool EnableConcurrentReadWriteTests => true;
+
         [Fact]
         public async Task ConcurrentReadWrite_ResponseBlocksThenGetsNullStream()
         {
+            if (!EnableConcurrentReadWriteTests) return;
+
             string path = Path.GetTempFileName();
             try
             {
@@ -261,8 +265,18 @@ namespace System.Net.Tests
 
     public sealed class SyncFileWebRequestTestBase : FileWebRequestTestBase
     {
+        protected override bool EnableConcurrentReadWriteTests => false;
         public override Task<WebResponse> GetResponseAsync(WebRequest request) => Task.Run(() => request.GetResponse());
         public override Task<Stream> GetRequestStreamAsync(WebRequest request) => Task.Run(() => request.GetRequestStream());
+    }
+
+    public sealed class BeginEndFileWebRequestTestBase : FileWebRequestTestBase
+    {
+        public override Task<WebResponse> GetResponseAsync(WebRequest request) =>
+            Task.Factory.FromAsync(request.BeginGetResponse, request.EndGetResponse, null);
+
+        public override Task<Stream> GetRequestStreamAsync(WebRequest request) =>
+            Task.Factory.FromAsync(request.BeginGetRequestStream, request.EndGetRequestStream, null);
     }
 
     public sealed class TaskFileWebRequestTestBase : FileWebRequestTestBase


### PR DESCRIPTION
When I ported FileWebRequest/Response to corefx, I added a test that invokes GetRequestStreamAsync and GetResponseAsync to run concurrently with each other, as there's logic in the implementation (for reasons I'm not clear about) that suggests this should work, by blocking the latter until the former has completed.  However, there's a race condition in the product that's causing the test to fail.

FileWebRequest overrides the base's Begin/EndXx methods.  It does not override the XxAsync methods.  The base XxAsync implementations just wrap the Begin/End calls, but for whatever reason they also wrap it in a Task.Run.  When FileWebRequest inherits that implementation, it causes problems for the test, as the marking that operations are in progress happens in the Begin overrides, which means they happen as part of the queued tasks from the base implementation.  In rare cases where the BeginGetResponse task runs first, or where it runs in parallel with the BeginGetRequestStream task, problems occur.

Three (simple) parts to the fix:
1. Override GetRequestStreamAsync/GetResponse so as to avoid the extra task the base class queues; it's unnecessary, causes this race condition, and adds a bit of overhead.  I did some small refactoring to reuse all of the other logic between the XxAsync and Begin/EndXx overrides.
2. Make sure this concurrency test doesn't run with the synchronous methods, which would potentially manifest the same problem.
3. Since with (1) the Task-based APIs no longer wrap the Begin/End APIs, make sure all of the tests also run with the Begin/End APIs.

cc: @ericeil