### PR TITLE
Port rest of System.NetCookie* methods

### DIFF
--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -211,6 +211,7 @@ namespace System.Net
         public static System.Net.IPAddress Parse(string ipString) { return default(System.Net.IPAddress); }
         public override string ToString() { return default(string); }
         public static bool TryParse(string ipString, out System.Net.IPAddress address) { address = default(System.Net.IPAddress); return default(bool); }
+        public long Address { get; set; }
     }
     public partial class IPEndPoint : System.Net.EndPoint
     {

--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -54,6 +54,8 @@ namespace System.Net
         public void Add(System.Net.CookieCollection cookies) { }
         public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
         void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        public void CopyTo(Cookie[] array, int index) { }
+        public bool IsReadOnly { get; }
     }
     public partial class CookieContainer
     {
@@ -61,12 +63,16 @@ namespace System.Net
         public const int DefaultCookieLimit = 300;
         public const int DefaultPerDomainCookieLimit = 20;
         public CookieContainer() { }
+        public CookieContainer(int capacity) { }
+        public CookieContainer(int capacity, int perDomainCapacity, int maxCookieSize) { }
         public int Capacity { get { return default(int); } set { } }
         public int Count { get { return default(int); } }
         public int MaxCookieSize { get { return default(int); } set { } }
         public int PerDomainCapacity { get { return default(int); } set { } }
         public void Add(System.Uri uri, System.Net.Cookie cookie) { }
         public void Add(System.Uri uri, System.Net.CookieCollection cookies) { }
+        public void Add(CookieCollection cookies) { }
+        public void Add(Cookie cookie) { }
         public string GetCookieHeader(System.Uri uri) { return default(string); }
         public System.Net.CookieCollection GetCookies(System.Uri uri) { return default(System.Net.CookieCollection); }
         public void SetCookies(System.Uri uri, string cookieHeader) { }

--- a/src/System.Net.Primitives/ref/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.10.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Net.Primitives.cs" />

--- a/src/System.Net.Primitives/ref/project.json
+++ b/src/System.Net.Primitives/ref/project.json
@@ -1,13 +1,27 @@
 {
-  "dependencies": {
-    "System.Runtime": "4.0.0",
-    "System.Runtime.Handles": "4.0.0"
-  },
   "frameworks": {
-    "netstandard1.3": {
-      "imports": [
-        "dotnet5.4"
-      ]
+    "netstandard1.7": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "Microsoft.Win32.Primitives": "4.3.0-beta-24604-02",
+        "System.Collections": "4.3.0-beta-24604-02",
+        "System.Diagnostics.Contracts": "4.3.0-beta-24604-02",
+        "System.Diagnostics.Debug": "4.3.0-beta-24604-02",
+        "System.Diagnostics.Tracing": "4.3.0-beta-24604-02",
+        "System.Globalization": "4.3.0-beta-24604-02",
+        "System.Resources.ResourceManager": "4.3.0-beta-24604-02",
+        "System.Runtime": "4.3.0-beta-24604-02",
+        "System.Runtime.Extensions": "4.3.0-beta-24604-02",
+        "System.Runtime.Handles": "4.3.0-beta-24604-02",
+        "System.Runtime.InteropServices": "4.3.0-beta-24604-02",
+        "System.Threading": "4.3.0-beta-24604-02",
+        "System.Threading.Tasks": "4.3.0-beta-24604-02"
+      }
+    },
+    "net463": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
     }
   }
 }

--- a/src/System.Net.Primitives/src/ApiCompatBaseline.netcore50.txt
+++ b/src/System.Net.Primitives/src/ApiCompatBaseline.netcore50.txt
@@ -1,0 +1,2 @@
+#Compat issues with assembly System.Net.Primitives
+CannotRemoveBaseTypeOrInterface : Type 'System.Security.Authentication.ExtendedProtection.ChannelBinding' does not inherit from base type 'System.Runtime.ConstrainedExecution.CriticalFinalizerObject' in the implementation but it does in the contract.

