### PR TITLE
Remove workaround for xunit crashing on invalid unicode chars (#7166) in tests

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -17,7 +17,7 @@
 
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
-    <AppXRunnerVersion>1.0.3-prerelease-00826-05</AppXRunnerVersion>
+    <AppXRunnerVersion>1.0.3-prerelease-00903-02</AppXRunnerVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-alpha-build0040</XunitPerfAnalysisPackageVersion>
   </PropertyGroup>
 

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -13,7 +13,7 @@
     "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0040",
     "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0040",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00830-02",
-    "xunit.console.netcore": "1.0.3-prerelease-00607-01"
+    "xunit.console.netcore": "1.0.3-prerelease-00903-02"
   },
   "frameworks": {
     "netstandard1.3": {},
@@ -60,8 +60,7 @@
         "System.Text.Encoding.CodePages": "4.0.1",
         "System.Xml.XmlSerializer": "4.0.11",
         "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.1-beta-000547-00",
-        "System.Console": "4.4.0-beta-24608-01",
-        "microsoft.xunit.runner.uwp": "1.0.3-prerelease-00826-05",
+        "microsoft.xunit.runner.uwp": "1.0.3-prerelease-00903-02",
         "Microsoft.DotNet.TestILC": {
           "version": "1.4.24208-prerelease",
           "include": "contentFiles"

--- a/src/System.Globalization/tests/StringInfo/StringInfoParseCombiningCharacters.cs
+++ b/src/System.Globalization/tests/StringInfo/StringInfoParseCombiningCharacters.cs
@@ -22,17 +22,17 @@ namespace System.Globalization.Tests
             yield return new object[] { "", new int[0] };
 
             // Invalid Unicode
-            yield return new object[] { "\u0000\uFFFFa", new int[] { 0, 1, 2 } };; // Control chars
-            yield return new object[] { "\uD800a", new int[] { 0, 1 } };; // Unmatched high surrogate
-            yield return new object[] { "\uDC00a", new int[] { 0, 1 } };; // Unmatched low surrogate
-            yield return new object[] { "\u00ADa", new int[] { 0, 1 } };; // Format character
+            yield return new object[] { "\u0000\uFFFFa", new int[] { 0, 1, 2 } }; // Control chars
+            yield return new object[] { "\uD800a", new int[] { 0, 1 } }; // Unmatched high surrogate
+            yield return new object[] { "\uDC00a", new int[] { 0, 1 } }; // Unmatched low surrogate
+            yield return new object[] { "\u00ADa", new int[] { 0, 1 } }; // Format character
 
-            yield return new object[] { "\u0000\u0300\uFFFF\u0300", new int[] { 0, 1, 2, 3 } };; // Control chars + combining char
-            yield return new object[] { "\uD800\u0300", new int[] { 0, 1 } };; // Unmatched high surrogate + combining char
-            yield return new object[] { "\uDC00\u0300", new int[] { 0, 1 } };; // Unmatched low surrogate + combing char
-            yield return new object[] { "\u00AD\u0300", new int[] { 0, 1 } };; // Format character + combining char
+            yield return new object[] { "\u0000\u0300\uFFFF\u0300", new int[] { 0, 1, 2, 3 } }; // Control chars + combining char
+            yield return new object[] { "\uD800\u0300", new int[] { 0, 1 } }; // Unmatched high surrogate + combining char
+            yield return new object[] { "\uDC00\u0300", new int[] { 0, 1 } }; // Unmatched low surrogate + combing char
+            yield return new object[] { "\u00AD\u0300", new int[] { 0, 1 } }; // Format character + combining char
 
-            yield return new object[] { "\u0300\u0300", new int[] { 0, 1 } };; // Two combining chars
+            yield return new object[] { "\u0300\u0300", new int[] { 0, 1 } }; // Two combining chars
         }
 
         [Theory]

--- a/src/System.Globalization/tests/StringInfo/StringInfoParseCombiningCharacters.cs
+++ b/src/System.Globalization/tests/StringInfo/StringInfoParseCombiningCharacters.cs
@@ -20,6 +20,19 @@ namespace System.Globalization.Tests
             yield return new object[] { "\u0300\u0300", new int[] { 0, 1 } };
             yield return new object[] { "   ", new int[] { 0, 1, 2 } };
             yield return new object[] { "", new int[0] };
+
+            // Invalid Unicode
+            yield return new object[] { "\u0000\uFFFFa", new int[] { 0, 1, 2 } };; // Control chars
+            yield return new object[] { "\uD800a", new int[] { 0, 1 } };; // Unmatched high surrogate
+            yield return new object[] { "\uDC00a", new int[] { 0, 1 } };; // Unmatched low surrogate
+            yield return new object[] { "\u00ADa", new int[] { 0, 1 } };; // Format character
+
+            yield return new object[] { "\u0000\u0300\uFFFF\u0300", new int[] { 0, 1, 2, 3 } };; // Control chars + combining char
+            yield return new object[] { "\uD800\u0300", new int[] { 0, 1 } };; // Unmatched high surrogate + combining char
+            yield return new object[] { "\uDC00\u0300", new int[] { 0, 1 } };; // Unmatched low surrogate + combing char
+            yield return new object[] { "\u00AD\u0300", new int[] { 0, 1 } };; // Format character + combining char
+
+            yield return new object[] { "\u0300\u0300", new int[] { 0, 1 } };; // Two combining chars
         }
 
         [Theory]
@@ -27,23 +40,6 @@ namespace System.Globalization.Tests
         public void ParseCombiningCharacters(string str, int[] expected)
         {
             Assert.Equal(expected, StringInfo.ParseCombiningCharacters(str));
-        }
-
-        [Fact]
-        public void ParseCombiningCharacters_InvalidUnicodeChars()
-        {
-            // TODO: move into ParseCombiningCharacters_TestData once #7166 is fixed 
-            ParseCombiningCharacters("\u0000\uFFFFa", new int[] { 0, 1, 2 }); // Control chars
-            ParseCombiningCharacters("\uD800a", new int[] { 0, 1 }); // Unmatched high surrogate
-            ParseCombiningCharacters("\uDC00a", new int[] { 0, 1 }); // Unmatched low surrogate
-            ParseCombiningCharacters("\u00ADa", new int[] { 0, 1 }); // Format character
-
-            ParseCombiningCharacters("\u0000\u0300\uFFFF\u0300", new int[] { 0, 1, 2, 3 }); // Control chars + combining char
-            ParseCombiningCharacters("\uD800\u0300", new int[] { 0, 1 }); // Unmatched high surrogate + combining char
-            ParseCombiningCharacters("\uDC00\u0300", new int[] { 0, 1 }); // Unmatched low surrogate + combing char
-            ParseCombiningCharacters("\u00AD\u0300", new int[] { 0, 1 }); // Format character + combining char
-
-            ParseCombiningCharacters("\u0300\u0300", new int[] { 0, 1 }); // Two combining chars
         }
         
         [Fact]

