### PR TITLE
Use ConsoleKeyInfo.Key in ConsoleKeyInfo.GetHashCode

### DIFF
--- a/src/System.Console/src/System/ConsoleKeyInfo.cs
+++ b/src/System.Console/src/System/ConsoleKeyInfo.cs
@@ -70,7 +70,11 @@ namespace System
 
         public override int GetHashCode()
         {
-            return (int)_keyChar | (int)_mods;
+            // For all normal cases we can fit all bits losslessly into the hash code:
+            // _keyChar could be any 16-bit value (though is most commonly ASCII). Use all 16 bits without conflict.
+            // _key is 32-bit, but the ctor throws for anything over 255. Use those 8 bits without conflict.
+            // _mods only has enum defined values for 1,2,4: 3 bits. Use the remaining 8 bits.
+            return _keyChar | ((int)_key << 16) | ((int)_mods << 24);
         }
     }
 }

--- a/src/System.Console/tests/ConsoleKeyInfoTests.cs
+++ b/src/System.Console/tests/ConsoleKeyInfoTests.cs
@@ -56,6 +56,14 @@ namespace System.Tests
             Assert.True(left != right);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // .NET Framework's hashing algorithm doesn't factor in CKI.Key
+        [Theory]
+        [MemberData(nameof(NotEqualConsoleKeyInfos))]
+        public void HashCodeNotEquals_DifferentData(ConsoleKeyInfo left, ConsoleKeyInfo right)
+        {
+            Assert.NotEqual(left.GetHashCode(), right.GetHashCode());
+        }
+
         [Fact]
         public void NotEquals_Object()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/12380
cc: @weshaggard, @Priya91, @ianhays, @lzybkr