### PR TITLE
Changing test projects to default to netcoreapp1.1 instead of netcoreapp1.0

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -499,17 +499,11 @@
 
   <!-- Default Test platform to deploy the netstandard compiled tests to -->
   <PropertyGroup>
-    <TestTFM Condition="'$(TestTFM)'=='' and ('$(TargetGroup)'=='netstandard1.7' or '$(TargetGroup)'=='netcoreapp1.1')">netcoreapp1.1</TestTFM>
-    <TestTFM Condition="'$(TestTFM)'==''">netcoreapp1.0</TestTFM>
-    <!-- we default FilterToTestTFM to netcoreapp1.1 if it is not explicity defined -->
-    <FilterToTestTFM Condition="'$(FilterToTestTFM)'==''">netcoreapp1.1</FilterToTestTFM>
+    <DefaultTestTFM>netcoreapp1.1</DefaultTestTFM>
+    <TestTFM Condition="'$(TestTFM)'==''">$(DefaultTestTFM)</TestTFM>
+    <!-- we default FilterToTestTFM to DefaultTestTFM if it is not explicity defined -->
+    <FilterToTestTFM Condition="'$(FilterToTestTFM)'==''">$(DefaultTestTFM)</FilterToTestTFM>
   </PropertyGroup>
-
-  <ItemGroup>
-    <TestNugetTargetMoniker Include=".NETCoreApp,Version=v1.1" Condition="'$(TestTFM)' == 'netcoreapp1.1'">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
 
   <PropertyGroup>
     <IsRedistAssembly Condition="'$(IsRedistAssembly)'=='' AND ($(MSBuildProjectFullPath.Contains('\redist\')) OR $(MSBuildProjectFullPath.Contains('/redist/')))">true</IsRedistAssembly>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -141,31 +141,19 @@
           BeforeTargets="TestAllProjects"
           Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
 
-    <PropertyGroup>
-      <TestTFMSupportSet>$(FilterToTestTFM)</TestTFMSupportSet>
-      <TestTFMSupportSet Condition="'$(FilterToTestTFM)'=='netcoreapp1.1'">$(TestTFMSupportSet)|netcoreapp1.0</TestTFMSupportSet>
-      <TestTFMSupportSet Condition="'$(FilterToTestTFM)'=='net461'">$(TestTFMSupportSet)|net46</TestTFMSupportSet>
-      <TestTFMSupportSet Condition="'$(FilterToTestTFM)'=='net462'">$(TestTFMSupportSet)|net461|net46</TestTFMSupportSet>
-      <TestTFMSupportSet Condition="'$(FilterToTestTFM)'=='net463'">$(TestTFMSupportSet)|net462|net461|net46</TestTFMSupportSet>
-    </PropertyGroup>
-
     <ItemGroup>
       <Project>
-        <!-- default to netcoreapp1.0.0 if TestTFMs aren't set on the project -->
-        <TestTFMs Condition="'%(Project.TestTFMs)'==''">netcoreapp1.0</TestTFMs>
+        <!-- default to DefaultTestTFM defined in root dir.props if TestTFMs aren't set on the project -->
+        <TestTFMs Condition="'%(Project.TestTFMs)'==''">$(DefaultTestTFM)</TestTFMs>
       </Project>
       <Project>
         <!-- make sure every defined TestTFM value are surrounded by semicolons for easier search, e.g. ";net46;"" -->
         <TestTFMs>;%(Project.TestTFMs);</TestTFMs>
       </Project>
-      <Project>
-        <!-- Use the supported set to find a match and replace it with that match (i.e. $1) -->
-        <FilteredTestTFM>$([System.Text.RegularExpressions.Regex]::Replace('%(Project.TestTFMs)', '.*;($(TestTFMSupportSet));.*', '$1'))</FilteredTestTFM>
-      </Project>
 
       <!-- Include all projects which have TestTFM from the supported set -->
-      <ProjectsToTest Include="@(Project)" Condition="'%(Project.Extension)'=='.csproj' And '%(Project.FilteredTestTFM)'!='%(Project.TestTFMs)'">
-        <TestTFM>%(Project.FilteredTestTFM)</TestTFM>
+      <ProjectsToTest Include="@(Project)" Condition="'%(Project.Extension)'=='.csproj' And $([System.String]::new('%(Project.TestTFMs)').Contains(';$(FilterToTestTFM);'))">
+        <TestTFM>$(FilterToTestTFM)</TestTFM>
       </ProjectsToTest>
 
       <ProjectsToTest>

--- a/src/System.CodeDom/tests/System.CodeDom.Tests.builds
+++ b/src/System.CodeDom/tests/System.CodeDom.Tests.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.CodeDom.Tests.csproj">
-    	<TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
+    <Project Include="System.CodeDom.Tests.csproj" />
     <Project Include="System.CodeDom.Tests.csproj">
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
@@ -12,4 +10,3 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.CodeDom/tests/System.CodeDom.Tests.csproj
+++ b/src/System.CodeDom/tests/System.CodeDom.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -6,11 +6,6 @@
     <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
     <ProjectGuid>{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}</ProjectGuid>
   </PropertyGroup>
-  <ItemGroup>
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU' " />
   <ItemGroup>

--- a/src/System.CodeDom/tests/project.json
+++ b/src/System.CodeDom/tests/project.json
@@ -31,23 +31,7 @@
     "netstandard1.7": {}
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.1": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.netcoreapp1.1": {},
+    "coreFx.Test.net463": {}
   }
 }

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.builds
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.builds
@@ -2,16 +2,16 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Collections.Concurrent.Tests.csproj"/>
+    <Project Include="System.Collections.Concurrent.Tests.csproj" />
     <Project Include="System.Collections.Concurrent.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Collections.Concurrent.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -8,8 +8,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Concurrent.Tests</AssemblyName>
     <RootNamespace>System.Collections.Concurrent.Tests</RootNamespace>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netstandard17</DefineConstants>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -85,16 +85,16 @@
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'!='netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)'!=''">
     <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
       <Link>Common\System\SerializableAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs" >
+  <ItemGroup Condition="'$(TargetGroup)'==''">
+    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Serialization.Tests.cs" >
+    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.Generic.Serialization.Tests.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.builds
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.builds
@@ -2,17 +2,17 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Collections.NonGeneric.Tests.csproj"/>
+    <Project Include="Performance\System.Collections.NonGeneric.Performance.Tests.csproj" />
     <Project Include="System.Collections.NonGeneric.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
+    <Project Include="System.Collections.NonGeneric.Tests.csproj" />
     <Project Include="System.Collections.NonGeneric.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
-    <Project Include="Performance\System.Collections.NonGeneric.Performance.Tests.csproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -8,8 +8,8 @@
     <RootNamespace>System.Collections.NonGeneric.Tests</RootNamespace>
     <AssemblyName>System.Collections.NonGeneric.Tests</AssemblyName>
     <ProjectGuid>{EE95AE39-845A-42D3-86D0-8065DBE56612}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netstandard17</DefineConstants>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -38,7 +38,6 @@
     </Compile>
     <Compile Include="ArrayListTests.cs" />
     <Compile Include="ArrayList\ArrayList.IList.Tests.cs" />
-    <Compile Include="CaseInsensitiveHashCodeProviderTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
     <Compile Include="Hashtable\Hashtable.Values.Tests.cs" />
     <Compile Include="Hashtable\Hashtable.Keys.Tests.cs" />
     <Compile Include="Hashtable\Hashtable.IDictionary.Tests.cs" />
@@ -57,13 +56,14 @@
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'!='netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)'!=''">
     <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
       <Link>Common\System\SerializableAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs" >
