### PR TITLE
Servicing the Network libraries

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -16,6 +16,8 @@
     <XmlDocFileRoot>$(PackagesDir)Microsoft.Private.Intellisense/1.0.0-rc4-24206-00/xmldocs</XmlDocFileRoot>
     <!-- We're currently not building a "live" baseline, instead we're using .NETCore 1.0 RTM stable versions as the baseline -->
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
+    <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.0.2</LineupPackageVersion>  
+    <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.0.2</PlatformPackageVersion>  
   </PropertyGroup>
 
   <Import Condition="Exists('pkg/baseline/baseline.props')" Project="pkg/baseline/baseline.props" />

--- a/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
+++ b/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>$(PlatformPackageVersion)</Version>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
   

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>$(LineupPackageVersion)</Version>
     <IsLineupPackage>true</IsLineupPackage>
     <RuntimeFileSource>runtime.json</RuntimeFileSource>
     <SkipValidatePackage>true</SkipValidatePackage>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <Version>4.0.2</Version>
+    <Version>4.0.1</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>

--- a/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
+++ b/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <Version>4.0.1.0</Version>
+  </PropertyGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.Http.WinHttpHandler.csproj">

--- a/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.csproj
+++ b/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.1</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{F75E3008-0562-42DF-BE72-C1384F12157E}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Net.Http.WinHttpHandler</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.1</AssemblyVersion>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
     <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.Net.Http/pkg/System.Net.Http.pkgproj
+++ b/src/System.Net.Http/pkg/System.Net.Http.pkgproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>4.1.0.0</Version>
+    <Version>4.1.1.0</Version>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>

--- a/src/System.Net.Http/ref/System.Net.Http.csproj
+++ b/src/System.Net.Http/ref/System.Net.Http.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.1</AssemblyVersion>
     <OutputType>Library</OutputType>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Net.Http</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.1</AssemblyVersion>
     <WindowsRID>win</WindowsRID>
     <PackageTargetFramework Condition="'$(TargetsUnix)' == 'true'">netstandard1.6</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -24,7 +24,7 @@
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipManagedPackageBuild)' != 'true'" >
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
-    <Project Include="..\pkg\Microsoft.NETCore.Platforms\Microsoft.NetCore.Platforms.builds">
+    <Project Include="..\pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <Project Include="Native\pkg\runtime.native.System.Net.Http\runtime.native.System.Net.Http.pkgproj">

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -24,17 +24,17 @@
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipManagedPackageBuild)' != 'true'" >
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
-    <Project Include="System.Private.Uri\pkg\win\System.Private.Uri.pkgproj">
-      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
-    <Project Include="..\pkg\Microsoft.NETCore.Targets\Microsoft.NETCore.Targets.builds">
+    <Project Include="..\pkg\Microsoft.NETCore.Platforms\Microsoft.NetCore.Platforms.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
-    <Project Include="System.Diagnostics.StackTrace\pkg\System.Diagnostics.StackTrace.builds">
+    <Project Include="Native\pkg\runtime.native.System.Net.Http\runtime.native.System.Net.Http.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
+    </Project>
+    <Project Include="System.Net.Http\pkg\System.Net.Http.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
-    <Project Include="System.IO.Compression\pkg\System.IO.Compression.builds">
+    <Project Include="System.Net.Http.WinHttpHandler\pkg\System.Net.Http.WinHttpHandler.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
   </ItemGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -27,10 +27,6 @@
     <Project Include="..\pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
-    <Project Include="Native\pkg\runtime.native.System.Net.Http\runtime.native.System.Net.Http.pkgproj">
-      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
-      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
-    </Project>
     <Project Include="System.Net.Http\pkg\System.Net.Http.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -17,5 +17,19 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="Build" DependsOnTargets="CreateContainerName;UploadToAzure" />
+  <!-- For servicing branches, we may not be producing packages on a given platform, and that's ok. -->
+  <Target Name="DetermineIfPackagesAreAvailableForUpload">
+    <ItemGroup>
+      <_PackagesForPublishing Include="$(PublishPattern)" />
+    </ItemGroup>
+    <Message Condition="'@(_PackagesForPublishing)' == ''" Text="Skipping Azure upload, no packages available matching this pattern, '$(PublishPattern)'" />
+  </Target>
+
+  <!-- If 'BuildAllPackages' is 'false', then we are producing a servicing build and it is not an error if packages are not available. -->
+  <Target Name="UploadToAzureTargets"
+          Condition="'@(_PackagesForPublishing)' != '' and '$(BuildAllPackages)' != 'true'"
+          DependsOnTargets="CreateContainerName;UploadToAzure"
+          AfterTargets="DetermineIfPackagesAreAvailableForUpload" />
+  
+  <Target Name="Build" DependsOnTargets="DetermineIfPackagesAreAvailableForUpload" />
 </Project>


### PR DESCRIPTION
Servicing change for the networking libraries.

@ericstj @weshaggard @davidsh 

/cc @gkhanna79 @Chrisboh

You'll notice that this also includes an update to publish.proj.  That change is because our official builds expect each native platform build to be producing packages.  If a native platform build doesn't produce any packages for publishing to Azure, then it gets reported as an error and fails the build.  The change below skips the "UploadToAzure" step if the build didn't produce any packages. 

Two alternative solutions I considered:
- Making the fix in BuildTools, but this requires a buildtools update and I didn't want to gate on that (i'm not certain that we have a good story for buildtools servicing changes for release/1.0.0).
- Switch the official build step to non-blocking.  An alternative would be to switch the "publish-packages" step of the build definition to non-blocking, but that has the potential to hide a real publishing error which we wouldn't catch until much later (or as another servicing fix).
