### PR TITLE
Fix clean.sh build break

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -20,8 +20,12 @@ fi
 
 __working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# OSX doesn't support Bash 4, so ${var,,} is not supported.
 clean_arg=$*
-if [[ "${clean_arg,,}" == *"all"* ]]
+clean_arg=${clean_arg//A/a}
+clean_arg=${clean_arg//L/l}
+clean_arg=${clean_arg//-/}
+if [[ "${clean_arg}" == "all" ]]
 then
    echo "Removing all untracked files in the working tree"
    git clean -xdf $__working_tree_root


### PR DESCRIPTION
@weshaggard 
I missed this because I assumed simple string manipulation was everywhere Bash was, but using ${variable_name,,} or ^^ to get toLower()/toUpper() effects is not supported on our mac machines.

Latest change tested on Ubuntu 14.04 and OSX 10.11.