+  <ItemGroup Condition="'$(TargetGroup)'==''">
+    <Compile Include="CaseInsensitiveHashCodeProviderTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.builds
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.builds
@@ -4,14 +4,14 @@
   <ItemGroup>
     <Project Include="System.Collections.Specialized.Tests.csproj" />
     <Project Include="System.Collections.Specialized.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Collections.Specialized.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>System.Collections.Specialized.Tests</RootNamespace>
     <AssemblyName>System.Collections.Specialized.Tests</AssemblyName>
     <ProjectGuid>{7F5F5134-00FE-4DE8-B20C-3DA8BA2EBA68}</ProjectGuid>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -92,13 +92,13 @@
     <Compile Include="StringDictionary\StringDictionary.ValuesTests.cs" />
     <Compile Include="StringDictionary\StringDictionaryClearTests.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'!='netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)'!=''">
     <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
       <Link>Common\System\SerializableAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs" >
+  <ItemGroup Condition="'$(TargetGroup)'==''">
+    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/System.Collections/tests/System.Collections.Tests.builds
+++ b/src/System.Collections/tests/System.Collections.Tests.builds
@@ -2,21 +2,20 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Collections.Tests.csproj"/>
+    <Project Include="Performance\System.Collections.Performance.Tests.csproj" />
     <Project Include="System.Collections.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
+    <Project Include="System.Collections.Tests.csproj" />
     <Project Include="System.Collections.Tests.csproj">
       <TargetGroup>netcoreapp1.1</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
     </Project>
     <Project Include="System.Collections.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
-    <Project Include="Performance\System.Collections.Performance.Tests.csproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -8,8 +8,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Tests</AssemblyName>
     <RootNamespace>System.Collections.Tests</RootNamespace>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netstandard17</DefineConstants>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -126,7 +126,7 @@
     <Compile Include="Generic\List\List.Generic.Tests.AddRange.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.BinarySearch.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.Constructor.cs" />
-    <Compile Include="Generic\List\List.Generic.Tests.ConvertAll.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
+    <Compile Include="Generic\List\List.Generic.Tests.ConvertAll.cs" Condition="'$(TargetGroup)'==''" />
     <Compile Include="Generic\List\List.Generic.Tests.Find.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.Remove.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.Sort.cs" />
@@ -155,12 +155,12 @@
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'!='netstandard1.7' and '$(TargetGroup)'!='netcoreapp1.1'">
+  <ItemGroup Condition="'$(TargetGroup)'!='' and '$(TargetGroup)'!='netcoreapp1.1'">
     <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
       <Link>Common\System\SerializableAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs" >
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
     </Compile>

--- a/src/System.ComponentModel.Primitives/tests/System.ComponentModel.Primitives.Tests.builds
+++ b/src/System.ComponentModel.Primitives/tests/System.ComponentModel.Primitives.Tests.builds
@@ -2,16 +2,16 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.ComponentModel.Primitives.Tests.csproj"/>
+    <Project Include="System.ComponentModel.Primitives.Tests.csproj" />
     <Project Include="System.ComponentModel.Primitives.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.ComponentModel.Primitives.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.ComponentModel.Primitives/tests/System.ComponentModel.Primitives.Tests.csproj
+++ b/src/System.ComponentModel.Primitives/tests/System.ComponentModel.Primitives.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -8,7 +8,7 @@
     <ProjectGuid>{C9534425-93FB-494F-8DD8-1E4E3E626FDE}</ProjectGuid>
     <AssemblyName>System.ComponentModel.Primitives.Tests</AssemblyName>
     <RootNamespace>System.ComponentModel.Primitives.Tests</RootNamespace>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -33,11 +33,9 @@
     <Compile Include="ReadOnlyAttributeTests.cs" />
     <Compile Include="RefreshPropertiesAttributeTests.cs" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="EventHandlerListTests.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.ComponentModel.Primitives.pkgproj">
       <Project>{F620F382-30D1-451E-B125-2A612F92068B}</Project>

--- a/src/System.ComponentModel.TypeConverter/tests/Performance/System.ComponentModel.TypeConverter.Performance.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/Performance/System.ComponentModel.TypeConverter.Performance.Tests.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>System.ComponentModel.TypeConverter.Performance.Tests</RootNamespace>
     <AssemblyName>System.ComponentModel.TypeConverter.Performance.Tests</AssemblyName>
     <IncludePerformanceTests>true</IncludePerformanceTests>
-    <NugetTargetMoniker>.NETStandard,Version=v1.5</NugetTargetMoniker>
+    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
     <DefineConstants>$(DefineConstants);PERFORMANCE_TESTS</DefineConstants>
     <ProjectGuid>{89C76728-ECAF-4905-A33F-BD6BFED5E91D}</ProjectGuid>
   </PropertyGroup>
@@ -28,6 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\pkg\System.ComponentModel.TypeConverter.pkgproj">
     </ProjectReference>
+    <ProjectReference Include="..\..\..\System.ComponentModel.Primitives\pkg\System.ComponentModel.Primitives.pkgproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.ComponentModel.TypeConverter/tests/Performance/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/Performance/project.json
@@ -20,11 +20,10 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {
-    "netstandard1.5": {}
+    "netstandard1.7": {}
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.0": {},
-    "coreFx.Test.net462": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net463": {}
   }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.builds
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.builds
@@ -2,22 +2,21 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.ComponentModel.TypeConverter.Tests.csproj" />
     <Project Include="System.ComponentModel.TypeConverter.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
-    <Project Include="System.ComponentModel.TypeConverter.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="System.ComponentModel.TypeConverter.Tests.csproj"/>
     <Project Include="System.ComponentModel.TypeConverter.Tests.csproj">
+      <TargetGroup>netstandard1.5</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
+    </Project>
+    <Project Include="System.ComponentModel.TypeConverter.Tests.csproj">
+      <TargetGroup>netstandard1.5</TargetGroup>
       <TestTFMs>net462</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Performance\System.ComponentModel.TypeConverter.Performance.Tests.csproj"/>
+    <Project Include="Performance\System.ComponentModel.TypeConverter.Performance.Tests.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -8,7 +8,7 @@
     <ProjectGuid>{3F0326A1-9E19-4A6C-95CE-63E65C9D2030}</ProjectGuid>
     <RootNamespace>System.ComponentModel.TypeConverter.Tests</RootNamespace>
     <AssemblyName>System.ComponentModel.TypeConverter.Tests</AssemblyName>
-    <NugetTargetMoniker Condition=" '$(TargetGroup)' == '' ">.NETStandard,Version=v1.5</NugetTargetMoniker>
+    <NugetTargetMoniker Condition=" '$(TargetGroup)' == '' ">.NETStandard,Version=v1.7</NugetTargetMoniker>
     <DefineConstants>$(DefineConstants);FUNCTIONAL_TESTS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
@@ -71,7 +71,7 @@
     <Compile Include="UInt64ConverterTests.cs" />
     <Compile Include="UriTypeConverterTests.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetGroup)' == 'netstandard1.7'">
+  <ItemGroup Condition=" '$(TargetGroup)' == ''">
     <Compile Include="Drawing\ColorConverterTests.cs" />
     <Compile Include="Drawing\PointConverterTests.cs" />
     <Compile Include="Drawing\RectangleConverterTests.cs" />
@@ -79,7 +79,7 @@
     <Compile Include="Drawing\SizeFConverterTests.cs" />
     <Compile Include="Drawing\StringTypeConverterTestBase.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="TimerTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Diagnostics.Tools/tests/System.Diagnostics.Tools.Tests.builds
