### PR TITLE
Adding instruction assertion mechanism for expression interpreter.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -395,6 +395,8 @@ namespace System.Linq.Expressions.Interpreter
                 return Array.Empty<object>();
             }
         }
+
+        public override string ToString() => "Call(" + _target + ")";
     }
 
     internal class ByRefMethodInfoCallInstruction : MethodInfoCallInstruction

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -312,6 +312,8 @@ namespace System.Linq.Expressions.Interpreter
             _tryHandler = tryHandler;
         }
 
+        internal TryCatchFinallyHandler Handler => _tryHandler;
+
         public override int ProducedContinuations => _hasFinally ? 1 : 0;
 
         private EnterTryCatchFinallyInstruction(int targetIndex, bool hasFinally)
@@ -448,6 +450,8 @@ namespace System.Linq.Expressions.Interpreter
             Debug.Assert(_tryHandler == null, "the tryHandler can be set only once");
             _tryHandler = tryHandler;
         }
+
+        internal TryFaultHandler Handler => _tryHandler;
 
         public override int ProducedContinuations => 1;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -114,7 +114,7 @@ namespace System.Linq.Expressions.Interpreter
                 int stackDepth = 0;
                 int continuationsDepth = 0;
 
-                var cookieEnumerator = (debugCookies != null ? debugCookies : Array.Empty<KeyValuePair<int, object>>()).GetEnumerator();
+                var cookieEnumerator = (debugCookies ?? Array.Empty<KeyValuePair<int, object>>()).GetEnumerator();
                 var hasCookie = cookieEnumerator.MoveNext();
 
                 for (int i = 0, n = instructions.Count; i < n; i++)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -50,17 +50,16 @@ namespace System.Linq.Expressions.Interpreter
             }
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public InstructionList.DebugView.InstructionView[]/*!*/ A0
+            public InstructionList.DebugView.InstructionView[]/*!*/ A0 => GetInstructionViews(includeDebugCookies: true);
+
+            public InstructionList.DebugView.InstructionView[] GetInstructionViews(bool includeDebugCookies = false)
             {
-                get
-                {
-                    return InstructionList.DebugView.GetInstructionViews(
-                        _array.Instructions,
-                        _array.Objects,
-                        (index) => _array.Labels[index].Index,
-                        _array.DebugCookies
-                    );
-                }
+                return InstructionList.DebugView.GetInstructionViews(
+                    _array.Instructions,
+                    _array.Objects,
+                    (index) => _array.Labels[index].Index,
+                    includeDebugCookies ? _array.DebugCookies : null
+                );
             }
         }
         #endregion
