### PR TITLE
Improve pattern recognition of Concat chains

### DIFF
--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -28,7 +28,7 @@
     <Compile Include="System\Linq\Average.cs" />
     <Compile Include="System\Linq\Buffer.cs" />
     <Compile Include="System\Linq\Cast.cs" />
-    <Compile Include="System\Linq\Concatenate.cs" />
+    <Compile Include="System\Linq\Concat.cs" />
     <Compile Include="System\Linq\Contains.cs" />
     <Compile Include="System\Linq\Count.cs" />
     <Compile Include="System\Linq\DebugView.cs" />

--- a/src/System.Linq/src/System/Linq/Concat.cs
+++ b/src/System.Linq/src/System/Linq/Concat.cs
@@ -419,16 +419,22 @@ namespace System.Linq
 
                 // We've reached the first 2 collections that were concatenated
                 var current2 = (Concat2CollectionIterator<TSource>)current;
-                checked
+                int currentCount = current2.Count;
+
+                if (currentCount > 0)
                 {
-                    upperBound -= current2.Count; // We'll treat this node as an appended node
+                    checked
+                    {
+                        upperBound -= currentCount; // We'll treat this node as an appended node
+                    }
+                    current2.CopyTo(array, upperBound);
                 }
 
+#if DEBUG
                 int itemsPrepended = lowerBound - startIndex;
                 int itemsAppended = (startIndex + count) - upperBound;
                 Debug.Assert(itemsPrepended + itemsAppended == Count); // We should have copied all the elements
-
-                current2.CopyTo(array, upperBound);
+#endif
             }
 
             internal override IEnumerable<TSource> GetEnumerable(int index)

--- a/src/System.Linq/src/System/Linq/Concat.cs
+++ b/src/System.Linq/src/System/Linq/Concat.cs
@@ -21,7 +21,7 @@ namespace System.Linq
                 throw Error.ArgumentNull(nameof(second));
             }
 
-            Debug.Assert(!(first is ICollection<TSource> && first is ConcatIterator<TSource>), "Didn't expect enumerable to be both a collection and a concat iterator");
+            Debug.Assert(!(first is ICollection<TSource> && first is ConcatIterator<TSource>), "Didn't expect enumerable to be both a collection and a concat iterator.");
 
             var firstCollection = first as ICollection<TSource>;
             if (firstCollection != null)
@@ -31,14 +31,25 @@ namespace System.Linq
                 {
                     return new Concat2CollectionIterator<TSource>(firstCollection, secondCollection);
                 }
+                // We know first is an ICollection, second isn't.
             }
             else
             {
+                // We know first isn't an ICollection.
                 var firstConcat = first as ConcatIterator<TSource>;
                 if (firstConcat != null)
                 {
-                    return firstConcat.Concat(second);
+                    return firstConcat.ConcatAfter(second);
                 }
+                // We know first is neither an ICollection nor a ConcatIterator.
+            }
+
+            var secondConcat = second as ConcatIterator<TSource>;
+            if (secondConcat != null)
+            {
+                // We know first is not a ConcatIterator and second is a ConcatIterator.
+                Debug.Assert(!(first is ConcatIterator<TSource>));
+                return secondConcat.ConcatBefore(first);
             }
 
             return new Concat2EnumerableIterator<TSource>(first, second);
@@ -61,9 +72,14 @@ namespace System.Linq
                 return new Concat2EnumerableIterator<TSource>(_first, _second);
             }
 
-            internal override ConcatIterator<TSource> Concat(IEnumerable<TSource> next)
+            internal override ConcatIterator<TSource> ConcatAfter(IEnumerable<TSource> next)
             {
                 return new ConcatNEnumerableIterator<TSource>(this, next, 2);
+            }
+
+            internal override ConcatIterator<TSource> ConcatBefore(IEnumerable<TSource> previous)
+            {
+                return new ConcatNEnumerableIterator<TSource>(this, previous, 2 | int.MinValue);
             }
 
             internal override IEnumerable<TSource> GetEnumerable(int index)
@@ -78,35 +94,44 @@ namespace System.Linq
         }
 
         // To handle chains of >= 3 sources, we chain the concat iterators together and allow
