### PR TITLE
Add missing IO members to System.Runtime

### DIFF
--- a/src/System.IO/src/ApiCompatBaseline.uap101aot.txt
+++ b/src/System.IO/src/ApiCompatBaseline.uap101aot.txt
@@ -1,2 +1,7 @@
 MembersMustExist : Member 'System.IO.FileNotFoundException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.IO.IOException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileLoadException.FusionLog.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileNotFoundException.FusionLog.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.CreateWaitHandle()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.ObjectInvariant()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.Synchronized(System.IO.Stream)' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -4318,6 +4318,7 @@ namespace System.IO
         public FileLoadException(string message, string fileName, System.Exception inner) { }
         protected FileLoadException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public string FileName { get { return default(string); } }
+        public string FusionLog { get { return default(string); } }
         public override string Message { get { return default(string); } }
         public override string ToString() { return default(string); }
     }
@@ -4330,6 +4331,7 @@ namespace System.IO
         public FileNotFoundException(string message, string fileName, System.Exception innerException) { }
         protected FileNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public string FileName { get { return default(string); } }
+        public string FusionLog { get { return default(string); } }
         public override string Message { get { return default(string); } }
         public override string ToString() { return default(string); }
     }
@@ -4374,6 +4376,8 @@ namespace System.IO
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
         public virtual void Close() { }
+        [System.ObsoleteAttribute("CreateWaitHandle will be removed eventually.  Please use \"new ManualResetEvent(false)\" instead.")]
+        protected virtual System.Threading.WaitHandle CreateWaitHandle() { return default(System.Threading.WaitHandle); }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public virtual int EndRead(System.IAsyncResult asyncResult) { return 0; }
@@ -4381,12 +4385,15 @@ namespace System.IO
         public abstract void Flush();
         public System.Threading.Tasks.Task FlushAsync() { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
+        [System.ObsoleteAttribute("Do not call or override this method.")]
+        protected virtual void ObjectInvariant() { }
         public abstract int Read(byte[] buffer, int offset, int count);
         public System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count) { return default(System.Threading.Tasks.Task<int>); }
         public virtual System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task<int>); }
         public virtual int ReadByte() { return default(int); }
         public abstract long Seek(long offset, System.IO.SeekOrigin origin);
         public abstract void SetLength(long value);
+        public static System.IO.Stream Synchronized(System.IO.Stream stream) { return default(System.IO.Stream); ; }
         public abstract void Write(byte[] buffer, int offset, int count);
         public System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }

--- a/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
@@ -481,3 +481,8 @@ CannotSealType : Type 'System.MulticastDelegate' is sealed in the implementation
 MembersMustExist : Member 'System.MulticastDelegate..ctor(System.Object, System.String)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.MulticastDelegate..ctor(System.Type, System.String)' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.MulticastNotSupportedException' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileLoadException.FusionLog.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.FileNotFoundException.FusionLog.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.CreateWaitHandle()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.ObjectInvariant()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.IO.Stream.Synchronized(System.IO.Stream)' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -11,6 +11,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>1718</NoWarn>
     <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -63,6 +64,8 @@
     <Compile Include="System\IO\Exceptions.Utility.cs" />
     <Compile Include="System\IO\FileLoadExceptionTests.cs" />
     <Compile Include="System\IO\FileLoadException.InteropTests.cs" />
+    <Compile Include="System\IO\FileNotFoundException.InteropTests.cs" />
+    <Compile Include="System\IO\FileNotFoundExceptionTests.cs" />
     <Compile Include="System\IO\PathTooLongExceptionTests.cs" />
     <Compile Include="System\IO\PathTooLongException.InteropTests.cs" />
     <Compile Include="System\LazyTests.cs" />