@@ -95,17 +94,16 @@ namespace System.Linq.Expressions.Interpreter
             }
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public InstructionView[]/*!*/ A0
+            public InstructionView[]/*!*/ A0 => GetInstructionViews(includeDebugCookies: true);
+
+            public InstructionView[] GetInstructionViews(bool includeDebugCookies = false)
             {
-                get
-                {
-                    return GetInstructionViews(
+                return GetInstructionViews(
                         _list._instructions,
                         _list._objects,
                         (index) => _list._labels[index].TargetIndex,
-                        _list._debugCookies
+                        includeDebugCookies ? _list._debugCookies : null
                     );
-                }
             }
 
             internal static InstructionView[] GetInstructionViews(IList<Instruction> instructions, IList<object> objects,
@@ -116,7 +114,7 @@ namespace System.Linq.Expressions.Interpreter
                 int stackDepth = 0;
                 int continuationsDepth = 0;
 
-                var cookieEnumerator = (debugCookies != null ? debugCookies : new KeyValuePair<int, object>[0]).GetEnumerator();
+                var cookieEnumerator = (debugCookies != null ? debugCookies : Array.Empty<KeyValuePair<int, object>>()).GetEnumerator();
                 var hasCookie = cookieEnumerator.MoveNext();
 
                 for (int i = 0, n = instructions.Count; i < n; i++)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -80,6 +80,8 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
+        internal ExceptionHandler[] Handlers => _handlers;
+
         internal bool IsCatchBlockExist => _handlers != null;
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -117,13 +117,7 @@ namespace System.Linq.Expressions.Interpreter
             private void AddHandlerExit(int index)
             {
                 int count;
-                if (!_handlerExit.TryGetValue(index, out count))
-                {
-                    _handlerExit.Add(index, 1);
-                    return;
-                }
-
-                _handlerExit[index] = count + 1;
+                _handlerExit[index] = _handlerExit.TryGetValue(index, out count) ? count + 1 : 1;
             }
 
             private void Indent()
@@ -141,12 +135,12 @@ namespace System.Linq.Expressions.Interpreter
                 var sb = new StringBuilder();
 
                 string name = _interpreter.Name ?? "lambda_method";
-                sb.AppendLine("object " + name + "(object[])");
+                sb.Append("object ").Append(name).AppendLine("(object[])");
                 sb.AppendLine("{");
 
-                sb.AppendLine("  .locals " + _interpreter.LocalCount);
-                sb.AppendLine("  .maxstack " + _interpreter.Instructions.MaxStackDepth);
-                sb.AppendLine("  .maxcontinuation " + _interpreter.Instructions.MaxContinuationDepth);
+                sb.Append("  .locals ").Append(_interpreter.LocalCount).AppendLine();
+                sb.Append("  .maxstack ").Append(_interpreter.Instructions.MaxStackDepth).AppendLine();
+                sb.Append("  .maxcontinuation ").Append(_interpreter.Instructions.MaxContinuationDepth).AppendLine();
                 sb.AppendLine();
 
                 Instruction[] instructions = _interpreter.Instructions.Instructions;
@@ -162,8 +156,8 @@ namespace System.Linq.Expressions.Interpreter
                     {
                         for (int j = 0; j < startCount; j++)
                         {
-                            sb.AppendLine(_indent + ".try");
-                            sb.AppendLine(_indent + "{");
+                            sb.Append(_indent).AppendLine(".try");
+                            sb.Append(_indent).AppendLine("{");
                             Indent();
                         }
                     }
@@ -171,15 +165,15 @@ namespace System.Linq.Expressions.Interpreter
                     string handler;
                     if (_handlerEnter.TryGetValue(i, out handler))
                     {
-                        sb.AppendLine(_indent + handler);
-                        sb.AppendLine(_indent + "{");
+                        sb.Append(_indent).AppendLine(handler);
+                        sb.Append(_indent).AppendLine("{");
                         Indent();
                     }
 
                     Instruction instruction = instructions[i];
                     InstructionList.DebugView.InstructionView instructionView = instructionViews[i];
 
-                    sb.AppendLine(_indent + string.Format(CultureInfo.InvariantCulture, "IP_{0}: {1}", i.ToString().PadLeft(4, '0'), instructionView.GetValue()));
+                    sb.AppendFormat(string.Format(CultureInfo.InvariantCulture, "{0}IP_{1}: {2}", _indent, i.ToString().PadLeft(4, '0'), instructionView.GetValue())).AppendLine();
                 }
 
                 EmitExits(sb, instructions.Length);
@@ -197,7 +191,7 @@ namespace System.Linq.Expressions.Interpreter
                     for (int j = 0; j < exitCount; j++)
                     {
                         Dedent();
-                        sb.AppendLine(_indent + "}");
+                        sb.Append(_indent).AppendLine("}");
                     }
                 }
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -150,7 +150,8 @@ namespace System.Linq.Expressions.Interpreter
                 sb.AppendLine();
 
                 Instruction[] instructions = _interpreter.Instructions.Instructions;
-                InstructionList.DebugView.InstructionView[] instructionViews = new InstructionArray.DebugView(_interpreter.Instructions).A0;
+                InstructionArray.DebugView debugView = new InstructionArray.DebugView(_interpreter.Instructions);
+                InstructionList.DebugView.InstructionView[] instructionViews = debugView.GetInstructionViews(includeDebugCookies: false);
 
                 for (int i = 0; i < instructions.Length; i++)
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Dynamic.Utils;
+using System.Globalization;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
@@ -31,6 +32,174 @@ namespace System.Linq.Expressions.Interpreter
             _delegateCreator = delegateCreator;
             _closure = closure;
             _interpreter = delegateCreator.Interpreter;