--- a/src/System.Reflection.Emit/tests/PropertyBuilder/PropertyBuilderName.cs
+++ b/src/System.Reflection.Emit/tests/PropertyBuilder/PropertyBuilderName.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,6 +16,11 @@ namespace System.Reflection.Emit.Tests
             yield return new object[] { "привет" };
             yield return new object[] { "class" };
             yield return new object[] { new string('a', short.MaxValue) };
+
+            // Invalid Unicode
+            yield return new object[] { "\uDC00" };
+            yield return new object[] { "\uD800" };
+            yield return new object[] { "1A\0\t\v\r\n\n\uDC81\uDC91" };
         }
 
         [Theory]
@@ -25,15 +30,6 @@ namespace System.Reflection.Emit.Tests
             TypeBuilder type = Helpers.DynamicType(TypeAttributes.Class | TypeAttributes.Public);
             PropertyBuilder property = type.DefineProperty(name, PropertyAttributes.None, typeof(int), null);
             Assert.Equal(name, property.Name);
-        }
-
-        [Fact]
-        public void Name_InvalidString()
-        {
-            // TODO: move into Names_TestData when #7166 is fixed
-            Name("\uDC00");
-            Name("\uD800");
-            Name("1A\0\t\v\r\n\n\uDC81\uDC91");
         }
     }
 }

--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -31,6 +31,10 @@ namespace System.Reflection.Tests
             yield return new object[] { "name with spaces", "name with spaces" };
             yield return new object[] { "\uD800\uDC00", "\uD800\uDC00" };
             yield return new object[] { "привет", "привет" };
+
+            // Invalid Unicode
+            yield return new object[] { "\uD800", "\uFFFD" };
+            yield return new object[] { "\uDC00", "\uFFFD" };
         }
 
         [Fact]
@@ -48,14 +52,6 @@ namespace System.Reflection.Tests
             AssemblyName assemblyName = new AssemblyName(name);
             Assert.Equal(expectedName, assemblyName.Name);
             Assert.Equal(ProcessorArchitecture.None, assemblyName.ProcessorArchitecture);
-        }
-
-        [Fact]
-        public void Ctor_String_InvalidUnicode_UsesReplacementChar()
-        {
-            // TODO: move into Names_TestData when #7166 is fixed
-            Ctor_String("\uD800", "\uFFFD");
-            Ctor_String("\uDC00", "\uFFFD");
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/CharTests.cs
+++ b/src/System.Runtime/tests/System/CharTests.cs
@@ -33,25 +33,23 @@ namespace System.Tests
             Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("H")); // Value not a char
         }
 
-        [Fact]
-        public static void ConvertFromUtf32_InvalidChar()
+        public static IEnumerable<object[]> ConvertFromUtf32_TestData()
         {
-            // TODO: add this as [InlineData] when #7166 is fixed
-            ConvertFromUtf32(0xFFFF, "\uFFFF");
+            yield return new object[] { 0x10000, "\uD800\uDC00" };
+            yield return new object[] { 0x103FF, "\uD800\uDFFF" };
+            yield return new object[] { 0xFFFFF, "\uDBBF\uDFFF" };
+            yield return new object[] { 0x10FC00, "\uDBFF\uDC00" };
+            yield return new object[] { 0x10FFFF, "\uDBFF\uDFFF" };
+            yield return new object[] { 0, "\0" };
+            yield return new object[] { 0x3FF, "\u03FF" };
+            yield return new object[] { 0xE000, "\uE000" };
+            yield return new object[] { 0xFFFF, "\uFFFF" };
         }
 
         [Theory]
-        [InlineData(0x10000, "\uD800\uDC00")]
-        [InlineData(0x103FF, "\uD800\uDFFF")]
-        [InlineData(0xFFFFF, "\uDBBF\uDFFF")]
-        [InlineData(0x10FC00, "\uDBFF\uDC00")]
-        [InlineData(0x10FFFF, "\uDBFF\uDFFF")]
-        [InlineData(0, "\0")]
-        [InlineData(0x3FF, "\u03FF")]
-        [InlineData(0xE000, "\uE000")]
+        [MemberData(nameof(ConvertFromUtf32_TestData))]
         public static void ConvertFromUtf32(int utf32, string expected)
         {
-            // TODO: add this as [InlineData] when #7166 is fixed
             Assert.Equal(expected, char.ConvertFromUtf32(utf32));
         }
 
@@ -68,28 +66,29 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>("utf32", () => char.ConvertFromUtf32(utf32));
         }
 
-        [Fact]
-        public static void ConvertToUtf32_String_Int()
+        public static IEnumerable<object[]> ConvertToUtf32_String_Int_TestData()
         {
-            // TODO: add this as [InlineData] when #7166 is fixed
-            ConvertToUtf32_String_Int("\uD800\uD800\uDFFF", 1, 0x103FF);
-            ConvertToUtf32_String_Int("\uD800\uD7FF", 1, 0xD7FF);  // High, non-surrogate
-            ConvertToUtf32_String_Int("\uD800\u0000", 1, 0);  // High, non-surrogate
-            ConvertToUtf32_String_Int("\uDF01\u0000", 1, 0);  // Low, non-surrogate
+            yield return new object[] { "\uD800\uDC00", 0, 0x10000 };
+            yield return new object[] { "\uDBBF\uDFFF", 0, 0xFFFFF };
+            yield return new object[] { "\uDBBF\uDFFF", 0, 0xFFFFF };
+            yield return new object[] { "\uDBFF\uDC00", 0, 0x10FC00 };
+            yield return new object[] { "\uDBFF\uDFFF", 0, 0x10FFFF };
+            yield return new object[] { "\u0000\u0001", 0, 0 };
+            yield return new object[] { "\u0000\u0001", 1, 1 };
+            yield return new object[] { "\u0000", 0, 0 };
+            yield return new object[] { "\u0020\uD7FF", 0, 32 };
+            yield return new object[] { "\u0020\uD7FF", 1, 0xD7FF };
+            yield return new object[] { "abcde", 4, 'e' };
+
+            // Invalid unicode
+            yield return new object[] { "\uD800\uD800\uDFFF", 1, 0x103FF };
+            yield return new object[] { "\uD800\uD7FF", 1, 0xD7FF }; // High, non-surrogate
+            yield return new object[] { "\uD800\u0000", 1, 0 }; // High, non-surrogate
+            yield return new object[] { "\uDF01\u0000", 1, 0 }; // Low, non-surrogate
         }
 
         [Theory]