+++ b/src/System.Diagnostics.Tools/tests/System.Diagnostics.Tools.Tests.builds
@@ -2,16 +2,16 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-  <Project Include="System.Diagnostics.Tools.Tests.csproj"/>
+    <Project Include="System.Diagnostics.Tools.Tests.csproj" />
+    <Project Include="System.Diagnostics.Tools.Tests.csproj">
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
+    </Project>
     <Project Include="System.Diagnostics.Tools.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
-    </Project>
-    <Project Include="System.Diagnostics.Tools.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Diagnostics.Tools/tests/System.Diagnostics.Tools.Tests.csproj
+++ b/src/System.Diagnostics.Tools/tests/System.Diagnostics.Tools.Tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>System</RootNamespace>
     <AssemblyName>System.Diagnostics.Tools.Tests</AssemblyName>
-    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -17,12 +17,12 @@
     <Compile Include="System\CodeDom\Compiler\GeneratedCodeAttributeTests.cs" />
     <Compile Include="System\Diagnostics\CodeAnalysis\SuppressMessageAttributeTests.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
-    <Compile Include="System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttributeTests.cs" />    
+  <ItemGroup Condition="'$(TargetGroup)'==''">
+    <Compile Include="System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttributeTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-   <ProjectReference Include="..\pkg\System.Diagnostics.Tools.pkgproj">
+    <ProjectReference Include="..\pkg\System.Diagnostics.Tools.pkgproj">
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.builds
+++ b/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.builds
@@ -2,17 +2,17 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Drawing.Primitives.Tests.csproj"/>
+    <Project Include="System.Drawing.Primitives.Tests.csproj" />
+    <Project Include="System.Drawing.Primitives.Tests.csproj">
+      <TargetGroup>netcoreapp1.0</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
+    </Project>
     <Project Include="System.Drawing.Primitives.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcoreapp1.0</TargetGroup>
     </Project>
     <Project Include="System.Drawing.Primitives.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
-    <Project Include="System.Drawing.Primitives.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>

--- a/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.csproj
+++ b/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.csproj
@@ -7,8 +7,8 @@
     <RootNamespace>System.Drawing.Primitives.Tests</RootNamespace>
     <AssemblyName>System.Drawing.Primitives.Tests</AssemblyName>
     <ProjectGuid>{297A9116-1005-499D-A895-2063D03E4C94}</ProjectGuid>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
-
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU' ">
   </PropertyGroup>
@@ -18,7 +18,6 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU' ">
   </PropertyGroup>
-  
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
@@ -36,7 +35,7 @@
     <Compile Include="SizeFTests.cs" />
     <Compile Include="SizeTests.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="ColorTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.builds
+++ b/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.builds
@@ -2,14 +2,15 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Globalization.Calendars.Tests.csproj"/>
+    <Project Include="System.Globalization.Calendars.Tests.csproj" />
     <Project Include="System.Globalization.Calendars.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Globalization.Calendars.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
+++ b/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Globalization.Calendars.Tests</AssemblyName>
     <RootNamespace>System.Globalization.Calendars.Tests</RootNamespace>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -121,11 +121,9 @@
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="Misc\Calendars.netstandard1.7.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Globalization.Extensions/tests/System.Globalization.Extensions.Tests.builds
+++ b/src/System.Globalization.Extensions/tests/System.Globalization.Extensions.Tests.builds
@@ -2,21 +2,15 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Globalization.Extensions.Tests.csproj" />
     <Project Include="System.Globalization.Extensions.Tests.csproj">
-      <OSGroup>Unix</OSGroup>
-    </Project>
-    <Project Include="System.Globalization.Extensions.Tests.csproj">
-      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Globalization.Extensions.Tests.csproj">
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="System.Globalization.Extensions.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>        
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Globalization.Extensions/tests/System.Globalization.Extensions.Tests.csproj
+++ b/src/System.Globalization.Extensions/tests/System.Globalization.Extensions.Tests.csproj
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,14 +8,13 @@
     <RootNamespace>System.Globalization.Extensions.Tests</RootNamespace>
     <AssemblyName>System.Globalization.Extensions.Tests</AssemblyName>
     <ProjectGuid>{BC439554-4AB4-4C94-8E28-C00EDE4FD1C7}</ProjectGuid>
-    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  
   <ItemGroup>
     <Compile Include="GetStringComparerTests.cs" />
     <Compile Include="IdnMapping\IdnMappingIdnaConformanceTests.cs" />
@@ -39,21 +35,19 @@
   <ItemGroup>
     <EmbeddedResource Include="IdnMapping\Data\Unicode_6_0\IdnaTest_6.txt" />
     <EmbeddedResource Include="IdnMapping\Data\Unicode_Win7\IdnaTest_Win7.txt" />
-    <EmbeddedResource Include="Normalization\Data\win8.txt" >
+    <EmbeddedResource Include="Normalization\Data\win8.txt">
       <LogicalName>NormalizationDataWin8</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="Normalization\Data\win7.txt">
       <LogicalName>NormalizationDataWin7</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
-  
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.Runtime" />
     <TargetingPackReference Include="System.Threading.Tasks" />
   </ItemGroup>
-  
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Globalization/tests/System.Globalization.Tests.builds
+++ b/src/System.Globalization/tests/System.Globalization.Tests.builds
@@ -2,17 +2,17 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Globalization.Tests.csproj"/>
+    <Project Include="Performance\System.Globalization.Performance.Tests.csproj" />
     <Project Include="System.Globalization.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>    
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
+    </Project>
+    <Project Include="System.Globalization.Tests.csproj" />
     <Project Include="System.Globalization.Tests.csproj">
       <TestTFMs>net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
-    <Project Include="Performance\System.Globalization.Performance.Tests.csproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -9,8 +9,7 @@
     <RootNamespace>System.Globalization.Tests</RootNamespace>
     <AssemblyName>System.Globalization.Tests</AssemblyName>
     <DefineConstants Condition="'$(TargetGroup)' == 'net46'">$(DefineConstants);net46</DefineConstants>
-    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7' AND '$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -153,7 +152,7 @@
       <Name>System.Globalization</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="CharUnicodeInfo\CharUnicodeInfoTests.netstandard1.7.cs" />
     <Compile Include="CompareInfo\CompareInfoTests.netstandard1.7.cs" />
     <Compile Include="CultureInfo\CultureInfoTests.netstandard1.7.cs" />

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.builds
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="Performance\System.IO.Compression.Performance.Tests.csproj" />
     <Project Include="System.IO.Compression.Tests.csproj">
       <OSGroup>Unix</OSGroup>
     </Project>
@@ -9,8 +10,6 @@
       <TestTFMs>netcore50;netcoreapp1.0;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Performance\System.IO.Compression.Performance.Tests.csproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.builds
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.builds
@@ -4,30 +4,28 @@
   <ItemGroup>
     <Project Include="System.IO.FileSystem.Watcher.Tests.csproj">
       <OSGroup>Linux</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.IO.FileSystem.Watcher.Tests.csproj">
       <OSGroup>OSX</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.IO.FileSystem.Watcher.Tests.csproj">
       <TestTFMs>netcoreapp1.0;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
     <Project Include="System.IO.FileSystem.Watcher.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
       <OSGroup>Linux</OSGroup>
     </Project>
     <Project Include="System.IO.FileSystem.Watcher.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
       <OSGroup>OSX</OSGroup>
     </Project>
     <Project Include="System.IO.FileSystem.Watcher.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -10,8 +10,8 @@
     <ProjectGuid>{20411A66-C7A4-4941-8FA2-66308365FD22}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Watcher.Tests</AssemblyName>
