### PR TITLE
Update S.S.C.Primitives test project for ns1.7

### DIFF
--- a/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.builds
+++ b/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.builds
@@ -4,9 +4,9 @@
   <ItemGroup>
     <Project Include="System.Security.Cryptography.Primitives.Tests.csproj"/>
     <Project Include="System.Security.Cryptography.Primitives.Tests.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcoreapp1.1</TestTFMs>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
+++ b/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
@@ -9,8 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Primitives.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Primitives.Tests</RootNamespace>
-    <NugetTargetMoniker Condition="'$(TargetGroup)'=='netstandard1.7' AND '$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)'==''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Security.Cryptography.Primitives.pkgproj">


### PR DESCRIPTION
@joperezr please review

I updated Primitives package for ns1.7 during the phase when test projects were converted to use ns1.7 by default, so this fix was missed.