-        [InlineData("\uD800\uDC00", 0, 0x10000)]
-        [InlineData("\uDBBF\uDFFF", 0, 0xFFFFF)]
-        [InlineData("\uDBBF\uDFFF", 0, 0xFFFFF)]
-        [InlineData("\uDBFF\uDC00", 0, 0x10FC00)]
-        [InlineData("\uDBFF\uDFFF", 0, 0x10FFFF)]
-        [InlineData("\u0000\u0001", 0, 0)]
-        [InlineData("\u0000\u0001", 1, 1)]
-        [InlineData("\u0000", 0, 0)]
-        [InlineData("\u0020\uD7FF", 0, 32)]
-        [InlineData("\u0020\uD7FF", 1, 0xD7FF)]
-        [InlineData("abcde", 4, 'e')]
+        [MemberData(nameof(ConvertToUtf32_String_Int_TestData))]
         public static void ConvertToUtf32_String_Int(string s, int index, int expected)
         {
             Assert.Equal(expected, char.ConvertToUtf32(s, index));
@@ -116,19 +115,19 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>("index", () => char.ConvertToUtf32("", 0)); // Index >= string.Length
         }
 
-        [Fact]
-        public static void ConvertToUtf32_Char_Char()
+        public static IEnumerable<object[]> ConvertToUtf32_Char_Char_TestData()
         {
-            // TODO: add this as [InlineData] when #7166 is fixed
-            TestConvertToUtf32_Char_Char('\uD800', '\uDC00', 0x10000);
-            TestConvertToUtf32_Char_Char('\uD800', '\uDC00', 0x10000);
-            TestConvertToUtf32_Char_Char('\uD800', '\uDFFF', 0x103FF);
-            TestConvertToUtf32_Char_Char('\uDBBF', '\uDFFF', 0xFFFFF);
-            TestConvertToUtf32_Char_Char('\uDBFF', '\uDC00', 0x10FC00);
-            TestConvertToUtf32_Char_Char('\uDBFF', '\uDFFF', 0x10FFFF);
+            yield return new object[] { '\uD800', '\uDC00', 0x10000 };
+            yield return new object[] { '\uD800', '\uDC00', 0x10000 };
+            yield return new object[] { '\uD800', '\uDFFF', 0x103FF };
+            yield return new object[] { '\uDBBF', '\uDFFF', 0xFFFFF };
+            yield return new object[] { '\uDBFF', '\uDC00', 0x10FC00 };
+            yield return new object[] { '\uDBFF', '\uDFFF', 0x10FFFF };
         }
 
-        private static void TestConvertToUtf32_Char_Char(char highSurrogate, char lowSurrogate, int expected)
+        [Theory]
+        [MemberData(nameof(ConvertToUtf32_Char_Char_TestData))]
+        public static void ConvertToUtf32_Char_Char(char highSurrogate, char lowSurrogate, int expected)
         {
             Assert.Equal(expected, char.ConvertToUtf32(highSurrogate, lowSurrogate));
         }
@@ -868,16 +867,24 @@ namespace System.Tests
             }
         }
 
+        public static IEnumerable<object[]> Parse_TestData()
+        {
+            yield return new object[] { "a", 'a' };
+            yield return new object[] { "4", '4' };
+            yield return new object[] { " ", ' ' };
+            yield return new object[] { "\n", '\n' };
+            yield return new object[] { "\0", '\0' };
+            yield return new object[] { "\u0135", '\u0135' };
+            yield return new object[] { "\u05d9", '\u05d9' };
+            yield return new object[] { "\ue001", '\ue001' }; // Private use codepoint
+
+            // Lone surrogate
+            yield return new object[] { "\ud801", '\ud801' }; // High surrogate
+            yield return new object[] { "\udc01", '\udc01' }; // Low surrogate
+        }
 
         [Theory]