-    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NugetTargetMoniker>
-    </PropertyGroup>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
@@ -38,7 +38,7 @@
     <Compile Include="FileSystemWatcher.InternalBufferSize.cs" />
     <Compile Include="FileSystemWatcher.WaitForChanged.cs" />
     <Compile Include="FileSystemWatcher.unit.cs" />
-    <Compile Include="InternalBufferOverflowException.cs" Condition="'$(TargetGroup)' == 'netstandard1.7'"/>
+    <Compile Include="InternalBufferOverflowException.cs" Condition="'$(TargetGroup)' == ''" />
     <!-- Helpers -->
     <Compile Include="Utility\TestFileSystemWatcher.cs" />
     <Compile Include="Utility\FileSystemWatcherTest.cs" />
@@ -54,7 +54,7 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs" Condition="'$(TargetGroup)' == 'netstandard1.7'">
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs" Condition="'$(TargetGroup)' == ''">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.builds
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.builds
@@ -2,25 +2,23 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="Performance\System.IO.FileSystem.Performance.Tests.csproj" />
     <Project Include="System.IO.FileSystem.Tests.csproj">
       <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.IO.FileSystem.Tests.csproj">
       <TestTFMs>netcoreapp1.0;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
     <Project Include="System.IO.FileSystem.Tests.csproj">
       <OSGroup>Unix</OSGroup>
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
     </Project>
     <Project Include="System.IO.FileSystem.Tests.csproj">
-      <TestTFMs>netcoreapp1.1</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
-      <TargetGroup>netstandard1.7</TargetGroup>
     </Project>
-    <Project Include="Performance\System.IO.FileSystem.Performance.Tests.csproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -11,7 +11,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -34,8 +34,8 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
-    <Compile Include="FileStream\Handle.cs"/>
+  <ItemGroup Condition="'$(TargetGroup)'==''">
+    <Compile Include="FileStream\Handle.cs" />
     <Compile Include="Directory\GetLogicalDrives.cs" />
     <Compile Include="FileStream\BeginRead.cs" />
     <Compile Include="FileStream\EndRead.cs" />

--- a/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.builds
+++ b/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.builds
@@ -8,15 +8,10 @@
     </Project>
     <Project Include="System.IO.IsolatedStorage.Tests.csproj">
       <OSGroup>Unix</OSGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
-      <TargetGroup>netstandard1.7</TargetGroup>
     </Project>
     <Project Include="System.IO.IsolatedStorage.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
-      <TargetGroup>netstandard1.7</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <TestTFM Condition="'$(TestTFM)' == ''">netcoreapp1.1</TestTFM>
@@ -11,7 +11,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.IsolatedStorage.Tests</AssemblyName>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
     <RuntimeTargetMonikers>.NETCoreApp,Version=v1.1</RuntimeTargetMonikers>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
@@ -23,11 +23,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap101_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
-  <ItemGroup>
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.IO.IsolatedStorage/tests/project.json
+++ b/src/System.IO.IsolatedStorage/tests/project.json
@@ -35,23 +35,6 @@
     "netstandard1.7": {}
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.1-ns17": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.netcoreapp1.1": {}
   }
 }

--- a/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.builds
+++ b/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="Performance\System.IO.MemoryMappedFiles.Performance.Tests.csproj" />
     <Project Include="System.IO.MemoryMappedFiles.Tests.csproj">
       <OSGroup>Unix</OSGroup>
     </Project>
@@ -9,8 +10,6 @@
       <TestTFMs>netcoreapp1.0;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Performance\System.IO.MemoryMappedFiles.Performance.Tests.csproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.builds
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="Performance\System.IO.Pipes.Performance.Tests.csproj" />
     <Project Include="System.IO.Pipes.Tests.csproj">
       <OSGroup>Unix</OSGroup>
     </Project>
@@ -9,8 +10,6 @@
       <TestTFMs>netcoreapp1.0;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Performance\System.IO.Pipes.Performance.Tests.csproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.IO/tests/System.IO.Tests.builds
+++ b/src/System.IO/tests/System.IO.Tests.builds
@@ -2,21 +2,20 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.IO.Tests.csproj"/>
+    <Project Include="System.IO.Tests.csproj" />
+    <Project Include="System.IO.Tests.csproj">
+      <TargetGroup>netcoreapp1.0</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
+    </Project>
     <Project Include="System.IO.Tests.csproj">
       <TestTFMs>net462</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcoreapp1.0</TargetGroup>
     </Project>
     <Project Include="System.IO.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
-    <Project Include="System.IO.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -8,14 +8,15 @@
     <RootNamespace>System.IO</RootNamespace>
     <AssemblyName>System.IO.Tests</AssemblyName>
     <ProjectGuid>{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netstandard17</DefineConstants>
+    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="IndentedTextWriter.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
-    <Compile Include="BinaryReader\BinaryReaderTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
+    <Compile Include="IndentedTextWriter.cs" Condition="'$(TargetGroup)'==''" />
+    <Compile Include="BinaryReader\BinaryReaderTests.cs" Condition="'$(TargetGroup)'==''" />
     <Compile Include="BinaryWriter\BinaryWriter.WriteByteCharTests.cs" />
     <Compile Include="BinaryWriter\BinaryWriter.WriteTests.cs" />
     <Compile Include="BinaryWriter\BinaryWriterTests.cs" />
@@ -23,7 +24,7 @@
     <Compile Include="BufferedStream\BufferedStreamTests.cs" />
     <Compile Include="InvalidDataException\InvalidDataExceptionTests.cs" />
     <Compile Include="MemoryStream\MemoryStream.ConstructorTests.cs" />
-    <Compile Include="MemoryStream\MemoryStream.GetBufferTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'" />
+    <Compile Include="MemoryStream\MemoryStream.GetBufferTests.cs" Condition="'$(TargetGroup)'==''" />
     <Compile Include="MemoryStream\MemoryStream.TryGetBufferTests.cs" />
     <Compile Include="MemoryStream\MemoryStreamTests.cs" />
     <Compile Include="StreamReader\StreamReader.CtorTests.cs" />

--- a/src/System.Net.Mime/tests/Functional/System.Net.Mime.Functional.Tests.builds
+++ b/src/System.Net.Mime/tests/Functional/System.Net.Mime.Functional.Tests.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Net.Mime.Functional.Tests.csproj">
-    	<TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
+    <Project Include="System.Net.Mime.Functional.Tests.csproj" />
     <Project Include="System.Net.Mime.Functional.Tests.csproj">
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
@@ -12,4 +10,3 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Net.Mime/tests/Functional/System.Net.Mime.Functional.Tests.csproj
+++ b/src/System.Net.Mime/tests/Functional/System.Net.Mime.Functional.Tests.csproj
@@ -1,22 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <!--
-      Until we get first class support for NS1.7 and Netcoreapp1.1
-      we need to hard code $(TestTFM) and $(TestNugetTargetMoniker)
-      in the project file.
-    -->
-    <TestTFM>netcoreapp1.1</TestTFM>
     <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
     <ProjectGuid>{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}</ProjectGuid>
   </PropertyGroup>
-  <ItemGroup>
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU' " />
   <ItemGroup>

--- a/src/System.Net.Mime/tests/Functional/project.json
+++ b/src/System.Net.Mime/tests/Functional/project.json
@@ -29,23 +29,6 @@
     "netstandard1.7": {}
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.1-ns17": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.netcoreapp1.1": {}
   }
 }

