### PR TITLE
Remove the finalizers from types that now derive from Component.

### DIFF
--- a/src/System.ComponentModel.EventBasedAsync/src/System/ComponentModel/BackgroundWorker.cs
+++ b/src/System.ComponentModel.EventBasedAsync/src/System/ComponentModel/BackgroundWorker.cs
@@ -26,11 +26,6 @@ namespace System.ComponentModel
             _progressReporter = new SendOrPostCallback(ProgressReporter);
         }
 
-        ~BackgroundWorker() // exists for backwards compatibility
-        {
-            Dispose(false);
-        }
-
         private void AsyncOperationCompleted(object arg)
         {
             _isRunning = false;

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -120,11 +120,6 @@ namespace System.Diagnostics
             _errorStreamReadMode = StreamReadMode.Undefined;
         }
 
-        ~Process()
-        {
-            Dispose(false);
-        }
-
         public SafeProcessHandle SafeHandle
         {
             get

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -71,11 +71,6 @@ namespace System.IO
         }
 #endif
 
-        ~FileSystemWatcher()
-        {
-            this.Dispose(false);
-        }
-
         /// <devdoc>
         ///    Initializes a new instance of the <see cref='System.IO.FileSystemWatcher'/> class.
         /// </devdoc>

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
@@ -41,11 +41,6 @@ namespace System.Net.NetworkInformation
             }
         }
 
-        ~Ping()
-        {
-            Dispose(false);
-        }
-
         private void CheckStart()
         {
             if (_disposeRequested)


### PR DESCRIPTION
These finalizers were added before Component was available and were missed in the previous change.