### PR TITLE
SqlClient CLR UDT binary support

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -986,6 +986,11 @@ namespace System.Data.SqlClient
                 statistics = SqlStatistics.StartTimer(Statistics);
                 CheckMetaDataIsReady(columnIndex: i);
 
+                if (_metaData[i].type == SqlDbType.Udt)
+                {
+                    throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
+                }
+
                 return GetProviderSpecificFieldTypeInternal(_metaData[i]);
             }
             finally
@@ -2031,6 +2036,11 @@ namespace System.Data.SqlClient
             bool result = TryReadColumn(i, setTimeout: false);
             if (!result) { throw SQL.SynchronousCallMayNotPend(); }
 
+            if (_metaData[i].type == SqlDbType.Udt)
+            {
+                throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
+            }
+
             return GetSqlValueFromSqlBufferInternal(_data[i], _metaData[i]);
         }
 
@@ -2195,6 +2205,11 @@ namespace System.Data.SqlClient
             bool result = TryReadColumn(i, setTimeout: false);
             if (!result) { throw SQL.SynchronousCallMayNotPend(); }
 
+            if (_metaData[i].type == SqlDbType.Udt)
+            {
+                throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
+            }
+
             return GetValueFromSqlBufferInternal(_data[i], _metaData[i]);
         }
 
@@ -2251,6 +2266,11 @@ namespace System.Data.SqlClient
             Debug.Assert(_stateObj == null || _stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
             bool result = TryReadColumn(i, setTimeout: false);
             if (!result) { throw SQL.SynchronousCallMayNotPend(); }
+
+            if (_metaData[i].type == SqlDbType.Udt)
+            {
+                throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
+            }
 
             return GetFieldValueFromSqlBufferInternal<T>(_data[i], _metaData[i]);
         }
