### PR TITLE
Fix XmlSerializerNamespaces.ToArray

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializerNamespaces.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializerNamespaces.cs
@@ -74,7 +74,7 @@ namespace System.Xml.Serialization
         {
             if (NamespaceList == null)
                 return Array.Empty<XmlQualifiedName>();
-            return (XmlQualifiedName[])NamespaceList.ToArray();
+            return (XmlQualifiedName[])NamespaceList.ToArray(typeof(XmlQualifiedName));
         }
 
         /// <devdoc>


### PR DESCRIPTION
ArrayList.ToArray() returns an array strongly-typed as Object[].  It can't be cast to XmlQualifiedName[].  The type needs to be passed to the ArrayList.ToArray overload to get it to allocate the right type of array.

Fixes https://github.com/dotnet/corefx/issues/12290
cc: @shmao, @sepideh