-        [InlineData("a", 'a')]
-        [InlineData("4", '4')]
-        [InlineData(" ", ' ')]
-        [InlineData("\n", '\n')]
-        [InlineData("\0", '\0')]
-        [InlineData("\u0135", '\u0135')]
-        [InlineData("\u05d9", '\u05d9')]
-        [InlineData("\ue001", '\ue001')] // Private use codepoint
+        [MemberData(nameof(Parse_TestData))]
         public static void Parse(string s, char expected)
         {
             char c;
@@ -885,14 +892,6 @@ namespace System.Tests
             Assert.Equal(expected, c);
 
             Assert.Equal(expected, char.Parse(s));
-        }
-
-        [Fact]
-        public static void Parse_Surrogate()
-        {
-            // TODO: add this as [InlineData] when #7166 is fixed
-            Parse("\ud801", '\ud801'); // High surrogate
-            Parse("\udc01", '\udc01'); // Low surrogate
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/EnumTests.cs
+++ b/src/System.Runtime/tests/System/EnumTests.cs
@@ -1453,7 +1453,7 @@ namespace System.Tests
         [Fact]
         public static void ToString_InvalidUnicodeChars()
         {
-            // TODO: move into ToString_Format_TestData when #7166 is fixed
+            // TODO: move into ToString_Format_TestData when dotnet/buildtools#1091 is fixed
             ToString_Format((Enum)Enum.ToObject(s_charEnumType, char.MaxValue), "D", char.MaxValue.ToString());
             ToString_Format((Enum)Enum.ToObject(s_charEnumType, char.MaxValue), "X", "FFFF");
             ToString_Format((Enum)Enum.ToObject(s_charEnumType, char.MaxValue), "F", char.MaxValue.ToString());

--- a/src/System.Runtime/tests/System/Uri.CreateStringTests.cs
+++ b/src/System.Runtime/tests/System/Uri.CreateStringTests.cs
@@ -1127,6 +1127,10 @@ namespace System.Tests
             yield return new object[] { "uri://a:65536", UriKind.Absolute };
             yield return new object[] { "uri://a:2147483648", UriKind.Absolute };
             yield return new object[] { "uri://a:80:80", UriKind.Absolute };
+
+            // Invalid unicode
+            yield return new object[] { "http://\uD800", UriKind.Absolute };
+            yield return new object[] { "http://\uDC00", UriKind.Absolute };
         }
 
         [Theory]
@@ -1142,13 +1146,6 @@ namespace System.Tests
             Uri uri;
             Assert.False(Uri.TryCreate(uriString, uriKind, out uri));
             Assert.Null(uri);
-        }
-
-        [Fact]
-        public void Create_String_InvalidUnicode()
-        {
-            Create_String_Invalid("http://\uD800", UriKind.Absolute);
-            Create_String_Invalid("http://\uDC00", UriKind.Absolute);
         }
 
         public static void PerformAction(string uriString, UriKind uriKind, Action<Uri> action)

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingEncode.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingEncode.cs
@@ -62,6 +62,23 @@ namespace System.Text.Tests
             yield return new object[] { "a\uD800\uDC00b", 0, 2 };
 
             yield return new object[] { "\uD800\uDC00\u0061\u0CFF", 0, 4 };
+
+            // Invalid Unicode
+            yield return new object[] { "\uD800", 0, 1 }; // Lone high surrogate
+            yield return new object[] { "\uDC00", 0, 1 }; // Lone low surrogate
+            yield return new object[] { "\uD800\uDC00", 0, 1 }; // Surrogate pair out of range
+            yield return new object[] { "\uD800\uDC00", 1, 1 }; // Surrogate pair out of range
+
+            yield return new object[] { "\uD800\uD800", 0, 2 }; // High, high
+            yield return new object[] { "\uDC00\uD800", 0, 2 }; // Low, high
+            yield return new object[] { "\uDC00\uDC00", 0, 2 }; // Low, low
+
+            yield return new object[] { "\u0080\u00FF\u0B71\uFFFF\uD800\uDFFF", 0, 6 };
+
+            // High BMP non-chars
+            yield return new object[] { "\uFFFD", 0, 1 };
+            yield return new object[] { "\uFFFE", 0, 1 };
+            yield return new object[] { "\uFFFF", 0, 1 };
         }
 
         [Theory]
@@ -74,27 +91,6 @@ namespace System.Text.Tests
             // Encoding invalid chars should throw with an EncoderExceptionFallback
             Encoding exceptionEncoding = Encoding.GetEncoding("ascii", new EncoderExceptionFallback(), new DecoderReplacementFallback("?"));
             NegativeEncodingTests.Encode_Invalid(exceptionEncoding, source, index, count);
-        }
-
-        [Fact]
-        public void Encode_InvalidChars()
-        {
-            // TODO: move to Encode_InvalidChars_TestData when #7166 is fixed
-            Encode_InvalidChars("\uD800", 0, 1); // Lone high surrogate
-            Encode_InvalidChars("\uDC00", 0, 1); // Lone low surrogate
-            Encode_InvalidChars("\uD800\uDC00", 0, 1); // Surrogate pair out of range
-            Encode_InvalidChars("\uD800\uDC00", 1, 1); // Surrogate pair out of range
-
-            Encode_InvalidChars("\uD800\uD800", 0, 2); // High, high
-            Encode_InvalidChars("\uDC00\uD800", 0, 2); // Low, high
-            Encode_InvalidChars("\uDC00\uDC00", 0, 2); // Low, low
-
-            Encode_InvalidChars("\u0080\u00FF\u0B71\uFFFF\uD800\uDFFF", 0, 6);
-
-            // High BMP non-chars
-            Encode_InvalidChars("\uFFFD", 0, 1);
-            Encode_InvalidChars("\uFFFE", 0, 1);
-            Encode_InvalidChars("\uFFFF", 0, 1);
         }
 
         private static byte[] GetBytes(string source, int index, int count)

--- a/src/System.Text.Encoding/tests/Latin1Encoding/Latin1EncodingEncode.cs
+++ b/src/System.Text.Encoding/tests/Latin1Encoding/Latin1EncodingEncode.cs
@@ -59,6 +59,22 @@ namespace System.Text.Tests
             yield return new object[] { "a\uD800\uDC00b", 0, 2 };
 
             yield return new object[] { "\uD800\uDFFF", 0, 2 };
+
+            // Invalid Unicode
+            yield return new object[] { "\uD800", 0, 1 }; // Lone high surrogate
+            yield return new object[] { "\uDC00", 0, 1 }; // Lone low surrogate
+            yield return new object[] { "\uD800\uDC00", 0, 1 }; // Surrogate pair out of range
+            yield return new object[] { "\uD800\uDC00", 1, 1 }; // Surrogate pair out of range
+
+            yield return new object[] { "\uD800\uD800", 0, 2 }; // High, high
+            yield return new object[] { "\uDC00\uD800", 0, 2 }; // Low, high
+            yield return new object[] { "\uDC00\uDC00", 0, 2 }; // Low, low
+
+            // High BMP non-chars
+            yield return new object[] { "\uFFFD", 0, 1 };
+            yield return new object[] { "\uFFFE", 0, 1 };
+            yield return new object[] { "\uFFFF", 0, 1 };
+
         }
 
         [Theory]
