### PR TITLE
Disable Default_GetHashCodeCompare test until it's investigated

### DIFF
--- a/src/System.Collections.NonGeneric/tests/CaseInsensitiveHashCodeProviderTests.cs
+++ b/src/System.Collections.NonGeneric/tests/CaseInsensitiveHashCodeProviderTests.cs
@@ -158,6 +158,7 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentNullException>("obj", () => new CaseInsensitiveHashCodeProvider().GetHashCode(null));
         }
 
+        [ActiveIssue(11598)]
         [Theory]
         [InlineData("hello", "HELLO", true)]
         [InlineData("hello", "hello", true)]


### PR DESCRIPTION
There must be some kind of race condition involved in either the product or another test modifying global state that's causing this to fail sporadically.

https://github.com/dotnet/corefx/issues/11598