--- a/src/System.Net.Mime/tests/Unit/System.Net.Mime.Unit.Tests.builds
+++ b/src/System.Net.Mime/tests/Unit/System.Net.Mime.Unit.Tests.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Net.Mime.Unit.Tests.csproj">
-    	<TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
+    <Project Include="System.Net.Mime.Unit.Tests.csproj" />
     <Project Include="System.Net.Mime.Unit.Tests.csproj">
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
@@ -12,4 +10,3 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Net.Mime/tests/Unit/System.Net.Mime.Unit.Tests.csproj
+++ b/src/System.Net.Mime/tests/Unit/System.Net.Mime.Unit.Tests.csproj
@@ -1,24 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
-    <!--
-      Until we get first class support for NS1.7 and Netcoreapp1.1
-      we need to hard code $(TestTFM) and $(TestNugetTargetMoniker)
-      in the project file.
-    -->
-    <TestTFM>netcoreapp1.1</TestTFM>
     <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
     <ProjectGuid>{2525E37E-0EC1-4374-92FD-D2752BEED978}</ProjectGuid>
   </PropertyGroup>
-  <ItemGroup>
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU' " />
   <ItemGroup>

--- a/src/System.Net.Mime/tests/Unit/project.json
+++ b/src/System.Net.Mime/tests/Unit/project.json
@@ -29,23 +29,6 @@
     "netstandard1.7": {}
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.1-ns17": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.netcoreapp1.1": {}
   }
 }

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.builds
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.builds
@@ -2,14 +2,15 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Net.Requests.Tests.csproj"/>
+    <Project Include="System.Net.Requests.Tests.csproj" />
     <Project Include="System.Net.Requests.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Net.Requests.Tests.csproj">
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -7,22 +7,19 @@
     <ProjectGuid>{851A40FE-7F07-415D-8592-5FE2096E84D3}</ProjectGuid>
     <OutputType>Library</OutputType>
     <StringResourcesPath>../src/Resources/Strings.resx</StringResourcesPath>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netstandard17</DefineConstants>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
-  
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />  
-  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="HttpWebRequestTest.cs" />
     <Compile Include="HttpWebResponseTest.cs" />
     <Compile Include="RequestStreamTest.cs" />
     <Compile Include="WebRequestTest.cs" />
-
     <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
@@ -36,8 +33,7 @@
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
     </Compile>
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="AuthorizationTest.cs" />
     <Compile Include="AuthenticationManagerTest.cs" />
     <Compile Include="FileWebRequestTest.cs" />
@@ -45,17 +41,14 @@
     <Compile Include="RequestCachePolicyTest.cs" />
     <Compile Include="ServicePointManagerTest.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Net.Requests.pkgproj">
       <Name>System.Net.Requests</Name>
       <Project>{5EE76DCC-9FD5-47FD-AB45-BD0F0857740F}</Project>
     </ProjectReference>
   </ItemGroup>
-
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.builds
+++ b/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Net.WebClient.Tests.csproj">
-    	<TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
+    <Project Include="System.Net.WebClient.Tests.csproj" />
     <Project Include="System.Net.WebClient.Tests.csproj">
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
@@ -12,4 +10,3 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
+++ b/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
@@ -1,22 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <!--
-      Until we get first class support for NS1.7 and Netcoreapp1.1
-      we need to hard code $(TestTFM) and $(TestNugetTargetMoniker)
-      in the project file.
-    -->
-    <TestTFM>netcoreapp1.1</TestTFM>
     <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
     <ProjectGuid>{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}</ProjectGuid>
   </PropertyGroup>
-  <ItemGroup>
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU' " />
   <ItemGroup>

--- a/src/System.Net.WebClient/tests/project.json
+++ b/src/System.Net.WebClient/tests/project.json
@@ -32,23 +32,6 @@
     "netstandard1.7": {}
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.1-ns17": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.netcoreapp1.1": {}
   }
 }

--- a/src/System.Net.WebProxy/tests/System.Net.WebProxy.Tests.builds
+++ b/src/System.Net.WebProxy/tests/System.Net.WebProxy.Tests.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Net.WebProxy.Tests.csproj">
-    	<TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
+    <Project Include="System.Net.WebProxy.Tests.csproj" />
     <Project Include="System.Net.WebProxy.Tests.csproj">
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>

--- a/src/System.Net.WebProxy/tests/System.Net.WebProxy.Tests.csproj
+++ b/src/System.Net.WebProxy/tests/System.Net.WebProxy.Tests.csproj
@@ -1,22 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <!--
-      Until we get first class support for NS1.7 and Netcoreapp1.1
-      we need to hard code $(TestTFM) and $(TestNugetTargetMoniker)
-      in the project file.
-    -->
-    <TestTFM>netcoreapp1.1</TestTFM>
     <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
     <ProjectGuid>{0D1E2954-A5C7-4B8C-932A-31EB4A96A726}</ProjectGuid>
   </PropertyGroup>
-  <ItemGroup>
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Release|AnyCPU' " />
   <ItemGroup>

--- a/src/System.Net.WebProxy/tests/project.json
+++ b/src/System.Net.WebProxy/tests/project.json
@@ -31,23 +31,6 @@
     }
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.1-ns17": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.netcoreapp1.1": {}
   }
 }

--- a/src/System.Private.Uri/tests/ExtendedFunctionalTests/System.Private.Uri.ExtendedFunctional.Tests.csproj
+++ b/src/System.Private.Uri/tests/ExtendedFunctionalTests/System.Private.Uri.ExtendedFunctional.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -6,25 +6,13 @@
     <ProjectGuid>{0febe054-68ac-446f-b999-9068736d3cec}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Private.Uri.Tests</AssemblyName>
-    <!--
-      Until we get first class support for NS1.7 and Netcoreapp1.1
-      we need to hard code $(TestTFM) and $(TestNugetTargetMoniker)
-      in the project file.
-    -->
-    <TestTFM>netcoreapp1.1</TestTFM>
     <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
-  <ItemGroup>
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="UriRelativeResolutionTest.cs" />
     <Compile Include="UriTests.cs" />
-
     <!-- Test common -->
     <Compile Include="$(CommonTestPath)\System\ThreadCultureChange.cs">
       <Link>Common\System\ThreadCultureChange.cs</Link>

--- a/src/System.Private.Uri/tests/ExtendedFunctionalTests/project.json
+++ b/src/System.Private.Uri/tests/ExtendedFunctionalTests/project.json
@@ -19,23 +19,6 @@
     "netstandard1.7": {}
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.1-ns17": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.netcoreapp1.1": {}
   }
 }

--- a/src/System.Private.Uri/tests/System.Private.Uri.Tests.builds
+++ b/src/System.Private.Uri/tests/System.Private.Uri.Tests.builds
@@ -17,13 +17,9 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="ExtendedFunctionalTests\System.Private.Uri.ExtendedFunctional.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
       <OSGroup>Unix</OSGroup>
     </Project>
     <Project Include="ExtendedFunctionalTests\System.Private.Uri.ExtendedFunctional.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Private.Xml/tests/System.Private.Xml.Tests.builds
+++ b/src/System.Private.Xml/tests/System.Private.Xml.Tests.builds
@@ -2,110 +2,97 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="Readers\CharCheckingReader\System.Xml.RW.CharCheckingReader.Tests.csproj" >
+    <Project Include="XmlDocument\Performance\System.Xml.XmlDocument.Performance.Tests.csproj" />
+    <Project Include="Readers\CharCheckingReader\System.Xml.RW.CharCheckingReader.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Readers\CustomReader\System.Xml.RW.CustomReader.Tests.csproj" >
+    <Project Include="Readers\CustomReader\System.Xml.RW.CustomReader.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Readers\FactoryReader\System.Xml.RW.FactoryReader.Tests.csproj" >
+    <Project Include="Readers\FactoryReader\System.Xml.RW.FactoryReader.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Readers\NameTable\System.Xml.RW.NameTable.Tests.csproj" >
+    <Project Include="Readers\NameTable\System.Xml.RW.NameTable.Tests.csproj">
       <TestTFMs>netcoreapp1.0;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Readers\ReaderSettings\System.Xml.RW.ReaderSettings.Tests.csproj" >
