### PR TITLE
Add reference to System.Resources.ResourceManager

### DIFF
--- a/src/System.Security.Cryptography.Encoding/tests/project.json
+++ b/src/System.Security.Cryptography.Encoding/tests/project.json
@@ -4,6 +4,7 @@
     "System.Linq": "4.0.0",
     "System.Linq.Expressions": "4.1.0",
     "System.ObjectModel": "4.0.12",
+    "System.Resources.ResourceManager": "4.0.1",
     "System.Runtime": "4.1.0",
     "System.Runtime.Numerics": "4.0.1",
     "System.Security.Cryptography.Primitives": "4.0.0",


### PR DESCRIPTION
This fix was not ported to release/1.0.0 where we are building tests against packages.  

Fixes this test build break - 
```
E:\gh\chcosta\corefx\Tools\AssemblyInfoPartial.cs(3,18): error CS0234: The type or namespace name 'Resources' does not exist in the namespace 'System' (are you missing an assembly reference?) [E:\gh\ch
costa\corefx\src\System.Security.Cryptography.Encoding\tests\System.Security.Cryptography.Encoding.Tests.csproj]
E:\gh\chcosta\corefx\src\Common\src\System\SR.cs(5,14): error CS0234: The type or namespace name 'Resources' does not exist in the namespace 'System' (are you missing an assembly reference?) [E:\gh\chc
osta\corefx\src\System.Security.Cryptography.Encoding\tests\System.Security.Cryptography.Encoding.Tests.csproj]
E:\gh\chcosta\corefx\src\Common\src\System\SR.cs(14,24): error CS0246: The type or namespace name 'ResourceManager' could not be found (are you missing a using directive or an assembly reference?) [E:\
gh\chcosta\corefx\src\System.Security.Cryptography.Encoding\tests\System.Security.Cryptography.Encoding.Tests.csproj]
E:\gh\chcosta\corefx\src\Common\src\System\SR.cs(12,24): error CS0246: The type or namespace name 'ResourceManager' could not be found (are you missing a using directive or an assembly reference?) [E:\
gh\chcosta\corefx\src\System.Security.Cryptography.Encoding\tests\System.Security.Cryptography.Encoding.Tests.csproj]
```
This was fixed relatively soon after in the main dev branch with https://github.com/dotnet/corefx/commit/77b5065fa52d817482e15b4efc3e13b5af72ae63

We need this fix in release/1.0.0 to get clean test builds.

@weshaggard @ericstj
/cc @gkhanna79 @Chrisboh @markwilkie 

