### PR TITLE
Optimize ImmutableArray.Insert for insertion @ front/back

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
@@ -534,9 +534,17 @@ namespace System.Collections.Immutable
             }
 
             T[] tmp = new T[self.Length + 1];
-            Array.Copy(self.array, 0, tmp, 0, index);
             tmp[index] = item;
-            Array.Copy(self.array, index, tmp, index + 1, self.Length - index);
+
+            if (index != 0)
+            {
+                Array.Copy(self.array, 0, tmp, 0, index);
+            }
+            if (index != self.Length)
+            {
+                Array.Copy(self.array, index, tmp, index + 1, self.Length - index);
+            }
+            
             return new ImmutableArray<T>(tmp);
         }
 


### PR DESCRIPTION
`ImmutableArray<T>.Add` just calls through to `ImmutableArray<T>.Insert` at the end of the array. However, `Insert` is not optimized for inserting at the end of the array; it calls `Array.Copy` twice, even if there are no elements to be copied before/after the inserted item.

This PR adds 2 if statements that avoid calling through to `Copy` if the inserted item is at the front/back of the array. This improves perf by ~25-40% for `Add` on small collections, and even on length-100 arrays is still faster 10-20% faster. [benchmark](https://gist.github.com/jamesqo/e91188815521bdcff6b689d49becff82)

This path is already covered by tests: https://github.com/dotnet/corefx/blob/master/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs#L704-L708

@stephentoub, @justinvp, @AArnott 