### PR TITLE
Add uap10.1 target to System.Runtime.WindowsRuntime and change System…

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.builds
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.builds
@@ -9,6 +9,10 @@
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>
+    <Project Include="System.Runtime.WindowsRuntime.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>uap101aot</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -9,26 +9,27 @@
     <AssemblyName>System.Runtime.WindowsRuntime</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ClsCompliant>true</ClsCompliant>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <!-- CS1698 - Disable warning about reference to 4.0.0.0 System.Runtime.WindowsRuntime having same simple name as target assembly -->
     <NoWarn>$(NoWarn)1698</NoWarn>
     <ProjectGuid>{844A2A0B-4169-49C3-B367-AFDC4894E487}</ProjectGuid>
     <PackageTargetRuntime>win8</PackageTargetRuntime>
     <PackageTargetRuntime Condition="'$(TargetGroup)' == 'netcore50aot'">win8-aot</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' == 'uap101aot'">win8-aot</PackageTargetRuntime>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)'==''">
     <DefineConstants>$(DefineConstants);netstandard;FEATURE_APPX</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'uap101aot'">
+    <DefineConstants>$(DefineConstants);netstandard;</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50aot_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)'=='netcore50aot'">
-    <TargetingPackReference Include="System.Private.Interop.Extensions" />
-    <TargetingPackReference Include="System.Private.Threading.AsyncCausalitySupport" />
-    <TargetingPackReference Include="Windows" />
-    <ProjectReference Include="$(SourceDir)\mscorlib.WinRT-Facade\mscorlib.WinRT-Facade.csproj" />
-  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <TargetingPackReference Include="mscorlib" />
     <!-- Needed for the compiler to resolve IObservableMap.MapChanged. -->
@@ -45,6 +46,45 @@
     <ProjectReference Include="..\..\System.Runtime\src\redist\System.Runtime.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netcore50aot'">
+    <TargetingPackReference Include="System.Private.Interop.Extensions" />
+    <TargetingPackReference Include="System.Private.Threading.AsyncCausalitySupport" />
+    <TargetingPackReference Include="Windows" />
+    <ProjectReference Include="$(SourceDir)\mscorlib.WinRT-Facade\mscorlib.WinRT-Facade.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap101aot'">
+    <!-- We need to add this for now because these three types exist in System.Private.Interop.dll and Windows.winmd. -->
+    <SeedTypePreference Include="Windows.Foundation.Point">
+      <Assembly>System.Private.Interop</Assembly>
+    </SeedTypePreference>
+    <SeedTypePreference Include="Windows.Foundation.Rect">
+      <Assembly>System.Private.Interop</Assembly>
+    </SeedTypePreference>
+    <SeedTypePreference Include="Windows.Foundation.Size">
+      <Assembly>System.Private.Interop</Assembly>
+    </SeedTypePreference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap101aot'">
+    <TargetingPackReference Include="System.Private.Interop" />
+    <TargetingPackReference Include="System.Private.Corelib" />
+    <TargetingPackReference Include="System.Private.Threading" />
+    <TargetingPackReference Include="Windows" />
+    <ProjectReference Include="$(SourceDir)\mscorlib.WinRT-Facade\mscorlib.WinRT-Facade.csproj" />
+    <TargetingPackReference Include="System.Private.CoreLib.WinRTInterop" />
+    <ProjectReference Include="..\..\System.IO\src\System.IO.csproj">
+      <TargetGroup>uap101aot</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj">
+      <TargetGroup>uap101aot</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Resources.ResourceManager\ref\System.Resources.ResourceManager.csproj">
+      <TargetGroup>uap101aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="System\IO\StreamOperationAsyncResult.CoreCLR.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\MarshalingHelpers.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\RestrictedErrorInfoHelper.cs" />
@@ -54,6 +94,10 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetRestrictedErrorInfo.cs">
       <Link>Common\Interop\Windows\mincore\Interop.GetRestrictedErrorInfo.cs</Link>
     </Compile>