@@ -2336,6 +2356,11 @@ namespace System.Data.SqlClient
 
                 for (int i = 0; i < copyLen; i++)
                 {
+                    if (_metaData[i].type == SqlDbType.Udt)
+                    {
+                        throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
+                    }
+
                     // Get the usable, TypeSystem-compatible value from the internal buffer
                     values[_metaData.indexMap[i]] = GetValueFromSqlBufferInternal(_data[i], _metaData[i]);
 
@@ -4141,6 +4166,11 @@ namespace System.Data.SqlClient
                     var metaData = _metaData;
                     if ((data != null) && (metaData != null))
                     {
+                        if (_metaData[i].type == SqlDbType.Udt)
+                        {
+                            return Task.FromException<T>(ADP.DbTypeNotSupported(SqlDbType.Udt.ToString()));
+                        }
+
                         return Task.FromResult<T>(GetFieldValueFromSqlBufferInternal<T>(data[i], metaData[i]));
                     }
                     else

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -866,7 +866,7 @@ namespace System.Data.SqlClient
 
                 if (metaData.type == SqlDbType.Udt)
                 {
-                    throw UdtNotSupportedException();
+                    dataTypeName = metaData.udtDatabaseName + "." + metaData.udtSchemaName + "." + metaData.udtTypeName;
                 }
                 else
                 { // For all other types, including Xml - use data in MetaType.
@@ -939,7 +939,7 @@ namespace System.Data.SqlClient
 
                 if (metaData.type == SqlDbType.Udt)
                 {
-                    throw UdtNotSupportedException();
+                    fieldType = MetaType.MetaMaxVarBinary.ClassType;
                 }
                 else
                 { // For all other types, including Xml - use data in MetaType.
@@ -1020,7 +1020,7 @@ namespace System.Data.SqlClient
 
                 if (metaData.type == SqlDbType.Udt)
                 {
-                    throw UdtNotSupportedException();
+                    providerSpecificFieldType = MetaType.MetaMaxVarBinary.SqlType;
                 }
                 else
                 { // For all other types, including Xml - use data in MetaType.
@@ -2051,24 +2051,8 @@ namespace System.Data.SqlClient
             }
             else if (_typeSystem != SqlConnectionString.TypeSystem.SQLServer2000)
             {
-                // TypeSystem.SQLServer2005
-
-                if (metaData.type == SqlDbType.Udt)
-                {
-                    var connection = _connection;
-                    if (connection != null)
-                    {
-                        throw UdtNotSupportedException();
-                    }
-                    else
-                    {
-                        throw ADP.DataReaderClosed();
-                    }
-                }
-                else
-                {
-                    return data.SqlValue;
-                }
+                // CLR UDT types are not supported on .NET Core.  So, we're treating them as binary instead.
+                return data.SqlValue;
             }
             else
             {
@@ -2245,15 +2229,9 @@ namespace System.Data.SqlClient
                 }
                 else
                 {
-                    var connection = _connection;
-                    if (connection != null)
-                    {
-                        throw UdtNotSupportedException();
-                    }
-                    else
-                    {
-                        throw ADP.DataReaderClosed();
-                    }
+                    // CLR UDT types are not supported on .NET Core.  So, we're treating them as binary instead.
+
+                    return data.Value;
                 }
             }
             else
@@ -2388,7 +2366,11 @@ namespace System.Data.SqlClient
 
             MetaType metaType = null;
 
-            if (actualMetaType == MetaType.MetaXml)
+            if (actualMetaType == MetaType.MetaUdt)
+            {
+                metaType = MetaType.MetaVarBinary;
+            }
+            else if (actualMetaType == MetaType.MetaXml)
             {
                 metaType = MetaType.MetaNText;
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDbColumn.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDbColumn.cs
@@ -52,7 +52,7 @@ namespace System.Data.SqlClient
 
             IsReadOnly = (0 == _metadata.updatability);
 
-            UdtAssemblyQualifiedName = null;
+            UdtAssemblyQualifiedName = _metadata.udtAssemblyQualifiedName;
 
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlEnums.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlEnums.cs
@@ -209,6 +209,7 @@ namespace System.Data.SqlClient
                 case SqlDbType.Variant: return s_metaVariant;
                 case (SqlDbType)TdsEnums.SmallVarBinary: return s_metaSmallVarBinary;
                 case SqlDbType.Xml: return MetaXml;
+                case SqlDbType.Udt: return MetaUdt;
                 case SqlDbType.Structured:
                     if (isMultiValued)
                     {
@@ -280,8 +281,7 @@ namespace System.Data.SqlClient
                 case SqlDbType.NChar:
                     return MetaMaxNVarChar;
                 case SqlDbType.Udt:
-                    Debug.Assert(false, "UDT is not supported");
-                    return mt;
+                    return s_metaMaxUdt;
                 default:
                     return mt;
             }
@@ -699,7 +699,7 @@ namespace System.Data.SqlClient
                 case TdsEnums.SQLNVARCHAR: return MetaNVarChar;
                 case TdsEnums.SQLNTEXT: return MetaNText;
                 case TdsEnums.SQLVARIANT: return s_metaVariant;
-                case TdsEnums.SQLUDT: return s_metaUdt;
+                case TdsEnums.SQLUDT: return MetaUdt;
                 case TdsEnums.SQLXMLTYPE: return MetaXml;
                 case TdsEnums.SQLTABLE: return s_metaTable;
                 case TdsEnums.SQLDATE: return s_metaDate;
@@ -828,8 +828,11 @@ namespace System.Data.SqlClient
         private static readonly MetaType s_metaVariant = new MetaType
             (255, 255, -1, true, false, false, TdsEnums.SQLVARIANT, TdsEnums.SQLVARIANT, MetaTypeName.VARIANT, typeof(System.Object), typeof(System.Object), SqlDbType.Variant, DbType.Object, 0);
 
-        private static readonly MetaType s_metaUdt = new MetaType
+        internal static readonly MetaType MetaUdt = new MetaType
            (255, 255, -1, false, false, true, TdsEnums.SQLUDT, TdsEnums.SQLUDT, MetaTypeName.UDT, typeof(System.Object), typeof(System.Object), SqlDbType.Udt, DbType.Object, 0);
+
+        private static readonly MetaType s_metaMaxUdt = new MetaType
+            (255, 255, -1, false, true, true, TdsEnums.SQLUDT, TdsEnums.SQLUDT, MetaTypeName.UDT, typeof(System.Object), typeof(System.Object), SqlDbType.Udt, DbType.Object, 0);
 
         private static readonly MetaType s_metaTable = new MetaType
             (255, 255, -1, false, false, false, TdsEnums.SQLTABLE, TdsEnums.SQLTABLE, MetaTypeName.TABLE, typeof(IEnumerable<DbDataRecord>), typeof(IEnumerable<DbDataRecord>), SqlDbType.Structured, DbType.Object, 0);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -3691,11 +3691,11 @@ namespace System.Data.SqlClient
                 if (col.length == TdsEnums.SQL_USHORTVARMAXLEN)
                 {
                     Debug.Assert(tdsType == TdsEnums.SQLXMLTYPE ||
-                                    tdsType == TdsEnums.SQLBIGVARCHAR ||
-                                    tdsType == TdsEnums.SQLBIGVARBINARY ||
-                                    tdsType == TdsEnums.SQLNVARCHAR ||
-                                    tdsType == TdsEnums.SQLUDT,
-                                    "Invalid streaming datatype");
+                                 tdsType == TdsEnums.SQLBIGVARCHAR ||
+                                 tdsType == TdsEnums.SQLBIGVARBINARY ||
+                                 tdsType == TdsEnums.SQLNVARCHAR ||
+                                 tdsType == TdsEnums.SQLUDT,
+                                 "Invalid streaming datatype");
                     col.metaType = MetaType.GetMaxMetaTypeFromMetaType(col.metaType);
                     Debug.Assert(col.metaType.IsLong, "Max datatype not IsLong");
                     col.length = Int32.MaxValue;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
@@ -485,8 +485,8 @@ namespace System.Data.SqlClient
         internal string xmlSchemaCollectionOwningSchema;
         internal string xmlSchemaCollectionName;
         internal MetaType metaType; // cached metaType
-     
-           
+
+
         internal SqlMetaDataPriv()
         {
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
@@ -472,13 +472,21 @@ namespace System.Data.SqlClient
         internal Encoding encoding;
         internal bool isNullable;
 
+        // UDT specific metadata
+        // server metadata info
+        // additional temporary UDT meta data
+        internal string udtDatabaseName;
+        internal string udtSchemaName;
+        internal string udtTypeName;
+        internal string udtAssemblyQualifiedName;
+        
         // Xml specific metadata
         internal string xmlSchemaCollectionDatabase;
         internal string xmlSchemaCollectionOwningSchema;
         internal string xmlSchemaCollectionName;
         internal MetaType metaType; // cached metaType
-
-
+     
+           
         internal SqlMetaDataPriv()
         {
         }
@@ -494,6 +502,10 @@ namespace System.Data.SqlClient
             this.codePage = original.codePage;
             this.encoding = original.encoding;
             this.isNullable = original.isNullable;
+            this.udtDatabaseName = original.udtDatabaseName;
+            this.udtSchemaName = original.udtSchemaName;
+            this.udtTypeName = original.udtTypeName;
+            this.udtAssemblyQualifiedName = original.udtAssemblyQualifiedName;
             this.xmlSchemaCollectionDatabase = original.xmlSchemaCollectionDatabase;
             this.xmlSchemaCollectionOwningSchema = original.xmlSchemaCollectionOwningSchema;
             this.xmlSchemaCollectionName = original.xmlSchemaCollectionName;

--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDDataTypesTest/DDDataTypesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDDataTypesTest/DDDataTypesTest.cs
@@ -257,6 +257,58 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        [CheckConnStrSetupFact]
+        public static void TestUdtSqlParameterThrowsPlatformNotSupportedException()
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                connection.Open();
+                SqlCommand command = connection.CreateCommand();
+
+                // This command is not executed on the server since we should throw well before we send the query
+                command.CommandText = "select @p as col0";
+
+                command.Parameters.Add(new SqlParameter
+                {
+                    ParameterName = "@p",
+                    SqlDbType = SqlDbType.Udt,
+                    Direction = ParameterDirection.Input,
+                });
+
+                Assert.Throws<PlatformNotSupportedException>(() =>
+                {
+                    command.ExecuteReader();
+                });
+
+
+                command.Parameters.Clear();
+                command.Parameters.Add(new SqlParameter
+                {
+                    ParameterName = "@p",
+                    SqlDbType = SqlDbType.Udt,
+                    Direction = ParameterDirection.InputOutput,
+                });
+
+                Assert.Throws<PlatformNotSupportedException>(() =>
+                {
+                    command.ExecuteReader();
+                });
+
+
+                command.Parameters.Clear();
+                command.Parameters.Add(new SqlParameter
+                {
+                    ParameterName = "@p",
+                    SqlDbType = SqlDbType.Udt,
+                    Direction = ParameterDirection.Output,
+                });
+
+                Assert.Throws<PlatformNotSupportedException>(() =>
+                {
+                    command.ExecuteReader();
+                });
+            }
+        }
 
         [CheckConnStrSetupFact]
         public static void TestUdtSqlCommandExecuteScalarThrowsPlatformNotSupportedException()

--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDDataTypesTest/DDDataTypesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDDataTypesTest/DDDataTypesTest.cs
@@ -2,9 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Data.Common;
 using System.Data.SqlTypes;
+using System.IO;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using System.Xml;
 using Xunit;
 
@@ -47,7 +52,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     using (SqlDataReader reader = cmd.ExecuteReader())
                     {
                         int currentValue = 0;
-                        string[] expectedValues = 
+                        string[] expectedValues =
                         {
                             "<doc>Hello World</doc>",
                             "<NewDataSet><builtinCLRtypes><colsbyte>1</colsbyte><colbyte>2</colbyte><colint16>-20</colint16><coluint16>40</coluint16><colint32>-300</colint32><coluint32>300</coluint32><colint64>-4000</colint64><coluint64>4000</coluint64><coldecimal>50000.01</coldecimal><coldouble>600000.987</coldouble><colsingle>70000.9</colsingle><colstring>string variable</colstring><colboolean>true</colboolean><coltimespan>P10675199DT2H48M5.4775807S</coltimespan><coldatetime>9999-12-30T23:59:59.9999999-08:00</coldatetime><colGuid>00000001-0002-0003-0405-060708010101</colGuid><colbyteArray>AQIDBAUGBwgJCgsMDQ4PEA==</colbyteArray><colUri>http://www.abc.com/</colUri><colobjectsbyte xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"byte\">1</colobjectsbyte><colobjectbyte xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"unsignedByte\">2</colobjectbyte><colobjectint16 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"short\">-20</colobjectint16><colobjectuint16 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"unsignedShort\">40</colobjectuint16><colobjectint32 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"int\">-300</colobjectint32><colobjectuint32 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"unsignedInt\">300</colobjectuint32><colobjectint64 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"long\">-4000</colobjectint64><colobjectuint64 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"unsignedLong\">4000</colobjectuint64><colobjectdecimal xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"decimal\">50000.01</colobjectdecimal><colobjectdouble xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"double\">600000.987</colobjectdouble><colobjectsingle xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"float\">70000.9</colobjectsingle><colobjectstring xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"string\">string variable</colobjectstring><colobjectboolean xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"boolean\">true</colobjectboolean><colobjecttimespan xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"duration\">P10675199DT2H48M5.4775807S</colobjecttimespan><colobjectdatetime xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"dateTime\">9999-12-30T23:59:59.9999999-08:00</colobjectdatetime><colobjectguid xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\" msdata:InstanceType=\"System.Guid\">00000001-0002-0003-0405-060708010101</colobjectguid><colobjectbytearray xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"base64Binary\">AQIDBAUGBwgJCgsMDQ4PEA==</colobjectbytearray><colobjectUri xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"anyURI\">http://www.abc.com/</colobjectUri></builtinCLRtypes><builtinCLRtypes><colbyte>2</colbyte><colint16>-20</colint16><colint32>-300</colint32><coluint32>300</coluint32><coluint64>4000</coluint64><coldecimal>50000.01</coldecimal><coldouble>600000.987</coldouble><colsingle>70000.9</colsingle><colboolean>true</colboolean><colobjectsbyte xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"byte\">11</colobjectsbyte><colobjectbyte xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"unsignedByte\">22</colobjectbyte><colobjectint16 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"short\">-200</colobjectint16><colobjectuint16 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"unsignedShort\">400</colobjectuint16><colobjectint32 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"int\">-3000</colobjectint32><colobjectuint32 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"unsignedInt\">3000</colobjectuint32><colobjectint64 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"long\">-40000</colobjectint64><colobjectuint64 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"unsignedLong\">40000</colobjectuint64><colobjectdecimal xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"decimal\">500000.01</colobjectdecimal><colobjectdouble xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"double\">6000000.987</colobjectdouble><colobjectsingle xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"float\">700000.9</colobjectsingle><colobjectstring xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"string\">string variable 2</colobjectstring><colobjectboolean xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"boolean\">false</colobjectboolean><colobjecttimespan xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"duration\">-P10675199DT2H48M5.4775808S</colobjecttimespan><colobjectdatetime xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"dateTime\">0001-01-01T00:00:00.0000000-08:00</colobjectdatetime><colobjectguid xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\" msdata:InstanceType=\"System.Guid\">00000002-0001-0001-0807-060504030201</colobjectguid><colobjectbytearray xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"base64Binary\">EA8ODQwLCgkIBwYFBAMCAQ==</colobjectbytearray></builtinCLRtypes></NewDataSet>"
@@ -148,7 +153,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                         int currentValue = 0;
                         string[][] expectedValues =
                         {
-                            new string[] 
+                            new string[]
                             {
                                 "ASCIASCIASCIASCIASCIASCIThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first row",
                                 "This is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first rowThis is the first row",
@@ -189,61 +194,338 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         }
 
         [CheckConnStrSetupFact]
-        public static void TestUdt()
+        public static void TestUdtDataReaderGetValueThrowsPlatformNotSupportedException()
         {
-            SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr);
-            connection.Open();
-            Console.WriteLine("Connected...");
-
-            SqlCommand command = connection.CreateCommand();
-            command.CommandText = "select cast('0x0000' as varbinary(max)) as col0, hierarchyid::Parse('/1/1/3/') as col1, 2 as col2, geometry::Parse('LINESTRING (100 100, 20 180, 180 180)') as col3";
-            SqlDataReader reader = command.ExecuteReader();
-            Console.WriteLine("Executed...");
-
-            foreach (DbColumn column in reader.GetColumnSchema())
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
             {
-                Console.WriteLine("Schema for column: {0}", column.ColumnName);
-                Console.WriteLine("\tudt: {0}", column.UdtAssemblyQualifiedName);
-                Console.WriteLine("\ttype: {0}", column.DataTypeName);
+                connection.Open();
+                SqlCommand command = connection.CreateCommand();
+                command.CommandText = "select hierarchyid::Parse('/') as col0";
+                using (SqlDataReader reader = command.ExecuteReader())
+                {
+                    Assert.True(reader.Read());
+
+                    Assert.Throws<PlatformNotSupportedException>(() =>
+                    {
+                        object valud = reader[0];
+                    });
+
+                    Assert.Throws<PlatformNotSupportedException>(() =>
+                    {
+                        reader.GetValue(0);
+                    });
+
+                    Assert.Throws<PlatformNotSupportedException>(() =>
+                    {
+                        reader.GetFieldValue<byte[]>(0);
+                    });
+
+                    AggregateException exception = Assert.Throws<AggregateException>(() =>
+                    {
+                        reader.GetFieldValueAsync<byte[]>(0).Wait();
+                    });
+                    Assert.IsType(typeof(PlatformNotSupportedException), exception.InnerException);
+
+                    Assert.Throws<PlatformNotSupportedException>(() =>
+                    {
+                        object[] values = new object[1];
+                        reader.GetValues(values);
+                    });
+
+                    Assert.Throws<PlatformNotSupportedException>(() =>
+                    {
+                        object[] values = new object[1];
+                        reader.GetSqlValues(values);
+                    });
+
+                    Assert.Throws<PlatformNotSupportedException>(() =>
+                    {
+                        reader.GetProviderSpecificFieldType(0);
+                    });
+
+                    Assert.Throws<PlatformNotSupportedException>(() =>
+                    {
+                        reader.GetProviderSpecificValue(0);
+                    });
+
+                    Assert.Throws<PlatformNotSupportedException>(() =>
+                    {
+                        object[] values = new object[1];
+                        reader.GetProviderSpecificValues(values);
+                    });
+                }
             }
-
-            reader.Read();
-            Console.WriteLine("Read...");
-
-            Console.WriteLine();
-            Console.WriteLine("Read column 0...");
-            SqlBytes sqlBytes = reader.GetSqlBytes(0);
-            Console.WriteLine("Value length: {0}", sqlBytes.Length);
-            Console.WriteLine("SqlBytes Value is null: {0}", sqlBytes.IsNull);
-            Console.WriteLine("SqlBytes Value length: {0}", sqlBytes.Length);
-            WriteBytes(sqlBytes.Value);
-
-            Console.WriteLine();
-            Console.WriteLine("Read column 1...");
-            byte[] bytes = (byte[])reader.GetValue(1);
-            Console.WriteLine("Value length: {0}", bytes.Length);
-            WriteBytes(bytes);
-
-            Console.WriteLine();
-            Console.WriteLine("Read column 2...");
-            Console.WriteLine(reader.GetValue(2));
-
-            Console.WriteLine();
-            Console.WriteLine("Read column 3...");
-            sqlBytes = reader.GetSqlBytes(3);
-            Console.WriteLine("Value length: {0}", sqlBytes.Length);
-            Console.WriteLine("SqlBytes Value is null: {0}", sqlBytes.IsNull);
-            Console.WriteLine("SqlBytes Value length: {0}", sqlBytes.Length);
-            WriteBytes(sqlBytes.Value);
         }
 
-        private static void WriteBytes(byte[] bytes)
+
+        [CheckConnStrSetupFact]
+        public static void TestUdtSqlCommandExecuteScalarThrowsPlatformNotSupportedException()
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                connection.Open();
+
+                SqlCommand command = connection.CreateCommand();
+                command.CommandText = "select hierarchyid::Parse('/') as col0";
+                Assert.Throws<PlatformNotSupportedException>(() =>
+                {
+                    object value = command.ExecuteScalar();
+                });
+
+
+                SqlCommand asyncCommand = connection.CreateCommand();
+                asyncCommand.CommandText = "select hierarchyid::Parse('/') as col0";
+                AggregateException exception = Assert.Throws<AggregateException>(() =>
+                {
+                    asyncCommand.ExecuteScalarAsync().Wait();
+                });
+                Assert.IsType(typeof(PlatformNotSupportedException), exception.InnerException);
+            }
+        }
+
+        [CheckConnStrSetupFact]
+        public static void TestUdtZeroByte()
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                connection.Open();
+                SqlCommand command = connection.CreateCommand();
+                command.CommandText = "select hierarchyid::Parse('/') as col0";
+                using (SqlDataReader reader = command.ExecuteReader())
+                {
+                    Assert.True(reader.Read());
+                    Assert.False(reader.IsDBNull(0));
+                    SqlBytes sqlBytes = reader.GetSqlBytes(0);
+                    Assert.False(sqlBytes.IsNull, "Expected a zero length byte array");
+                    Assert.True(sqlBytes.Length == 0, "Expected a zero length byte array");
+                }
+            }
+        }
+
+        [CheckConnStrSetupFact]
+        public static void TestUdtSqlDataReaderGetSqlBytesSequentialAccess()
+        {
+            TestUdtSqlDataReaderGetSqlBytes(CommandBehavior.SequentialAccess);
+        }
+
+        [CheckConnStrSetupFact]
+        public static void TestUdtSqlDataReaderGetSqlBytes()
+        {
+            TestUdtSqlDataReaderGetSqlBytes(CommandBehavior.Default);
+        }
+
+        private static void TestUdtSqlDataReaderGetSqlBytes(CommandBehavior behavior)
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                connection.Open();
+                SqlCommand command = connection.CreateCommand();
+                command.CommandText = "select hierarchyid::Parse('/1/1/3/') as col0, geometry::Parse('LINESTRING (100 100, 20 180, 180 180)') as col1, geography::Parse('LINESTRING(-122.360 47.656, -122.343 47.656)') as col2";
+                using (SqlDataReader reader = command.ExecuteReader(behavior))
+                {
+                    Assert.True(reader.Read());
+
+                    SqlBytes sqlBytes = null;
+
+                    sqlBytes = reader.GetSqlBytes(0);
+                    Assert.Equal("5ade", ToHexString(sqlBytes.Value));
+
+                    sqlBytes = reader.GetSqlBytes(1);
+                    Assert.Equal("0000000001040300000000000000000059400000000000005940000000000000344000000000008066400000000000806640000000000080664001000000010000000001000000ffffffff0000000002", ToHexString(sqlBytes.Value));
+
+                    sqlBytes = reader.GetSqlBytes(2);
+                    Assert.Equal("e610000001148716d9cef7d34740d7a3703d0a975ec08716d9cef7d34740cba145b6f3955ec0", ToHexString(sqlBytes.Value));
+
+                    if (behavior == CommandBehavior.Default)
+                    {
+                        sqlBytes = reader.GetSqlBytes(0);
+                        Assert.Equal("5ade", ToHexString(sqlBytes.Value));
+                    }
+                }
+            }
+        }
+
+        [CheckConnStrSetupFact]
+        public static void TestUdtSqlDataReaderGetBytesSequentialAccess()
+        {
+            TestUdtSqlDataReaderGetBytes(CommandBehavior.SequentialAccess);
+        }
+
+        [CheckConnStrSetupFact]
+        public static void TestUdtSqlDataReaderGetBytes()
+        {
+            TestUdtSqlDataReaderGetBytes(CommandBehavior.Default);
+        }
+
+        private static void TestUdtSqlDataReaderGetBytes(CommandBehavior behavior)
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                connection.Open();
+                SqlCommand command = connection.CreateCommand();
+                command.CommandText = "select hierarchyid::Parse('/1/1/3/') as col0, geometry::Parse('LINESTRING (100 100, 20 180, 180 180)') as col1, geography::Parse('LINESTRING(-122.360 47.656, -122.343 47.656)') as col2";
+                using (SqlDataReader reader = command.ExecuteReader(behavior))
+                {
+                    Assert.True(reader.Read());
+
+                    int byteCount = 0;
+                    byte[] bytes = null;
+
+                    byteCount = (int) reader.GetBytes(0, 0, null, 0, 0);
+                    Assert.True(byteCount > 0);
+                    bytes = new byte[byteCount];
+                    reader.GetBytes(0, 0, bytes, 0, bytes.Length);
+                    Assert.Equal("5ade", ToHexString(bytes));
+
+                    byteCount = (int)reader.GetBytes(1, 0, null, 0, 0);
+                    Assert.True(byteCount > 0);
+                    bytes = new byte[byteCount];
+                    reader.GetBytes(1, 0, bytes, 0, bytes.Length);
+                    Assert.Equal("0000000001040300000000000000000059400000000000005940000000000000344000000000008066400000000000806640000000000080664001000000010000000001000000ffffffff0000000002", ToHexString(bytes));
+
+                    byteCount = (int)reader.GetBytes(2, 0, null, 0, 0);
+                    Assert.True(byteCount > 0);
+                    bytes = new byte[byteCount];
+                    reader.GetBytes(2, 0, bytes, 0, bytes.Length);
+                    Assert.Equal("e610000001148716d9cef7d34740d7a3703d0a975ec08716d9cef7d34740cba145b6f3955ec0", ToHexString(bytes));
+
+                    if (behavior == CommandBehavior.Default)
+                    {
+                        byteCount = (int)reader.GetBytes(0, 0, null, 0, 0);
+                        Assert.True(byteCount > 0);
+                        bytes = new byte[byteCount];
+                        reader.GetBytes(0, 0, bytes, 0, bytes.Length);
+                        Assert.Equal("5ade", ToHexString(bytes));
+                    }
+                }
+            }
+        }
+
+        [CheckConnStrSetupFact]
+        public static void TestUdtSqlDataReaderGetStreamSequentialAccess()
+        {
+            TestUdtSqlDataReaderGetStream(CommandBehavior.SequentialAccess);
+        }
+
+        [CheckConnStrSetupFact]
+        public static void TestUdtSqlDataReaderGetStream()
+        {
+            TestUdtSqlDataReaderGetStream(CommandBehavior.Default);
+        }
+
+        private static void TestUdtSqlDataReaderGetStream(CommandBehavior behavior)
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                connection.Open();
+                SqlCommand command = connection.CreateCommand();
+                command.CommandText = "select hierarchyid::Parse('/1/1/3/') as col0, geometry::Parse('LINESTRING (100 100, 20 180, 180 180)') as col1, geography::Parse('LINESTRING(-122.360 47.656, -122.343 47.656)') as col2";
+                using (SqlDataReader reader = command.ExecuteReader(behavior))
+                {
+                    Assert.True(reader.Read());
+
+                    MemoryStream buffer = null;
+                    byte[] bytes = null;
+
+                    buffer = new MemoryStream();
+                    using (Stream stream = reader.GetStream(0))
+                    {
+                        stream.CopyTo(buffer);
+                    }
+                    bytes = buffer.ToArray();
+                    Assert.Equal("5ade", ToHexString(bytes));
+
+                    buffer = new MemoryStream();
+                    using (Stream stream = reader.GetStream(1))
+                    {
+                        stream.CopyTo(buffer);
+                    }
+                    bytes = buffer.ToArray();
+                    Assert.Equal("0000000001040300000000000000000059400000000000005940000000000000344000000000008066400000000000806640000000000080664001000000010000000001000000ffffffff0000000002", ToHexString(bytes));
+
+                    buffer = new MemoryStream();
+                    using (Stream stream = reader.GetStream(2))
+                    {
+                        stream.CopyTo(buffer);
+                    }
+                    bytes = buffer.ToArray();
+                    Assert.Equal("e610000001148716d9cef7d34740d7a3703d0a975ec08716d9cef7d34740cba145b6f3955ec0", ToHexString(bytes));
+
+                    if (behavior == CommandBehavior.Default)
+                    {
+                        buffer = new MemoryStream();
+                        using (Stream stream = reader.GetStream(0))
+                        {
+                            stream.CopyTo(buffer);
+                        }
+                        bytes = buffer.ToArray();
+                        Assert.Equal("5ade", ToHexString(bytes));
+                    }
+                }
+            }
+        }
+
+        [CheckConnStrSetupFact]
+        public static void TestUdtSchemaMetadata()
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                connection.Open();
+                SqlCommand command = connection.CreateCommand();
+                command.CommandText = "select hierarchyid::Parse('/1/1/3/') as col0, geometry::Parse('LINESTRING (100 100, 20 180, 180 180)') as col1, geography::Parse('LINESTRING(-122.360 47.656, -122.343 47.656)') as col2";
+                using (SqlDataReader reader = command.ExecuteReader(CommandBehavior.SchemaOnly))
+                {
+                    ReadOnlyCollection<DbColumn> columns = reader.GetColumnSchema();
+
+                    DbColumn column = null;
+
+                    // Validate Microsoft.SqlServer.Types.SqlHierarchyId, Microsoft.SqlServer.Types, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91
+                    column = columns[0];
+                    Assert.Equal(column.ColumnName, "col0");
+                    Assert.NotNull(column.UdtAssemblyQualifiedName);
+                    AssertSqlUdtAssemblyQualifiedName(column.UdtAssemblyQualifiedName, "Microsoft.SqlServer.Types.SqlHierarchyId");
+
+                    // Validate Microsoft.SqlServer.Types.SqlGeometry, Microsoft.SqlServer.Types, Version = 11.0.0.0, Culture = neutral, PublicKeyToken = 89845dcd8080cc91
+                    column = columns[1];
+                    Assert.Equal(column.ColumnName, "col1");
+                    Assert.NotNull(column.UdtAssemblyQualifiedName);
+                    AssertSqlUdtAssemblyQualifiedName(column.UdtAssemblyQualifiedName, "Microsoft.SqlServer.Types.SqlGeometry");
+
+                    // Validate Microsoft.SqlServer.Types.SqlGeography, Microsoft.SqlServer.Types, Version = 11.0.0.0, Culture = neutral, PublicKeyToken = 89845dcd8080cc91
+                    column = columns[2];
+                    Assert.Equal(column.ColumnName, "col2");
+                    Assert.NotNull(column.UdtAssemblyQualifiedName);
+                    AssertSqlUdtAssemblyQualifiedName(column.UdtAssemblyQualifiedName, "Microsoft.SqlServer.Types.SqlGeography");
+                }
+            }
+        }
+
+        private static void AssertSqlUdtAssemblyQualifiedName(string assemblyQualifiedName, string expectedType)
+        {
+            List<string> parts = assemblyQualifiedName.Split(',').Select(x => x.Trim()).ToList();
+
+            string type = parts[0];
+            string assembly = parts.Count < 2 ? string.Empty : parts[1];
+            string version = parts.Count < 3 ? string.Empty : parts[2];
+            string culture = parts.Count < 4 ? string.Empty : parts[3];
+            string token = parts.Count < 5 ? string.Empty : parts[4];
+
+            Assert.Equal(expectedType, type);
+            Assert.Equal("Microsoft.SqlServer.Types", assembly);
+            Assert.True(version.StartsWith("Version"));
+            Assert.True(culture.StartsWith("Culture"));
+            Assert.True(token.StartsWith("PublicKeyToken"));
+        }
+
+        private static string ToHexString(byte[] bytes)
         {
             StringBuilder hex = new StringBuilder(bytes.Length * 2);
             foreach (byte b in bytes)
+            {
                 hex.AppendFormat("{0:x2}", b);
-            Console.WriteLine("Value: {0}", hex.ToString());
-            Console.WriteLine();
+            }
+
+            return hex.ToString();
         }
 
         private static char localByteToChar(int b)

