### PR TITLE
Enable netstandard 1.7 string tests

### DIFF
--- a/src/System.Globalization.Extensions/tests/Normalization/StringNormalizationTests.cs
+++ b/src/System.Globalization.Extensions/tests/Normalization/StringNormalizationTests.cs
@@ -14,7 +14,6 @@ namespace System.Globalization.Tests
         [InlineData("\u00C4\u00C7", NormalizationForm.FormD, false)]
         [InlineData("A\u0308C\u0327", NormalizationForm.FormC, false)]
         [InlineData("A\u0308C\u0327", NormalizationForm.FormD, true)]
-        [ActiveIssue(11803, Xunit.PlatformID.AnyUnix)]
         public void IsNormalized(string value, NormalizationForm normalizationForm, bool expected)
         {
             if (normalizationForm == NormalizationForm.FormC)
@@ -25,7 +24,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(11803, Xunit.PlatformID.AnyUnix)]
         public void IsNormalized_Invalid()
         {
             Assert.Throws<ArgumentException>(() => "\uFB01".IsNormalized((NormalizationForm)10));
@@ -55,7 +53,6 @@ namespace System.Globalization.Tests
         [InlineData("\u1E9b\u0323", NormalizationForm.FormD, "\u017f\u0323\u0307")]
         [InlineData("\u1E9b\u0323", NormalizationForm.FormKC, "\u1E69")]
         [InlineData("\u1E9b\u0323", NormalizationForm.FormKD, "\u0073\u0323\u0307")]
-        [ActiveIssue(11803, Xunit.PlatformID.AnyUnix)]
         public void Normalize(string value, NormalizationForm normalizationForm, string expected)
         {
             if (normalizationForm == NormalizationForm.FormC)
@@ -66,7 +63,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(11803, Xunit.PlatformID.AnyUnix)]
         public void Normalize_Invalid()
         {
             Assert.Throws<ArgumentException>(() => "\uFB01".Normalize((NormalizationForm)7));

--- a/src/System.Runtime/tests/System/StringTests.netstandard1.7.cs
+++ b/src/System.Runtime/tests/System/StringTests.netstandard1.7.cs
@@ -52,7 +52,6 @@ namespace System.Tests
         }
 
         [Theory]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         [MemberData(nameof(Compare_TestData))]
         public static void CompareTest(string s1, string s2, string cultureName, bool ignoreCase, int expected)
         {
@@ -80,7 +79,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         public static void CompareNegativeTest()
         {
             Assert.Throws<ArgumentNullException>("culture", () => String.Compare("a", "b", false, null));
@@ -97,7 +95,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(UpperLowerCasing_TestData))]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         public static void CasingTest(string lowerForm, string upperForm, string cultureName)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
@@ -106,7 +103,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         public static void CasingNegativeTest()
         {
             Assert.Throws<ArgumentNullException>("culture", () => "".ToLower(null));
@@ -115,7 +111,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(StartEndWith_TestData))]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         public static void StartEndWithTest(string source, string start, string end, string cultureName, bool ignoreCase, bool expected)
         {
              CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
@@ -124,7 +119,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         public static void StartEndNegativeTest()
         {
             Assert.Throws<ArgumentNullException>("value", () => "".StartsWith(null, true, null));
@@ -132,7 +126,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         public static unsafe void ConstructorsTest()
         {
             string s = "This is a string constructor test";
@@ -155,7 +148,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         public static unsafe void CloneTest()
         {
             string s = "some string to clone";
@@ -165,7 +157,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         public static unsafe void CopyTest()
         {
             string s = "some string to copy";
@@ -175,7 +166,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         public static unsafe void InternTest()
         {
             String s1 = "MyTest";
@@ -191,7 +181,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         public static unsafe void NormalizationTest()
         {
             // U+0063  LATIN SMALL LETTER C
@@ -225,7 +214,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(11617, Xunit.PlatformID.AnyUnix)]
         public static unsafe void GetEnumeratorTest()
         {
             string s = "This is some string to enumerate its characters using String.GetEnumerator";


### PR DESCRIPTION
Currently the tested functionality got supported in coreclr.