### PR TITLE
Add docs for Microsoft.NETCore.Platforms & RIDs

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/readme.md
+++ b/pkg/Microsoft.NETCore.Platforms/readme.md
@@ -101,6 +101,7 @@ Binary compatibility is represented through imports.  If a platform is considere
 
 ###Import convention
 Imports should be used when the added RID is considered compatible with an existing RID.
+
 1. Architecture-specific RIDs should first import the architecture-less RID.  EG: `osx.10.11-x64` should first import `osx.10.11`.
 2. Architecture-specific RIDs that are compatible with a previous version RID for the same OS should then import the previous version, architecture specific RID.  EG: `osx.10.11-x64` should then import `osx.10.10-x64`.  If there is no earlier compatible/supported version, then a versionless RID should be imported.  EG: `osx.10.10-x64` should import `osx-x64`.
 3. Architecture-less RIDs that are compatible with a previous version RID for the same OS should then import the previous version, architecture neutral RID.  EG: `osx.10.11` should import `osx.10.10`. If there is no earlier compatible/supported version, then a versionless RID should be imported.  EG: `osx.10.10` should import `osx`.

--- a/pkg/Microsoft.NETCore.Platforms/readme.md
+++ b/pkg/Microsoft.NETCore.Platforms/readme.md
@@ -1,0 +1,104 @@
+#Runtime IDs
+The package `Microsoft.NETCore.Platforms` defines the runtime identifiers (RIDs) used by .NET packages to represent runtime-specific assets in NuGet packages.
+
+##What is a RID?
+A RID is an opaque string that describes a platform.  RIDs have relationships to other RIDs by "importing" the other RID.  In that way a RID is a graph of compatible RIDs.
+
+##How does NuGet use RIDs?
+When NuGet is deciding which assets to use from a package and which packages to include NuGet will consider a RID if the project.json lists a RID in its `runtimes` section.
+
+- NuGet chooses the best RID-specific asset, where best is determined by a breadth first traversal of the RID graph.  Breadth ordering is document order.
+- NuGet considers RID-specific assets for two asset types: lib and native.
+- NuGet never considers RID-specific assets for compile.
+
+###Best RID
+Consider the partial RID-graph:
+```
+        "any": {},
+
+        "win": {
+            "#import": [ "any" ]
+        },
+        "win-x86": {
+            "#import": [ "win" ]
+        },
+        "win-x64": {
+            "#import": [ "win" ]
+        },
+        "win7": {
+            "#import": [ "win" ]
+        },
+        "win7-x86": {
+            "#import": [ "win7", "win-x86" ]
+        },
+        "win7-x64": {
+            "#import": [ "win7", "win-x64" ]
+        }
+```
+
+This can be visualized as a directed graph, as follows:
+```
+    win7-x64    win7-x86
+       |   \   /    |
+       |   win7     |
+       |     |      |
+    win-x64  |  win7-x86
+          \  |  /
+            win
+             |
+            any
+```
+As such, best RID, when evaluating for win7-x64 would be:`win7-x64`, `win7`, `win-x64`, `win`, `any`
+Similarly, when evaluating for `win-x64`: `win-x64`, `win`, `any`
+Note that `win7` comes before `win-x64` due to the import for `win7` appearing before the import for `win-x64` in document order.
+
+###RID-qualified assets are preferred
+NuGet will always prefer a RID-qualified asset over a RID-less asset.  For example if a package contains
+```
+lib/netcoreapp1.0/foo.dll
+runtimes/win/lib/netcoreapp1.0/foo.dll
+```
+NuGet will choose `runtimes/win/lib/netcoreapp1.0/foo.dll`.
+
+Additionally, NuGet will always prefer a RID-qualified asset over a RID-less asset, even if the framework is less specific for the RID-qualified asset.
+```
+lib/netstandard1.5/foo.dll
+runtimes/win/lib/netstandard1.0/foo.dll
+```
+When resolving for netstandard1.5/win7-x64 NuGet will choose `runtimes/win/lib/netstandard1.0/foo.dll` over `lib/netstandard1.5/foo.dll` even though `netstandard1.5` is more specific than `netstandard1.0`.
+
+### RID-qualified assets are never used for compile
+NuGet will select different compile-assets than runtime-assets.  The compile assets can never be RID-qualified.  Consider the package:
+```
+lib/netstandard1.5/foo.dll
+runtimes/win/lib/netstandard1.0/foo.dll
+```
+When resolving for netstandard1.5/win7-x64 will select `lib/netstandard1.5/foo.dll` for the compile asset and `runtimes/win/lib/netstandard1.0/foo.dll` for the runtime asset.
+
+##Adding new RIDs
+
+###Why do I need to add a new RID?
+NuGet's extensibility mechanism for platform-specific assets requires a RID be defined for any platform that needs assets specific to that platform.  Unlike TFMs, which have a known relationship in NuGet (eg net4.5 is compatible with net4.0), RIDs are opaque strings whigh NuGet knows nothing about.  The definition and relationship of RIDs comes solely from the `runtime.json` files within the root of the packages referenced by the project.
+As such, whenever we want to put a new RID in a project.json in order to get assets specific for that RID we have to define the rid in some package.  Typically that package is `Microsoft.NETCore.Platforms` if the RID is "official".  If you'd like to prototype you can put the RID in any other package and so long as that package is referenced you can use that RID.
+
+###Do I really need to add a new RID?
+If you're prototyping on a platform that is compatible with an existing platform then you can reuse the RID for that exsisting platform.  New RIDs are only needed when an asset needs to be different on a particular platform.
+
+`Microsoft.NETCore.Platforms` attempts to define all RIDs that packages may need, and as such will define RIDs for platforms that we don't actually cross compile for.  This is to support higher-level packages, 3rd party packages, that may need to cross-compile for that RID.
+
+###Naming convention
+We use the following convention in all newly-defined RIDs.  Some RIDs (win7-x64, win8-x64) predate this convention and don't follow it, but all new RIDs should follow it.
+`[os name].[version]-[architecture]-[additional qualifiers]`, for example `osx.10.10-x64` or `ubuntu.14.04-x64`
+- `[os name]` can contain any characters other than `.`
+- `[version]` can contain any characters other than `-`.  Typically a numeric version like 14.04 or 10.0.
+- `[architecture]` can contain any characters other than `-`. Typically: `x86`, `x64`, `arm`, `arm64`
+- `[additional qualifiers]` can be things like `aot`.  Used to further differentiate different platforms.
+
+###Import convention
+Imports should be used when the added RID is considered compatible with an existing RID.
+1. Architecture-specific RIDs should first import the architecture-less RID.  EG: `ubuntu.14.10-x64` should first import `ubuntu.14.10`.
+2. Architecture-specific RIDs that are compatible with a previous version RID for the same OS should then import the previous version, architecture specific RID.  EG: `ubuntu.14.10-x64` should then import `ubuntu.14.04-x64`.  If there is no earlier compatible/supported version, then a versionless RID should be imported.  EG: `ubuntu14.04-x64` should import `ubuntu-x64`.
+3. Architecture-less RIDs that are compatible with a previous version RID for the same OS should then import the previous version, architecture neutral RID.  EG: `ubuntu.14.10` should import `ubuntu.14.04`. If there is no earlier compatible/supported version, then a versionless RID should be imported.  EG: `ubuntu14.04` should import `ubuntu`.
+4. Version-less RIDs shoudld import an OS category.  EG: `ubuntu-x64` should import `linux-x64`, `ubuntu` should import `linux`.
+
+


### PR DESCRIPTION
I've added some docs for RIDs to the repo.  I put them next to Microsoft.NETCore.Platforms since that's where folks seem to look.  LMK if you think they should go somewhere else.

I cribbed some of this from emails in the past with @anurse

/cc @ellismg @mellinoe @davidfowl @weshaggard @eerhardt 