### PR TITLE
Bring StreamWriter/Reader to CoreFX, add path constructors

### DIFF
--- a/src/System.IO/ref/System.IO.cs
+++ b/src/System.IO/ref/System.IO.cs
@@ -128,7 +128,7 @@ namespace System.IO
         public virtual void Write(ulong value) { }
         protected void Write7BitEncodedInt(int value) { }
     }
-    public sealed partial class BufferedStream : System.IO.Stream 
+    public sealed partial class BufferedStream : System.IO.Stream
     {
         public BufferedStream(Stream stream) { }
         public BufferedStream(Stream stream, int bufferSize) { }
@@ -210,6 +210,11 @@ namespace System.IO
         public StreamReader(System.IO.Stream stream, System.Text.Encoding encoding, bool detectEncodingFromByteOrderMarks) { }
         public StreamReader(System.IO.Stream stream, System.Text.Encoding encoding, bool detectEncodingFromByteOrderMarks, int bufferSize) { }
         public StreamReader(System.IO.Stream stream, System.Text.Encoding encoding, bool detectEncodingFromByteOrderMarks, int bufferSize, bool leaveOpen) { }
+        public StreamReader(string path) { }
+        public StreamReader(string path, bool detectEncodingFromByteOrderMarks) { }
+        public StreamReader(string path, System.Text.Encoding encoding) { }
+        public StreamReader(string path, System.Text.Encoding encoding, bool detectEncodingFromByteOrderMarks) { }
+        public StreamReader(string path, System.Text.Encoding encoding, bool detectEncodingFromByteOrderMarks, int bufferSize) { }
         public virtual System.IO.Stream BaseStream { get { return default(System.IO.Stream); } }
         public virtual System.Text.Encoding CurrentEncoding { get { return default(System.Text.Encoding); } }
         public bool EndOfStream { get { return default(bool); } }
@@ -234,6 +239,10 @@ namespace System.IO
         public StreamWriter(System.IO.Stream stream, System.Text.Encoding encoding) { }
         public StreamWriter(System.IO.Stream stream, System.Text.Encoding encoding, int bufferSize) { }
         public StreamWriter(System.IO.Stream stream, System.Text.Encoding encoding, int bufferSize, bool leaveOpen) { }
+        public StreamWriter(string path) { }
+        public StreamWriter(string path, bool append) { }
+        public StreamWriter(string path, bool append, System.Text.Encoding encoding) { }
+        public StreamWriter(string path, bool append, System.Text.Encoding encoding, int bufferSize) { }
         public virtual bool AutoFlush { get { return default(bool); } set { } }
         public virtual System.IO.Stream BaseStream { get { return default(System.IO.Stream); } }
         public override System.Text.Encoding Encoding { get { return default(System.Text.Encoding); } }

--- a/src/System.IO/src/Resources/Strings.netcore50aot.resx
+++ b/src/System.IO/src/Resources/Strings.netcore50aot.resx
@@ -225,4 +225,7 @@
   <data name="UnauthorizedAccess_MemStreamBuffer" xml:space="preserve">
     <value>MemoryStream's internal buffer cannot be accessed.</value>
   </data>
+  <data name="Argument_EmptyPath" xml:space="preserve">
+    <value>Empty path name is not legal.</value>
+  </data>
 </root>

--- a/src/System.IO/src/Resources/Strings.resx
+++ b/src/System.IO/src/Resources/Strings.resx
@@ -146,5 +146,26 @@
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
     <value>Cannot access a closed Stream.</value>
+  </data>  
+  <data name="InvalidOperation_AsyncIOInProgress" xml:space="preserve">
+    <value>The stream is currently in use by a previous operation on the stream.</value>
+  </data>
+  <data name="Argument_EmptyPath" xml:space="preserve">
+    <value>Empty path name is not legal.</value>
+  </data>
+  <data name="Argument_StreamNotReadable" xml:space="preserve">
+    <value>Stream was not readable.</value>
+  </data>
+  <data name="Argument_StreamNotWritable" xml:space="preserve">
+    <value>Stream was not writable.</value>
+  </data>
+  <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
+    <value>Positive number required.</value>
+  </data>
+  <data name="ObjectDisposed_WriterClosed" xml:space="preserve">
+    <value>Cannot write to a closed TextWriter.</value>
+  </data>
+  <data name="ObjectDisposed_ReaderClosed" xml:space="preserve">
+    <value>Cannot read from a closed TextReader.</value>
   </data>
 </root>

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -9,6 +9,7 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7;uap10.1</PackageTargetFramework>
+    <NoWarn Condition="'$(TargetGroup)' != 'net462' and '$(TargetGroup)' != 'net463'">CS0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -27,6 +28,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ExcludeAssemblyInfoPartialFile>true</ExcludeAssemblyInfoPartialFile>
     <StringResourcesPath>Resources/Strings.netcore50aot.resx</StringResourcesPath>
+    <DefineConstants>$(DefineConstants);uap101aot</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetGroup)' == '' Or '$(TargetGroup)'=='netstandard1.6'">
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
@@ -38,6 +40,9 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net462' and '$(TargetGroup)' != 'net463'">
     <Compile Include="System\CodeDom\Compiler\IndentedTextWriter.cs" />
