### PR TITLE
Move ImmutableArray.Builder.ToImmutable empty optimization downstream

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -174,11 +174,6 @@ namespace System.Collections.Immutable
             /// <returns>An immutable array.</returns>
             public ImmutableArray<T> ToImmutable()
             {
-                if (Count == 0)
-                {
-                    return Empty;
-                }
-
                 return new ImmutableArray<T>(this.ToArray());
             }
 
@@ -408,6 +403,11 @@ namespace System.Collections.Immutable
             /// </summary>
             public T[] ToArray()
             {
+                if (this.Count == 0)
+                {
+                    return Empty.array;
+                }
+
                 T[] result = new T[this.Count];
                 Array.Copy(_elements, 0, result, 0, this.Count);
                 return result;


### PR DESCRIPTION
Instead of returning an empty `ImmutableArray` in `ToImmutable()`, we can just return an empty array from `ToArray()` and delete the optimization in `ToImmutable()`.

@AArnott, @stephentoub 