--- a/src/System.Runtime/tests/System/IO/Exceptions.HResults.cs
+++ b/src/System.Runtime/tests/System/IO/Exceptions.HResults.cs
@@ -6,9 +6,14 @@ namespace System.IO.Tests
 {
     public static class HResults
     {
+        // DirectoryNotFoundException
         public const int COR_E_DIRECTORYNOTFOUND = unchecked((int)0x80070003);
         public const int STG_E_PATHNOTFOUND = unchecked((int)0x80030003);
         public const int CTL_E_PATHNOTFOUND = unchecked((int)0x800A004C);
+
+        // FileNotFoundException
+        public const int COR_E_FILENOTFOUND = unchecked((int)0x80070002);
+        public const int CTL_E_FILENOTFOUND = unchecked((int)0x800A0035);
 
         public const int COR_E_EXCEPTION = unchecked((int)0x80131500);
 

--- a/src/System.Runtime/tests/System/IO/FileNotFoundException.InteropTests.cs
+++ b/src/System.Runtime/tests/System/IO/FileNotFoundException.InteropTests.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public static class FileNotFoundExceptionInteropTests
+    {
+        [Theory]
+        [InlineData(HResults.COR_E_FILENOTFOUND)]
+        [InlineData(HResults.CTL_E_FILENOTFOUND)]
+        public static void From_HR(int hr)
+        {
+            FileNotFoundException exception = Marshal.GetExceptionForHR(hr) as FileNotFoundException;
+            Assert.NotNull(exception);
+
+            // Don't validate the message.  Currently .NET Native does not produce HR-specific messages
+            ExceptionUtility.ValidateExceptionProperties(exception, hResult: hr, validateMessage: false);
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/IO/FileNotFoundExceptionTests.cs
+++ b/src/System.Runtime/tests/System/IO/FileNotFoundExceptionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,13 +6,13 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    public static class FileLoadExceptionTests
+    public static class FileNotFoundExceptionTests
     {
         [Fact]
         public static void Ctor_Empty()
         {
-            var exception = new FileLoadException();
-            ExceptionUtility.ValidateExceptionProperties(exception, hResult: HResults.COR_E_FILELOAD, validateMessage: false);
+            var exception = new FileNotFoundException();
+            ExceptionUtility.ValidateExceptionProperties(exception, hResult: HResults.COR_E_FILENOTFOUND, validateMessage: false);
             Assert.Null(exception.FileName);
         }
 
@@ -20,8 +20,8 @@ namespace System.IO.Tests
         public static void Ctor_String()
         {
             string message = "this is not the file you're looking for";
-            var exception = new FileLoadException(message);
-            ExceptionUtility.ValidateExceptionProperties(exception, hResult: HResults.COR_E_FILELOAD, message: message);
+            var exception = new FileNotFoundException(message);
+            ExceptionUtility.ValidateExceptionProperties(exception, hResult: HResults.COR_E_FILENOTFOUND, message: message);
             Assert.Null(exception.FileName);
         }
 
@@ -30,8 +30,8 @@ namespace System.IO.Tests
         {
             string message = "this is not the file you're looking for";
             var innerException = new Exception("Inner exception");
-            var exception = new FileLoadException(message, innerException);
-            ExceptionUtility.ValidateExceptionProperties(exception, hResult: HResults.COR_E_FILELOAD, innerException: innerException, message: message);
+            var exception = new FileNotFoundException(message, innerException);
+            ExceptionUtility.ValidateExceptionProperties(exception, hResult: HResults.COR_E_FILENOTFOUND, innerException: innerException, message: message);
             Assert.Equal(null, exception.FileName);
         }
 
@@ -40,8 +40,8 @@ namespace System.IO.Tests
         {
             string message = "this is not the file you're looking for";
             string fileName = "file.txt";
-            var exception = new FileLoadException(message, fileName);
-            ExceptionUtility.ValidateExceptionProperties(exception, hResult: HResults.COR_E_FILELOAD, message: message);
+            var exception = new FileNotFoundException(message, fileName);
+            ExceptionUtility.ValidateExceptionProperties(exception, hResult: HResults.COR_E_FILENOTFOUND, message: message);
             Assert.Equal(fileName, exception.FileName);
         }
 
@@ -51,8 +51,8 @@ namespace System.IO.Tests
             string message = "this is not the file you're looking for";
             string fileName = "file.txt";
             var innerException = new Exception("Inner exception");
-            var exception = new FileLoadException(message, fileName, innerException);
-            ExceptionUtility.ValidateExceptionProperties(exception, hResult: HResults.COR_E_FILELOAD, innerException: innerException, message: message);
+            var exception = new FileNotFoundException(message, fileName, innerException);
+            ExceptionUtility.ValidateExceptionProperties(exception, hResult: HResults.COR_E_FILENOTFOUND, innerException: innerException, message: message);
             Assert.Equal(fileName, exception.FileName);
         }
 
@@ -62,7 +62,7 @@ namespace System.IO.Tests
             string message = "this is not the file you're looking for";
             string fileName = "file.txt";
             var innerException = new Exception("Inner exception");
-            var exception = new FileLoadException(message, fileName, innerException);
+            var exception = new FileNotFoundException(message, fileName, innerException);
 
             var toString = exception.ToString();
             Assert.Contains(": " + message, toString);
@@ -85,7 +85,7 @@ namespace System.IO.Tests
             string message = "this is not the file you're looking for";
             string fileName = "file.txt";
             var innerException = new Exception("Inner exception");
-            var exception = new FileLoadException(message, fileName, innerException);
+            var exception = new FileNotFoundException(message, fileName, innerException);
 
             Assert.Null(exception.FusionLog);
         }


### PR DESCRIPTION
- Adds ref entries for the 5 remaining IO members missing from System.Runtime
  - Adds tests for the FusionLog properties
  - Tests for the Stream functions are coming in a separate commit since those tests live in the System.IO assembly
- Adds full test suite for FileNotfoundException since we apparently didn't have any

progress towards https://github.com/dotnet/corefx/issues/9465

@joperezr @AlexGhiondea @stephentoub @JeremyKuhne 