--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -11,8 +11,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableWinRT Condition="'$(TargetGroup)' == 'netcore50'">true</EnableWinRT>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50'">
+    <DefineConstants>$(DefineConstants);netcore50</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(EnableWinRT)' != 'true' AND '$(TargetGroup)' == ''">
     <DefineConstants>$(DefineConstants);FEATURE_CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -93,6 +93,14 @@ namespace System.Net
             }
         }
 
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         bool ICollection.IsSynchronized
         {
             get
@@ -110,6 +118,11 @@ namespace System.Net
         }
 
         void ICollection.CopyTo(Array array, int index)
+        {
+            ((ICollection)_list).CopyTo(array, index);
+        }
+
+        public void CopyTo(Cookie[] array, int index)
         {
             ((ICollection)_list).CopyTo(array, index);
         }

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -116,7 +116,7 @@ namespace System.Net
             // Otherwise it will remain string.Empty.
         }
 
-        internal CookieContainer(int capacity) : this()
+        public CookieContainer(int capacity) : this()
         {
             if (capacity <= 0)
             {
@@ -125,7 +125,7 @@ namespace System.Net
             _maxCookies = capacity;
         }
 
-        internal CookieContainer(int capacity, int perDomainCapacity, int maxCookieSize) : this(capacity)
+        public CookieContainer(int capacity, int perDomainCapacity, int maxCookieSize) : this(capacity)
         {
             if (perDomainCapacity != Int32.MaxValue && (perDomainCapacity <= 0 || perDomainCapacity > capacity))
             {
@@ -213,7 +213,7 @@ namespace System.Net
         }
 
         // This method will construct a faked URI: the Domain property is required for param.
-        internal void Add(Cookie cookie)
+        public void Add(Cookie cookie)
         {
             if (cookie == null)
             {
@@ -519,7 +519,7 @@ namespace System.Net
             }
         }
 
-        internal void Add(CookieCollection cookies)
+        public void Add(CookieCollection cookies)
         {
             if (cookies == null)
             {

--- a/src/System.Net.Primitives/src/System/Net/CookieException.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieException.cs
@@ -10,6 +10,12 @@
 // System.Private.Networking dll. So, we need to move the classes to a different namespace. Those classes are never
 // exposed up to user code so there isn't a problem.  In the future, we might expose some of the internal methods
 // as new public APIs and then we can remove this duplicate source code inclusion in the binaries.
+using System;
+
+#if !netcore50
+using System.Runtime.Serialization;
+#endif
+
 #if NETNative_SystemNetHttp
 namespace System.Net.Internal
 #else
@@ -17,6 +23,9 @@ namespace System.Net
 #endif
 {
     public class CookieException : FormatException
+#if !netcore50
+        , ISerializable
+#endif
     {
         public CookieException() : base()
         {
@@ -29,5 +38,21 @@ namespace System.Net
         internal CookieException(string message, Exception inner) : base(message, inner)
         {
         }
+#if !netcore50
+        protected CookieException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext)
+            : base(serializationInfo, streamingContext)
+        {
+        }
+
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext)
+        {
+            base.GetObjectData(serializationInfo, streamingContext);
+        }
+
+        void ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, StreamingContext streamingContext) 
+        {
+            base.GetObjectData(serializationInfo, streamingContext);
+        }
+#endif
     }
 }

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -150,6 +150,42 @@ namespace System.Net
             PrivateScopeId = (uint)scopeid;
         }
 
+        public long Address
+        {
+            get
+            {
+                //
+                // IPv6 Changes: Can't do this for IPv6, so throw an exception.
+                //
+                //
+                if (AddressFamily == AddressFamily.InterNetworkV6)
+                {
+                    throw new SocketException(SocketError.OperationNotSupported);
+                }
+                else
+                {
+                    return (long)PrivateAddress;
+                }
+            }
+            set
+            {
+                //
+                // IPv6 Changes: Can't do this for IPv6 addresses
+                if (AddressFamily == AddressFamily.InterNetworkV6)
+                {
+                    throw new SocketException(SocketError.OperationNotSupported);
+                }
+                else
+                {
+                    if (PrivateAddress != value)
+                    {
+                        _toString = null;
+                        PrivateAddress = (uint)value;
+                    }
+                }
+            }
+        }
+
         private IPAddress(ushort[] numbers, uint scopeid)
         {
             Debug.Assert(numbers != null);
@@ -249,15 +285,7 @@ namespace System.Net
             {
                 return IsIPv4 ? AddressFamily.InterNetwork : AddressFamily.InterNetworkV6;
             }
-        }
-
-        // When IPv6 support was added to the .NET Framework, the public Address property was marked as Obsolete.
-        // The public obsolete Address property has not been carried forward in .NET Core, but remains here as
-        // internal to allow internal types that understand IPv4 to still access it without obsolete warnings.
-        internal long Address
-        {
-            get { return PrivateAddress; }
-        }
+        }  
 
         /// <devdoc>
         ///   <para>

