### PR TITLE
Remove the CreateManyConcurrent test

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -545,37 +545,6 @@ namespace System.IO.Tests
         [Fact]
         [PlatformSpecific(PlatformID.Linux)]
         [OuterLoop]
-        public void FileSystemWatcher_CreateManyConcurrentInstances()
-        {
-            int maxUserInstances = int.Parse(File.ReadAllText("/proc/sys/fs/inotify/max_user_instances"));
-            var watchers = new List<FileSystemWatcher>();
-
-            using (var dir = new TempDirectory(GetTestFilePath()))
-            {
-                try
-                {
-                    Assert.Throws<IOException>(() =>
-                    {
-                        // Create enough inotify instances to exceed the number of allowed watches
-                        for (int i = 0; i <= maxUserInstances; i++)
-                        {
-                            watchers.Add(new FileSystemWatcher(dir.Path) { EnableRaisingEvents = true });
-                        }
-                    });
-                }
-                finally
-                {
-                    foreach (FileSystemWatcher watcher in watchers)
-                    {
-                        watcher.Dispose();
-                    }
-                }
-            }
-        }
-
-        [Fact]
-        [PlatformSpecific(PlatformID.Linux)]
-        [OuterLoop]
         public void FileSystemWatcher_CreateManyConcurrentWatches()
         {
             int maxUserWatches = int.Parse(File.ReadAllText("/proc/sys/fs/inotify/max_user_watches"));


### PR DESCRIPTION
The test is causing intermittent failures in other tests and is also intermittently failing itself. Without modifying system resources we can't make this test trustworthy, so it's better to remove it for the sake of stability.

ported https://github.com/dotnet/corefx/pull/11721/
resolves https://github.com/dotnet/corefx/issues/11622 for release/1.1.0

@stephentoub @karelz 