+        }
+
+        internal string DebugView => new DebugViewPrinter(_interpreter).ToString();
+
+        class DebugViewPrinter
+        {
+            private readonly Interpreter _interpreter;
+            private readonly Dictionary<int, int> _tryStart = new Dictionary<int, int>();
+            private readonly Dictionary<int, string> _handlerEnter = new Dictionary<int, string>();
+            private readonly Dictionary<int, int> _handlerExit = new Dictionary<int, int>();
+            private string _indent = "  ";
+
+            public DebugViewPrinter(Interpreter interpreter)
+            {
+                _interpreter = interpreter;
+
+                Analyze();
+            }
+
+            private void Analyze()
+            {
+                Instruction[] instructions = _interpreter.Instructions.Instructions;
+
+                foreach (Instruction instruction in instructions)
+                {
+                    var enterTryCatchFinally = instruction as EnterTryCatchFinallyInstruction;
+                    if (enterTryCatchFinally != null)
+                    {
+                        TryCatchFinallyHandler handler = enterTryCatchFinally.Handler;
+
+                        AddTryStart(handler.TryStartIndex);
+                        AddHandlerExit(handler.TryEndIndex + 1 /* include Goto instruction that acts as a "leave" */);
+
+                        if (handler.IsFinallyBlockExist)
+                        {
+                            _handlerEnter.Add(handler.FinallyStartIndex, "finally");
+                            AddHandlerExit(handler.FinallyEndIndex);
+                        }
+
+                        if (handler.IsCatchBlockExist)
+                        {
+                            foreach (ExceptionHandler catchHandler in handler.Handlers)
+                            {
+                                _handlerEnter.Add(catchHandler.HandlerStartIndex - 1 /* include EnterExceptionHandler instruction */, catchHandler.ToString());
+                                AddHandlerExit(catchHandler.HandlerEndIndex);
+
+                                ExceptionFilter filter = catchHandler.Filter;
+                                if (filter != null)
+                                {
+                                    _handlerEnter.Add(filter.StartIndex - 1 /* include EnterExceptionFilter instruction */, "filter");
+                                    AddHandlerExit(filter.EndIndex);
+                                }
+                            }
+                        }
+                    }
+
+                    var enterTryFault = instruction as EnterTryFaultInstruction;
+                    if (enterTryFault != null)
+                    {
+                        TryFaultHandler handler = enterTryFault.Handler;
+
+                        AddTryStart(handler.TryStartIndex);
+                        AddHandlerExit(handler.TryEndIndex + 1 /* include Goto instruction that acts as a "leave" */);
+
+                        _handlerEnter.Add(handler.FinallyStartIndex, "fault");
+                        AddHandlerExit(handler.FinallyEndIndex);
+                    }
+                }
+            }
+
+            private void AddTryStart(int index)
+            {
+                int count;
+                if (!_tryStart.TryGetValue(index, out count))
+                {
+                    _tryStart.Add(index, 1);
+                    return;
+                }
+
+                _tryStart[index] = count + 1;
+            }
+
+            private void AddHandlerExit(int index)
+            {
+                int count;
+                if (!_handlerExit.TryGetValue(index, out count))
+                {
+                    _handlerExit.Add(index, 1);
+                    return;
+                }
+
+                _handlerExit[index] = count + 1;
+            }
+
+            private void Indent()
+            {
+                _indent = new string(' ', _indent.Length + 2);
+            }
+
+            private void Dedent()
+            {
+                _indent = new string(' ', _indent.Length - 2);
+            }
+
+            public override string ToString()
+            {
+                var sb = new StringBuilder();
+
+                string name = _interpreter.Name ?? "lambda_method";
+                sb.AppendLine("object " + name + "(object[])");
+                sb.AppendLine("{");
+
+                sb.AppendLine("  .locals " + _interpreter.LocalCount);
+                sb.AppendLine("  .maxstack " + _interpreter.Instructions.MaxStackDepth);
+                sb.AppendLine("  .maxcontinuation " + _interpreter.Instructions.MaxContinuationDepth);
+                sb.AppendLine();
+
+                Instruction[] instructions = _interpreter.Instructions.Instructions;
+                InstructionList.DebugView.InstructionView[] instructionViews = new InstructionArray.DebugView(_interpreter.Instructions).A0;
+
+                for (int i = 0; i < instructions.Length; i++)
+                {
+                    EmitExits(sb, i);
+
+                    int startCount;
+                    if (_tryStart.TryGetValue(i, out startCount))
+                    {
+                        for (int j = 0; j < startCount; j++)
+                        {
+                            sb.AppendLine(_indent + ".try");
+                            sb.AppendLine(_indent + "{");
+                            Indent();
+                        }
+                    }
+
+                    string handler;
+                    if (_handlerEnter.TryGetValue(i, out handler))
+                    {
+                        sb.AppendLine(_indent + handler);
+                        sb.AppendLine(_indent + "{");
+                        Indent();
+                    }
+
+                    Instruction instruction = instructions[i];
+                    InstructionList.DebugView.InstructionView instructionView = instructionViews[i];
+
+                    sb.AppendLine(_indent + string.Format(CultureInfo.InvariantCulture, "IP_{0}: {1}", i.ToString().PadLeft(4, '0'), instructionView.GetValue()));
+                }
+
+                EmitExits(sb, instructions.Length);
+
+                sb.AppendLine("}");
+
+                return sb.ToString();
+            }
+
+            private void EmitExits(StringBuilder sb, int index)
+            {
+                int exitCount;
+                if (_handlerExit.TryGetValue(index, out exitCount))
+                {
+                    for (int j = 0; j < exitCount; j++)
+                    {
+                        Dedent();
+                        sb.AppendLine(_indent + "}");
+                    }
+                }
+            }
         }
 
 #if NO_FEATURE_STATIC_DELEGATE

