### PR TITLE
Add netstandard1.7 build to Threading.Timers

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -261,7 +261,7 @@
       "AssemblyVersionInPackageVersion": {
         "4.0.2.0": "4.3.0",
         "4.0.1.0": "4.4.0",
-        "4.0.3.0": "4.4.0"
+        "4.1.0.0": "4.4.0"
       }
     },
     "runtime.aot.System.Collections": {
@@ -418,7 +418,7 @@
       "BaselineVersion": "4.4.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.2.0": "4.3.0",
-        "4.0.3.0": "4.4.0"
+        "4.0.1.0": "4.4.0"
       }
     },
     "runtime.debian.8-x64.runtime.native.System": {
@@ -2441,7 +2441,7 @@
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
         "4.0.2.0": "4.3.0",
-        "4.0.3.0": "4.4.0"
+        "4.1.0.0": "4.4.0"
       }
     },
     "System.Xml.ReaderWriter": {

--- a/src/System.Threading.Timer/System.Threading.Timer.sln
+++ b/src/System.Threading.Timer/System.Threading.Timer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading.Timer.Tests", "tests\System.Threading.Timer.Tests.csproj", "{AC20A28F-FDA8-45E8-8728-058EAD16E44C}"
 EndProject
@@ -39,14 +39,14 @@ Global
 		{AC20A28F-FDA8-45E8-8728-058EAD16E44C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50_Debug|Any CPU.ActiveCfg = netcore50_Debug|Any CPU
-		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50_Debug|Any CPU.Build.0 = netcore50_Debug|Any CPU
-		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50_Release|Any CPU.ActiveCfg = netcore50_Release|Any CPU
-		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50_Release|Any CPU.Build.0 = netcore50_Release|Any CPU
-		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50aot_Debug|Any CPU.ActiveCfg = netcore50aot_Debug|Any CPU
-		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50aot_Debug|Any CPU.Build.0 = netcore50aot_Debug|Any CPU
-		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50aot_Release|Any CPU.ActiveCfg = netcore50aot_Release|Any CPU
-		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50aot_Release|Any CPU.Build.0 = netcore50aot_Release|Any CPU
+		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50_Release|Any CPU.Build.0 = Release|Any CPU
+		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50aot_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50aot_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50aot_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.netcore50aot_Release|Any CPU.Build.0 = Release|Any CPU
 		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{97EEEDF4-D074-4D68-BB1D-B7C3EE36D522}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -66,8 +66,8 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA} = {9BA4D6A6-C48D-4470-8FA6-D12102F47EA5}
 		{AC20A28F-FDA8-45E8-8728-058EAD16E44C} = {C68160F1-EC89-4B68-B2FE-9DB33E6360CE}
+		{248D07D6-0DA9-4F3B-9F05-A17C72F3EDAA} = {9BA4D6A6-C48D-4470-8FA6-D12102F47EA5}
 		{97EEEDF4-D074-4D68-BB1D-B7C3EE36D522} = {32AFC2C9-4EE5-4EE7-A5D8-8FBF49D488A3}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Threading.Timer/dir.props
+++ b/src/System.Threading.Timer/dir.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Timer/pkg/System.Threading.Timer.pkgproj
+++ b/src/System.Threading.Timer/pkg/System.Threading.Timer.pkgproj
@@ -3,7 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.Timer.csproj">
-      <SupportedFramework>net451;netcore451;netcoreapp1.0;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Threading.Timer.csproj">
+      <TargetGroup>net463</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="any\System.Threading.Timer.pkgproj" />
     <ProjectReference Include="aot\System.Threading.Timer.pkgproj" />

--- a/src/System.Threading.Timer/pkg/aot/System.Threading.Timer.pkgproj
+++ b/src/System.Threading.Timer/pkg/aot/System.Threading.Timer.pkgproj
@@ -7,11 +7,5 @@
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\System.Threading.Timer.csproj">
-      <TargetGroup>netcore50aot</TargetGroup>
-    </ProjectReference>
-  </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Timer/ref/System.Threading.Timer.csproj
+++ b/src/System.Threading.Timer/ref/System.Threading.Timer.csproj
@@ -2,9 +2,8 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.2</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Threading.Timer.cs" />

--- a/src/System.Threading.Timer/ref/project.json
+++ b/src/System.Threading.Timer/ref/project.json
@@ -1,12 +1,8 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.0"
+    "System.Runtime": "4.1.0"
   },
   "frameworks": {
-    "netstandard1.2": {
-      "imports": [
-        "dotnet5.3"
-      ]
-    }
+    "netstandard1.7": { }
   }
 }

--- a/src/System.Threading.Timer/src/System.Threading.Timer.builds
+++ b/src/System.Threading.Timer/src/System.Threading.Timer.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.Threading.Timer.csproj" />
     <Project Include="System.Threading.Timer.csproj">
-      <TargetGroup>netcore50aot</TargetGroup>
+      <TargetGroup>net463</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Threading.Timer/src/System.Threading.Timer.csproj
+++ b/src/System.Threading.Timer/src/System.Threading.Timer.csproj
@@ -4,17 +4,16 @@
   <PropertyGroup>
     <AssemblyName>System.Threading.Timer</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
   <ItemGroup>
-    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' == 'net46'" />
-    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' != 'net46' and '$(TargetGroup)' != 'netcore50aot'" />
-    <TargetingPackReference Include="System.Private.Threading" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' == 'net463'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' != 'net463'" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Threading.Timer/src/project.json
+++ b/src/System.Threading.Timer/src/project.json
@@ -1,17 +1,13 @@
-{
+d{
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
       },
-      "imports": [
-        "dotnet5.4"
-      ]
     },
-    "netcore50": {
+    "net463": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24604-01",
-        "System.Runtime": "4.0.20"
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
     }
   }

--- a/src/System.Threading.Timer/tests/System.Threading.Timer.Tests.builds
+++ b/src/System.Threading.Timer/tests/System.Threading.Timer.Tests.builds
@@ -5,6 +5,11 @@
     <Project Include="System.Threading.Timer.Tests.csproj" />
     <Project Include="System.Threading.Timer.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
+      <TestTFMs>net463</TestTFMs>
+    </Project>
+    <Project Include="System.Threading.Timer.Tests.csproj">
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcore50;net46</TestTFMs>
     </Project>
   </ItemGroup>

--- a/src/System.Threading.Timer/tests/System.Threading.Timer.Tests.csproj
+++ b/src/System.Threading.Timer/tests/System.Threading.Timer.Tests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Threading.Timer.Tests</AssemblyName>
     <ProjectGuid>{ac20a28f-fda8-45e8-8728-058ead16e44c}</ProjectGuid>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Threading.Timer/tests/project.json
+++ b/src/System.Threading.Timer/tests/project.json
@@ -16,7 +16,8 @@
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00830-02"
   },
   "frameworks": {
-    "netstandard1.3": {}
+    "netstandard1.3": {},
+    "netstandard1.7": {}
   },
   "supports": {
     "coreFx.Test.netcore50": {},


### PR DESCRIPTION
This retargets the ref and src to netstandard1.7. It splits up the test
to run against both netstandard1.3 and netstandard1.7.

This is the last of the split packages (hard to port) that wasn't targeting ns1.7.

/cc @danmosemsft @weshaggard @stephentoub 