### PR TITLE
Enable Calendar netstandard 1.7 Tests

### DIFF
--- a/src/System.Globalization.Calendars/tests/Misc/Calendars.netstandard1.7.cs
+++ b/src/System.Globalization.Calendars/tests/Misc/Calendars.netstandard1.7.cs
@@ -32,8 +32,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Calendars_TestData))]
-        [ActiveIssue(11605, TestPlatforms.AnyUnix)]
-        [ActiveIssue(11605, TestPlatforms.AnyUnix)]
         public static void CloningTest(Calendar calendar, int yearHasLeapMonth, CalendarAlgorithmType algorithmType)
         {
             Calendar cloned = (Calendar) calendar.Clone();
@@ -42,7 +40,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Calendars_TestData))]
-        [ActiveIssue(11605, TestPlatforms.AnyUnix)]
         public static void GetLeapMonthTest(Calendar calendar, int yearHasLeapMonth, CalendarAlgorithmType algorithmType)
         {
             if (yearHasLeapMonth > 0)
@@ -57,7 +54,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Calendars_TestData))]
-        [ActiveIssue(11605, TestPlatforms.AnyUnix)]
         public static void ReadOnlyTest(Calendar calendar, int yearHasLeapMonth, CalendarAlgorithmType algorithmType)
         {
             Assert.False(calendar.IsReadOnly);
@@ -69,14 +65,12 @@ namespace System.Globalization.Tests
         
         [Theory]
         [MemberData(nameof(Calendars_TestData))]
-        [ActiveIssue(11605, TestPlatforms.AnyUnix)]
         public static void AlgorithmTypeTest(Calendar calendar, int yearHasLeapMonth, CalendarAlgorithmType algorithmType)
         {
             Assert.Equal(calendar.AlgorithmType, algorithmType);
         }
 
         [Fact]
-        [ActiveIssue(11605, TestPlatforms.AnyUnix)]
         public static void CalendarErasTest()
         {
             Assert.Equal(1, ChineseLunisolarCalendar.ChineseEra);


### PR DESCRIPTION
We have exposed and implemented all new Calendars APIs in coreclr so we are enabling the test in corefx now