### PR TITLE
Add tests for UnmanagedMemoryAccessor struct methods

### DIFF
--- a/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
+++ b/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -15,13 +15,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NugetTargetMoniker Condition=" '$(TargetGroup)' == '' ">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup>
-  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
+    <Compile Include="Uma.ReadWriteStruct.cs" Condition="'$(TargetGroup)' == ''" />
+    <Compile Include="Uma.ReadWriteStructArray.cs" Condition="'$(TargetGroup)' == ''" />
     <Compile Include="ArrayHelpers.cs" />
     <Compile Include="UmaTests.cs" />
     <Compile Include="UmsCtorTests.cs" />

--- a/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
+++ b/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
@@ -17,9 +17,12 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup Condition="'$(TargetGroup)' == ''" >
+    <Compile Include="Uma.TestStructs.cs" />
+    <Compile Include="Uma.ReadWriteStruct.cs" />
+    <Compile Include="Uma.ReadWriteStructArray.cs"/>
+  </ItemGroup>
   <ItemGroup>
-    <Compile Include="Uma.ReadWriteStruct.cs" Condition="'$(TargetGroup)' == ''" />
-    <Compile Include="Uma.ReadWriteStructArray.cs" Condition="'$(TargetGroup)' == ''" />
     <Compile Include="ArrayHelpers.cs" />
     <Compile Include="UmaTests.cs" />
     <Compile Include="UmsCtorTests.cs" />

--- a/src/System.IO.UnmanagedMemoryStream/tests/Uma.ReadWriteStruct.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/Uma.ReadWriteStruct.cs
@@ -1,0 +1,138 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class Uma_ReadWriteStruct
+    {
+        private const int UmaTestStruct_DisalignedSize = 2 * sizeof(int) + 2 * sizeof(bool) + sizeof(char);
+        private const int UmaTestStruct_AlignedSize = 16; // potentially architecture dependent.
+        private struct UmaTestStruct
+        {
+            public int int1;
+            public bool bool1;
+            public int int2;
+            public char char1;
+            public bool bool2;
+        }
+
+        private struct UmaTestStruct_ContainsReferenceType
+        {
+            public object referenceType;
+        }
+
+        [Fact]
+        public static void UmaReadWriteStruct_NegativePosition()
+        {
+            const int capacity = 100;
+            UmaTestStruct inStruct = new UmaTestStruct();
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => uma.Write<UmaTestStruct>(-1, ref inStruct));
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => uma.Read<UmaTestStruct>(-1, out inStruct));
+            }
+        }
+
+        [Fact]
+        public static void UmaReadWriteStruct_Closed()
+        {
+            const int capacity = 100;
+            UmaTestStruct inStruct = new UmaTestStruct();
+            using (var buffer = new TestSafeBuffer(capacity))
+            {
+                UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite);
+                uma.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => uma.Write<UmaTestStruct>(0, ref inStruct));
+                Assert.Throws<ObjectDisposedException>(() => uma.Read<UmaTestStruct>(0, out inStruct));
+            }
+        }
+
+        [Fact]
+        public static void UmaReadStruct_WriteMode()
+        {
+            const int capacity = 100;
+            UmaTestStruct inStruct = new UmaTestStruct();
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.Write))
+            {
+                Assert.Throws<NotSupportedException>(() => uma.Read<UmaTestStruct>(0, out inStruct));
+            }
+        }
+
+        [Fact]
+        public static void UmaWriteStruct_ReadMode()
+        {
+            const int capacity = 100;
+            UmaTestStruct inStruct = new UmaTestStruct();
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.Read))
+            {
+                Assert.Throws<NotSupportedException>(() => uma.Write<UmaTestStruct>(0, ref inStruct));
+            }
+        }
+
+        [Fact]
+        public static void UmaReadWriteStruct_PositionGreaterThanCapacity()
+        {
+            const int capacity = 100;
+            UmaTestStruct inStruct = new UmaTestStruct();
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => uma.Write<UmaTestStruct>(capacity, ref inStruct));
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => uma.Read<UmaTestStruct>(capacity, out inStruct));
+            }
+        }
+
+        [Fact]
+        public static void UmaReadWriteStruct_InsufficientSpace()
+        {
+            const int capacity = 100;
+            UmaTestStruct inStruct = new UmaTestStruct();
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                Assert.Throws<ArgumentException>(() => uma.Write<UmaTestStruct>(capacity - UmaTestStruct_DisalignedSize + 1, ref inStruct));
+                Assert.Throws<ArgumentException>(() => uma.Write<UmaTestStruct>(capacity - UmaTestStruct_AlignedSize + 1, ref inStruct));
+                Assert.Throws<ArgumentException>(() => uma.Read<UmaTestStruct>(capacity - UmaTestStruct_DisalignedSize + 1, out inStruct));
+                Assert.Throws<ArgumentException>(() => uma.Read<UmaTestStruct>(capacity - UmaTestStruct_AlignedSize + 1, out inStruct));
+            }
+        }
+
+        [Fact]
+        public static void UmaReadStructWithReferenceType_ThrowsArgumentException()
+        {
+            const int capacity = 100;
+            UmaTestStruct_ContainsReferenceType inStruct = new UmaTestStruct_ContainsReferenceType { referenceType = new object() };
+            using (var buffer = new TestSafeBuffer(capacity))
+            using (var uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                Assert.Throws<ArgumentException>("type", () => uma.Write<UmaTestStruct_ContainsReferenceType>(0, ref inStruct));
+                Assert.Throws<ArgumentException>("type", () => uma.Read<UmaTestStruct_ContainsReferenceType>(0, out inStruct));
+            }
+        }
+
+        [Fact]
+        public static void UmaReadWriteStruct_Valid()
+        {
+            const int capacity = 100;
+            UmaTestStruct inStruct = new UmaTestStruct(){ int1 = 1, int2 = 2, bool1 = false, char1 = 'p', bool2 = true};
+            UmaTestStruct outStruct;
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                uma.Write<UmaTestStruct>(capacity - UmaTestStruct_AlignedSize, ref inStruct);
+                uma.Read<UmaTestStruct>(capacity - UmaTestStruct_AlignedSize, out outStruct);
+                Assert.Equal(inStruct.int1, outStruct.int1);
+                Assert.Equal(inStruct.int2, outStruct.int2);
+                Assert.Equal(inStruct.bool1, outStruct.bool1);
+                Assert.Equal(inStruct.char1, outStruct.char1);
+                Assert.Equal(inStruct.bool2, outStruct.bool2);
+            }
+        }
+    }
+}