@@ -66,25 +82,6 @@ namespace System.Text.Tests
         public void Encode_InvalidChars(string source, int index, int count)
         {
             Encode(source, index, count, GetBytes(source, index, count), valid: false);
-        }
-
-        [Fact]
-        public void Encode_InvalidChars()
-        {
-            // TODO: move to Encode_InvalidChars_TestData when #7166 is fixed
-            Encode_InvalidChars("\uD800", 0, 1); // Lone high surrogate
-            Encode_InvalidChars("\uDC00", 0, 1); // Lone low surrogate
-            Encode_InvalidChars("\uD800\uDC00", 0, 1); // Surrogate pair out of range
-            Encode_InvalidChars("\uD800\uDC00", 1, 1); // Surrogate pair out of range
-
-            Encode_InvalidChars("\uD800\uD800", 0, 2); // High, high
-            Encode_InvalidChars("\uDC00\uD800", 0, 2); // Low, high
-            Encode_InvalidChars("\uDC00\uDC00", 0, 2); // Low, low
-
-            // High BMP non-chars
-            Encode_InvalidChars("\uFFFD", 0, 1);
-            Encode_InvalidChars("\uFFFE", 0, 1);
-            Encode_InvalidChars("\uFFFF", 0, 1);
         }
 
         public void Encode(string source, int index, int count, byte[] expected, bool valid)

--- a/src/System.Text.Encoding/tests/UTF32Encoding/UTF32EncodingEncode.cs
+++ b/src/System.Text.Encoding/tests/UTF32Encoding/UTF32EncodingEncode.cs
@@ -31,6 +31,12 @@ namespace System.Text.Tests
             // Mixture of ASCII and Unciode
             yield return new object[] { "FooBA\u0400R", 0, 7, new byte[] { 70, 0, 0, 0, 111, 0, 0, 0, 111, 0, 0, 0, 66, 0, 0, 0, 65, 0, 0, 0, 0, 4, 0, 0, 82, 0, 0, 0 } };
 
+            // High BMP non-chars: U+FFFF, U+FFFE, U+FFFD
+            yield return new object[] { "\uFFFD", 0, 1, new byte[] { 253, 255, 0, 0 } };
+            yield return new object[] { "\uFFFE", 0, 1, new byte[] { 254, 255, 0, 0 } };
+            yield return new object[] { "\uFFFF", 0, 1, new byte[] { 255, 255, 0, 0 } };
+            yield return new object[] { "\uFFFF\uFFFE\uFFFD", 0, 3, new byte[] { 0xFF, 0xFF, 0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0xFD, 0xFF, 0x00, 0x00 } };
+
             // Empty strings
             yield return new object[] { "abc", 3, 0, new byte[0] };
             yield return new object[] { "abc", 0, 0, new byte[0] };
@@ -54,6 +60,27 @@ namespace System.Text.Tests
             EncodingHelpers.Encode(new UTF32Encoding(false, false, true), chars, index, count, littleEndianExpected);
         }
 
+        public static IEnumerable<object[]> Encode_InvalidChars_TestData()
+        {
+            byte[] unicodeReplacementBytes1 = new byte[] { 253, 255, 0, 0 };
+            yield return new object[] { "\uD800", 0, 1, unicodeReplacementBytes1 }; // Lone high surrogate
+            yield return new object[] { "\uDD75", 0, 1, unicodeReplacementBytes1 }; // Lone high surrogate
+            yield return new object[] { "\uDC00", 0, 1, unicodeReplacementBytes1 }; // Lone low surrogate
+            yield return new object[] { "\uD800\uDC00", 0, 1, unicodeReplacementBytes1 }; // Surrogate pair out of range
+            yield return new object[] { "\uD800\uDC00", 1, 1, unicodeReplacementBytes1 }; // Surrogate pair out of range
+
+            byte[] unicodeReplacementBytes2 = new byte[] { 253, 255, 0, 0, 253, 255, 0, 0 };
+            yield return new object[] { "\uD800\uD800", 0, 2, unicodeReplacementBytes2 }; // High, high
+            yield return new object[] { "\uDC00\uD800", 0, 2, unicodeReplacementBytes2 }; // Low, high
+            yield return new object[] { "\uDC00\uDC00", 0, 2, unicodeReplacementBytes2 }; // Low, low
+
+            // Invalid first/second in surrogate pair
+            yield return new object[] { "\uD800\u0041", 0, 2, new byte[] { 0xFD, 0xFF, 0x00, 0x00, 0x41, 0x00, 0x00, 0x00 } };
+            yield return new object[] { "\u0065\uDC00", 0, 2, new byte[] { 0x65, 0x00, 0x00, 0x00, 0xFD, 0xFF, 0x00, 0x00 } };
+        }
+
+        [Theory]
+        [MemberData(nameof(Encode_InvalidChars_TestData))]
         public void Encode_InvalidChars(string chars, int index, int count, byte[] littleEndianExpected)
         {
             byte[] bigEndianExpected = GetBigEndianBytes(littleEndianExpected);
@@ -67,33 +94,6 @@ namespace System.Text.Tests
             NegativeEncodingTests.Encode_Invalid(new UTF32Encoding(true, false, true), chars, index, count);
             NegativeEncodingTests.Encode_Invalid(new UTF32Encoding(false, true, true), chars, index, count);
             NegativeEncodingTests.Encode_Invalid(new UTF32Encoding(false, false, true), chars, index, count);
-        }
-
-        [Fact]
-        public void Encode_InvalidChars()
-        {
-            // TODO: add into Encode_TestData or Encode_InvalidChars_TestData once #7166 is fixed
-            byte[] unicodeReplacementBytes1 = new byte[] { 253, 255, 0, 0 };
-            Encode_InvalidChars("\uD800", 0, 1, unicodeReplacementBytes1); // Lone high surrogate
-            Encode_InvalidChars("\uDD75", 0, 1, unicodeReplacementBytes1); // Lone high surrogate
-            Encode_InvalidChars("\uDC00", 0, 1, unicodeReplacementBytes1); // Lone low surrogate
-            Encode_InvalidChars("\uD800\uDC00", 0, 1, unicodeReplacementBytes1); // Surrogate pair out of range
-            Encode_InvalidChars("\uD800\uDC00", 1, 1, unicodeReplacementBytes1); // Surrogate pair out of range
-
-            byte[] unicodeReplacementBytes2 = new byte[] { 253, 255, 0, 0, 253, 255, 0, 0 };
-            Encode_InvalidChars("\uD800\uD800", 0, 2, unicodeReplacementBytes2); // High, high
-            Encode_InvalidChars("\uDC00\uD800", 0, 2, unicodeReplacementBytes2); // Low, high
-            Encode_InvalidChars("\uDC00\uDC00", 0, 2, unicodeReplacementBytes2); // Low, low
-
-            // Invalid first/second in surrogate pair
-            Encode_InvalidChars("\uD800\u0041", 0, 2, new byte[] { 0xFD, 0xFF, 0x00, 0x00, 0x41, 0x00, 0x00, 0x00 });
-            Encode_InvalidChars("\u0065\uDC00", 0, 2, new byte[] { 0x65, 0x00, 0x00, 0x00, 0xFD, 0xFF, 0x00, 0x00 });
-
-            // High BMP non-chars: U+FFFF, U+FFFE, U+FFFD
-            Encode("\uFFFD", 0, 1, unicodeReplacementBytes1);
-            Encode("\uFFFE", 0, 1, new byte[] { 254, 255, 0, 0 });
-            Encode("\uFFFF", 0, 1, new byte[] { 255, 255, 0, 0 });
-            Encode("\uFFFF\uFFFE\uFFFD", 0, 3, new byte[] { 0xFF, 0xFF, 0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0xFD, 0xFF, 0x00, 0x00 });
         }
 
         public static byte[] GetBigEndianBytes(byte[] littleEndianBytes)