-        // GetEnumerable to fetch enumerables from the previous sources.  This means that rather
-        // than each MoveNext/Current calls having to traverse all of the previous sources, we
-        // only have to traverse all of the previous sources once per chained enumerable.  An
+        // GetEnumerable to fetch enumerables from the other sources.  This means that rather
+        // than each MoveNext/Current calls having to traverse all of the other sources, we
+        // only have to traverse all of the other sources once per chained enumerable.  An
         // alternative would be to use an array to store all of the enumerables, but this has
         // a much better memory profile and without much additional run-time cost.
         private sealed class ConcatNEnumerableIterator<TSource> : ConcatIterator<TSource>
         {
-            private readonly ConcatIterator<TSource> _previousConcat;
-            private readonly IEnumerable<TSource> _next;
-            private readonly int _nextIndex;
+            private readonly ConcatIterator<TSource> _linked; // Singly-inked list of other enumerables being concatenated.
+            private readonly IEnumerable<TSource> _concatee; // The enumerable represented by this node.
+            private readonly int _index; // Sign bit is set if we're adding _concatee before other enumerables (prepending),
+                                         // otherwise we're adding it after other enumerables (appending).
+                                         // The rest of the int (_index & int.MaxValue) represents how many Concat calls
+                                         // have been chained, e.g. for a.Concat(b).Concat(c) or a.Concat(b.Concat(c))
+                                         // this number will be 2.
+                                         // For appended nodes which are at the head of the linked list, this will also
+                                         // be equal to their index in the list (the last index).
 
-            internal ConcatNEnumerableIterator(ConcatIterator<TSource> previousConcat, IEnumerable<TSource> next, int nextIndex)
+            internal ConcatNEnumerableIterator(ConcatIterator<TSource> linked, IEnumerable<TSource> concatee, int index)
             {
-                Debug.Assert(previousConcat != null);
-                Debug.Assert(next != null);
-                Debug.Assert(nextIndex >= 2);
-                _previousConcat = previousConcat;
-                _next = next;
-                _nextIndex = nextIndex;
+                Debug.Assert(linked != null);
+                Debug.Assert(concatee != null);
+                Debug.Assert((index & int.MaxValue) >= 2);
+
+                _linked = linked;
+                _concatee = concatee;
+                _index = index;
             }
+
+            private bool IsAppended => _index >= 0;
 
             public override Iterator<TSource> Clone()
             {
-                return new ConcatNEnumerableIterator<TSource>(_previousConcat, _next, _nextIndex);
+                return new ConcatNEnumerableIterator<TSource>(_linked, _concatee, _index);
             }
 
-            internal override ConcatIterator<TSource> Concat(IEnumerable<TSource> next)
+            internal override ConcatIterator<TSource> ConcatAfter(IEnumerable<TSource> next)
             {
-                if (_nextIndex == int.MaxValue - 2)
+                if (_index == int.MaxValue - 2)
                 {
                     // In the unlikely case of this many concatenations, if we produced a ConcatNEnumerableIterator
                     // with int.MaxValue then state would overflow before it matched its index.
@@ -114,50 +139,70 @@ namespace System.Linq
                     return new Concat2EnumerableIterator<TSource>(this, next);
                 }
 
-                return new ConcatNEnumerableIterator<TSource>(this, next, _nextIndex + 1);
+                return new ConcatNEnumerableIterator<TSource>(this, next, (_index & int.MaxValue) + 1);
+            }
+
+            internal override ConcatIterator<TSource> ConcatBefore(IEnumerable<TSource> previous)
+            {
+                return new ConcatNEnumerableIterator<TSource>(this, previous, (_index | int.MinValue) + 1);
             }
 
             internal override IEnumerable<TSource> GetEnumerable(int index)
             {
-                if (index > _nextIndex)
-                {
-                    return null;
-                }
+                // We need to walk back through the chain of ConcatNIterators to
+                // look for the iterator that corresponds to a certain index.
+                // The rules for this are as follows:
+                // - If the current node is an appended node, meaning this concatee
+                //   comes last, then the result should be _concatee if index == _index.
+                //   Otherwise, it should be the same as _linked.GetEnumerable(index).
+                // - If the current node is a prepended node, meaning this concatee
+                //   comes first, then the result should be _concatee if index == 0.
+                //   Otherwise, it should be the same as _linked.GetEnumerable(index - 1).
 
-                // Walk back through the chain of ConcatNIterators looking for the one
-                // that has its _nextIndex equal to index.  If we don't find one, then it
-                // must be prior to any of them, so call GetEnumerable on the previous
-                // Concat2Iterator.  This avoids a deep recursive call chain.
+                // Another thing we have to do is stop at the first appended node we
+                // encounter (including this), which will hold the last concatee.
+                // If index is greater than that node's index at that point, then we
+                // need to return null to indicate that there are no more concatees.
+
                 ConcatNEnumerableIterator<TSource> current = this;
                 while (true)
                 {
-                    if (index == current._nextIndex)
+                    Debug.Assert(index >= 0);
+
+                    if (current.IsAppended)
                     {
-                        return current._next;
+                        if (index >= current._index)
+                        {
+                            return index > current._index ? null : current._concatee;
+                        }
+                    }
+                    else if (index-- == 0)
+                    {
+                        return current._concatee;
                     }
 
-                    ConcatIterator<TSource> previous = current._previousConcat;
+                    ConcatIterator<TSource> linked = current._linked;
 
-                    var previousEnumerables = previous as ConcatNEnumerableIterator<TSource>;
-                    if (previousEnumerables != null)
+                    var linkedEnumerables = linked as ConcatNEnumerableIterator<TSource>;
+                    if (linkedEnumerables != null)
                     {
-                        current = previousEnumerables;
+                        current = linkedEnumerables;
                         continue;
                     }
 
-                    var previousCollections = previous as ConcatNCollectionIterator<TSource>;
-                    if (previousCollections != null)
+                    var linkedCollections = linked as ConcatNCollectionIterator<TSource>;
+                    if (linkedCollections != null)
                     {
                         // Since ConcatNCollectionIterator.GetEnumerable does not call into this method,
                         // it is safe to call GetEnumerable on it here. It also makes things faster, since
                         // the above type-cast will only ever be run once per call of this method.
-                        return previousCollections.GetEnumerable(index);
+                        return linkedCollections.GetEnumerable(index);
                     }
 
                     // We've reached the tail of the linked list, which contains the first 2 enumerables.
-                    Debug.Assert(previous is Concat2EnumerableIterator<TSource> || previous is Concat2CollectionIterator<TSource>);
-                    Debug.Assert(index == 0 || index == 1);
-                    return previous.GetEnumerable(index);
+                    Debug.Assert(linked is Concat2EnumerableIterator<TSource> || linked is Concat2CollectionIterator<TSource>);
+                    Debug.Assert(index >= 0 && index <= 2); // index can be 2 if we prepend to a Concat2Iterator.
+                    return linked.GetEnumerable(index);
                 }
             }
         }