+    <Compile Include="System\IO\WindowsRuntimeStreamExtensions.cs" />
+    <Compile Include="System\Windows\Point.cs" />
+    <Compile Include="System\Windows\Rect.cs" />
+    <Compile Include="System\Windows\Size.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcore50aot'">
     <Compile Include="System\IO\BufferedStream.cs" />
@@ -61,7 +105,20 @@
     <Compile Include="System\IO\UnmanagedMemoryStreamInternal.cs" />
     <Compile Include="System\Threading\Tasks\AsyncInfoToTaskBridge.CoreRT.cs" />
     <Compile Include="System\WindowsRuntimeSystemExtensions.CoreRT.cs" />
+    <Compile Include="System\IO\WindowsRuntimeStreamExtensions.cs" />
+    <Compile Include="System\Windows\Point.cs" />
+    <Compile Include="System\Windows\Rect.cs" />
+    <Compile Include="System\Windows\Size.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='uap101aot'">
+    <Compile Include="System\IO\StreamOperationAsyncResult.CoreRT.cs" />
+    <Compile Include="System\IO\UnmanagedMemoryStreamInternal.cs" />
+    <Compile Include="System\IO\WindowsRuntimeStreamExtensions.CoreRT.cs" />
+    <Compile Include="System\Threading\Tasks\AsyncInfoToTaskBridge.CoreRT.cs" />
+    <Compile Include="System\WindowsRuntimeSystemExtensions.CoreRT.cs" />
+    <Compile Include="System\IO\BufferedStreamWrapper.CoreRT.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.ResolveLocaleName.cs">
       <Link>Common\Interop\Windows\mincore\Interop.ResolveLocaleName.cs</Link>
@@ -77,7 +134,6 @@
     <Compile Include="System\IO\StreamOperationAsyncResult.cs" />
     <Compile Include="System\IO\StreamOperationsImplementation.cs" />
     <Compile Include="System\IO\WindowsRuntimeStorageExtensions.cs" />
-    <Compile Include="System\IO\WindowsRuntimeStreamExtensions.cs" />
     <Compile Include="System\IO\WinRtIOHelper.cs" />
     <Compile Include="System\IO\WinRtToNetFxStreamAdapter.cs" />
     <Compile Include="System\Resources\WindowsRuntimeResourceManager.cs" />
@@ -96,9 +152,6 @@
     <Compile Include="System\Threading\Tasks\TaskToAsyncOperationAdapter.cs" />
     <Compile Include="System\Threading\Tasks\TaskToAsyncOperationWithProgressAdapter.cs" />
     <Compile Include="System\VoidTypeParameter.cs" />