--- a/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingDecode.cs
+++ b/src/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingDecode.cs
@@ -80,6 +80,20 @@ namespace System.Text.Tests
             // Surrogate pairs
             yield return new object[] { new byte[] { 0x2B, 0x32, 0x41, 0x44, 0x66, 0x2F, 0x77, 0x2D }, 0, 8, "\uD800\uDFFF" };
 
+            // Invalid Unicode
+            yield return new object[] { new byte[] { 43, 50, 65, 65, 45 }, 0, 5, "\uD800" }; // Lone high surrogate
+            yield return new object[] { new byte[] { 43, 51, 65, 65, 45 }, 0, 5, "\uDC00" }; // Lone low surrogate
+            yield return new object[] { new byte[] { 0x2B, 0x33, 0x2F, 0x38, 0x2D }, 0, 5, "\uDFFF" }; // Lone low surrogate
+
+            yield return new object[] { new byte[] { 43, 50, 65, 68, 89, 65, 65, 45 }, 0, 8, "\uD800\uD800" }; // High, high
+            yield return new object[] { new byte[] { 43, 51, 65, 68, 89, 65, 65, 45 }, 0, 8, "\uDC00\uD800" }; // Low, high
+            yield return new object[] { new byte[] { 43, 51, 65, 68, 99, 65, 65, 45 }, 0, 8, "\uDC00\uDC00" }; // Low, low
+
+            // High BMP non-chars
+            yield return new object[] { new byte[] { 43, 47, 47, 48, 45 }, 0, 5, "\uFFFD" };
+            yield return new object[] { new byte[] { 43, 47, 47, 52, 45 }, 0, 5, "\uFFFE" };
+            yield return new object[] { new byte[] { 43, 47, 47, 56, 45 }, 0, 5, "\uFFFF" };
+
             // Empty strings
             yield return new object[] { new byte[0], 0, 0, string.Empty };
             yield return new object[] { new byte[10], 0, 0, string.Empty };
@@ -92,24 +106,6 @@ namespace System.Text.Tests
         {
             EncodingHelpers.Decode(new UTF7Encoding(true), bytes, index, count, expected);
             EncodingHelpers.Decode(new UTF7Encoding(false), bytes, index, count, expected);
-        }
-
-        [Fact]
-        public void Decode_InvalidUnicode()
-        {
-            // TODO: add into Decode_TestData once #7166 is fixed
-            Decode(new byte[] { 43, 50, 65, 65, 45 }, 0, 5, "\uD800"); // Lone high surrogate
-            Decode(new byte[] { 43, 51, 65, 65, 45 }, 0, 5, "\uDC00"); // Lone low surrogate
-            Decode(new byte[] { 0x2B, 0x33, 0x2F, 0x38, 0x2D }, 0, 5, "\uDFFF"); // Lone low surrogate
-
-            Decode(new byte[] { 43, 50, 65, 68, 89, 65, 65, 45 }, 0, 8, "\uD800\uD800"); // High, high
-            Decode(new byte[] { 43, 51, 65, 68, 89, 65, 65, 45 }, 0, 8, "\uDC00\uD800"); // Low, high
-            Decode(new byte[] { 43, 51, 65, 68, 99, 65, 65, 45 }, 0, 8, "\uDC00\uDC00"); // Low, low
-
-            // High BMP non-chars
-            Decode(new byte[] { 43, 47, 47, 48, 45 }, 0, 5, "\uFFFD");
-            Decode(new byte[] { 43, 47, 47, 52, 45 }, 0, 5, "\uFFFE");
-            Decode(new byte[] { 43, 47, 47, 56, 45 }, 0, 5, "\uFFFF");
         }
     }
 }

--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingEncode.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingEncode.cs
@@ -96,6 +96,18 @@ namespace System.Text.Tests
             yield return new object[] { "\uD800\uDC00\u00E1\uD800\uDC00\uD800\uDC00\uD800\uDC00\uD800\uDC00\uD800\uDC00\uD800\uDC00", 0, 15, new byte[] { 0xF0, 0x90, 0x80, 0x80, 0xC3, 0xA1, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x80 } };
             yield return new object[] { "\uD800\uDC00\u8000\uD800\uDC00\uD800\uDC00\uD800\uDC00\uD800\uDC00\uD800\uDC00\uD800\uDC00", 0, 15, new byte[] { 0xF0, 0x90, 0x80, 0x80, 0xE8, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x80 } };
 
+            // U+FDD0 - U+FDEF
+            yield return new object[] { "\uFDD0\uFDEF", 0, 2, new byte[] { 0xEF, 0xB7, 0x90, 0xEF, 0xB7, 0xAF } };
+
+            // BOM
+            yield return new object[] { "\uFEFF\u0041", 0, 2, new byte[] { 0xEF, 0xBB, 0xBF, 0x41 } };
+
+            // High BMP non-chars
+            yield return new object[] { "\uFFFD", 0, 1, new byte[] { 239, 191, 189 } };
+            yield return new object[] { "\uFFFE", 0, 1, new byte[] { 239, 191, 190 } };
+            yield return new object[] { "\uFFFF", 0, 1, new byte[] { 239, 191, 191 } };
+
+
             // Empty strings
             yield return new object[] { string.Empty, 0, 0, new byte[0] };
             yield return new object[] { "abc", 3, 0, new byte[0] };