+    <Compile Include="System\IO\StreamReader.cs" />
+    <Compile Include="System\IO\StreamWriter.cs" />
+    <Compile Include="System\IO\FileStreamHelpers.cs" />
     <Compile Include="System\IO\BufferedStream.cs" />
     <Compile Include="System\IO\InvalidDataException.cs" />
     <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
@@ -49,8 +54,6 @@
     <Compile Include="System\IO\BinaryWriter.cs" />
     <Compile Include="System\IO\EndOfStreamException.cs" />
     <Compile Include="System\IO\MemoryStream.cs" />
-    <Compile Include="System\IO\StreamReader.cs" />
-    <Compile Include="System\IO\StreamWriter.cs" />
     <Compile Include="System\IO\StringReader.cs" />
     <Compile Include="System\IO\StringWriter.cs" />
     <Compile Include="System\IO\TextReader.cs" />

--- a/src/System.IO/src/System/IO/FileStreamHelpers.cs
+++ b/src/System.IO/src/System/IO/FileStreamHelpers.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Diagnostics;
+
+namespace System.IO
+{
+    // Use reflection to access the implementation of FileStream in System.IO.FileSystem.dll. While far from ideal,
+    // we do this to avoid having to directly reference FileSystem as doing so introduces a dependency cycle. A more
+    // permanent solution would be to merge the IO and FileSystem assemblies.
+    internal static class FileStreamHelpers
+    {
+        private const int FileMode_Create = 2;
+        private const int FileMode_Open = 3;
+        private const int FileMode_Append = 6;
+        private const int FileAccess_Read = 1;
+        private const int FileAccess_Write = 2;
+
+        private static FileOpenDelegate s_fileOpen;
+        private delegate Stream FileOpenDelegate(string path, int fileMode, int fileAccess);
+
+        public static Stream CreateFileStream(string path, bool write, bool append)
+        {
+            if (s_fileOpen == null)
+            {
+                s_fileOpen = GetFileOpenFunction();
+            }
+            int filemode = !write ? FileMode_Open : append ? FileMode_Append : FileMode_Create;
+            int fileaccess = write ? FileAccess_Write : FileAccess_Read;
+            return s_fileOpen(path, filemode, fileaccess);
+        }
+
+        private static FileOpenDelegate GetFileOpenFunction()
+        {
+            Type fileSystemType = Type.GetType("System.IO.File, System.IO.FileSystem, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", throwOnError: false);
+            var methodInfos = fileSystemType?.GetTypeInfo().GetDeclaredMethods("Open");
+            if (methodInfos != null)
+            {
+                foreach (MethodInfo methodInfo in methodInfos)
+                {
+                    var methodParams = methodInfo.GetParameters();
+                    if (methodParams?.Length == 3 &&
+                        methodParams[0].Name == "path" &&
+                        methodParams[1].Name == "mode" &&
+                        methodParams[2].Name == "access")
+                    {
+                        return (FileOpenDelegate)methodInfo.CreateDelegate(typeof(FileOpenDelegate));
+                    }
+                }
+            }
+            Debug.Fail("Could not access the File.Open function via reflection into System.IO.FileSystem version 4.0.1.0.");
+            return null;
+        }
+    }
+}