+    <Project Include="Readers\ReaderSettings\System.Xml.RW.ReaderSettings.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Readers\SubtreeReader\System.Xml.RW.SubtreeReader.Tests.csproj" >
+    <Project Include="Readers\SubtreeReader\System.Xml.RW.SubtreeReader.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Readers\WrappedReader\System.Xml.RW.WrappedReader.Tests.csproj" >
+    <Project Include="Readers\WrappedReader\System.Xml.RW.WrappedReader.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Writers\RwFactory\System.Xml.RW.RwFactory.Tests.csproj" >
+    <Project Include="Writers\RwFactory\System.Xml.RW.RwFactory.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Writers\XmlWriterApi\System.Xml.RW.XmlWriterApi.Tests.csproj" >
+    <Project Include="Writers\XmlWriterApi\System.Xml.RW.XmlWriterApi.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XmlConvert\System.Xml.RW.XmlConvert.Tests.csproj" >
+    <Project Include="XmlConvert\System.Xml.RW.XmlConvert.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XmlReader\ReadContentAs\System.Xml.RW.XmlReader.ReadContentAs.Tests.csproj" >
+    <Project Include="XmlReader\ReadContentAs\System.Xml.RW.XmlReader.ReadContentAs.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XmlReader\Tests\System.Xml.RW.XmlReader.Tests.csproj" >
+    <Project Include="XmlReader\Tests\System.Xml.RW.XmlReader.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XmlReader\XmlResolver\System.Xml.RW.XmlSystemPathResolver.Tests.csproj" >
+    <Project Include="XmlReader\XmlResolver\System.Xml.RW.XmlSystemPathResolver.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XmlReaderLib\System.Xml.RW.XmlReaderLib.csproj" >
+    <Project Include="XmlReaderLib\System.Xml.RW.XmlReaderLib.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XmlWriter\System.Xml.RW.XmlWriter.Tests.csproj" >
+    <Project Include="XmlWriter\System.Xml.RW.XmlWriter.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XmlSchema\XmlSchemaSet\System.Xml.XmlSchemaSet.Tests.csproj" >
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1;net463</TestTFMs>
+    <Project Include="XmlSchema\XmlSchemaSet\System.Xml.XmlSchemaSet.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XmlSchema\XmlSchemaValidatorApi\System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj" >
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1;net463</TestTFMs>
+    <Project Include="XmlSchema\XmlSchemaValidatorApi\System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Xslt\XslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj" >
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1;net463</TestTFMs>
+    <Project Include="Xslt\XslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Xslt\XslCompiledTransformApi\System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" >
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1;net463</TestTFMs>
+    <Project Include="Xslt\XslCompiledTransformApi\System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="Xslt\XsltCompiler\XsltCompiler.Tests.csproj" >
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+    <Project Include="Xslt\XsltCompiler\XsltCompiler.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XPath\XPathDocument\System.Xml.XPath.Tests.csproj" >
+    <Project Include="XPath\XPathDocument\System.Xml.XPath.Tests.csproj">
       <TestTFMs>netcoreapp1.0;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XPath\XmlDocument\System.Xml.XPath.XmlDocument.Tests.csproj" >
+    <Project Include="XPath\XmlDocument\System.Xml.XPath.XmlDocument.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XmlDocument\System.Xml.XmlDocument.Tests.csproj" >
+    <Project Include="XmlDocument\System.Xml.XmlDocument.Tests.csproj">
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-    <Project Include="XmlSerializer\System.Xml.XmlSerializer.Tests.csproj" >
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1;uap101;uap101aot;netcore50;netcore50aot;net463</TestTFMs>
+    <Project Include="XmlSerializer\System.Xml.XmlSerializer.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-
-    <Project Include="XmlDocument\Performance\System.Xml.XmlDocument.Performance.Tests.csproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/System.Xml.XmlSchemaSet.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/System.Xml.XmlSchemaSet.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -48,7 +48,6 @@
     <Compile Include="TC_SchemaSet_XmlNameTable.cs" />
     <Compile Include="TC_SchemaSet_XmlResolver.cs" />
     <Compile Include="XmlSystemPathResolverTests.cs" />
-
     <Content Include="..\TestFiles\**\*.*">
       <Link>TestFiles\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -14,12 +14,7 @@
     <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
     <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
-  <ItemGroup>
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
-  <PropertyGroup Condition="'$(UseContractReferences)' == 'true'" >
+  <PropertyGroup Condition="'$(UseContractReferences)' == 'true'">
     <ProjectJson>Performance/project.json</ProjectJson>
     <ProjectLockJson>Performance/project.lock.json</ProjectLockJson>
   </PropertyGroup>

--- a/src/System.Private.Xml/tests/XmlSerializer/project.json
+++ b/src/System.Private.Xml/tests/XmlSerializer/project.json
@@ -36,23 +36,6 @@
     "netstandard1.7": {}
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.1-ns17": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.netcoreapp1.1": {}
   }
 }

--- a/src/System.Runtime.Extensions/tests/Performance/System.Runtime.Extensions.Performance.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/Performance/System.Runtime.Extensions.Performance.Tests.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>System.Runtime.Extensions.Performance.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludePerformanceTests>true</IncludePerformanceTests>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.5</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.builds
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.builds
@@ -2,14 +2,18 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="Performance\System.Runtime.Extensions.Performance.Tests.csproj" />
     <Project Include="System.Runtime.Extensions.Tests.csproj">
       <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.5</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Runtime.Extensions.Tests.csproj">
       <TestTFMs>netcoreapp1.0;net462</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.5</TargetGroup>
     </Project>
-<!--
+    <!--
     Can't reliably test multiple target groups against the same TestTFM (at least in parallel).
     Need to hunt down colliding usages of TestTFM, such as _TestDependencyListRoot in tests.targets.
 
@@ -30,19 +34,12 @@
 -->
     <Project Include="System.Runtime.Extensions.Tests.csproj">
       <TargetGroup>netcoreapp1.1</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.Runtime.Extensions.Tests.csproj">
       <TargetGroup>netcoreapp1.1</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
       <OSGroup>Unix</OSGroup>
-    </Project>
-    <Project Include="Performance\System.Runtime.Extensions.Performance.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -13,7 +13,7 @@
     <AssemblyName>System.Runtime.Extensions.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.5</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.5</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Folder logic needs moved into common targets: https://github.com/dotnet/corefx/issues/11468 -->
   <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.builds
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Runtime.Serialization.Formatters.Tests.csproj">
-    	<TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
+    <Project Include="System.Runtime.Serialization.Formatters.Tests.csproj" />
     <Project Include="System.Runtime.Serialization.Formatters.Tests.csproj">
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
@@ -12,4 +10,3 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -8,19 +8,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Runtime.Serialization.Formatters.Tests</AssemblyName>
     <RootNamespace>System.Runtime.Serialization.Formatters.Tests</RootNamespace>
-    <!--
-      Until we get first class support for NS1.7 and Netcoreapp1.1
-      we need to hard code $(TestTFM) and $(TestNugetTargetMoniker)
-      in the project file.
-    -->
-    <TestTFM>netcoreapp1.1</TestTFM>
     <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
-  <ItemGroup>
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/System.Runtime.Serialization.Formatters/tests/project.json
+++ b/src/System.Runtime.Serialization.Formatters/tests/project.json
@@ -27,23 +27,6 @@
     "netstandard1.7": {}
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.1-ns17": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.netcoreapp1.1": {}
   }
 }