@@ -113,6 +125,43 @@ namespace System.Text.Tests
             EncodingHelpers.Encode(new UTF8Encoding(true, true), chars, index, count, expected);
         }
 
+        public static IEnumerable<object[]> Encode_InvalidChars_TestData()
+        {
+            byte[] unicodeReplacementBytes1 = new byte[] { 239, 191, 189 };
+
+            // Lone high surrogate
+            yield return new object[] { "\uD800", 0, 1, unicodeReplacementBytes1 };
+            yield return new object[] { "\uDD75", 0, 1, unicodeReplacementBytes1 };
+            yield return new object[] { "\uDBFF", 0, 1, unicodeReplacementBytes1 };
+
+            // Lone low surrogate
+            yield return new object[] { "\uDC00", 0, 1, unicodeReplacementBytes1 };
+            yield return new object[] { "\uDC00", 0, 1, unicodeReplacementBytes1 };
+
+            // Surrogate pair out of range
+            yield return new object[] { "\uD800\uDC00", 0, 1, unicodeReplacementBytes1 };
+            yield return new object[] { "\uD800\uDC00", 1, 1, unicodeReplacementBytes1 };
+
+            // Invalid surrogate pair
+            yield return new object[] { "\u0041\uD800\uE000", 0, 3, new byte[] { 0x41, 0xEF, 0xBF, 0xBD, 0xEE, 0x80, 0x80 } };
+            yield return new object[] { "\uD800\u0041\uDC00", 0, 3, new byte[] { 0xEF, 0xBF, 0xBD, 0x41, 0xEF, 0xBF, 0xBD } };
+            yield return new object[] { "\uD800\u0041\u0042\u07FF\u0043\uDC00", 0, 6, new byte[] { 0xEF, 0xBF, 0xBD, 0x41, 0x42, 0xDF, 0xBF, 0x43, 0xEF, 0xBF, 0xBD } };
+
+            // Mixture of ASCII, valid Unicode and invalid unicode
+            yield return new object[] { "\uDD75\uDD75\uD803\uDD75\uDD75\uDD75\uDD75\uD803\uD803\uD803\uDD75\uDD75\uDD75\uDD75", 0, 14, new byte[] { 239, 191, 189, 239, 191, 189, 240, 144, 181, 181, 239, 191, 189, 239, 191, 189, 239, 191, 189, 239, 191, 189, 239, 191, 189, 240, 144, 181, 181, 239, 191, 189, 239, 191, 189, 239, 191, 189 } };
+            yield return new object[] { "Test\uD803Test", 0, 9, new byte[] { 84, 101, 115, 116, 239, 191, 189, 84, 101, 115, 116 } };
+            yield return new object[] { "Test\uDD75Test", 0, 9, new byte[] { 84, 101, 115, 116, 239, 191, 189, 84, 101, 115, 116 } };
+            yield return new object[] { "TestTest\uDD75", 0, 9, new byte[] { 84, 101, 115, 116, 84, 101, 115, 116, 239, 191, 189 } };
+            yield return new object[] { "TestTest\uD803", 0, 9, new byte[] { 84, 101, 115, 116, 84, 101, 115, 116, 239, 191, 189 } };
+            
+            byte[] unicodeReplacementBytes2 = new byte[] { 239, 191, 189, 239, 191, 189 };
+            yield return new object[] { "\uD800\uD800", 0, 2, unicodeReplacementBytes2 }; // High, high
+            yield return new object[] { "\uDC00\uD800", 0, 2, unicodeReplacementBytes2 }; // Low, high
+            yield return new object[] { "\uDC00\uDC00", 0, 2, unicodeReplacementBytes2 }; // Low, low
+        }
+
+        [Theory]
+        [MemberData(nameof(Encode_InvalidChars_TestData))]
         public void Encode_InvalidChars(string chars, int index, int count, byte[] expected)
         {
             EncodingHelpers.Encode(new UTF8Encoding(true, false), chars, index, count, expected);
@@ -120,54 +169,6 @@ namespace System.Text.Tests
 
             NegativeEncodingTests.Encode_Invalid(new UTF8Encoding(false, true), chars, index, count);
             NegativeEncodingTests.Encode_Invalid(new UTF8Encoding(true, true), chars, index, count);
-        }
-
-        [Fact]
-        public void Encode_InvalidChars()
-        {
-            // TODO: add into Encode_TestData or Encode_InvalidChars_TestData once #7166 is fixed
-            byte[] unicodeReplacementBytes1 = new byte[] { 239, 191, 189 };
-
-            // Lone high surrogate
-            Encode_InvalidChars("\uD800", 0, 1, unicodeReplacementBytes1);
-            Encode_InvalidChars("\uDD75", 0, 1, unicodeReplacementBytes1);
-            Encode_InvalidChars("\uDBFF", 0, 1, unicodeReplacementBytes1);
-
-            // Lone low surrogate
-            Encode_InvalidChars("\uDC00", 0, 1, unicodeReplacementBytes1);
-            Encode_InvalidChars("\uDC00", 0, 1, unicodeReplacementBytes1);
-
-            // Surrogate pair out of range
-            Encode_InvalidChars("\uD800\uDC00", 0, 1, unicodeReplacementBytes1);
-            Encode_InvalidChars("\uD800\uDC00", 1, 1, unicodeReplacementBytes1);
-
-            // Invalid surrogate pair
-            Encode_InvalidChars("\u0041\uD800\uE000", 0, 3, new byte[] { 0x41, 0xEF, 0xBF, 0xBD, 0xEE, 0x80, 0x80 });
-            Encode_InvalidChars("\uD800\u0041\uDC00", 0, 3, new byte[] { 0xEF, 0xBF, 0xBD, 0x41, 0xEF, 0xBF, 0xBD });
-            Encode_InvalidChars("\uD800\u0041\u0042\u07FF\u0043\uDC00", 0, 6, new byte[] { 0xEF, 0xBF, 0xBD, 0x41, 0x42, 0xDF, 0xBF, 0x43, 0xEF, 0xBF, 0xBD });
-
-            // Mixture of ASCII, valid Unicode and invalid unicode
-            Encode_InvalidChars("\uDD75\uDD75\uD803\uDD75\uDD75\uDD75\uDD75\uD803\uD803\uD803\uDD75\uDD75\uDD75\uDD75", 0, 14, new byte[] { 239, 191, 189, 239, 191, 189, 240, 144, 181, 181, 239, 191, 189, 239, 191, 189, 239, 191, 189, 239, 191, 189, 239, 191, 189, 240, 144, 181, 181, 239, 191, 189, 239, 191, 189, 239, 191, 189 });
-            Encode_InvalidChars("Test\uD803Test", 0, 9, new byte[] { 84, 101, 115, 116, 239, 191, 189, 84, 101, 115, 116 });
-            Encode_InvalidChars("Test\uDD75Test", 0, 9, new byte[] { 84, 101, 115, 116, 239, 191, 189, 84, 101, 115, 116 });
-            Encode_InvalidChars("TestTest\uDD75", 0, 9, new byte[] { 84, 101, 115, 116, 84, 101, 115, 116, 239, 191, 189 });
-            Encode_InvalidChars("TestTest\uD803", 0, 9, new byte[] { 84, 101, 115, 116, 84, 101, 115, 116, 239, 191, 189 });
-            
-            byte[] unicodeReplacementBytes2 = new byte[] { 239, 191, 189, 239, 191, 189 };
-            Encode_InvalidChars("\uD800\uD800", 0, 2, unicodeReplacementBytes2); // High, high
-            Encode_InvalidChars("\uDC00\uD800", 0, 2, unicodeReplacementBytes2); // Low, high
-            Encode_InvalidChars("\uDC00\uDC00", 0, 2, unicodeReplacementBytes2); // Low, low
-
-            // U+FDD0 - U+FDEF
-            Encode("\uFDD0\uFDEF", 0, 2, new byte[] { 0xEF, 0xB7, 0x90, 0xEF, 0xB7, 0xAF });
-
-            // BOM
-            Encode("\uFEFF\u0041", 0, 2, new byte[] { 0xEF, 0xBB, 0xBF, 0x41 });
-
-            // High BMP non-chars
-            Encode("\uFFFD", 0, 1, unicodeReplacementBytes1);
-            Encode("\uFFFE", 0, 1, new byte[] { 239, 191, 190 });
-            Encode("\uFFFF", 0, 1, new byte[] { 239, 191, 191 });
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -578,6 +578,15 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(?(cat)|catdog)", "catdog", RegexOptions.None, new string[] { "" } };
             yield return new object[] { @"(?(cat)|dog)", "dog", RegexOptions.None, new string[] { "dog" } };
 
+            // Invalid unicode
+            yield return new object[] { "([\u0000-\uFFFF-[azAZ09]]|[\u0000-\uFFFF-[^azAZ09]])+", "azAZBCDE1234567890BCDEFAZza", RegexOptions.None, new string[] { "azAZBCDE1234567890BCDEFAZza", "a" } };
+            yield return new object[] { "[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[a]]]]]]+", "abcxyzABCXYZ123890", RegexOptions.None, new string[] { "bcxyzABCXYZ123890" } };
+            yield return new object[] { "[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[a]]]]]]]+", "bcxyzABCXYZ123890a", RegexOptions.None, new string[] { "a" } };
+            yield return new object[] { "[\u0000-\uFFFF-[\\p{P}\\p{S}\\p{C}]]+", "!@`';.,$+<>=\x0001\x001FazAZ09", RegexOptions.None, new string[] { "azAZ09" } };
+
+            yield return new object[] { @"[\uFFFD-\uFFFF]+", "\uFFFC\uFFFD\uFFFE\uFFFF", RegexOptions.IgnoreCase, new string[] { "\uFFFD\uFFFE\uFFFF" } };
+            yield return new object[] { @"[\uFFFC-\uFFFE]+", "\uFFFB\uFFFC\uFFFD\uFFFE\uFFFF", RegexOptions.IgnoreCase, new string[] { "\uFFFC\uFFFD\uFFFE" } };
+
             // Empty Match
             yield return new object[] { @"([a*]*)+?$", "ab", RegexOptions.None, new string[] { "", "" } };
             yield return new object[] { @"(a*)+?$", "b", RegexOptions.None, new string[] { "", "" } };
@@ -650,18 +659,6 @@ namespace System.Text.RegularExpressions.Tests
                     CultureInfo.CurrentCulture = originalCulture;
                 }
             }