@@ -181,7 +226,7 @@ namespace System.Linq
                 return new Concat2CollectionIterator<TSource>(_first, _second);
             }
 
-            internal override ConcatIterator<TSource> Concat(IEnumerable<TSource> next)
+            internal override ConcatIterator<TSource> ConcatAfter(IEnumerable<TSource> next)
             {
                 var nextCollection = next as ICollection<TSource>;
                 if (nextCollection != null)
@@ -191,9 +236,20 @@ namespace System.Linq
                 return new ConcatNEnumerableIterator<TSource>(this, next, 2);
             }
 
+            internal override ConcatIterator<TSource> ConcatBefore(IEnumerable<TSource> previous)
+            {
+                var previousCollection = previous as ICollection<TSource>;
+                if (previousCollection != null)
+                {
+                    return new ConcatNCollectionIterator<TSource>(this, previousCollection, 2 | int.MinValue);
+                }
+                return new ConcatNEnumerableIterator<TSource>(this, previous, 2 | int.MinValue);
+            }
+
             internal void CopyTo(TSource[] array, int arrayIndex)
             {
                 Debug.Assert(array != null);
+                Debug.Assert(arrayIndex >= 0);
                 Debug.Assert(array.Length - arrayIndex >= Count);
 
                 _first.CopyTo(array, 0);
@@ -233,20 +289,21 @@ namespace System.Linq
 
         private sealed class ConcatNCollectionIterator<TSource> : ConcatIterator<TSource>
         {
-            private readonly ConcatIterator<TSource> _previous;
-            private readonly ICollection<TSource> _next;
-            private readonly int _nextIndex;
+            private readonly ConcatIterator<TSource> _linked;
+            private readonly ICollection<TSource> _concatee;
+            private readonly int _index;
 
-            internal ConcatNCollectionIterator(ConcatIterator<TSource> previous, ICollection<TSource> next, int nextIndex)
+            internal ConcatNCollectionIterator(ConcatIterator<TSource> linked, ICollection<TSource> concatee, int index)
             {
-                Debug.Assert(previous != null);
-                Debug.Assert(previous is Concat2CollectionIterator<TSource> || previous is ConcatNCollectionIterator<TSource>);
-                Debug.Assert(next != null);
-                Debug.Assert(nextIndex >= 2);
+                Debug.Assert(linked != null);
+                // A collection iterator should only be linked to other collection iterators
+                Debug.Assert(linked is Concat2CollectionIterator<TSource> || linked is ConcatNCollectionIterator<TSource>);
+                Debug.Assert(concatee != null);
+                Debug.Assert((index & int.MaxValue) >= 2);
 
-                _previous = previous;
-                _next = next;
-                _nextIndex = nextIndex;
+                _linked = linked;
+                _concatee = concatee;
+                _index = index;
             }
 
             private int Count
@@ -255,38 +312,40 @@ namespace System.Linq
                 {
                     // Walk the linked list of Concat{2,N}CollectionIterators and call .Count
                     // on each of the collections.
-                    // Note that we start from the last collection and make our way to the first,
+                    // It's possible that we may not start from the first nor end at the last collection,
                     // but the cumulative count will be the same either way.
                     
-                    int totalCount = _next.Count;
-                    ConcatIterator<TSource> previous = _previous;
+                    int totalCount = _concatee.Count;
+                    ConcatIterator<TSource> linked = _linked;
 
-                    ConcatNCollectionIterator<TSource> previousN;
-                    while ((previousN = previous as ConcatNCollectionIterator<TSource>) != null)
+                    ConcatNCollectionIterator<TSource> linkedN;
+                    while ((linkedN = linked as ConcatNCollectionIterator<TSource>) != null)
                     {
                         checked
                         {
-                            totalCount += previousN._next.Count;
+                            totalCount += linkedN._concatee.Count;
                         }
-                        previous = previousN._previous;
+                        linked = linkedN._linked;
                     }
 
-                    var previous2 = (Concat2CollectionIterator<TSource>)previous;
-                    return checked(totalCount + previous2.Count);
+                    var linked2 = (Concat2CollectionIterator<TSource>)linked;
+                    return checked(totalCount + linked2.Count);
                 }
             }
 
+            private bool IsAppended => _index >= 0;
+
             public override Iterator<TSource> Clone()
             {
-                return new ConcatNCollectionIterator<TSource>(_previous, _next, _nextIndex);
+                return new ConcatNCollectionIterator<TSource>(_linked, _concatee, _index);
             }
 
-            internal override ConcatIterator<TSource> Concat(IEnumerable<TSource> next)
+            internal override ConcatIterator<TSource> ConcatAfter(IEnumerable<TSource> next)
             {
                 var nextCollection = next as ICollection<TSource>;
                 if (nextCollection != null)
                 {
-                    if (_nextIndex == int.MaxValue - 2)
+                    if (_index == int.MaxValue - 2)
                     {
                         // In the unlikely case of this many concatenations, if we produced a ConcatNCollectionIterator
                         // with int.MaxValue then state would overflow before it matched its index.
@@ -294,79 +353,109 @@ namespace System.Linq
                         return new Concat2EnumerableIterator<TSource>(this, next);
                     }
 
-                    return new ConcatNCollectionIterator<TSource>(this, nextCollection, _nextIndex + 1);
+                    return new ConcatNCollectionIterator<TSource>(this, nextCollection, (_index & int.MaxValue) + 1);
                 }
                 
                 // If we encounter a non-ICollection then getting .Count and performing .ToArray()
                 // will no longer be cheap, due to enumerables' lazy nature. So, fall back to using
                 // enumerable-based iterators for any further chaining.
-                return new ConcatNEnumerableIterator<TSource>(this, next, _nextIndex + 1);
+                return new ConcatNEnumerableIterator<TSource>(this, next, (_index & int.MaxValue) + 1);
             }
 
-            // Copy all of the elements in the iterator, finishing before indexAfterCopy.
-            // If indexAfterCopy is array.Length, we'll finish copying at the end of the array.
-            // The reason we take an ending index as opposed to a starting one is because
-            // we only hold a reference to the most recently concat'd collection. So to start
-            // copying at a certain index, we'd have to re-walk the linked list of iterators
-            // all the way back to the least recent one, and repeat that for all of the
-            // collections we hold.
-            private void CopyBefore(TSource[] array, int indexAfterCopy)
+            internal override ConcatIterator<TSource> ConcatBefore(IEnumerable<TSource> previous)
+            {
+                var previousCollection = previous as ICollection<TSource>;
+                if (previousCollection != null)
+                {
+                    return new ConcatNCollectionIterator<TSource>(this, previousCollection, (_index | int.MinValue) + 1);
+                }
+                return new ConcatNEnumerableIterator<TSource>(this, previous, (_index | int.MinValue) + 1);
+            }
+
+            // Copy all of the elements in the iterator to the specified array.
+            // Collections from prepended nodes are copied starting at startIndex.
+            // Collections from appended nodes are copied ending at startIndex + count - 1.
+            private void CopyTo(TSource[] array, int startIndex, int count)
             {
                 Debug.Assert(array != null);
-                Debug.Assert(indexAfterCopy >= 0 && indexAfterCopy <= array.Length);
-                Debug.Assert(indexAfterCopy >= Count);
+                Debug.Assert(startIndex >= 0);
+                Debug.Assert(count >= 0);
+                Debug.Assert(array.Length - startIndex >= count);
+                Debug.Assert(count >= Count);
 
-                // Copy the items from this collection, which is the last
-                // one that was concatenated
-                int copied = _next.Count;
-                _next.CopyTo(array, indexAfterCopy - copied);
+                int lowerBound = startIndex;
+                int upperBound = startIndex + count;
 
-                ConcatIterator<TSource> previous = _previous;
+                ConcatIterator<TSource> current;
+                ConcatNCollectionIterator<TSource> currentN = this;
 
-                ConcatNCollectionIterator<TSource> previousN;
-                while ((previousN = previous as ConcatNCollectionIterator<TSource>) != null)
+                do
                 {
+                    ICollection<TSource> concatee = currentN._concatee;
+
                     checked
                     {
-                        copied += previousN._next.Count;
+                        if (currentN.IsAppended)
+                        {
+                            // Copy towards the end of the array.
+                            upperBound -= concatee.Count;
+                            concatee.CopyTo(array, upperBound);
+                        }
+                        else
+                        {
+                            // Copy towards the beginning of the array.
+                            concatee.CopyTo(array, lowerBound);
+                            lowerBound += concatee.Count;
+                        }
                     }
-                    previousN._next.CopyTo(array, indexAfterCopy - copied);
-                    previous = previousN._previous;
+                    
+                    current = currentN._linked;
                 }
+                while ((currentN = current as ConcatNCollectionIterator<TSource>) != null);
 
                 // We've reached the first 2 collections that were concatenated
-                var previous2 = (Concat2CollectionIterator<TSource>)previous;
-                copied += previous2.Count;
-                Debug.Assert(copied == Count); // We should have copied all the elements
+                var current2 = (Concat2CollectionIterator<TSource>)current;
+                checked
+                {
+                    upperBound -= current2.Count; // We'll treat this node as an appended node
+                }
 
-                previous2.CopyTo(array, indexAfterCopy - copied);
+                int itemsPrepended = lowerBound - startIndex;
+                int itemsAppended = (startIndex + count) - upperBound;
+                Debug.Assert(itemsPrepended + itemsAppended == Count); // We should have copied all the elements
+
+                current2.CopyTo(array, upperBound);
             }
 
             internal override IEnumerable<TSource> GetEnumerable(int index)
             {
-                if (index > _nextIndex)
-                {
-                    return null;
-                }
-
                 ConcatNCollectionIterator<TSource> current = this;
                 while (true)
                 {
-                    if (index == current._nextIndex)
+                    Debug.Assert(index >= 0);
+
+                    if (current.IsAppended)
                     {
-                        return current._next;
+                        if (index >= current._index)
+                        {
+                            return index > current._index ? null : current._concatee;
+                        }
+                    }
+                    else if (index-- == 0)
+                    {
+                        return current._concatee;
                     }
 
-                    var previousN = current._previous as ConcatNCollectionIterator<TSource>;
-                    if (previousN != null)
+                    var linkedN = current._linked as ConcatNCollectionIterator<TSource>;
+                    if (linkedN != null)
                     {
-                        current = previousN;
+                        current = linkedN;
                         continue;
                     }
 
-                    var previous2 = (Concat2CollectionIterator<TSource>)current._previous;
-                    Debug.Assert(index == 0 || index == 1);
-                    return previous2.GetEnumerable(index);
+                    var linked2 = (Concat2CollectionIterator<TSource>)current._linked;
+                    Debug.Assert(index >= 0 && index <= 2); // index can be 2 if we prepend to a Concat2Iterator.
+                    return linked2.GetEnumerable(index);
                 }
             }
 
@@ -379,7 +468,7 @@ namespace System.Linq
                 }
 
                 var result = new TSource[totalCount];