--- a/src/System.IO/src/System/IO/StreamReader.cs
+++ b/src/System.IO/src/System/IO/StreamReader.cs
@@ -155,6 +155,41 @@ namespace System.IO
             Init(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize, leaveOpen);
         }
 
+        public StreamReader(string path)
+            : this(path, true)
+        {
+        }
+
+        public StreamReader(string path, bool detectEncodingFromByteOrderMarks)
+            : this(path, Encoding.UTF8, detectEncodingFromByteOrderMarks, DefaultBufferSize)
+        {
+        }
+
+        public StreamReader(string path, Encoding encoding)
+            : this(path, encoding, true, DefaultBufferSize)
+        {
+        }
+
+        public StreamReader(string path, Encoding encoding, bool detectEncodingFromByteOrderMarks)
+            : this(path, encoding, detectEncodingFromByteOrderMarks, DefaultBufferSize)
+        {
+        }
+
+        public StreamReader(string path, Encoding encoding, bool detectEncodingFromByteOrderMarks, int bufferSize)
+        {
+            if (path == null)
+                throw new ArgumentNullException(nameof(path));
+            if (encoding == null)
+                throw new ArgumentNullException(nameof(encoding));
+            if (path.Length == 0)
+                throw new ArgumentException(SR.Argument_EmptyPath);
+            if (bufferSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
+
+            Stream stream = FileStreamHelpers.CreateFileStream(path, write: false, append: false);
+            Init(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize, leaveOpen: false);
+        }
+
         private void Init(Stream stream, Encoding encoding, bool detectEncodingFromByteOrderMarks, int bufferSize, bool leaveOpen)
         {
             _stream = stream;
@@ -471,6 +506,12 @@ namespace System.IO
                     CompressBuffer(2);
                     changedEncoding = true;
                 }
+                else
+                {
+                    _encoding = Encoding.UTF32;
+                    CompressBuffer(4);
+                    changedEncoding = true;
+                }
             }
 
             else if (_byteLen >= 3 && _byteBuffer[0] == 0xEF && _byteBuffer[1] == 0xBB && _byteBuffer[2] == 0xBF)
@@ -478,6 +519,14 @@ namespace System.IO
                 // UTF-8
                 _encoding = Encoding.UTF8;
                 CompressBuffer(3);
+                changedEncoding = true;
+            }
+            else if (_byteLen >= 4 && _byteBuffer[0] == 0 && _byteBuffer[1] == 0 &&
+                _byteBuffer[2] == 0xFE && _byteBuffer[3] == 0xFF)
+            {
+                // Big Endian UTF32
+                _encoding = new UTF32Encoding(bigEndian: true, byteOrderMark: true);
+                CompressBuffer(4);
                 changedEncoding = true;
             }
             else if (_byteLen == 2)
@@ -962,8 +1011,12 @@ namespace System.IO
 
             return task;
         }
-
+// TODO #12381: Move TextReader to CoreFX so this can be overridden for netstandard builds
+#if uap101aot
         internal override async Task<int> ReadAsyncInternal(char[] buffer, int index, int count)
+#else
+        internal async Task<int> ReadAsyncInternal(char[] buffer, int index, int count)
+#endif
         {
             if (CharPos_Prop == CharLen_Prop && (await ReadBufferAsync().ConfigureAwait(false)) == 0)
             {
@@ -1170,7 +1223,7 @@ namespace System.IO
             return task;
         }
 
-        #region Private properties for async method performance
+#region Private properties for async method performance
         // Access to instance fields of MarshalByRefObject-derived types requires special JIT helpers that check
         // if the instance operated on is remote. This is optimised for fields on 'this' but if a method is Async
         // and is thus lifted to a state machine type, access will be slow.
@@ -1247,7 +1300,7 @@ namespace System.IO
         {
             get { return _maxCharsPerBuffer; }
         }
-        #endregion Private properties for async method performance
+#endregion Private properties for async method performance
         private async Task<int> ReadBufferAsync()
         {
             CharLen_Prop = 0;
@@ -1321,7 +1374,7 @@ namespace System.IO
 
             return CharLen_Prop;
         }
-        #endregion
+#endregion
 
 
         // No data, class doesn't need to be serializable.

--- a/src/System.IO/src/System/IO/StreamWriter.cs
+++ b/src/System.IO/src/System/IO/StreamWriter.cs
@@ -125,6 +125,36 @@ namespace System.IO
             Init(stream, encoding, bufferSize, leaveOpen);
         }
 
