### PR TITLE
Revert "Build Linq.Expression tests against live Regex"

### DIFF
--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -226,8 +226,6 @@
       <Project>{aef718e9-d4fc-418f-a7ae-ed6b2c7b3787}</Project>
       <Name>System.Linq.Expressions</Name>
     </ProjectReference>
-    <!-- temporarily compile against the live build of RegularExpressions to handle assembly-version change -->
-    <ProjectReference Include="..\..\System.Text.RegularExpressions\pkg\System.Text.RegularExpressions.pkgproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
This reverts commit 4f192affbc07a77e6660e75caeae5fba07a9cddf.