### PR TITLE
Add project.json to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,9 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
+[project.json]
+indent_size = 2
+
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true


### PR DESCRIPTION
Currently the tooling produces project.json files with 2 space tabs and the editorconfig tells editors to use 4 space tabs. This change updates the editorconfig to use 2 space tabs in project.json files.