+        public StreamWriter(string path)
+            : this(path, false, UTF8NoBOM, DefaultBufferSize)
+        {
+        }
+
+        public StreamWriter(string path, bool append)
+            : this(path, append, UTF8NoBOM, DefaultBufferSize)
+        {
+        }
+
+        public StreamWriter(string path, bool append, Encoding encoding)
+            : this(path, append, encoding, DefaultBufferSize)
+        {
+        }
+
+        public StreamWriter(string path, bool append, Encoding encoding, int bufferSize)
+        { 
+            if (path == null)
+                throw new ArgumentNullException(nameof(path));
+            if (encoding == null)
+                throw new ArgumentNullException(nameof(encoding));
+            if (path.Length == 0)
+                throw new ArgumentException(SR.Argument_EmptyPath);
+            if (bufferSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
+
+            Stream stream = FileStreamHelpers.CreateFileStream(path, write: true, append: append);
+            Init(stream, encoding, bufferSize, shouldLeaveOpen: false);
+        }
+
         private void Init(Stream streamArg, Encoding encodingArg, int bufferSize, bool shouldLeaveOpen)
         {
             _stream = streamArg;

--- a/src/System.IO/tests/StreamReader/StreamReader.StringCtorTests.cs
+++ b/src/System.IO/tests/StreamReader/StreamReader.StringCtorTests.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class StreamReader_StringCtorTests
+    {
+        [Fact]
+        public static void NullArgs_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("path", () => new StreamReader((string)null));
+            Assert.Throws<ArgumentNullException>("path", () => new StreamReader((string)null, null));
+            Assert.Throws<ArgumentNullException>("path", () => new StreamReader((string)null, null, true));
+            Assert.Throws<ArgumentNullException>("path", () => new StreamReader((string)null, null, true, -1));
+            Assert.Throws<ArgumentNullException>("encoding", () => new StreamReader("", null));
+            Assert.Throws<ArgumentNullException>("encoding", () => new StreamReader("", null, true));
+            Assert.Throws<ArgumentNullException>("encoding", () => new StreamReader("", null, true, -1));
+        }
+
+        [Fact]
+        public static void EmptyPath_ThrowsArgumentException()
+        {
+            // No argument name for the empty path exception
+            Assert.Throws<ArgumentException>(() => new StreamReader(""));
+            Assert.Throws<ArgumentException>(() => new StreamReader("", Encoding.UTF8));
+            Assert.Throws<ArgumentException>(() => new StreamReader("", Encoding.UTF8, true));
+            Assert.Throws<ArgumentException>(() => new StreamReader("", Encoding.UTF8, true, -1));
+        }
+
+        [Fact]
+        public static void NegativeBufferSize_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => new StreamReader("path", Encoding.UTF8, true, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => new StreamReader("path", Encoding.UTF8, true, 0));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void ReadToEnd_detectEncodingFromByteOrderMarks(bool detectEncodingFromByteOrderMarks)
+        {
+            string testfile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(testfile, new byte[] { 65, 66, 67, 68 });
+                using (var sr2 = new StreamReader(testfile, detectEncodingFromByteOrderMarks))
+                {
+                    Assert.Equal("ABCD", sr2.ReadToEnd());
+                }
+            }
+            finally
+            {
+                File.Delete(testfile);
+            }
+        }
+    }
+}

