### PR TITLE
Increment native package implementation versions

### DIFF
--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/win/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/win/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <!-- use the same naming convention as a runtime package, but don't treat as a runtime dependency -->
     <IdPrefix>runtime.win7-$(PackagePlatform).</IdPrefix>
     <PackagePlatforms>x64;x86;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/debian/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/debian/runtime.native.System.IO.Compression.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>debian.8-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/fedora/23/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/fedora/23/runtime.native.System.IO.Compression.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/opensuse/13.2/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/opensuse/13.2/runtime.native.System.IO.Compression.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/osx/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/osx/runtime.native.System.IO.Compression.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/rhel/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/rhel/runtime.native.System.IO.Compression.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>rhel.7-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/14.04/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/14.04/runtime.native.System.IO.Compression.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/16.04/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/16.04/runtime.native.System.IO.Compression.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <WinVersion Condition="'$(PackagePlatform)'=='arm'">win8</WinVersion>
     <WinVersion Condition="'$(PackagePlatform)'!='arm'">win7</WinVersion>
     <PackageTargetRuntime>$(WinVersion)-$(PackagePlatform)</PackageTargetRuntime>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win10/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win10/runtime.native.System.IO.Compression.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <PackageTargetRuntime>win10-$(PackagePlatform)-aot</PackageTargetRuntime>
   </PropertyGroup>
 

--- a/src/Native/pkg/runtime.native.System.Net.Http/debian/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/debian/runtime.native.System.Net.Http.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>debian.8-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Http/fedora/23/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/fedora/23/runtime.native.System.Net.Http.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Http/opensuse/13.2/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/opensuse/13.2/runtime.native.System.Net.Http.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Http/osx/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/osx/runtime.native.System.Net.Http.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Http/rhel/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/rhel/runtime.native.System.Net.Http.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>rhel.7-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/14.04/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/14.04/runtime.native.System.Net.Http.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/16.04/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/16.04/runtime.native.System.Net.Http.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Security/debian/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/debian/runtime.native.System.Net.Security.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>debian.8-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Security/fedora/23/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/fedora/23/runtime.native.System.Net.Security.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Security/opensuse/13.2/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/opensuse/13.2/runtime.native.System.Net.Security.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Security/osx/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/osx/runtime.native.System.Net.Security.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Security/rhel/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/rhel/runtime.native.System.Net.Security.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-      <Version>1.0.1</Version>
+      <Version>1.0.2</Version>
       <PackageTargetRuntime>rhel.7-$(PackagePlatform)</PackageTargetRuntime>
       <!-- only build for x64 -->
       <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Security/ubuntu/14.04/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/ubuntu/14.04/runtime.native.System.Net.Security.pkgproj
@@ -3,7 +3,7 @@
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Net.Security/ubuntu/16.04/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/ubuntu/16.04/runtime.native.System.Net.Security.pkgproj
@@ -3,7 +3,7 @@
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>debian.8-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>rhel.7-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System/debian/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/debian/runtime.native.System.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>debian.8-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System/fedora/23/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/fedora/23/runtime.native.System.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System/opensuse/13.2/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/opensuse/13.2/runtime.native.System.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System/osx/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/osx/runtime.native.System.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System/rhel/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/rhel/runtime.native.System.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>rhel.7-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System/ubuntu/14.04/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/ubuntu/14.04/runtime.native.System.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/Native/pkg/runtime.native.System/ubuntu/16.04/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/ubuntu/16.04/runtime.native.System.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>

--- a/src/System.Net.WebHeaderCollection/pkg/System.Net.WebHeaderCollection.pkgproj
+++ b/src/System.Net.WebHeaderCollection/pkg/System.Net.WebHeaderCollection.pkgproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>4.0.1.0</Version>
+    <Version>4.0.2.0</Version>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>


### PR DESCRIPTION
Native implementation package versions were not incremented in my previous round of updates

Companion change with https://github.com/dotnet/corefx/pull/12263 

/cc @ericstj @gkhanna79 @chrisboh
