### PR TITLE
Fix _echo to be uniform marker for logging in .CMD scripts

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,4 @@
-@if "%_echo%" neq "on" echo off
+@if not defined _echo @echo off
 setlocal
 
 if /I [%1] == [-?] goto Usage

--- a/clean.cmd
+++ b/clean.cmd
@@ -1,4 +1,4 @@
-@if "%_echo%" neq "on" echo off
+@if not defined _echo @echo off
 setlocal EnableDelayedExpansion
 
 echo Stop VBCSCompiler.exe execution.

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -1,4 +1,4 @@
-@if "%_echo%" neq "on" echo off
+@if not defined _echo @echo off
 setlocal
 
 set INIT_TOOLS_LOG=%~dp0init-tools.log

--- a/run-test.cmd
+++ b/run-test.cmd
@@ -1,4 +1,4 @@
-@if "%_echo%" neq "on" echo off
+@if not defined _echo @echo off
 
 :: To run tests outside of MSBuild.exe
 :: %1 is the path to the tests\<OSConfig> folder

--- a/run.cmd
+++ b/run.cmd
@@ -1,4 +1,4 @@
-@if "%_echo%" neq "on" echo off
+@if not defined _echo @echo off
 setlocal
 
 if not defined VisualStudioVersion (

--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -1,4 +1,4 @@
-@if "%_echo%" neq "on" echo off
+@if not defined _echo @echo off
 setlocal
 
 :SetupArgs


### PR DESCRIPTION
The other .CMD files in CoreCLR repo use the convention that echo is on if _echo is defined
at all.   Currently we require _echo to be equal to 'on'.   Relaxing it to just require _echo to be
defined to be consistent.

@jkotas 