--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDDataTypesTest/DDDataTypesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/DDDataTypesTest/DDDataTypesTest.cs
@@ -534,18 +534,21 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     // Validate Microsoft.SqlServer.Types.SqlHierarchyId, Microsoft.SqlServer.Types, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91
                     column = columns[0];
                     Assert.Equal(column.ColumnName, "col0");
+                    Assert.Equal(typeof(byte[]), column.DataType);
                     Assert.NotNull(column.UdtAssemblyQualifiedName);
                     AssertSqlUdtAssemblyQualifiedName(column.UdtAssemblyQualifiedName, "Microsoft.SqlServer.Types.SqlHierarchyId");
 
                     // Validate Microsoft.SqlServer.Types.SqlGeometry, Microsoft.SqlServer.Types, Version = 11.0.0.0, Culture = neutral, PublicKeyToken = 89845dcd8080cc91
                     column = columns[1];
                     Assert.Equal(column.ColumnName, "col1");
+                    Assert.Equal(typeof(byte[]), column.DataType);
                     Assert.NotNull(column.UdtAssemblyQualifiedName);
                     AssertSqlUdtAssemblyQualifiedName(column.UdtAssemblyQualifiedName, "Microsoft.SqlServer.Types.SqlGeometry");
 
                     // Validate Microsoft.SqlServer.Types.SqlGeography, Microsoft.SqlServer.Types, Version = 11.0.0.0, Culture = neutral, PublicKeyToken = 89845dcd8080cc91
                     column = columns[2];
                     Assert.Equal(column.ColumnName, "col2");
