### PR TITLE
Adding some IL tests for closure generation.

### DIFF
--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -192,9 +192,159 @@ namespace System.Linq.Expressions.Tests
                   }");
         }
 
-        public static void VerifyIL(this LambdaExpression expression, string expected)
+        [Fact]
+        public static void VerifyIL_Closure1()
         {
-            var actual = expression.GetIL();
+            Expression<Func<Func<int>>> f = () => () => 42;
+
+            f.VerifyIL(
+                @".method class [System.Private.CoreLib]System.Func`1<int32> ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure)
+                  {
+                    .maxstack 3
+                  
+                    IL_0000: ldarg.0    
+                    IL_0001: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
+                    IL_0006: ldc.i4.0   
+                    IL_0007: ldelem.ref 
+                    IL_0008: castclass  class [System.Private.CoreLib]System.Reflection.MethodInfo
+                    IL_000d: ldtoken    class [System.Private.CoreLib]System.Func`1<int32>
+                    IL_0012: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
+                    IL_0017: ldnull     
+                    IL_0018: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
+                    IL_001d: castclass  class [System.Private.CoreLib]System.Func`1<int32>
+                    IL_0022: ret        
+                  }
+                  
+                  // closure.Constants[0]
+                  .method int32 ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure)
+                  {
+                    .maxstack 1
+                  
+                    IL_0000: ldc.i4.s   42
+                    IL_0002: ret        
+                  }",
+                appendInnerLambdas: true);
+        }
+
+        [Fact]
+        public static void VerifyIL_Closure2()
+        {
+            Expression<Func<int, Func<int>>> f = x => () => x;
+
+            f.VerifyIL(
+                @".method class [System.Private.CoreLib]System.Func`1<int32> ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure,int32)
+                  {
+                    .maxstack 8
+                    .locals init (
+                      [0] object[]
+                    )
+                  
+                    IL_0000: ldc.i4.1   
+                    IL_0001: newarr     object
+                    IL_0006: dup        
+                    IL_0007: ldc.i4.0   
+                    IL_0008: ldarg.1    
+                    IL_0009: newobj     instance void class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::.ctor(int32)
+                    IL_000e: stelem.ref 
+                    IL_000f: stloc.0    
+                    IL_0010: ldarg.0    
+                    IL_0011: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
+                    IL_0016: ldc.i4.0   
+                    IL_0017: ldelem.ref 
+                    IL_0018: castclass  class [System.Private.CoreLib]System.Reflection.MethodInfo
+                    IL_001d: ldtoken    class [System.Private.CoreLib]System.Func`1<int32>
+                    IL_0022: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
+                    IL_0027: ldnull     
+                    IL_0028: ldloc.0    
+                    IL_0029: newobj     instance void class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::.ctor(object[],object[])
+                    IL_002e: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
+                    IL_0033: castclass  class [System.Private.CoreLib]System.Func`1<int32>
+                    IL_0038: ret        
+                  }
+                  
+                  // closure.Constants[0]
+                  .method int32 ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure)
+                  {
+                    .maxstack 2
+                    .locals init (
+                      [0] object[]
+                    )
+                  
+                    IL_0000: ldarg.0    
+                    IL_0001: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Locals
+                    IL_0006: stloc.0    
+                    IL_0007: ldloc.0    
+                    IL_0008: ldc.i4.0   
+                    IL_0009: ldelem.ref 
+                    IL_000a: castclass  class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>
+                    IL_000f: ldfld      class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::Value
+                    IL_0014: ret        
+                  }",
+                appendInnerLambdas: true);
+        }
+
+        [Fact]
+        public static void VerifyIL_Closure3()
+        {
+            Expression<Func<int, Func<int, int>>> f = x => y => x + y;
+
+            f.VerifyIL(
+                @".method class [System.Private.CoreLib]System.Func`2<int32,int32> ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure,int32)
+                  {
+                    .maxstack 8
+                    .locals init (
+                      [0] object[]
+                    )
+                  
+                    IL_0000: ldc.i4.1   
+                    IL_0001: newarr     object
+                    IL_0006: dup        
+                    IL_0007: ldc.i4.0   
+                    IL_0008: ldarg.1    
+                    IL_0009: newobj     instance void class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::.ctor(int32)
+                    IL_000e: stelem.ref 
+                    IL_000f: stloc.0    
+                    IL_0010: ldarg.0    
+                    IL_0011: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
+                    IL_0016: ldc.i4.0   
+                    IL_0017: ldelem.ref 
+                    IL_0018: castclass  class [System.Private.CoreLib]System.Reflection.MethodInfo
+                    IL_001d: ldtoken    class [System.Private.CoreLib]System.Func`2<int32,int32>
+                    IL_0022: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
+                    IL_0027: ldnull     
+                    IL_0028: ldloc.0    
+                    IL_0029: newobj     instance void class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::.ctor(object[],object[])
+                    IL_002e: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
+                    IL_0033: castclass  class [System.Private.CoreLib]System.Func`2<int32,int32>
+                    IL_0038: ret        
+                  }
+                  
+                  // closure.Constants[0]
+                  .method int32 ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure,int32)
+                  {
+                    .maxstack 2
+                    .locals init (
+                      [0] object[]
+                    )
+                  
+                    IL_0000: ldarg.0    
+                    IL_0001: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Locals
+                    IL_0006: stloc.0    
+                    IL_0007: ldloc.0    
+                    IL_0008: ldc.i4.0   
+                    IL_0009: ldelem.ref 
+                    IL_000a: castclass  class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>
+                    IL_000f: ldfld      class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::Value
+                    IL_0014: ldarg.1    
+                    IL_0015: add        
+                    IL_0016: ret        
+                  }",
+                appendInnerLambdas: true);
+        }
+
+        public static void VerifyIL(this LambdaExpression expression, string expected, bool appendInnerLambdas = false)
+        {
+            var actual = expression.GetIL(appendInnerLambdas);
 
             var nExpected = Normalize(expected);
             var nActual = Normalize(actual);


### PR DESCRIPTION
As I'm working on making closures generated by `LambdaCompiler` cheaper (see https://github.com/bartdesmet/corefx/tree/CheaperClosures for work in progress), I need IL-level verification of compiled delegates including inner ones. This PR adds support to print the IL for these with a few simple examples.