-    <Compile Include="System\Windows\Point.cs" />
-    <Compile Include="System\Windows\Rect.cs" />
-    <Compile Include="System\Windows\Size.cs" />
     <Compile Include="System\Windows\TokenizerHelper.cs" />
     <Compile Include="System\Windows\UI\Color.cs" />
   </ItemGroup>

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/BufferedStreamWrapper.CoreRT.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/BufferedStreamWrapper.CoreRT.cs
@@ -1,0 +1,208 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.WindowsRuntime.Internal;
+using System.Threading;
+using System.Collections.ObjectModel;
+using System.Security;
+using System.Threading.Tasks;
+
+namespace System.IO
+{
+    /// <summary>
+    /// A BufferedStream wrapper which expose BufferedStream's UnderlyingStream and BufferSize
+    /// </summary>
+    internal sealed class BufferedStreamWrapper : Stream
+    {
+        private BufferedStream _bufferedStream;
+        private Stream _stream;                               // Underlying stream.  Close sets _stream to null.
+        private readonly Int32 _bufferSize;                   // Length of internal buffer (not counting the shadow buffer).
+
+        public BufferedStreamWrapper(Stream stream, Int32 bufferSize)
+        {
+            _bufferedStream = new BufferedStream(stream, bufferSize);
+            _stream = stream;
+            _bufferSize = bufferSize;
+        }
+
+        private void EnsureNotClosed()
+        {
+            if (_bufferedStream == null)
+                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
+        }
+
+        internal BufferedStream bufferedStream
+        {
+            [Pure]
+            get
+            { return _bufferedStream; }
+        }
+
+        internal Stream UnderlyingStream
+        {
+            [Pure]
+            get
+            { return _stream; }
+        }
+
+        internal Int32 BufferSize
+        {
+            [Pure]
+            get
+            { return _bufferSize; }
+        }
+
+        public override bool CanRead
+        {
+            [Pure]
+            get
+            { return _bufferedStream != null && _bufferedStream.CanRead; }
+        }
+
+
+        public override bool CanWrite
+        {
+            [Pure]
+            get
+            { return _bufferedStream != null && _bufferedStream.CanWrite; }
+        }
+
+
+        public override bool CanSeek
+        {
+            [Pure]
+            get
+            { return _bufferedStream != null && _bufferedStream.CanSeek; }
+        }
+
+        public override Int64 Length
+        {
+            get
+            {
+                EnsureNotClosed();
+                return _bufferedStream.Length;
+            }
+        }
+
+        public override Int64 Position
+        {
+            get
+            {
+                EnsureNotClosed();
+                return _bufferedStream.Position;
+            }
+            set
+            {
+                EnsureNotClosed();
+                _bufferedStream.Position = value;
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                if (disposing && _bufferedStream != null)
+                {
+                    _bufferedStream.Dispose();
+                }
+            }
+            finally
+            {
+                _bufferedStream = null;
+                _stream = null;
+            }
+        }
+
+        public override void Flush()
+        {
+            EnsureNotClosed();
+            _bufferedStream.Flush();
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken) 
+        {
+             EnsureNotClosed();
+             return _bufferedStream.FlushAsync();
+        }
+
+        public override IAsyncResult BeginRead(Byte[] buffer, Int32 offset, Int32 count, AsyncCallback callback, Object state)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.BeginRead(buffer, offset, count, callback, state);
+        }
+
+        public override Int32 EndRead(IAsyncResult asyncResult)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.EndRead(asyncResult);
+        }
+
+        public override int Read(byte[] array, int offset, int count)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.Read(array, offset, count);
+        }
+
+        public override Task<int> ReadAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override Int32 ReadByte()
+        {
+            EnsureNotClosed();
+            return _bufferedStream.ReadByte();
+        }
+
+        public override void Write(Byte[] array, Int32 offset, Int32 count)
+        {
+            EnsureNotClosed();
+            _bufferedStream.Write(array, offset, count);
+        }
+
+        public override IAsyncResult BeginWrite(Byte[] buffer, Int32 offset, Int32 count, AsyncCallback callback, Object state)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+           EnsureNotClosed();
+            _bufferedStream.EndWrite(asyncResult);
+        }
+
+        public override Task WriteAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override void WriteByte(Byte value)
+        {
+            EnsureNotClosed();
+            _bufferedStream.WriteByte(value);
+        }
+
+        public override Int64 Seek(Int64 offset, SeekOrigin origin)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(Int64 value)
+        {
+            EnsureNotClosed();
+            _bufferedStream.SetLength(value);
+        }
+    }  // class BufferedStreamWrapper
+}  // namespace

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStreamExtensions.CoreRT.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStreamExtensions.CoreRT.cs
@@ -1,0 +1,361 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.Storage.Streams;
+
+namespace System.IO
+{
+    /// <summary>
+    /// Contains extension methods for conversion between WinRT streams and managed streams.
+    /// This class is the public facade for the stream adapters library.
+    /// </summary>
+    public static class WindowsRuntimeStreamExtensions
+    {
+        #region Constants and static Fields
+
+        private const Int32 DefaultBufferSize = 16384;  // = 0x4000 = 16 KBytes.
+
+        private static ConditionalWeakTable<Object, Stream> s_winRtToNetFxAdapterMap
+                 = new ConditionalWeakTable<Object, Stream>();
+
+        private static ConditionalWeakTable<Stream, NetFxToWinRtStreamAdapter> s_netFxToWinRtAdapterMap
+                 = new ConditionalWeakTable<Stream, NetFxToWinRtStreamAdapter>();
+
+        #endregion Constants and static Fields
+
+        #region Helpers
+
+#if DEBUG
+        private static void AssertMapContains<TKey, TValue>(ConditionalWeakTable<TKey, TValue> map, TKey key, TValue value,
+                                                            bool valueMayBeWrappedInBufferedStream)
+                                                                                                where TKey : class
+                                                                                                where TValue : class
+        {
+            TValue valueInMap;
+
+            Debug.Assert(key != null);
+
+            bool hasValueForKey = map.TryGetValue(key, out valueInMap);
+
+            Debug.Assert(hasValueForKey);
+
+            if (valueMayBeWrappedInBufferedStream)
+            {
+                BufferedStreamWrapper bufferedValueInMap = valueInMap as BufferedStreamWrapper;
+                Debug.Assert(Object.ReferenceEquals(value, valueInMap)
+                                || (bufferedValueInMap != null && Object.ReferenceEquals(value, bufferedValueInMap.UnderlyingStream)));
+            }
+            else
+            {
+                Debug.Assert(Object.ReferenceEquals(value, valueInMap));
+            }
+        }
+#endif  // DEBUG
+
+        private static void EnsureAdapterBufferSize(Stream adapter, Int32 requiredBufferSize, String methodName)
+        {
+            Debug.Assert(adapter != null);
+            Debug.Assert(!String.IsNullOrWhiteSpace(methodName));
+
+            Int32 currentBufferSize = 0;
+            BufferedStreamWrapper bufferedAdapter = adapter as BufferedStreamWrapper;
+            if (bufferedAdapter != null)
+                currentBufferSize = bufferedAdapter.BufferSize;
+
+            if (requiredBufferSize != currentBufferSize)
+            {
+                if (requiredBufferSize == 0)
+                    throw new InvalidOperationException(SR.Format(SR.InvalidOperation_CannotChangeBufferSizeOfWinRtStreamAdapterToZero, methodName));
+
+                throw new InvalidOperationException(SR.Format(SR.InvalidOperation_CannotChangeBufferSizeOfWinRtStreamAdapter, methodName));
+            }
+        }
+
+        #endregion Helpers
+
+        #region WinRt-to-NetFx conversion
+
+        [CLSCompliant(false)]
+        public static Stream AsStreamForRead(this IInputStream windowsRuntimeStream)
+        {
+            return AsStreamInternal(windowsRuntimeStream, DefaultBufferSize, "AsStreamForRead", forceBufferSize: false);
+        }
+
+
+        [CLSCompliant(false)]
+        public static Stream AsStreamForRead(this IInputStream windowsRuntimeStream, Int32 bufferSize)
+        {
+            return AsStreamInternal(windowsRuntimeStream, bufferSize, "AsStreamForRead", forceBufferSize: true);
+        }
+
+
+        [CLSCompliant(false)]
+        public static Stream AsStreamForWrite(this IOutputStream windowsRuntimeStream)
+        {
+            return AsStreamInternal(windowsRuntimeStream, DefaultBufferSize, "AsStreamForWrite", forceBufferSize: false);
+        }
+
+
+        [CLSCompliant(false)]
+        public static Stream AsStreamForWrite(this IOutputStream windowsRuntimeStream, Int32 bufferSize)
+        {
+            return AsStreamInternal(windowsRuntimeStream, bufferSize, "AsStreamForWrite", forceBufferSize: true);
+        }
+
+
+        [CLSCompliant(false)]
+        public static Stream AsStream(this IRandomAccessStream windowsRuntimeStream)
+        {
+            return AsStreamInternal(windowsRuntimeStream, DefaultBufferSize, "AsStream", forceBufferSize: false);
+        }
+
+
+        [CLSCompliant(false)]
+        public static Stream AsStream(this IRandomAccessStream windowsRuntimeStream, Int32 bufferSize)
+        {
+            return AsStreamInternal(windowsRuntimeStream, bufferSize, "AsStream", forceBufferSize: true);
+        }
+
+
+        private static Stream AsStreamInternal(Object windowsRuntimeStream, Int32 bufferSize, String invokedMethodName, bool forceBufferSize)
+        {
+            if (windowsRuntimeStream == null)
+                throw new ArgumentNullException(nameof(windowsRuntimeStream));
+
+            if (bufferSize < 0)
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_WinRtAdapterBufferSizeMayNotBeNegative);
+
+            Debug.Assert(!String.IsNullOrWhiteSpace(invokedMethodName));
+            Contract.Ensures(Contract.Result<Stream>() != null);
+            Contract.EndContractBlock();
+
+            // If the WinRT stream is actually a wrapped managed stream, we will unwrap it and return the original.
+            // In that case we do not need to put the wrapper into the map.
+
+            // We currently do capability-based adapter selection for WinRt->NetFx, but not vice versa (time constraints).
+            // Once we added the reverse direction, we will be able replce this entire section with just a few lines.
+            NetFxToWinRtStreamAdapter sAdptr = windowsRuntimeStream as NetFxToWinRtStreamAdapter;
+            if (sAdptr != null)
+            {
+                Stream wrappedNetFxStream = sAdptr.GetManagedStream();
+                if (wrappedNetFxStream == null)
+                    throw new ObjectDisposedException(nameof(windowsRuntimeStream), SR.ObjectDisposed_CannotPerformOperation);
+
+#if DEBUG  // In Chk builds, verify that the original managed stream is correctly entered into the NetFx->WinRT map:
+                AssertMapContains(s_netFxToWinRtAdapterMap, wrappedNetFxStream, sAdptr,
+                                  valueMayBeWrappedInBufferedStream: false);
+#endif  // DEBUG
+
+                return wrappedNetFxStream;
+            }
+
+            // We have a real WinRT stream.
+
+            Stream adapter;
+            bool adapterExists = s_winRtToNetFxAdapterMap.TryGetValue(windowsRuntimeStream, out adapter);
+
+            // There is already an adapter:
+            if (adapterExists)
+            {
+                Debug.Assert((adapter is BufferedStreamWrapper && ((BufferedStreamWrapper)adapter).UnderlyingStream is WinRtToNetFxStreamAdapter) 
+                    || (adapter is WinRtToNetFxStreamAdapter));
+
+                if (forceBufferSize)
+                    EnsureAdapterBufferSize(adapter, bufferSize, invokedMethodName);
+
+                return adapter;
+            }
+
+            // We do not have an adapter for this WinRT stream yet and we need to create one.
+            // Do that in a thread-safe manner in a separate method such that we only have to pay for the compiler allocating
+            // the required closure if this code path is hit:
+
+            return AsStreamInternalFactoryHelper(windowsRuntimeStream, bufferSize, invokedMethodName, forceBufferSize);
+        }
+
+
+        // Separate method so we only pay for closure allocation if this code is executed:
+        private static Stream WinRtToNetFxAdapterMap_GetValue(Object winRtStream)
+        {
+            return s_winRtToNetFxAdapterMap.GetValue(winRtStream, (wrtStr) => WinRtToNetFxStreamAdapter.Create(wrtStr));
+        }
+
+
+        // Separate method so we only pay for closure allocation if this code is executed:
+        private static Stream WinRtToNetFxAdapterMap_GetValue(Object winRtStream, Int32 bufferSize)
+        {
+            return s_winRtToNetFxAdapterMap.GetValue(winRtStream, (wrtStr) => new BufferedStreamWrapper(WinRtToNetFxStreamAdapter.Create(wrtStr), bufferSize));
+        }
+
+
+        private static Stream AsStreamInternalFactoryHelper(Object windowsRuntimeStream, Int32 bufferSize, String invokedMethodName, bool forceBufferSize)
+        {
+            Debug.Assert(windowsRuntimeStream != null);
+            Debug.Assert(bufferSize >= 0);
+            Debug.Assert(!String.IsNullOrWhiteSpace(invokedMethodName));
+
+            Contract.Ensures(Contract.Result<Stream>() != null);
+            Contract.EndContractBlock();
+
+            // Get the adapter for this windowsRuntimeStream again (it may have been created concurrently).
+            // If none exists yet, create a new one:
+            Stream adapter = (bufferSize == 0)
+                                ? WinRtToNetFxAdapterMap_GetValue(windowsRuntimeStream)
+                                : WinRtToNetFxAdapterMap_GetValue(windowsRuntimeStream, bufferSize);
+
+            Debug.Assert(adapter != null);
+            Debug.Assert((adapter is BufferedStreamWrapper && ((BufferedStreamWrapper)adapter).UnderlyingStream is WinRtToNetFxStreamAdapter)
+                                || (adapter is WinRtToNetFxStreamAdapter));
+
+            if (forceBufferSize)
+                EnsureAdapterBufferSize(adapter, bufferSize, invokedMethodName);
+
+            WinRtToNetFxStreamAdapter actualAdapter = adapter as WinRtToNetFxStreamAdapter;
+            if (actualAdapter == null)
+                actualAdapter = ((BufferedStreamWrapper)adapter).UnderlyingStream as WinRtToNetFxStreamAdapter;
+
+            actualAdapter.SetWonInitializationRace();
+
+            return adapter;
+        }
+
+        #endregion WinRt-to-NetFx conversion
+
+        #region NetFx-to-WinRt conversion
+
+        [CLSCompliant(false)]
+        public static IInputStream AsInputStream(this Stream stream)
+        {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+
+            if (!stream.CanRead)
+                throw new NotSupportedException(SR.NotSupported_CannotConvertNotReadableToInputStream);
+
+            Contract.Ensures(Contract.Result<IInputStream>() != null);
+            Contract.EndContractBlock();
+
+            Object adapter = AsWindowsRuntimeStreamInternal(stream);
+
+            IInputStream winRtStream = adapter as IInputStream;
+            Debug.Assert(winRtStream != null);
+
+            return winRtStream;
+        }
+
+
+        [CLSCompliant(false)]
+        public static IOutputStream AsOutputStream(this Stream stream)
+        {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+
+            if (!stream.CanWrite)
+                throw new NotSupportedException(SR.NotSupported_CannotConvertNotWritableToOutputStream);
+
+            Contract.Ensures(Contract.Result<IOutputStream>() != null);
+            Contract.EndContractBlock();
+
+            Object adapter = AsWindowsRuntimeStreamInternal(stream);
+
+            IOutputStream winRtStream = adapter as IOutputStream;
+            Debug.Assert(winRtStream != null);
+
+            return winRtStream;
+        }
+
+
+        [CLSCompliant(false)]
+        public static IRandomAccessStream AsRandomAccessStream(this Stream stream)
+        {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+
+            if (!stream.CanSeek)
+                throw new NotSupportedException(SR.NotSupported_CannotConvertNotSeekableToRandomAccessStream);
+
+            Contract.Ensures(Contract.Result<IRandomAccessStream>() != null);
+            Contract.EndContractBlock();
+
+            Object adapter = AsWindowsRuntimeStreamInternal(stream);
+
+            IRandomAccessStream winRtStream = adapter as IRandomAccessStream;
+            Debug.Assert(winRtStream != null);
+
+            return winRtStream;
+        }
+
+
+        private static Object AsWindowsRuntimeStreamInternal(Stream stream)
+        {
+            Contract.Ensures(Contract.Result<Object>() != null);
+            Contract.EndContractBlock();
+
+            // Check to see if the managed stream is actually a wrapper of a WinRT stream:
+            // (This can be either an adapter directly, or an adapter wrapped in a BufferedStream.)
+            WinRtToNetFxStreamAdapter sAdptr = stream as WinRtToNetFxStreamAdapter;
+            if (sAdptr == null)
+            {
+                BufferedStreamWrapper buffAdptr = stream as BufferedStreamWrapper;
+                if (buffAdptr != null)
+                    sAdptr = buffAdptr.UnderlyingStream as WinRtToNetFxStreamAdapter;
+            }
+
+            // If the managed stream us actually a WinRT stream, we will unwrap it and return the original.
+            // In that case we do not need to put the wrapper into the map.
+            if (sAdptr != null)
+            {
+                Object wrappedWinRtStream = sAdptr.GetWindowsRuntimeStream<Object>();
+                if (wrappedWinRtStream == null)
+                    throw new ObjectDisposedException(nameof(stream), SR.ObjectDisposed_CannotPerformOperation);
+
+#if DEBUG  // In Chk builds, verify that the original WinRT stream is correctly entered into the WinRT->NetFx map:
+                AssertMapContains(s_winRtToNetFxAdapterMap, wrappedWinRtStream, sAdptr, valueMayBeWrappedInBufferedStream: true);
+#endif  // DEBUG
+                return wrappedWinRtStream;
+            }
+
+            // We have a real managed Stream.
+
+            // See if the managed stream already has an adapter:
+            NetFxToWinRtStreamAdapter adapter;
+            bool adapterExists = s_netFxToWinRtAdapterMap.TryGetValue(stream, out adapter);
+
+            // There is already an adapter:
+            if (adapterExists)
+                return adapter;
+
+            // We do not have an adapter for this managed stream yet and we need to create one.
+            // Do that in a thread-safe manner in a separate method such that we only have to pay for the compiler allocating
+            // the required closure if this code path is hit:
+            return AsWindowsRuntimeStreamInternalFactoryHelper(stream);
+        }
+
+
+        private static NetFxToWinRtStreamAdapter AsWindowsRuntimeStreamInternalFactoryHelper(Stream stream)
+        {
+            Debug.Assert(stream != null);
+            Contract.Ensures(Contract.Result<NetFxToWinRtStreamAdapter>() != null);
+            Contract.EndContractBlock();
+
+            // Get the adapter for managed stream again (it may have been created concurrently).
+            // If none exists yet, create a new one:
+            NetFxToWinRtStreamAdapter adapter = s_netFxToWinRtAdapterMap.GetValue(stream, (str) => NetFxToWinRtStreamAdapter.Create(str));
+
+            Debug.Assert(adapter != null);
+            adapter.SetWonInitializationRace();
+
+            return adapter;
+        }
+        #endregion NetFx-to-WinRt conversion
+
+    }  // class WindowsRuntimeStreamExtensions
+}  // namespace

--- a/src/System.Runtime.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.WindowsRuntime/src/project.json
@@ -8,6 +8,12 @@
       "imports": [
         "dotnet5.4"
       ]
+    },
+    "uap10.1": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24522-01",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.1"
+      }
     }
   }
 }


### PR DESCRIPTION
….Runtime.WindowsRuntime Partial facades

After this change, System.Runtime.WindowsRuntime will type forwards the following 3 types into System.Private.Inteorp.
1.Windows.Foundation.Point
2.Windows.Foundation.Rect
3. Windows.Foundation.Size

During this change, It doesn't change behavior for netcore50aot target--netcore50aot still use BufferedStream.cs and WindowsRuntimeStreamExtensions.cs

CC: @weshaggard , @yizhang82 , @tarekgh , @SedarG 