-                CopyBefore(result, result.Length);
+                CopyTo(result, startIndex: 0, count: result.Length);
                 return result;
             }
 
@@ -403,7 +492,9 @@ namespace System.Linq
 
             internal abstract IEnumerable<TSource> GetEnumerable(int index);
 
-            internal abstract ConcatIterator<TSource> Concat(IEnumerable<TSource> next);
+            internal abstract ConcatIterator<TSource> ConcatAfter(IEnumerable<TSource> next);
+
+            internal abstract ConcatIterator<TSource> ConcatBefore(IEnumerable<TSource> previous);
 
             public override bool MoveNext()
             {

--- a/src/System.Linq/src/System/Linq/Concat.cs
+++ b/src/System.Linq/src/System/Linq/Concat.cs
@@ -392,20 +392,24 @@ namespace System.Linq
                 do
                 {
                     ICollection<TSource> concatee = currentN._concatee;
+                    int toCopy = concatee.Count;
 
-                    checked
+                    if (toCopy > 0)
                     {
-                        if (currentN.IsAppended)
+                        checked
                         {
-                            // Copy towards the end of the array.
-                            upperBound -= concatee.Count;
-                            concatee.CopyTo(array, upperBound);
-                        }
-                        else
-                        {
-                            // Copy towards the beginning of the array.
-                            concatee.CopyTo(array, lowerBound);
-                            lowerBound += concatee.Count;
+                            if (currentN.IsAppended)
+                            {
+                                // Copy towards the end of the array.
+                                upperBound -= toCopy;
+                                concatee.CopyTo(array, upperBound);
+                            }
+                            else
+                            {
+                                // Copy towards the beginning of the array.
+                                concatee.CopyTo(array, lowerBound);
+                                lowerBound += toCopy;
+                            }
                         }
                     }
                     

--- a/src/System.Linq/src/System/Linq/Concat.cs
+++ b/src/System.Linq/src/System/Linq/Concat.cs
@@ -419,18 +419,14 @@ namespace System.Linq
 
                 // We've reached the first 2 collections that were concatenated
                 var current2 = (Concat2CollectionIterator<TSource>)current;
-                int currentCount = current2.Count;
-
-                if (currentCount > 0)
-                {
-                    checked
-                    {
-                        upperBound -= currentCount; // We'll treat this node as an appended node
-                    }
-                    current2.CopyTo(array, upperBound);
-                }
+                current2.CopyTo(array, lowerBound); // We'll treat this node as a prepended one so we don't have to get its .Count in Release
 
 #if DEBUG
+                checked
+                {
+                    lowerBound += current2.Count;
+                }
+
                 int itemsPrepended = lowerBound - startIndex;
                 int itemsAppended = (startIndex + count) - upperBound;
                 Debug.Assert(itemsPrepended + itemsAppended == Count); // We should have copied all the elements

--- a/src/System.Linq/src/System/Linq/Concat.cs
+++ b/src/System.Linq/src/System/Linq/Concat.cs
@@ -252,8 +252,8 @@ namespace System.Linq
                 Debug.Assert(arrayIndex >= 0);
                 Debug.Assert(array.Length - arrayIndex >= Count);
 
-                _first.CopyTo(array, 0);
-                _second.CopyTo(array, _first.Count);
+                _first.CopyTo(array, arrayIndex);
+                _second.CopyTo(array, arrayIndex + _first.Count);
             }
 
             internal override IEnumerable<TSource> GetEnumerable(int index)

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -90,6 +90,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(EnumerableSourcesData))]
         [MemberData(nameof(NonCollectionSourcesData))]
         [MemberData(nameof(ListSourcesData))]
