### PR TITLE
Reenable ECC crypto tests on Unix

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
@@ -34,7 +34,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [ActiveIssue(10206, TestPlatforms.AnyUnix)]
         [Theory, MemberData(nameof(TestNewCurves))]
         public void TestRegenKeyExplicit(CurveDef curveDef)
         {
@@ -135,7 +134,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [ActiveIssue(10206, TestPlatforms.AnyUnix)]
         [Theory, MemberData(nameof(TestCurves))]
         public void TestRegenKeyNamed(CurveDef curveDef)
         {
@@ -159,7 +157,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [ActiveIssue(10206, TestPlatforms.AnyUnix)]
         [ConditionalFact(nameof(ECExplicitCurvesSupported))]
         public void TestRegenKeyNistP256()
         {


### PR DESCRIPTION
Per issue #10206  

Unable to repro locally on Ubuntu. I believe this was caused by the tests pulling an old version of S.S.C.OpenSsl.dll perhaps caused by using a .csproj reference instead of a pkgref.

Will evaluate test runs on CI.