--- a/src/System.Runtime/tests/System.Runtime.Tests.builds
+++ b/src/System.Runtime/tests/System.Runtime.Tests.builds
@@ -2,17 +2,17 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Runtime.Tests.csproj" />
+    <Project Include="Performance\System.Runtime.Performance.Tests.csproj" />
     <Project Include="System.Runtime.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.5</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
+    <Project Include="System.Runtime.Tests.csproj" />
     <Project Include="System.Runtime.Tests.csproj">
       <TestTFMs>net462</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.5</TargetGroup>
     </Project>
-    <Project Include="Performance\System.Runtime.Performance.Tests.csproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -10,7 +10,7 @@
     <AssemblyName>System.Runtime.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>1718</NoWarn>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.5</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU' ">
@@ -22,7 +22,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.5_Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\EnumTypes.cs" >
+    <Compile Include="$(CommonTestPath)\System\EnumTypes.cs">
       <Link>Common\System\EnumTypes.cs</Link>
     </Compile>
     <Compile Include="Helpers.cs" />
@@ -54,7 +54,7 @@
     <Compile Include="System\IntPtrTests.cs" />
     <Compile Include="System\IO\DirectoryNotFoundExceptionTests.cs" />
     <Compile Include="System\IO\DirectoryNotFoundException.InteropTests.cs" />
-    <Compile Include="System\IO\EndOfStreamExceptionTests.cs" />    
+    <Compile Include="System\IO\EndOfStreamExceptionTests.cs" />
     <Compile Include="System\IO\Exceptions.HResults.cs" />
     <Compile Include="System\IO\Exceptions.Utility.cs" />
     <Compile Include="System\IO\FileLoadExceptionTests.cs" />
@@ -100,7 +100,7 @@
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="ArrayTests.netstandard1.7.cs" />
     <Compile Include="CompareToTests.cs" />
     <Compile Include="DecimalTests.netstandard1.7.cs" />
@@ -114,12 +114,12 @@
     <Compile Include="System\EntryPointNotFoundExceptionTests.cs" />
     <Compile Include="System\ExceptionTests.cs" />
     <Compile Include="System\ExecutionEngineExceptionTests.cs" />
-    <Compile Include="System\GuidTests.netstandard1.7.cs" />    
+    <Compile Include="System\GuidTests.netstandard1.7.cs" />
     <Compile Include="System\NotFiniteNumberExceptionTests.cs" />
     <Compile Include="System\StackOverflowExceptionTests.cs" />
     <Compile Include="System\SystemExceptionTests.cs" />
     <Compile Include="System\StringTests.netstandard1.7.cs" />
-    <Compile Include="System\TimeSpanTests.netstandard1.7.cs" />    
+    <Compile Include="System\TimeSpanTests.netstandard1.7.cs" />
     <Compile Include="TimeZoneInfoTests.netstandard1.7.cs" />
     <Compile Include="TimeZoneNotFoundExceptionTests.netstandard1.7.cs" />
     <Compile Include="VersionTests.netstandard1.7.cs" />
@@ -140,10 +140,10 @@
     <Compile Include="System\Reflection\TypeTests.GetInterface.cs" />
     <Compile Include="System\Reflection\TypeTests.GetMember.cs" />
     <Compile Include="System\Reflection\CustomAttributesTestData.cs" />
-    <EmbeddedResource Include="System\Reflection\EmbeddedImage.png" >
+    <EmbeddedResource Include="System\Reflection\EmbeddedImage.png">
       <LogicalName>System.Reflection.Tests.EmbeddedImage.png</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="System\Reflection\EmbeddedTextFile.txt" >
+    <EmbeddedResource Include="System\Reflection\EmbeddedTextFile.txt">
       <LogicalName>System.Reflection.Tests.EmbeddedTextFile.txt</LogicalName>
     </EmbeddedResource>
     <Compile Include="System\Threading\WaitHandleTests.netstandard1.7.cs" />

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.builds
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.builds
@@ -4,17 +4,18 @@
   <ItemGroup>
     <Project Include="System.Security.Cryptography.Algorithms.Tests.csproj">
       <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.6</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Security.Cryptography.Algorithms.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
       <OSGroup>Unix</OSGroup>
     </Project>
     <Project Include="System.Security.Cryptography.Algorithms.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.6</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Security.Cryptography.Algorithms.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
       <TestTFMs>netcoreapp1.1;net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -10,14 +10,14 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Algorithms.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Algorithms.Tests</RootNamespace>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.6</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Security.Cryptography.Algorithms.pkgproj">
       <Project>{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}</Project>
       <Name>System.Security.Cryptography.Algorithms</Name>
     </ProjectReference>
-  </ItemGroup>  
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>CommonTest\System\PlatformDetection.cs</Link>
@@ -131,8 +131,8 @@
     <Compile Include="TripleDesProvider.cs" />
     <Compile Include="TripleDesTests.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
-    <Compile Include="DefaultDSAProvider.cs"/>
+  <ItemGroup Condition="'$(TargetGroup)'==''">
+    <Compile Include="DefaultDSAProvider.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.builds
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.builds
@@ -4,13 +4,13 @@
   <ItemGroup>
     <Project Include="System.Security.Cryptography.Cng.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.6</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Security.Cryptography.Cng.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup> 
-      <TestTFMs>net463;netcoreapp1.1</TestTFMs>
+      <TestTFMs>netcoreapp1.1;net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_NT_Debug</Configuration>
@@ -10,8 +10,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Cng.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Cng.Tests</RootNamespace>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.6</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netstandard17</DefineConstants>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Debug|AnyCPU'" />
@@ -127,7 +127,7 @@
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="DSACngProvider.cs" />
     <Compile Include="DSACngTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.builds
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.builds
@@ -3,14 +3,13 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Security.Cryptography.Csp.Tests.csproj">
-        <OSGroup>Windows_NT</OSGroup>
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Security.Cryptography.Csp.Tests.csproj">
-        <TargetGroup>netstandard1.7</TargetGroup>
-        <TestTFMs>netcoreapp1.1</TestTFMs>
-        <OSGroup>Windows_NT</OSGroup>
+      <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -10,10 +10,9 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Csp.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Csp.Tests</RootNamespace>
-    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7' AND '$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
-    <!-- Default configurations to help VS understand the configurations -->
+  <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Release|AnyCPU'" />
   <ItemGroup>
@@ -53,7 +52,7 @@
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="DSACryptoServiceProviderProvider.cs" />
     <Compile Include="DSACryptoServiceProviderTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">

--- a/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.builds
+++ b/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.builds
@@ -4,21 +4,21 @@
   <ItemGroup>
     <Project Include="System.Security.Cryptography.Encoding.Tests.csproj">
       <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Security.Cryptography.Encoding.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
       <OSGroup>Unix</OSGroup>
     </Project>
     <Project Include="System.Security.Cryptography.Encoding.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Security.Cryptography.Encoding.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
       <TestTFMs>netcoreapp1.1;net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -12,7 +12,7 @@
     <AssemblyName>System.Security.Cryptography.Encoding.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Encoding.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Security.Cryptography.Encoding.pkgproj">
@@ -37,7 +37,7 @@
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="Base64TransformsTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.builds
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.builds
@@ -4,13 +4,12 @@
   <ItemGroup>
     <Project Include="System.Security.Cryptography.OpenSsl.Tests.csproj">
       <OSGroup>Unix</OSGroup>
+      <TargetGroup>netstandard1.6</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Security.Cryptography.OpenSsl.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
       <OSGroup>Unix</OSGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Unix_Debug</Configuration>
@@ -10,7 +10,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.OpenSsl.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.OpenSsl.Tests</RootNamespace>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.6</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
     <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU'" />