+        [MemberData(nameof(ConcatOfConcatsData))]
         [MemberData(nameof(ConcatWithSelfData))]
         [MemberData(nameof(ChainedCollectionConcatData))]
         [MemberData(nameof(AppendedPrependedConcatAlternationsData))]
@@ -125,6 +126,21 @@ namespace System.Linq.Tests
         public static IEnumerable<object[]> NonCollectionSourcesData() => GenerateSourcesData(outerTransform: e => ForceNotCollection(e));
 
         public static IEnumerable<object[]> ListSourcesData() => GenerateSourcesData(outerTransform: e => e.ToList());
+
+        public static IEnumerable<object[]> ConcatOfConcatsData()
+        {
+            yield return new object[]
+            {
+                Enumerable.Range(0, 20),
+                Enumerable.Concat(
+                    Enumerable.Concat(
+                        Enumerable.Range(0, 4),
+                        Enumerable.Range(4, 6)),
+                    Enumerable.Concat(
+                        Enumerable.Range(10, 3),
+                        Enumerable.Range(13, 7)))
+            };
+        }
 
         public static IEnumerable<object[]> ConcatWithSelfData()
         {


### PR DESCRIPTION
**TL;DR** Without adding any new types or fields, we now recognize patterns of the form `a.Concat(b.Concat(c))` (where we hold a reference to the first enumerable to be concatenated) in addition to `a.Concat(b).Concat(c)` (where we hold a reference to the last one). We can also optimize for mixing of the two, e.g. `a.Concat(b.Concat(c)).Concat(d)`.

### Summary

- ConcatIterator has 2 new abstract methods: `ConcatAfter` and `ConcatBefore`. `ConcatAfter` is just a renaming what was previously `Concat` (produces an iterator with the enumerable coming after the rest of the nodes). `ConcatBefore` produces an iterator with the enumerable coming before the rest of the nodes.

- Each iterator's implementation of ConcatBefore is basically exactly the same as ConcatAfter, with one small exception: we set the sign bit of `_index` to mark it as a 'prepended' node, or that the enumerable it holds comes before the other nodes.

  - Implementing `GetEnumerable` is now slightly tricky, since `_index & int.MaxValue` no longer represents the index of the enumerable, but rather the order in which it was added. For example, consider this code:

    ```cs
    List<T> Single<T>(T item) => new List<T> { item };

    Single(3).Concat(Single(2).Concat(Single(0).Concat(Single(1))))).Concat(Single(4))
    ```

    This will produce a node representation with these indices (x' stands for `x | int.MinValue` and represents a prepended node):

    `3' 2' [0 1] 4`

    Where 4 references 3', 3' references 2', and 2 references \[0 1\] (the first 2 collections). As you can see the lower 31 bits of `_index` for 3' and 2' will be 3 and 2, but they are actually indices 0 and 1 from the viewpoint of `GetEnumerable`.

    - To solve this problem, we say that `GetEnumerable(n)` of an appended node should be the items held by that node if `n == _index`, otherwise it should be `_linked.GetEnumerable(n)`. For prepended nodes, it should be the items held by that node if `n == 0`, otherwise it should be `_linked.GetEnumerable(n - 1)`. (This is all implemented iteratively to avoid SOs of course.)

      - In the above example, if we wanted `GetEnumerable(1)`, we would first check 4 == 1. Then we would hop to 3', and check 1 == 0, then decrement 1. Then we would hop to 2', find 0 == 0 and return the items at 2'.

    - Another problem we face is that the `index > _index` check no longer works if the head of the linked list is prepended-- we have to find the first appended node (which will hold the last concatee, and therefore the greatest index) before making that check.

- Other changes

  - `Concatenate.cs` has been renamed to `Concat.cs`. It was previously named `Concatenate` b/c it also housed Append/Prepend, but those have since been moved to another file.

  - Fixed existing bug where we ignore the `arrayIndex` in `Concat2CollectionIterator.CopyTo` and just use 0. (Note that this is dormant currently because w/ existing builds we only pass in 0 for `arrayIndex`.)

  - `_previous` / `_next` / `_nextIndex` are no longer accurate field names, so I changed them to `_linked` / `_concatee` / `_index`.

  - `ConcatNCollectionIterator.CopyBefore` has been eliminated-- we can't do `CopyTo(T[], int)` efficiently since we have to walk all the way to the first prepended node, and with `CopyBefore(T[], int)` we likewise have to find the first appended node. My idea was to have it accept a `startIndex` and a `count`; items from prepended nodes will be copied starting at `startIndex`, and ones from appended nodes towards the end.

  - Added strenuous testing for the new changes, which helped me uncover the bug I mentioned earlier.

@VSadov @stephentoub @justinvp PTAL