### PR TITLE
Prefer exception, not assert, during helper setup - System.Net.Security 

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
@@ -46,7 +46,7 @@ namespace System.Net.Security.Tests
                         Dispose();
                     }
 
-                    Assert.True(false, "KDC setup failure");
+                    throw new IllegalStateException("KDC setup failure");
                 }
             }
             else

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
@@ -46,7 +46,7 @@ namespace System.Net.Security.Tests
                         Dispose();
                     }
 
-                    throw new IllegalStateException("KDC setup failure");
+                    throw new InvalidOperationException("KDC setup failure");
                 }
             }
             else


### PR DESCRIPTION
Failure condition would occur during test setup, not during tests themselves. It's more appropriate to throw an exception in this sort of situation (as if the helper belonged to an external library).