--- a/src/System.Net.Primitives/src/project.json
+++ b/src/System.Net.Primitives/src/project.json
@@ -1,27 +1,25 @@
 {
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.Win32.Primitives": "4.0.0",
-        "System.Collections": "4.0.10",
-        "System.Diagnostics.Contracts": "4.0.0",
-        "System.Diagnostics.Debug": "4.0.10",
-        "System.Diagnostics.Tracing": "4.0.20",
-        "System.Globalization": "4.0.0",
-        "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.0.20",
-        "System.Runtime.Extensions": "4.0.10",
-        "System.Runtime.Handles": "4.0.0",
-        "System.Runtime.InteropServices": "4.0.20",
-        "System.Threading": "4.0.0",
-        "System.Threading.Tasks": "4.0.0"
-      },
-      "imports": [
-        "dotnet5.4"
-      ]
+        "Microsoft.Win32.Primitives": "4.3.0-beta-24604-02",
+        "System.Collections": "4.3.0-beta-24604-02",
+        "System.Diagnostics.Contracts": "4.3.0-beta-24604-02",
+        "System.Diagnostics.Debug": "4.3.0-beta-24604-02",
+        "System.Diagnostics.Tracing": "4.3.0-beta-24604-02",
+        "System.Globalization": "4.3.0-beta-24604-02",
+        "System.Resources.ResourceManager": "4.3.0-beta-24604-02",
+        "System.Runtime": "4.3.0-beta-24604-02",
+        "System.Runtime.Extensions": "4.3.0-beta-24604-02",
+        "System.Runtime.Handles": "4.3.0-beta-24604-02",
+        "System.Runtime.InteropServices": "4.3.0-beta-24604-02",
+        "System.Threading": "4.3.0-beta-24604-02",
+        "System.Threading.Tasks": "4.3.0-beta-24604-02",
+        "System.Runtime.Serialization.Primitives":"4.3.0-beta-24604-02"
+      }
     },
-    "net46": {
+    "net463": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -251,6 +251,16 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
+        public static void Address_Property_Success()
+        {
+            IPAddress ip1 = IPAddress.Parse("192.168.0.9");
+            //192.168.0.10
+            long newIp4Address = 192 << 24 | 168 << 16 | 0 << 8 | 10;
+            ip1.Address = newIp4Address;
+            Assert.Equal(ip1.ToString(), "192.168.0.10");
+        }
+
+        [Fact]
         public static void Equals_Compare_Success()
         {
             IPAddress ip1 = IPAddress.Parse("192.168.0.9"); //IpV4

--- a/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
+++ b/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
@@ -9,7 +9,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{4FE5ECEE-ACC5-4558-A946-573426599B73}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />

--- a/src/System.Net.Primitives/tests/FunctionalTests/project.json
+++ b/src/System.Net.Primitives/tests/FunctionalTests/project.json
@@ -15,6 +15,7 @@
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00830-02"
   },
   "frameworks": {
+    "netstandard1.7": {},
     "netstandard1.3": {}
   },
   "supports": {

--- a/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
+++ b/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
@@ -12,7 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>169,649</NoWarn>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />

--- a/src/System.Net.Primitives/tests/UnitTests/project.json
+++ b/src/System.Net.Primitives/tests/UnitTests/project.json
@@ -28,6 +28,7 @@
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00830-02"
   },
   "frameworks": {
+    "netstandard1.7": {},
     "netstandard1.3": {}
   },
   "supports": {


### PR DESCRIPTION
 -Mostly staight forward since the methods did exit but were internal
 -netcore50 complains about SafeHandle not derived from CriticalFinalizerObject , excluded in APICompat
 -public bool IsSynchronized { get; } and  public object SyncRoot { get; } both exits today
  not sure why they are listed as not available.
 -I haven't added any new test since the existing test cover the code path.

Ref: PR #12125