@@ -78,7 +78,7 @@
     <Compile Include="EcDsaOpenSslProvider.cs" />
     <Compile Include="RsaOpenSslTests.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="DsaOpenSslProvider.cs" />
     <Compile Include="DsaOpenSslTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.builds
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.builds
@@ -2,10 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Security.Permissions.Tests.csproj">
-      <TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
+    <Project Include="System.Security.Permissions.Tests.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -12,13 +12,8 @@
     <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
     <TestTFM>netcoreapp1.1</TestTFM>
     <ProjectGuid>{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}</ProjectGuid>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
-  <ItemGroup>
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Security.Permissions/tests/project.json
+++ b/src/System.Security.Permissions/tests/project.json
@@ -25,23 +25,6 @@
     "netstandard1.7": {}
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.1-ns17": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.netcoreapp1.1": {}
   }
 }

--- a/src/System.Text.Encoding.Extensions/tests/System.Text.Encoding.Extensions.Tests.builds
+++ b/src/System.Text.Encoding.Extensions/tests/System.Text.Encoding.Extensions.Tests.builds
@@ -2,16 +2,16 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Text.Encoding.Extensions.Tests.csproj"/>
+    <Project Include="System.Text.Encoding.Extensions.Tests.csproj" />
+    <Project Include="System.Text.Encoding.Extensions.Tests.csproj">
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
+    </Project>
     <Project Include="System.Text.Encoding.Extensions.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
-    </Project>
-    <Project Include="System.Text.Encoding.Extensions.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Text.Encoding.Extensions/tests/System.Text.Encoding.Extensions.Tests.csproj
+++ b/src/System.Text.Encoding.Extensions/tests/System.Text.Encoding.Extensions.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -9,7 +9,7 @@
     <AssemblyName>System.Text.Encoding.Extensions.Tests</AssemblyName>
     <RootNamespace>System.Text.Encoding.Extensions.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.builds
+++ b/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.builds
@@ -2,17 +2,17 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Text.Encoding.Tests.csproj"/>
+    <Project Include="Performance\System.Text.Encoding.Performance.Tests.csproj" />
+    <Project Include="System.Text.Encoding.Tests.csproj">
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
+    </Project>
     <Project Include="System.Text.Encoding.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
-    <Project Include="System.Text.Encoding.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
-    <Project Include="Performance\System.Text.Encoding.Performance.Tests.csproj"/>
+    <Project Include="System.Text.Encoding.Tests.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -9,7 +9,7 @@
     <AssemblyName>System.Text.Encoding.Tests</AssemblyName>
     <RootNamespace>System.Text.Encoding.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NugetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -79,7 +79,7 @@
     <Compile Include="UTF8Encoding\UTF8EncodingTests.cs" />
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="Encoding\Encoding.netstandard1.7.cs" />
     <Compile Include="UnicodeEncoding\UnicodeEncoding.netstandard1.7.cs" />
     <Compile Include="Decoder\Decoder.netstandard1.7.cs" />

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.builds
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.builds
@@ -2,16 +2,16 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Text.RegularExpressions.Tests.csproj"/>
+    <Project Include="System.Text.RegularExpressions.Tests.csproj" />
+    <Project Include="System.Text.RegularExpressions.Tests.csproj">
+      <TargetGroup>netstandard1.6</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
+    </Project>
     <Project Include="System.Text.RegularExpressions.Tests.csproj">
       <TestTFMs>net463</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
-    </Project>
-    <Project Include="System.Text.RegularExpressions.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netstandard1.6</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Text.RegularExpressions.Tests</AssemblyName>
-    <NugetTargetMoniker Condition=" '$(TargetGroup)' == ''">.NETStandard,Version=v1.6</NugetTargetMoniker>
+    <NugetTargetMoniker Condition=" '$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.7_Debug|AnyCPU' ">
@@ -32,7 +32,7 @@
     <Compile Include="Regex.Match.Tests.cs" />
     <Compile Include="Regex.Tests.Common.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetGroup)' == 'netstandard1.7'">
+  <ItemGroup Condition=" '$(TargetGroup)' == ''">
     <Compile Include="PrecompiledRegexScenarioTest.cs" />
     <Compile Include="RegexGroupNameTests.cs" />
     <Compile Include="Regex.Serialization.cs" />

--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.builds
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.builds
@@ -2,16 +2,16 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Threading.Tasks.Tests.csproj"/>
+    <Project Include="System.Threading.Tasks.Tests.csproj" />
     <Project Include="System.Threading.Tasks.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TargetGroup>netcoreapp1.0</TargetGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Threading.Tasks.Tests.csproj">
       <TestTFMs>net462</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcoreapp1.0</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -1,22 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Threading.Tasks.Tests</AssemblyName>
     <ProjectGuid>{B6C09633-D161-499A-8FE1-46B2D53A16E7}</ProjectGuid>
+    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <!-- Compile tests against the System.Runtime contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="..\pkg\System.Threading.Tasks.pkgproj"/>
+    <ProjectReference Include="..\pkg\System.Threading.Tasks.pkgproj" />
     <!-- ToDo: Remove this reference once prerelease gets updated again -->
     <ProjectReference Include="..\..\System.Runtime\pkg\System.Runtime.pkgproj" />
     <!-- ToDo: Remove this reference once prerelease gets updated again -->
@@ -64,7 +60,7 @@
       <Link>CommonTest\System\Threading\ThreadPoolHelpers.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.7'">
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="Task\TaskDisposeTests.netstandard1.7.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Transactions/tests/System.Transactions.Tests.builds
+++ b/src/System.Transactions/tests/System.Transactions.Tests.builds
@@ -2,10 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Transactions.Tests.csproj">
-    	<TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
+    <Project Include="System.Transactions.Tests.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Transactions/tests/System.Transactions.Tests.csproj
+++ b/src/System.Transactions/tests/System.Transactions.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -7,19 +7,8 @@
     <ProjectGuid>{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Transactions.Tests</AssemblyName>
-    <!--
-        Until we get first class support for NS1.7 and Netcoreapp1.1
-        we need to hard code $(TestTFM) and $(TestNugetTargetMoniker)
-        in the project file.
-      -->
-      <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
-      <TestTFM>netcoreapp1.1</TestTFM>
-    </PropertyGroup>
-  <ItemGroup>
-    <TestNugetTargetMoniker Include="$(NugetTargetMoniker)">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
+    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="NonMsdtcPromoterTests.cs" />
     <Compile Include="AsyncTransactionScopeTests.cs" />

--- a/src/System.Transactions/tests/project.json
+++ b/src/System.Transactions/tests/project.json
@@ -26,23 +26,6 @@
     "netstandard1.7": {}
   },
   "supports": {
-    "coreFx.Test.netcoreapp1.1-ns17": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.netcoreapp1.1": {}
   }
 }

--- a/src/System.Web.HttpUtility/tests/System.Web.HttpUtility.Tests.csproj
+++ b/src/System.Web.HttpUtility/tests/System.Web.HttpUtility.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NugetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'netstandard1.3_Debug|AnyCPU' ">
   </PropertyGroup>


### PR DESCRIPTION
Fixes #12129 

This change will make it such that netcoreapp1.1 will be the new default TestTFM for all projects, and it will also now only run the netcoreapp1.1 tests as part of the regular CI. One more thing I did with this change, is to make all of the test .csprojs to also default their nuget target moniker to netstandard1.7 if they were testing API that is specific to that framework, and I did this so that now all three (tests, refs, and impls) will have the same behavior and default to netstandard1.7 and x-compile only to older frameworks.

cc: @weshaggard @ericstj @danmosemsft @stephentoub @karajas 