### PR TITLE
Add uap10.1 target to System.Runtime.WindowsRuntime 

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.builds
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.builds
@@ -7,7 +7,7 @@
     </Project>
     <Project Include="System.Runtime.WindowsRuntime.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TargetGroup>netcore50aot</TargetGroup>
+      <TargetGroup>uap101aot</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -9,11 +9,12 @@
     <AssemblyName>System.Runtime.WindowsRuntime</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ClsCompliant>true</ClsCompliant>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <!-- CS1698 - Disable warning about reference to 4.0.0.0 System.Runtime.WindowsRuntime having same simple name as target assembly -->
     <NoWarn>$(NoWarn)1698</NoWarn>
     <ProjectGuid>{844A2A0B-4169-49C3-B367-AFDC4894E487}</ProjectGuid>
     <PackageTargetRuntime>win8</PackageTargetRuntime>
-    <PackageTargetRuntime Condition="'$(TargetGroup)' == 'netcore50aot'">win8-aot</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' == 'uap101aot'">win8-aot</PackageTargetRuntime>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)'==''">
@@ -21,14 +22,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50aot_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50aot_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)'=='netcore50aot'">
-    <TargetingPackReference Include="System.Private.Interop.Extensions" />
-    <TargetingPackReference Include="System.Private.Threading.AsyncCausalitySupport" />
-    <TargetingPackReference Include="Windows" />
-    <ProjectReference Include="$(SourceDir)\mscorlib.WinRT-Facade\mscorlib.WinRT-Facade.csproj" />
-  </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap101aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap101aot_Release|AnyCPU'" />
+
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <TargetingPackReference Include="mscorlib" />
     <!-- Needed for the compiler to resolve IObservableMap.MapChanged. -->
@@ -45,6 +41,38 @@
     <ProjectReference Include="..\..\System.Runtime\src\redist\System.Runtime.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap101aot'">
+    <!-- We need to add this for now because these three types exist in System.Private.Interop.dll and Windows.winmd. -->
+    <SeedTypePreference Include="Windows.Foundation.Point">
+      <Assembly>System.Private.Interop</Assembly>
+    </SeedTypePreference>
+    <SeedTypePreference Include="Windows.Foundation.Rect">
+      <Assembly>System.Private.Interop</Assembly>
+    </SeedTypePreference>
+    <SeedTypePreference Include="Windows.Foundation.Size">
+      <Assembly>System.Private.Interop</Assembly>
+    </SeedTypePreference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap101aot'">
+    <TargetingPackReference Include="System.Private.Interop" />
+    <TargetingPackReference Include="System.Private.Corelib" />
+    <TargetingPackReference Include="System.Private.Threading" />
+    <TargetingPackReference Include="Windows" />
+    <ProjectReference Include="$(SourceDir)\mscorlib.WinRT-Facade\mscorlib.WinRT-Facade.csproj" />
+    <TargetingPackReference Include="System.Private.CoreLib.WinRTInterop" />
+    <ProjectReference Include="..\..\System.IO\src\System.IO.csproj">
+      <TargetGroup>uap101aot</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj">
+      <TargetGroup>uap101aot</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Resources.ResourceManager\ref\System.Resources.ResourceManager.csproj">
+      <TargetGroup>uap101aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="System\IO\StreamOperationAsyncResult.CoreCLR.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\MarshalingHelpers.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\RestrictedErrorInfoHelper.cs" />
@@ -54,9 +82,11 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetRestrictedErrorInfo.cs">
       <Link>Common\Interop\Windows\mincore\Interop.GetRestrictedErrorInfo.cs</Link>
     </Compile>
+    <Compile Include="System\Windows\Point.cs" />
+    <Compile Include="System\Windows\Rect.cs" />
+    <Compile Include="System\Windows\Size.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netcore50aot'">
-    <Compile Include="System\IO\BufferedStream.cs" />
+  <ItemGroup Condition="'$(TargetGroup)'=='uap101aot'">
     <Compile Include="System\IO\StreamOperationAsyncResult.CoreRT.cs" />
     <Compile Include="System\IO\UnmanagedMemoryStreamInternal.cs" />
     <Compile Include="System\Threading\Tasks\AsyncInfoToTaskBridge.CoreRT.cs" />
@@ -73,6 +103,7 @@
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="System\InternalHelpers.cs" />
+    <Compile Include="System\IO\BufferedStreamWrapper.cs" />
     <Compile Include="System\IO\NetFxToWinRtStreamAdapter.cs" />
     <Compile Include="System\IO\StreamOperationAsyncResult.cs" />
     <Compile Include="System\IO\StreamOperationsImplementation.cs" />
@@ -96,9 +127,6 @@
     <Compile Include="System\Threading\Tasks\TaskToAsyncOperationAdapter.cs" />
     <Compile Include="System\Threading\Tasks\TaskToAsyncOperationWithProgressAdapter.cs" />
     <Compile Include="System\VoidTypeParameter.cs" />