--- a/src/System.IO.UnmanagedMemoryStream/tests/Uma.ReadWriteStructArray.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/Uma.ReadWriteStructArray.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class Uma_ReadWriteStructArray
+    {
+        private const int UmaTestStruct_DisalignedSize = 2 * sizeof(int) + 2 * sizeof(bool) + sizeof(char);
+        private const int UmaTestStruct_AlignedSize = 16; // potentially architecture dependent.
+        private struct UmaTestStruct
+        {
+            public int int1;
+            public bool bool1;
+            public int int2;
+            public char char1;
+            public bool bool2;
+        }
+
+        private struct UmaTestStruct_ContainsReferenceType
+        {
+            public object referenceType;
+        }
+
+        [Fact]
+        public static void UmaReadWriteStructArray_InvalidParameters()
+        {
+            const int capacity = 100;
+            UmaTestStruct[] structArr = new UmaTestStruct[1];
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                Assert.Throws<ArgumentNullException>("array", () => uma.WriteArray<UmaTestStruct>(0, null, 0, 1));
+                Assert.Throws<ArgumentNullException>("array", () => uma.ReadArray<UmaTestStruct>(0, null, 0, 1));
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => uma.WriteArray<UmaTestStruct>(0, structArr, -1, 1));
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => uma.ReadArray<UmaTestStruct>(0, structArr, -1, 1));
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => uma.WriteArray<UmaTestStruct>(0, structArr, 0, -1));
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => uma.ReadArray<UmaTestStruct>(0, structArr, 0, -1));
+                Assert.Throws<ArgumentException>(() => uma.WriteArray<UmaTestStruct>(0, structArr, 2, 0));
+                Assert.Throws<ArgumentException>(() => uma.ReadArray<UmaTestStruct>(0, structArr, 2, 0));
+                Assert.Throws<ArgumentException>(() => uma.WriteArray<UmaTestStruct>(0, structArr, 0, 2));
+                Assert.Throws<ArgumentException>(() => uma.ReadArray<UmaTestStruct>(0, structArr, 0, 2));
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => uma.WriteArray<UmaTestStruct>(-1, structArr, 0, 1));
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => uma.ReadArray<UmaTestStruct>(-1, structArr, 0, 1));
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => uma.WriteArray<UmaTestStruct>(capacity, structArr, 0, 1));
+                Assert.Throws<ArgumentOutOfRangeException>("position", () => uma.ReadArray<UmaTestStruct>(capacity, structArr, 0, 1));
+            }
+        }
+        
+        [Fact]
+        public static void UmaReadWriteStructArray_Closed()
+        {
+            const int capacity = 100;
+            UmaTestStruct[] structArr = new UmaTestStruct[1];
+            using (var buffer = new TestSafeBuffer(capacity))
+            {
+                UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite);
+                uma.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => uma.WriteArray<UmaTestStruct>(0, structArr, 0, 1));
+                Assert.Throws<ObjectDisposedException>(() => uma.ReadArray<UmaTestStruct>(0, structArr, 0, 1));
+            }
+        }
+
+        [Fact]
+        public static void UmaReadStructArray_WriteMode()
+        {
+            const int capacity = 100;
+            UmaTestStruct[] structArr = new UmaTestStruct[1];
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.Write))
+            {
+                Assert.Throws<NotSupportedException>(() => uma.ReadArray<UmaTestStruct>(0, structArr, 0, 1));
+            }
+        }
+
+        [Fact]
+        public static void UmaWriteStructArray_ReadMode()
+        {
+            const int capacity = 100;
+            UmaTestStruct[] structArr = new UmaTestStruct[1];
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.Read))
+            {
+                Assert.Throws<NotSupportedException>(() => uma.WriteArray<UmaTestStruct>(0, structArr, 0, 1));
+            }
+        }
+
+        [Fact]
+        public static void UmaReadWriteStructArray_InsufficientSpace()
+        {
+            const int capacity = 100;
+            UmaTestStruct[] structArr = new UmaTestStruct[1];
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                Assert.Throws<ArgumentException>(() => uma.WriteArray<UmaTestStruct>(capacity - UmaTestStruct_DisalignedSize + 1, structArr, 0, 1));
+                Assert.Throws<ArgumentException>(() => uma.WriteArray<UmaTestStruct>(capacity - UmaTestStruct_AlignedSize + 1, structArr, 0, 1));
+                Assert.Equal(0, uma.ReadArray<UmaTestStruct>(capacity - UmaTestStruct_DisalignedSize + 1, structArr, 0, 1));
+                Assert.Equal(0, uma.ReadArray<UmaTestStruct>(capacity - UmaTestStruct_AlignedSize + 1, structArr, 0, 1));
+            }
+        }
+
+        [Fact]
+        public static void UmaReadStructArrayWithReferenceType_ThrowsArgumentException()
+        {
+            const int capacity = 100;
+            UmaTestStruct_ContainsReferenceType[] structArr = new UmaTestStruct_ContainsReferenceType[1] { new UmaTestStruct_ContainsReferenceType() { referenceType = new object() } };
+            using (var buffer = new TestSafeBuffer(capacity))
+            using (var uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                Assert.Throws<ArgumentException>("type", () => uma.WriteArray<UmaTestStruct_ContainsReferenceType>(0, structArr, 0, 1));
+                Assert.Throws<ArgumentException>("type", () => uma.ReadArray<UmaTestStruct_ContainsReferenceType>(0, structArr, 0, 1));
+            }
+        }
+
+        [Fact]
+        public static void UmaReadWriteStructArray_OneItem()
+        {
+            const int capacity = 100;
+            UmaTestStruct[] inStructArr = new UmaTestStruct[1] { new UmaTestStruct() { int1 = 1, int2 = 2, bool1 = false, char1 = 'p', bool2 = true } };
+            UmaTestStruct[] outStructArr = new UmaTestStruct[1];
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                uma.WriteArray<UmaTestStruct>(capacity - UmaTestStruct_AlignedSize, inStructArr, 0, 1);
+                Assert.Equal(1, uma.ReadArray<UmaTestStruct>(capacity - UmaTestStruct_AlignedSize, outStructArr, 0, 1));
+                Assert.Equal(inStructArr[0].int1, outStructArr[0].int1);
+                Assert.Equal(inStructArr[0].int2, outStructArr[0].int2);
+                Assert.Equal(inStructArr[0].bool1, outStructArr[0].bool1);
+                Assert.Equal(inStructArr[0].char1, outStructArr[0].char1);
+                Assert.Equal(inStructArr[0].bool2, outStructArr[0].bool2);
+            }
+        }
+
+        [Fact]
+        public static void UmaReadWriteStructArray_Multiples()
+        {
+            const int numberOfStructs = 12;
+            const int capacity = numberOfStructs * UmaTestStruct_AlignedSize;
+            UmaTestStruct[] inStructArr = new UmaTestStruct[numberOfStructs];
+            UmaTestStruct[] outStructArr = new UmaTestStruct[numberOfStructs];
+            for (int i = 0; i < numberOfStructs; i++)
+            {
+                inStructArr[i] = new UmaTestStruct() { bool1 = false, bool2 = true, int1 = i, int2 = i + 1, char1 = (char)i };
+            }
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                uma.WriteArray<UmaTestStruct>(0, inStructArr, 0, numberOfStructs);
+                Assert.Equal(numberOfStructs, uma.ReadArray<UmaTestStruct>(0, outStructArr, 0, numberOfStructs));
+                for (int i = 0; i < numberOfStructs; i++)
+                {
+                    Assert.Equal(i, outStructArr[i].int1);
+                    Assert.Equal(i+1, outStructArr[i].int2);
+                    Assert.Equal(false, outStructArr[i].bool1);
+                    Assert.Equal((char)i, outStructArr[i].char1);
+                    Assert.Equal(true, outStructArr[i].bool2);
+                }
+            }
+        }
+
+        [Fact]
+        public static void UmaReadWriteStructArray_TryToReadMoreThanAvailable()
+        {
+            const int capacity = 100;
+            UmaTestStruct[] inStructArr = new UmaTestStruct[1] { new UmaTestStruct() { int1 = 1, int2 = 2, bool1 = false, char1 = 'p', bool2 = true } };
+            UmaTestStruct[] outStructArr = new UmaTestStruct[5000];
+            using (TestSafeBuffer buffer = new TestSafeBuffer(capacity))
+            using (UnmanagedMemoryAccessor uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
+            {
+                uma.WriteArray<UmaTestStruct>(0, inStructArr, 0, 1);
+                int readCount = uma.ReadArray<UmaTestStruct>(0, outStructArr, 0, 5000);
+                Assert.Equal(capacity / UmaTestStruct_AlignedSize, readCount);
+            }
+        }
+    }
+}

--- a/src/System.IO.UnmanagedMemoryStream/tests/Uma.TestStructs.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/Uma.TestStructs.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Tests
+{
+    public class Uma_TestStructs
+    {
+        public const int UmaTestStruct_UnalignedSize = 2 * sizeof(int) + 2 * sizeof(bool) + sizeof(char);
+        public const int UmaTestStruct_AlignedSize = 16; // potentially architecture dependent.
+        public struct UmaTestStruct
+        {
+            public int int1;
+            public bool bool1;
+            public int int2;
+            public char char1;
+            public bool bool2;
+        }
+
+        public struct UmaTestStruct_ContainsReferenceType
+        {
+            public object referenceType;
+        }
+
+        public struct UmaTestStruct_Generic<T>
+        {
+            public T ofT;
+        }
+    }
+}


### PR DESCRIPTION
Progress towards https://github.com/dotnet/corefx/issues/9465

exposure of the methods was completed by @alexperovich when he moved UnmanagedMemoryStream/Accessor to corelib in https://github.com/dotnet/corefx/pull/12391 & https://github.com/dotnet/coreclr/pull/7418

@stephentoub @joperezr @alexperovich 