--- a/src/System.IO/tests/StreamWriter/StreamWriter.StringCtorTests.cs
+++ b/src/System.IO/tests/StreamWriter/StreamWriter.StringCtorTests.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class StreamWriter_StringCtorTests
+    {
+        [Fact]
+        public static void NullArgs_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("path", () => new StreamWriter((string)null));
+            Assert.Throws<ArgumentNullException>("path", () => new StreamWriter((string)null, true));
+            Assert.Throws<ArgumentNullException>("path", () => new StreamWriter((string)null, true, null));
+            Assert.Throws<ArgumentNullException>("path", () => new StreamWriter((string)null, true, null, -1));
+            Assert.Throws<ArgumentNullException>("encoding", () => new StreamWriter("path", true, null));
+            Assert.Throws<ArgumentNullException>("encoding", () => new StreamWriter("path", true, null, -1));
+            Assert.Throws<ArgumentNullException>("encoding", () => new StreamWriter("", true, null));
+            Assert.Throws<ArgumentNullException>("encoding", () => new StreamWriter("", true, null, -1));
+        }
+
+        [Fact]
+        public static void EmptyPath_ThrowsArgumentException()
+        {
+            // No argument name for the empty path exception
+            Assert.Throws<ArgumentException>(() => new StreamWriter(""));
+            Assert.Throws<ArgumentException>(() => new StreamWriter("", true));
+            Assert.Throws<ArgumentException>(() => new StreamWriter("", true, Encoding.UTF8));
+            Assert.Throws<ArgumentException>(() => new StreamWriter("", true, Encoding.UTF8, -1));
+        }
+
+        [Fact]
+        public static void NegativeBufferSize_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => new StreamWriter("path", false, Encoding.UTF8, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => new StreamWriter("path", true, Encoding.UTF8, 0));
+        }
+
+        [Fact]
+        public static void CreateStreamWriter()
+        {
+            string testfile = Path.GetTempFileName();
+            string testString = "Hello World!";
+            try
+            {
+                using (StreamWriter writer = new StreamWriter(testfile))
+                {
+                    writer.Write(testString);
+                }
+
+                using (StreamReader reader = new StreamReader(testfile))
+                {
+                    Assert.Equal(testString, reader.ReadToEnd());
+                }
+            }
+            finally
+            {
+                File.Delete(testfile);
+            }
+        }
+
+        public static IEnumerable<object[]> EncodingsToTestStreamWriter()
+        {
+            yield return new object[] { Encoding.UTF8, "This is UTF8\u00FF" };
+            yield return new object[] { Encoding.BigEndianUnicode, "This is BigEndianUnicode\u00FF" };
+            yield return new object[] { Encoding.Unicode, "This is Unicode\u00FF" };
+        }
+
+        [Theory]
+        [MemberData(nameof(EncodingsToTestStreamWriter))]
+        public static void TestEncoding(Encoding encoding, string testString)
+        {
+            string testfile = Path.GetTempFileName();
+            try
+            {
+                using (StreamWriter writer = new StreamWriter(testfile, false, encoding))
+                {
+                    writer.Write(testString);
+                }
+
+                using (StreamReader reader = new StreamReader(testfile, encoding))
+                {
+                    Assert.Equal(testString, reader.ReadToEnd());
+                }
+            }
+            finally
+            {
+                File.Delete(testfile);
+            }
+        }
+    }
+}

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -28,9 +28,11 @@
     <Compile Include="MemoryStream\MemoryStream.TryGetBufferTests.cs" />
     <Compile Include="MemoryStream\MemoryStreamTests.cs" />
     <Compile Include="StreamReader\StreamReader.CtorTests.cs" />
+    <Compile Include="StreamReader\StreamReader.StringCtorTests.cs" Condition="'$(TargetGroup)'==''" />
     <Compile Include="StreamReader\StreamReaderTests.cs" />
     <Compile Include="StreamWriter\StreamWriter.BaseStream.cs" />
     <Compile Include="StreamWriter\StreamWriter.CloseTests.cs" />
+    <Compile Include="StreamWriter\StreamWriter.StringCtorTests.cs" Condition="'$(TargetGroup)'==''" />
     <Compile Include="StreamWriter\StreamWriter.CtorTests.cs" />
     <Compile Include="StreamWriter\StreamWriter.FlushTests.cs" />
     <Compile Include="StreamWriter\StreamWriter.WriteTests.cs" />


### PR DESCRIPTION
- Exposes StreamWriter and StreamReader from CoreFX instead of mscorlib
- Adds the string constructors that take a path to a file to read/write/append
  - Because of the FileStream dependency, Reflection is used in a separate internal helper class to attain access to File.Open.
- Adds tests for the string constructors
- Note: StreamReader.ReadAsyncInternal isn't overriding the TextReader parent when building for netstandard1.7 because TextReader is still contained within mscorlib and it is in an internal method.

replaces https://github.com/dotnet/corefx/pull/12101
resolves https://github.com/dotnet/corefx/issues/12124

@stephentoub 