-    <Compile Include="System\Windows\Point.cs" />
-    <Compile Include="System\Windows\Rect.cs" />
-    <Compile Include="System\Windows\Size.cs" />
     <Compile Include="System\Windows\TokenizerHelper.cs" />
     <Compile Include="System\Windows\UI\Color.cs" />
   </ItemGroup>

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/BufferedStreamWrapper.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/BufferedStreamWrapper.cs
@@ -1,0 +1,208 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.WindowsRuntime.Internal;
+using System.Threading;
+using System.Collections.ObjectModel;
+using System.Security;
+using System.Threading.Tasks;
+
+namespace System.IO
+{
+    /// <summary>
+    /// A BufferedStream wrapper which expose BufferedStream's UnderlyingStream and BufferSize
+    /// </summary>
+    internal sealed class BufferedStreamWrapper : Stream
+    {
+        private BufferedStream _bufferedStream;
+        private Stream _stream;                               // Underlying stream.  Close sets _stream to null.
+        private readonly Int32 _bufferSize;                   // Length of internal buffer (not counting the shadow buffer).
+
+        public BufferedStreamWrapper(Stream stream, Int32 bufferSize)
+        {
+            _bufferedStream = new BufferedStream(stream, bufferSize);
+            _stream = stream;
+            _bufferSize = bufferSize;
+        }
+
+        private void EnsureNotClosed()
+        {
+            if (_bufferedStream == null)
+                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
+        }
+
+        internal BufferedStream bufferedStream
+        {
+            [Pure]
+            get
+            { return _bufferedStream; }
+        }
+
+        internal Stream UnderlyingStream
+        {
+            [Pure]
+            get
+            { return _stream; }
+        }
+
+        internal Int32 BufferSize
+        {
+            [Pure]
+            get
+            { return _bufferSize; }
+        }
+
+        public override bool CanRead
+        {
+            [Pure]
+            get
+            { return _bufferedStream != null && _bufferedStream.CanRead; }
+        }
+
+
+        public override bool CanWrite
+        {
+            [Pure]
+            get
+            { return _bufferedStream != null && _bufferedStream.CanWrite; }
+        }
+
+
+        public override bool CanSeek
+        {
+            [Pure]
+            get
+            { return _bufferedStream != null && _bufferedStream.CanSeek; }
+        }
+
+        public override Int64 Length
+        {
+            get
+            {
+                EnsureNotClosed();
+                return _bufferedStream.Length;
+            }
+        }
+
+        public override Int64 Position
+        {
+            get
+            {
+                EnsureNotClosed();
+                return _bufferedStream.Position;
+            }
+            set
+            {
+                EnsureNotClosed();
+                _bufferedStream.Position = value;
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                if (disposing && _bufferedStream != null)
+                {
+                    _bufferedStream.Dispose();
+                }
+            }
+            finally
+            {
+                _bufferedStream = null;
+                _stream = null;
+            }
+        }
+
+        public override void Flush()
+        {
+            EnsureNotClosed();
+            _bufferedStream.Flush();
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken) 
+        {
+             EnsureNotClosed();
+             return _bufferedStream.FlushAsync();
+        }
+
+        public override IAsyncResult BeginRead(Byte[] buffer, Int32 offset, Int32 count, AsyncCallback callback, Object state)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.BeginRead(buffer, offset, count, callback, state);
+        }
+
+        public override Int32 EndRead(IAsyncResult asyncResult)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.EndRead(asyncResult);
+        }
+
+        public override int Read(byte[] array, int offset, int count)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.Read(array, offset, count);
+        }
+
+        public override Task<int> ReadAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override Int32 ReadByte()
+        {
+            EnsureNotClosed();
+            return _bufferedStream.ReadByte();
+        }
+
+        public override void Write(Byte[] array, Int32 offset, Int32 count)
+        {
+            EnsureNotClosed();
+            _bufferedStream.Write(array, offset, count);
+        }
+
+        public override IAsyncResult BeginWrite(Byte[] buffer, Int32 offset, Int32 count, AsyncCallback callback, Object state)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+           EnsureNotClosed();
+            _bufferedStream.EndWrite(asyncResult);
+        }
+
+        public override Task WriteAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override void WriteByte(Byte value)
+        {
+            EnsureNotClosed();
+            _bufferedStream.WriteByte(value);
+        }
+
+        public override Int64 Seek(Int64 offset, SeekOrigin origin)
+        {
+            EnsureNotClosed();
+            return _bufferedStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(Int64 value)
+        {
+            EnsureNotClosed();
+            _bufferedStream.SetLength(value);
+        }
+    }  // class BufferedStreamWrapper
+}  // namespace

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
@@ -479,11 +479,7 @@ namespace System.IO
             return asyncResult;
         }
 
-#if netstandard
         public override Int32 EndRead(IAsyncResult asyncResult)
-#else
-        public Int32 EndRead(IAsyncResult asyncResult)
-#endif
         {
             if (asyncResult == null)
                 throw new ArgumentNullException(nameof(asyncResult));
@@ -588,12 +584,7 @@ namespace System.IO
 
         #region Writing
 
-
-#if netstandard
         public override IAsyncResult BeginWrite(Byte[] buffer, Int32 offset, Int32 count, AsyncCallback callback, Object state)
-#else
-        public IAsyncResult BeginWrite(Byte[] buffer, Int32 offset, Int32 count, AsyncCallback callback, Object state)
-#endif
         {
             return BeginWrite(buffer, offset, count, callback, state, usedByBlockingWrapper: false);
         }
@@ -640,11 +631,7 @@ namespace System.IO
             return asyncResult;
         }
 