--- a/src/System.Linq.Expressions/tests/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/InterpreterTests.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if FEATURE_INTERPRET
+
+using System.Linq.Expressions.Interpreter;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public static class InterpreterTests
+    {
+        private static readonly PropertyInfo s_debugView = typeof(LightLambda).GetPropertyAssert("DebugView");
+
+        [Fact]
+        public static void VerifyInstructions_Simple()
+        {
+            Expression<Func<string, bool>> f = s => s != null && s.Substring(1).Length * 2 > 0;
+
+            f.VerifyInstructions(
+                @"object lambda_method(object[])
+                  {
+                    .locals 1
+                    .maxstack 2
+                    .maxcontinuation 0
+                  
+                    IP_0000: InitParameter(0)
+                    IP_0001: LoadLocal(s: 0)
+                    IP_0002: LoadObject(null)
+                    IP_0003: Call(Boolean op_Inequality(System.String, System.String))
+                    IP_0004: BranchFalse(10) -> 14
+                    IP_0005: LoadLocal(s: 0)
+                    IP_0006: LoadObject(1)
+                    IP_0007: Call(System.String Substring(Int32))
+                    IP_0008: Call(Int32 get_Length())
+                    IP_0009: LoadObject(2)
+                    IP_0010: Mul()
+                    IP_0011: LoadObject(0)
+                    IP_0012: GreaterThan()
+                    IP_0013: Branch(2) -> 15
+                    IP_0014: LoadObject(False)
+                  }");
+        }
+
+        [Fact]
+        public static void VerifyInstructions_Exceptions()
+        {
+            ParameterExpression x = Expression.Parameter(typeof(int), "x");
+            Expression<Func<int, int>> f =
+                Expression.Lambda<Func<int, int>>(
+                    Expression.TryCatchFinally(
+                        Expression.Call(
+                            typeof(Math).GetMethod(nameof(Math.Abs), new[] { typeof(int) }),
+                            Expression.Divide(
+                                Expression.Constant(42),
+                                x
+                            )
+                        ),
+                        Expression.Empty(),
+                        Expression.Catch(
+                            typeof(DivideByZeroException),
+                            Expression.Constant(-1)
+                        )
+                    ),
+                    x
+                );
+
+            f.VerifyInstructions(
+                @"object lambda_method(object[])
+                  {
+                    .locals 2
+                    .maxstack 3
+                    .maxcontinuation 1
+                  
+                    IP_0000: InitParameter(0)
+                    .try
+                    {
+                      IP_0001: EnterTryFinally[0] -> 11
+                      IP_0002: LoadObject(42)
+                      IP_0003: LoadLocal(x: 0)
+                      IP_0004: Div()
+                      IP_0005: Call(Int32 Abs(Int32))
+                      IP_0006: Goto[1] -> 13
+                    }
+                    catch(DivideByZeroException) [8->11]
+                    {
+                      IP_0007: EnterExceptionHandler()
+                      IP_0008: StoreLocal(1)
+                      IP_0009: LoadObject(-1)
+                      IP_0010: LeaveExceptionHandler[3] -> 6
+                    }
+                    finally
+                    {
+                      IP_0011: EnterFinally[0] -> 11
+                      IP_0012: LeaveFinally()
+                    }
+                  }");
+        }
+
+        public static void VerifyInstructions(this LambdaExpression expression, string expected)
+        {
+            var actual = expression.GetInstructions();
+
+            var nExpected = Normalize(expected);
+            var nActual = Normalize(actual);
+
+            Assert.Equal(nExpected, nActual);
+        }
+
+        private static string Normalize(string s)
+        {
+            var lines =
+                s
+                .Replace("\r\n", "\n")
+                .Split(new[] { '\n' })
+                .Select(line => line.Trim())
+                .Where(line => line != "" && !line.StartsWith("//"));
+
+            return string.Join("\n", lines);
+        }
+
+        private static string GetInstructions(this LambdaExpression expression)
+        {
+            Delegate d = expression.Compile(true);
+            var thunk = (Func<object[], object>)d.Target;
+            var lambda = (LightLambda)thunk.Target;
+            var debugView = (string)s_debugView.GetValue(lambda);
+            return debugView;
+        }
+    }
+}
+
+#endif

--- a/src/System.Linq.Expressions/tests/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/InterpreterTests.cs
@@ -27,11 +27,11 @@ namespace System.Linq.Expressions.Tests
                     .maxcontinuation 0
                   
                     IP_0000: InitParameter(0)
-                    IP_0001: LoadLocal(s: 0)
+                    IP_0001: LoadLocal(0)
                     IP_0002: LoadObject(null)
                     IP_0003: Call(Boolean op_Inequality(System.String, System.String))
                     IP_0004: BranchFalse(10) -> 14
-                    IP_0005: LoadLocal(s: 0)
+                    IP_0005: LoadLocal(0)
                     IP_0006: LoadObject(1)
                     IP_0007: Call(System.String Substring(Int32))
                     IP_0008: Call(Int32 get_Length())
@@ -79,7 +79,7 @@ namespace System.Linq.Expressions.Tests
                     {
                       IP_0001: EnterTryFinally[0] -> 11
                       IP_0002: LoadObject(42)
-                      IP_0003: LoadLocal(x: 0)
+                      IP_0003: LoadLocal(0)
                       IP_0004: Div()
                       IP_0005: Call(Int32 Abs(Int32))
                       IP_0006: Goto[1] -> 13

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="IndexExpression\IndexExpressionVisitorTests.cs" />
     <Compile Include="IndexExpression\SampleClassWithProperties.cs" />
     <Compile Include="IndexExpression\IndexExpressionTests.cs" />
+    <Compile Include="InterpreterTests.cs" />
     <Compile Include="Invoke\InvocationTests.cs" />
     <Compile Include="Invoke\InvokeFactoryTests.cs" />
     <Compile Include="Label\LabelTargetTests.cs" />


### PR DESCRIPTION
Initial iteration on pretty printing of expression interpreter instruction stream in order to perform asserts in test code.

The functionality leverages some of the existing `DebugView` printing for instructions that was already present in the library. It adds an internal `DebugView` to the `LightLambda` type, which can be used to retrieve the instructions in a pretty printed form.

Note the approach differs a bit from the IL visualizer for the expression compiler, where we have to peek into implementation details of `DynamicMethod` etc. While we could also use private reflection here, it seems much more pragmatic to add the printing support in the runtime library (adding to already existing support for `DebugView`-like functionality) and limit the test/product boundary contract to retrieving just the one `DebugView` property.