### PR TITLE
Fix builds files where we were passing netcoreapp1.0 as targetGroup

### DIFF
--- a/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.builds
+++ b/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.builds
@@ -4,13 +4,13 @@
   <ItemGroup>
     <Project Include="System.Drawing.Primitives.Tests.csproj" />
     <Project Include="System.Drawing.Primitives.Tests.csproj">
-      <TargetGroup>netcoreapp1.0</TargetGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
       <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Drawing.Primitives.Tests.csproj">
       <TestTFMs>netcore50;net46</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
-      <TargetGroup>netcoreapp1.0</TargetGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
     </Project>
     <Project Include="System.Drawing.Primitives.Tests.csproj">
       <TestTFMs>net463</TestTFMs>

--- a/src/System.IO/tests/System.IO.Tests.builds
+++ b/src/System.IO/tests/System.IO.Tests.builds
@@ -4,13 +4,13 @@
   <ItemGroup>
     <Project Include="System.IO.Tests.csproj" />
     <Project Include="System.IO.Tests.csproj">
-      <TargetGroup>netcoreapp1.0</TargetGroup>
+      <TargetGroup>netstandard1.5</TargetGroup>
       <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.IO.Tests.csproj">
       <TestTFMs>net462</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
-      <TargetGroup>netcoreapp1.0</TargetGroup>
+      <TargetGroup>netstandard1.5</TargetGroup>
     </Project>
     <Project Include="System.IO.Tests.csproj">
       <TestTFMs>net463</TestTFMs>

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>System.IO.Tests</AssemblyName>
     <ProjectGuid>{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}</ProjectGuid>
     <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netstandard17</DefineConstants>
-    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.builds
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.builds
@@ -4,13 +4,13 @@
   <ItemGroup>
     <Project Include="System.Threading.Tasks.Tests.csproj" />
     <Project Include="System.Threading.Tasks.Tests.csproj">
-      <TargetGroup>netcoreapp1.0</TargetGroup>
+      <TargetGroup>netstandard1.5</TargetGroup>
       <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Threading.Tasks.Tests.csproj">
       <TestTFMs>net462</TestTFMs>
       <OSGroup>Windows_NT</OSGroup>
-      <TargetGroup>netcoreapp1.0</TargetGroup>
+      <TargetGroup>netstandard1.5</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Threading.Tasks.Tests</AssemblyName>
     <ProjectGuid>{B6C09633-D161-499A-8FE1-46B2D53A16E7}</ProjectGuid>
-    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />


### PR DESCRIPTION
When we moved the default test build to be netstandard1.7, some projects didn't have a NugetTargetMoniker set so they were using 'netcoreapp1.0' as their moniker. This was fine except that we recently started using that moniker to set the TargetGroup in the .builds files, causing the Official build to fail since it didn't find a netcoreapp1.0 section in the generated project.json. This fixes that by changing the Moniker to be the right one.

cc: @chcosta @weshaggard 