### PR TITLE
Workaround lack of Uri support for Unix paths in System.Private.Xml

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/XmlResolver.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlResolver.cs
@@ -40,7 +40,7 @@ namespace System.Xml
                 Uri uri = new Uri(relativeUri, UriKind.RelativeOrAbsolute);
                 if (!uri.IsAbsoluteUri && uri.OriginalString.Length > 0)
                 {
-                    uri = new Uri(Path.GetFullPath(relativeUri));
+                    uri = new Uri(Uri.UriSchemeFile + Uri.SchemeDelimiter + Path.GetFullPath(relativeUri));
                 }
                 return uri;
             }


### PR DESCRIPTION
```new Uri(filePath)``` currently works on Windows and fails on Unix; there are special code paths that guess whether the specified url is a file path and automatically prepend a "file://" scheme if it is, but the logic is based on Windows paths.  On Unix, it ends up throwing a UriFormatException.

A bunch of the Xml types end up hitting this code path when provided with a string uri, e.g. XmlReader.Create(string), which causes failures when file paths are provided on Unix, and creating readers and such for file paths is very common.  This commit works around the issue by adding an explicit file scheme rather than leaving it up to the Uri implementation to determine that it's a file path.

Note that there are tests which would have caught this, but they're not getting run: https://github.com/dotnet/corefx/issues/12483

Issue for Uris on Unix: https://github.com/dotnet/corefx/issues/1745

cc: @sepidehMS, @krwq, @davidsh, @cipop