### PR TITLE
S.S.C.Algorithms and .Encoding ns2.0 misc additions

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -151,6 +151,14 @@ namespace System.Security.Cryptography
             public static System.Security.Cryptography.ECCurve nistP521 { get { return default(System.Security.Cryptography.ECCurve); } }
         }
     }
+    public abstract partial class ECDiffieHellmanPublicKey : System.IDisposable
+    {
+        protected ECDiffieHellmanPublicKey(byte[] keyBlob) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public virtual byte[] ToByteArray() { return default(byte[]); }
+        public virtual string ToXmlString() { return default(string); }
+    }
     public abstract partial class ECDsa : System.Security.Cryptography.AsymmetricAlgorithm
     {
         protected ECDsa() { }
@@ -201,6 +209,8 @@ namespace System.Security.Cryptography
     {
         public HMACSHA1() { }
         public HMACSHA1(byte[] key) { }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        public HMACSHA1(byte[] key, bool useManagedSha1) { }
         public override int HashSize { get { return default(int); } }
         public override byte[] Key { get { return default(byte[]); } set { } }
         protected override void Dispose(bool disposing) { }

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -38,6 +38,7 @@
     <Compile Include="System\Security\Cryptography\ECCurve.cs" />
     <Compile Include="System\Security\Cryptography\ECCurve.ECCurveType.cs" />
     <Compile Include="System\Security\Cryptography\ECCurve.NamedCurves.cs" />
+    <Compile Include="System\Security\Cryptography\ECDiffieHellmanPublicKey.cs" />
     <Compile Include="System\Security\Cryptography\ECDsa.cs" />
     <Compile Include="System\Security\Cryptography\ECParameters.cs" />
     <Compile Include="System\Security\Cryptography\ECPoint.cs" />

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanPublicKey.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanPublicKey.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography
+{
+    /// <summary>
+    ///     Wrapper for public key material passed between parties during Diffie-Hellman key material generation
+    /// </summary>
+    [Serializable]
+    public abstract class ECDiffieHellmanPublicKey : IDisposable
+    {
+        private byte[] _keyBlob;
+
+        protected ECDiffieHellmanPublicKey(byte[] keyBlob)
+        {
+            if (keyBlob == null)
+            {
+                throw new ArgumentNullException(nameof(keyBlob));
+            }
+
+            _keyBlob = keyBlob.Clone() as byte[];
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            return;
+        }
+
+        public virtual byte[] ToByteArray()
+        {
+            return _keyBlob.Clone() as byte[];
+        }
+
+        // This method must be implemented by derived classes. In order to conform to the contract, it cannot be abstract.
+        public virtual string ToXmlString()
+        {
+            throw new NotImplementedException(SR.NotSupported_SubclassOverride);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanPublicKey.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanPublicKey.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography
     [Serializable]
     public abstract class ECDiffieHellmanPublicKey : IDisposable
     {
-        private byte[] _keyBlob;
+        private readonly byte[] _keyBlob;
 
         protected ECDiffieHellmanPublicKey(byte[] keyBlob)
         {
@@ -27,10 +27,7 @@ namespace System.Security.Cryptography
             Dispose(true);
         }
 
-        protected virtual void Dispose(bool disposing)
-        {
-            return;
-        }
+        protected virtual void Dispose(bool disposing) { }
 
         public virtual byte[] ToByteArray()
         {

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Security.Cryptography;
-
 using Internal.Cryptography;
+using System.ComponentModel;
 
 namespace System.Security.Cryptography
 {
@@ -27,6 +24,12 @@ namespace System.Security.Cryptography
             this.HashName = HashAlgorithmNames.SHA1;
             _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA1, key, BlockSize);
             base.Key = _hMacCommon.ActualKey; 
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public HMACSHA1(byte[] key, bool useManagedSha1) : this (key)
+        {
+            // useManagedSha1 is ignored
         }
 
         public override int HashSize

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public HMACSHA1(byte[] key, bool useManagedSha1) : this (key)
+        public HMACSHA1(byte[] key, bool useManagedSha1) : this(key)
         {
             // useManagedSha1 is ignored
         }

--- a/src/System.Security.Cryptography.Algorithms/tests/ECDiffieHellmanPublicKeyTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/ECDiffieHellmanPublicKeyTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Test.Cryptography;
 using Xunit;
 
 namespace System.Security.Cryptography.ECDiffieHellman.Tests

--- a/src/System.Security.Cryptography.Algorithms/tests/ECDiffieHellmanPublicKeyTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/ECDiffieHellmanPublicKeyTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.ECDiffieHellman.Tests
+{
+    public class ECDiffieHellmanPublicKeyTests
+    {
+        private class TestDerived : ECDiffieHellmanPublicKey
+        {
+            public TestDerived(byte[] keyBlob) : base(keyBlob) { }
+        }
+
+        [Fact]
+        public void TestInvalidConstructorArgs()
+        {
+            Assert.Throws<ArgumentNullException>("keyBlob", () => new TestDerived(null));
+        }
+
+        [Fact]
+        public void TestToByteArray()
+        {
+            byte[] arg = new byte[1] { 1 };
+            var pk = new TestDerived(arg);
+
+            Assert.Equal(1, pk.ToByteArray()[0]);
+        }
+
+        [Fact]
+        public void TestToXmlString()
+        {
+            byte[] arg = new byte[1] { 1 };
+            var pk = new TestDerived(arg);
+
+            Assert.Throws<NotImplementedException>(() => pk.ToXmlString());
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
@@ -41,17 +41,25 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         [Fact]
         public void HmacSha1_Byte_Constructors()
         {
-            byte[] arg = new byte[]{ 1 };
+            byte[] key = (byte[])s_testKeys2202[1].Clone();
+            string digest = "b617318655057264e28bc0b6fb378c8ef146be00";
 
-            HMACSHA1 h1 = new HMACSHA1(arg);
-            Assert.Equal(1, h1.Key[0]);
-
+            using (HMACSHA1 h1 = new HMACSHA1(key))
+            {
+                VerifyHmac_KeyAlreadySet(h1, 1, digest);
 #if netstandard17
-            HMACSHA1 h2 = new HMACSHA1(arg, true);
-            Assert.Equal(1, h2.Key[0]);
-
-            Assert.Equal(h1.Key, h2.Key);
+                using (HMACSHA1 h2 = new HMACSHA1(key, true))
+                {
+                    VerifyHmac_KeyAlreadySet(h2, 1, digest);
+                    Assert.Equal(h1.Key, h2.Key);
+                }
+                using (HMACSHA1 h2 = new HMACSHA1(key, false))
+                {
+                    VerifyHmac_KeyAlreadySet(h1, 1, digest);
+                    Assert.Equal(h1.Key, h2.Key);
+                }
 #endif
+            }
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
@@ -39,6 +39,22 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         protected override int BlockSize { get { return 64; } }
 
         [Fact]
+        public void HmacSha1_Byte_Constructors()
+        {
+            byte[] arg = new byte[]{ 1 };
+
+            HMACSHA1 h1 = new HMACSHA1(arg);
+            Assert.Equal(1, h1.Key[0]);
+
+#if netstandard17
+            HMACSHA1 h2 = new HMACSHA1(arg, true);
+            Assert.Equal(1, h2.Key[0]);
+
+            Assert.Equal(h1.Key, h2.Key);
+#endif
+        }
+
+        [Fact]
         public void HmacSha1_Rfc2202_1()
         {
             VerifyHmac(1, "b617318655057264e28bc0b6fb378c8ef146be00");

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacTests.cs
@@ -64,6 +64,18 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             Assert.Equal(digestBytes, computedDigest);
         }
 
+        protected void VerifyHmac_KeyAlreadySet(
+            HMAC hmac,
+            int testCaseId,
+            string digest)
+        {
+            byte[] digestBytes = ByteUtils.HexToByteArray(digest);
+            byte[] computedDigest;
+
+            computedDigest = hmac.ComputeHash(_testData[testCaseId]);
+            Assert.Equal(digestBytes, computedDigest);
+        }
+
         protected void VerifyHmacRfc2104_2()
         {
             // Ensure that keys shorter than the threshold don't get altered.

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -135,6 +135,7 @@
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="AsymmetricSignatureFormatterTests.cs" />
     <Compile Include="DSASignatureFormatterTests.cs" />
+    <Compile Include="ECDiffieHellmanPublicKeyTests.cs" />
     <Compile Include="RSAKeyExchangeFormatterTests.cs" />
     <Compile Include="RSASignatureFormatterTests.cs" />
     <Compile Include="DefaultDSAProvider.cs" />

--- a/src/System.Security.Cryptography.Encoding/ref/System.Security.Cryptography.Encoding.cs
+++ b/src/System.Security.Cryptography.Encoding/ref/System.Security.Cryptography.Encoding.cs
@@ -25,9 +25,9 @@ namespace System.Security.Cryptography
         public AsnEncodedDataCollection() { }
         public AsnEncodedDataCollection(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
         public int Count { get { return default(int); } }
+        public bool IsSynchronized { get { return default(bool); } }
         public System.Security.Cryptography.AsnEncodedData this[int index] { get { return default(System.Security.Cryptography.AsnEncodedData); } }
-        bool System.Collections.ICollection.IsSynchronized { get { return default(bool); } }
-        object System.Collections.ICollection.SyncRoot { get { return default(object); } }
+        public object SyncRoot { get { return default(object); } }
         public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { return default(int); }
         public void CopyTo(System.Security.Cryptography.AsnEncodedData[] array, int index) { }
         public System.Security.Cryptography.AsnEncodedDataEnumerator GetEnumerator() { return default(System.Security.Cryptography.AsnEncodedDataEnumerator); }
@@ -65,6 +65,7 @@ namespace System.Security.Cryptography
     }
     public sealed partial class Oid
     {
+        public Oid() { }
         public Oid(System.Security.Cryptography.Oid oid) { }
         public Oid(string oid) { }
         public Oid(string value, string friendlyName) { }
@@ -77,10 +78,10 @@ namespace System.Security.Cryptography
     {
         public OidCollection() { }
         public int Count { get { return default(int); } }
+        public bool IsSynchronized { get { return default(bool); } }
         public System.Security.Cryptography.Oid this[int index] { get { return default(System.Security.Cryptography.Oid); } }
         public System.Security.Cryptography.Oid this[string oid] { get { return default(System.Security.Cryptography.Oid); } }
-        bool System.Collections.ICollection.IsSynchronized { get { return default(bool); } }
-        object System.Collections.ICollection.SyncRoot { get { return default(object); } }
+        public object SyncRoot { get { return default(object); } }
         public int Add(System.Security.Cryptography.Oid oid) { return default(int); }
         public void CopyTo(System.Security.Cryptography.Oid[] array, int index) { }
         public System.Security.Cryptography.OidEnumerator GetEnumerator() { return default(System.Security.Cryptography.OidEnumerator); }

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedDataCollection.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedDataCollection.cs
@@ -96,7 +96,7 @@ namespace System.Security.Cryptography
              _list.CopyTo(array, index);
         }
 
-        bool ICollection.IsSynchronized
+        public bool IsSynchronized
         {
             get
             {
@@ -104,7 +104,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        object ICollection.SyncRoot
+        public object SyncRoot
         {
             get
             {

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Oid.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Oid.cs
@@ -11,6 +11,8 @@ namespace System.Security.Cryptography
 {
     public sealed class Oid
     {
+        public Oid() { }
+
         public Oid(String oid)
         {
             // If we were passed the friendly name, retrieve the value String.

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/OidCollection.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/OidCollection.cs
@@ -81,9 +81,9 @@ namespace System.Security.Cryptography
             _list.CopyTo(array, index);
         }
 
-        bool ICollection.IsSynchronized => false;
+        public bool IsSynchronized => false;
 
-        object ICollection.SyncRoot => this;
+        public object SyncRoot => this;
 
         private readonly List<Oid> _list;
     }

--- a/src/System.Security.Cryptography.Encoding/tests/Oid.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Oid.cs
@@ -15,6 +15,12 @@ namespace System.Security.Cryptography.Encoding.Tests
             Oid oid = new Oid("");
             Assert.Equal("", oid.Value);
             Assert.Null(oid.FriendlyName);
+
+#if netstandard17
+            oid = new Oid();
+            Assert.Null(oid.Value);
+            Assert.Null(oid.FriendlyName);
+#endif            
         }
 
         [Theory]

--- a/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>System.Security.Cryptography.Encoding.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Encoding.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netstandard17</DefineConstants>
     <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
A collection of trivial changes for ns2.0 contract work.

@morganbr please review (@bartonjs OOF)

S.S.C.Algorithms:
#11121 M:System.Security.Cryptography.HMACSHA1.#ctor(System.Byte[],System.Boolean)
#12363 Port System.Security.Cryptography.ECDiffieHellmanPublicKey

S.S.C.Encoding:
#12365 Port System.Security.Cryptography.Oid#ctor
#12325 Make ICollection members non-explicit on AsnEncodedDataCollection and OidCollection