### PR TITLE
Skip a not support CodeDom test on desktop

### DIFF
--- a/src/System.CodeDom/src/System.CodeDom.csproj
+++ b/src/System.CodeDom/src/System.CodeDom.csproj
@@ -135,9 +135,5 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <!-- TODO: Replace this with a package reference. -->
-  <ItemGroup>
-    <ProjectReference Include="..\..\System.IO\pkg\System.IO.pkgproj" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.CodeDom/tests/CodeGenerationTests.cs
+++ b/src/System.CodeDom/tests/CodeGenerationTests.cs
@@ -23,6 +23,7 @@ namespace System.CodeDom.Tests
             Assert.Equal(provider.GetType(), provider2.GetType());
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [Fact]
         public void Compilation_NotSupported()
         {

--- a/src/System.CodeDom/tests/System.CodeDom.Tests.csproj
+++ b/src/System.CodeDom/tests/System.CodeDom.Tests.csproj
@@ -30,9 +30,5 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <!-- TODO: Replace this with a package reference. -->
-  <ItemGroup>
-    <ProjectReference Include="..\..\System.IO\pkg\System.IO.pkgproj"/>
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
One of the CodeDom tests is verifying that PlatformNotSupportedExceptions are thrown from certain operations that aren't supported yet on core, but are on desktop.  Just skip the test on desktop.