+                    Assert.Equal(typeof(byte[]), column.DataType);
                     Assert.NotNull(column.UdtAssemblyQualifiedName);
                     AssertSqlUdtAssemblyQualifiedName(column.UdtAssemblyQualifiedName, "Microsoft.SqlServer.Types.SqlGeography");
                 }


### PR DESCRIPTION
Adding SqlClient support to handle CLR UDTs as binary

@saurabh500 @YoungGah 

Currently, SqlClient on .NET Core throws an exception when it encounters a CLR UDT in the result set.

This change updates SqlClient to support working with CLR UDTs as binary data. The SqlClient API to work with UDTs as binary already exists in the full .NET Framework. This change just unblocks the API on .NET Core. The SqlClient surface area is not changed. 

The following SqlDataReader methods can be used to retrieve as UDT as binary:
- SqlDataReader.GetSqlBytes() 
- SqlDataReader.GetStream()
- SqlDataReader.GetBytes()

With this change, retrieving a CLR UDT instance is still not supported by SqlClient. The following SqlClient APIs to retrieve a CLR UDT instance have been updated to throw a PlatformNotSupported exception:
- SqlDataReader[] get property indexer 
- SqlDataReader.GetValue()
- SqlDataReader.GetValues() 
- SqlDataReader.GetSqlValue() 
- SqlDataReader.GetSqlValues()
- SqlDataReader.GetFieldValue<T>()
- SqlDataReader.GetFieldValueAsync<T>()
- SqlDataReader.GetProviderSpecificFieldType() 
- SqlDataReader.GetProviderSpecificValue() 
- SqlDataReader.GetProviderSpecificValues() 
- SqlCommand.ExecuteScalar()

For result set metadata obtained by calling SqlDataReader.GetColumnSchema(), we now populate the following properties for CLR UDTs: 
- Populate the DbColumn.UdtAssemblyQualifiedName property 
- Populate the DbColumn.DataType property with a Byte[] type

Using a Byte[] for DbColumn.DataType has interesting forward compat implications. Ideally, we'd return the Type for the underlying UDT. Since that's not possible, I feel returning a Byte[] is the best compromise as it describes how to work with the CLR UDT as binary data. If/when .NET Core ever supports CLR UDTs, we'd have to think about the impact of changing DbColumn.DataType to return the CLR UDT type.