-        }
-
-        [Fact]
-        public void Groups_InvalidUnicode()
-        {
-            Groups("([\u0000-\uFFFF-[azAZ09]]|[\u0000-\uFFFF-[^azAZ09]])+", "azAZBCDE1234567890BCDEFAZza", RegexOptions.None, new string[] { "azAZBCDE1234567890BCDEFAZza", "a" });
-            Groups("[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[a]]]]]]+", "abcxyzABCXYZ123890", RegexOptions.None, new string[] { "bcxyzABCXYZ123890" });
-            Groups("[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[a]]]]]]]+", "bcxyzABCXYZ123890a", RegexOptions.None, new string[] { "a" });
-            Groups("[\u0000-\uFFFF-[\\p{P}\\p{S}\\p{C}]]+", "!@`';.,$+<>=\x0001\x001FazAZ09", RegexOptions.None, new string[] { "azAZ09" });
-
-            Groups(@"[\uFFFD-\uFFFF]+", "\uFFFC\uFFFD\uFFFE\uFFFF", RegexOptions.IgnoreCase, new string[] { "\uFFFD\uFFFE\uFFFF" });
-            Groups(@"[\uFFFC-\uFFFE]+", "\uFFFB\uFFFC\uFFFD\uFFFE\uFFFF", RegexOptions.IgnoreCase, new string[] { "\uFFFC\uFFFD\uFFFE" });
         }
     }
 }


### PR DESCRIPTION
One more crash remains however! (dotnet/buildtools#1091)

/cc @jamesqo @ericstj @stephentoub