### PR TITLE
Expose MarshalByRefObject.ctor

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -1420,7 +1420,7 @@ namespace System
     }
     public abstract partial class MarshalByRefObject
     {
-        internal MarshalByRefObject() { }
+        protected MarshalByRefObject() { }
     }
     public partial class Lazy<T, TMetadata> : System.Lazy<T>
     {

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="System\ExceptionTests.cs" />
     <Compile Include="System\ExecutionEngineExceptionTests.cs" />
     <Compile Include="System\GuidTests.netstandard1.7.cs" />
+    <Compile Include="System\MarshalByRefObjectTests.cs" />
     <Compile Include="System\NotFiniteNumberExceptionTests.cs" />
     <Compile Include="System\StackOverflowExceptionTests.cs" />
     <Compile Include="System\SystemExceptionTests.cs" />

--- a/src/System.Runtime/tests/System/MarshalByRefObjectTests.cs
+++ b/src/System.Runtime/tests/System/MarshalByRefObjectTests.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Tests
+{
+    public static class MarshalByRefObjectTests
+    {
+        [Fact]
+        public static void CanConstructDerivedObject()
+        {
+            new DerivedMarshalByRefObject();
+        }
+
+        private sealed class DerivedMarshalByRefObject : MarshalByRefObject { }
+    }
+}


### PR DESCRIPTION
It's supposed to be protected, and it being internal is preventing us from deriving from MBRO elsewhere in corefx.

cc: @weshaggard, @danmosemsft 
Contributes to https://github.com/dotnet/corefx/issues/11809