### PR TITLE
Fix bug when calling clean.cmd with no args.  

### DIFF
--- a/clean.cmd
+++ b/clean.cmd
@@ -8,12 +8,13 @@ for /f "tokens=2 delims=," %%F in ('tasklist /nh /fi "imagename eq VBCSCompiler.
 :: compare to match as many versions of "all" that we can
 :: All other argument validation happens inside Run.exe
 set NO_DASHES_ARG=%1
+if not defined NO_DASHES_ARG goto no_args
 if /I [%NO_DASHES_ARG:-=%] == [all] (
   echo Cleaning entire working directory ...
   call git clean -xdf
   exit /b !ERRORLEVEL!
 )
-
+:no_args
 if [%1]==[] set __args=-b
 call %~dp0run.cmd clean %__args% %*
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
Mea culpa.  Tested with -all, --all, -AlL, -ALL, no args, -b, -c, and -s to do the right thing now.
@weshaggard 