-#if netstandard
         public override void EndWrite(IAsyncResult asyncResult)
-#else
-        public void EndWrite(IAsyncResult asyncResult)
-#endif
         {
             if (asyncResult == null)
                 throw new ArgumentNullException(nameof(asyncResult));

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStreamExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStreamExtensions.cs
@@ -50,7 +50,7 @@ namespace System.IO
 
             if (valueMayBeWrappedInBufferedStream)
             {
-                BufferedStream bufferedValueInMap = valueInMap as BufferedStream;
+                BufferedStreamWrapper bufferedValueInMap = valueInMap as BufferedStreamWrapper;
                 Debug.Assert(Object.ReferenceEquals(value, valueInMap)
                                 || (bufferedValueInMap != null && Object.ReferenceEquals(value, bufferedValueInMap.UnderlyingStream)));
             }
@@ -67,7 +67,7 @@ namespace System.IO
             Debug.Assert(!String.IsNullOrWhiteSpace(methodName));
 
             Int32 currentBufferSize = 0;
-            BufferedStream bufferedAdapter = adapter as BufferedStream;
+            BufferedStreamWrapper bufferedAdapter = adapter as BufferedStreamWrapper;
             if (bufferedAdapter != null)
                 currentBufferSize = bufferedAdapter.BufferSize;
 
@@ -167,7 +167,7 @@ namespace System.IO
             // There is already an adapter:
             if (adapterExists)
             {
-                Debug.Assert((adapter is BufferedStream && ((BufferedStream)adapter).UnderlyingStream is WinRtToNetFxStreamAdapter)
+                Debug.Assert((adapter is BufferedStreamWrapper && ((BufferedStreamWrapper)adapter).UnderlyingStream is WinRtToNetFxStreamAdapter) 
                                 || (adapter is WinRtToNetFxStreamAdapter));
 
                 if (forceBufferSize)
@@ -194,7 +194,7 @@ namespace System.IO
         // Separate method so we only pay for closure allocation if this code is executed:
         private static Stream WinRtToNetFxAdapterMap_GetValue(Object winRtStream, Int32 bufferSize)
         {
-            return s_winRtToNetFxAdapterMap.GetValue(winRtStream, (wrtStr) => new BufferedStream(WinRtToNetFxStreamAdapter.Create(wrtStr), bufferSize));
+            return s_winRtToNetFxAdapterMap.GetValue(winRtStream, (wrtStr) => new BufferedStreamWrapper(WinRtToNetFxStreamAdapter.Create(wrtStr), bufferSize));
         }
 
 
@@ -214,7 +214,7 @@ namespace System.IO
                                 : WinRtToNetFxAdapterMap_GetValue(windowsRuntimeStream, bufferSize);
 
             Debug.Assert(adapter != null);
-            Debug.Assert((adapter is BufferedStream && ((BufferedStream)adapter).UnderlyingStream is WinRtToNetFxStreamAdapter)
+            Debug.Assert((adapter is BufferedStreamWrapper && ((BufferedStreamWrapper)adapter).UnderlyingStream is WinRtToNetFxStreamAdapter)
                                 || (adapter is WinRtToNetFxStreamAdapter));
 
             if (forceBufferSize)
@@ -222,7 +222,7 @@ namespace System.IO
 
             WinRtToNetFxStreamAdapter actualAdapter = adapter as WinRtToNetFxStreamAdapter;
             if (actualAdapter == null)
-                actualAdapter = ((BufferedStream)adapter).UnderlyingStream as WinRtToNetFxStreamAdapter;
+                actualAdapter = ((BufferedStreamWrapper)adapter).UnderlyingStream as WinRtToNetFxStreamAdapter;
 
             actualAdapter.SetWonInitializationRace();
 
@@ -307,7 +307,7 @@ namespace System.IO
             WinRtToNetFxStreamAdapter sAdptr = stream as WinRtToNetFxStreamAdapter;
             if (sAdptr == null)
             {
-                BufferedStream buffAdptr = stream as BufferedStream;
+                BufferedStreamWrapper buffAdptr = stream as BufferedStreamWrapper;
                 if (buffAdptr != null)
                     sAdptr = buffAdptr.UnderlyingStream as WinRtToNetFxStreamAdapter;
             }

--- a/src/System.Runtime.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.WindowsRuntime/src/project.json
@@ -8,6 +8,12 @@
       "imports": [
         "dotnet5.4"
       ]
+    },
+    "uap10.1": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24603-00",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.1"
+      }
     }
   }
 }


### PR DESCRIPTION
Update code according to code review feedback for the original PR: https://github.com/dotnet/corefx/pull/12339

1. Remove netcore50aot
2. Unify code path for uap101aot and coreclr: both are using wrapper
3. Remove some #if netstandard which is only used in netcore50aot