### PR TITLE
Expose new String.Split overloads in netcoreapp1.1

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -1937,6 +1937,12 @@ namespace System
         public string Remove(int startIndex, int count) { return default(string); }
         public string Replace(char oldChar, char newChar) { return default(string); }
         public string Replace(string oldValue, string newValue) { return default(string); }
+#if netcoreapp11
+        public string[] Split(char separator, System.StringSplitOptions options = System.StringSplitOptions.None) { return default(string[]); }
+        public string[] Split(char separator, int count, System.StringSplitOptions options = System.StringSplitOptions.None) { return default(string[]); }
+        public string[] Split(string separator, System.StringSplitOptions options = System.StringSplitOptions.None) { return default(string[]); }
+        public string[] Split(string separator, int count, System.StringSplitOptions options = System.StringSplitOptions.None) { return default(string[]); }
+#endif
         public string[] Split(params char[] separator) { return default(string[]); }
         public string[] Split(char[] separator, int count) { return default(string[]); }
         public string[] Split(char[] separator, int count, System.StringSplitOptions options) { return default(string[]); }

--- a/src/System.Runtime/tests/Performance/Perf.String.cs
+++ b/src/System.Runtime/tests/Performance/Perf.String.cs
@@ -185,10 +185,11 @@ namespace System.Tests
             PerfUtils utils = new PerfUtils();
             string testString = utils.CreateString(size);
             string existingValue = testString.Substring(testString.Length / 2, 1);
+            string[] separator = new string[] { existingValue };
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < 10000; i++)
-                        testString.Split(existingValue);
+                        testString.Split(separator, StringSplitOptions.None);
         }
 
         [Benchmark]

--- a/src/System.Runtime/tests/Performance/System.Runtime.Performance.Tests.csproj
+++ b/src/System.Runtime/tests/Performance/System.Runtime.Performance.Tests.csproj
@@ -27,7 +27,6 @@
     <Compile Include="Perf.Int32.cs" />
     <Compile Include="Perf.IntPtr.cs" />
     <Compile Include="Perf.StringBuilder.cs" />
-    <Compile Include="..\System\String.SplitTests.cs" />
     <Compile Include="..\Helpers.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -109,6 +109,9 @@
     <Compile Include="System\Runtime\CompilerServices\RuntimeHelpersTests.netcoreapp1.1.cs" />
     <Compile Include="System\UIntPtrTests.netcoreapp1.1.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'netcoreapp1.1'">
+    <Compile Include="System\StringSplitExtensions.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="ArrayTests.netstandard1.7.cs" />
     <Compile Include="System\AttributeTests.netstandard1.7.cs" />

--- a/src/System.Runtime/tests/System/String.SplitTests.cs
+++ b/src/System.Runtime/tests/System/String.SplitTests.cs
@@ -2,45 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Tests
 {
-    // TODO: Remove these extension methods when the actual methods are available on String in System.Runtime.dll
-    internal static class TemporaryStringSplitExtensions
-    {
-        public static string[] Split(this string value, char separator)
-        {
-            return value.Split(new[] { separator });
-        }
-
-        public static string[] Split(this string value, char separator, StringSplitOptions options)
-        {
-            return value.Split(new[] { separator }, options);
-        }
-
-        public static string[] Split(this string value, char separator, int count, StringSplitOptions options)
-        {
-            return value.Split(new[] { separator }, count, options);
-        }
-
-        public static string[] Split(this string value, string separator)
-        {
-            return value.Split(new[] { separator }, StringSplitOptions.None);
-        }
-
-        public static string[] Split(this string value, string separator, StringSplitOptions options)
-        {
-            return value.Split(new[] { separator }, options);
-        }
-
-        public static string[] Split(this string value, string separator, int count, StringSplitOptions options)
-        {
-            return value.Split(new[] { separator }, count, options);
-        }
-    }
-
     public static class StringSplitTests
     {
         [Fact]
@@ -50,11 +15,13 @@ namespace System.Tests
             const int count = -1;
             const StringSplitOptions options = StringSplitOptions.None;
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => value.Split(',', count, options));
-            Assert.Throws<ArgumentOutOfRangeException>(() => value.Split(new[] { ',' }, count));
-            Assert.Throws<ArgumentOutOfRangeException>(() => value.Split(new[] { ',' }, count, options));
-            Assert.Throws<ArgumentOutOfRangeException>(() => value.Split(",", count, options));
-            Assert.Throws<ArgumentOutOfRangeException>(() => value.Split(new[] { "," }, count, options));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => value.Split(',', count));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => value.Split(',', count, options));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => value.Split(new[] { ',' }, count));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => value.Split(new[] { ',' }, count, options));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => value.Split(",", count));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => value.Split(",", count, options));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => value.Split(new[] { "," }, count, options));
         }
 
         [Fact]
@@ -92,9 +59,11 @@ namespace System.Tests
 
             string[] expected = new string[0];
 
+            Assert.Equal(expected, value.Split(',', count));
             Assert.Equal(expected, value.Split(',', count, options));
             Assert.Equal(expected, value.Split(new[] { ',' }, count));
             Assert.Equal(expected, value.Split(new[] { ',' }, count, options));
+            Assert.Equal(expected, value.Split(",", count));
             Assert.Equal(expected, value.Split(",", count, options));
             Assert.Equal(expected, value.Split(new[] { "," }, count, options));
         }
@@ -127,9 +96,11 @@ namespace System.Tests
 
             string[] expected = new[] { value };
 
+            Assert.Equal(expected, value.Split(',', count));
             Assert.Equal(expected, value.Split(',', count, options));
             Assert.Equal(expected, value.Split(new[] { ',' }, count));
             Assert.Equal(expected, value.Split(new[] { ',' }, count, options));
+            Assert.Equal(expected, value.Split(",", count));
             Assert.Equal(expected, value.Split(",", count, options));
             Assert.Equal(expected, value.Split(new[] { "," }, count, options));
         }
@@ -472,6 +443,15 @@ namespace System.Tests
             Assert.Equal(expected, value.Split(new[] { separator }, count, options));
         }
 
+        [Fact]
+        public static void SplitNullCharArraySeparator_BindsToCharArrayOverload()
+        {
+            string value = "a b c";
+            string[] expected = new[] { "a", "b", "c" };
+            // Ensure Split(null) compiles successfully as a call to Split(char[])
+            Assert.Equal(expected, value.Split(null));
+        }
+
         [Theory]
         [InlineData("a b c", null, M, StringSplitOptions.None, new[] { "a", "b", "c" })]
         [InlineData("a b c", new char[0], M, StringSplitOptions.None, new[] { "a", "b", "c" })]
@@ -515,5 +495,23 @@ namespace System.Tests
             }
             return result;
         }
+    }
+
+    // The below extension methods allow the tests to run on targets that *do not* have the new Split overloads.
+    // On targets that *do* have the new Split overloads (e.g. netcoreapp1.1), the actual overloads on String
+    // are called instead of the extension methods below (due to the way extension methods work).
+    internal static class StringSplitExtensions
+    {
+        public static string[] Split(this string value, char separator, StringSplitOptions options = StringSplitOptions.None) =>
+            value.Split(new[] { separator }, options);
+
+        public static string[] Split(this string value, char separator, int count, StringSplitOptions options = StringSplitOptions.None) =>
+            value.Split(new[] { separator }, count, options);
+
+        public static string[] Split(this string value, string separator, StringSplitOptions options = StringSplitOptions.None) =>
+            value.Split(new[] { separator }, options);
+
+        public static string[] Split(this string value, string separator, int count, StringSplitOptions options = StringSplitOptions.None) =>
+            value.Split(new[] { separator }, count, options);
     }
 }

--- a/src/System.Runtime/tests/System/String.SplitTests.cs
+++ b/src/System.Runtime/tests/System/String.SplitTests.cs
@@ -496,22 +496,4 @@ namespace System.Tests
             return result;
         }
     }
-
-    // The below extension methods allow the tests to run on targets that *do not* have the new Split overloads.
-    // On targets that *do* have the new Split overloads (e.g. netcoreapp1.1), the actual overloads on String
-    // are called instead of the extension methods below (due to the way extension methods work).
-    internal static class StringSplitExtensions
-    {
-        public static string[] Split(this string value, char separator, StringSplitOptions options = StringSplitOptions.None) =>
-            value.Split(new[] { separator }, options);
-
-        public static string[] Split(this string value, char separator, int count, StringSplitOptions options = StringSplitOptions.None) =>
-            value.Split(new[] { separator }, count, options);
-
-        public static string[] Split(this string value, string separator, StringSplitOptions options = StringSplitOptions.None) =>
-            value.Split(new[] { separator }, options);
-
-        public static string[] Split(this string value, string separator, int count, StringSplitOptions options = StringSplitOptions.None) =>
-            value.Split(new[] { separator }, count, options);
-    }
 }

--- a/src/System.Runtime/tests/System/StringSplitExtensions.cs
+++ b/src/System.Runtime/tests/System/StringSplitExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Tests
+{
+    // Allows the string.Split tests to run on targets that *do not* have the new string.Split overloads.
+    internal static class StringSplitExtensions
+    {
+        public static string[] Split(this string value, char separator, StringSplitOptions options = StringSplitOptions.None) =>
+            value.Split(new[] { separator }, options);
+
+        public static string[] Split(this string value, char separator, int count, StringSplitOptions options = StringSplitOptions.None) =>
+            value.Split(new[] { separator }, count, options);
+
+        public static string[] Split(this string value, string separator, StringSplitOptions options = StringSplitOptions.None) =>
+            value.Split(new[] { separator }, options);
+
+        public static string[] Split(this string value, string separator, int count, StringSplitOptions options = StringSplitOptions.None) =>
+            value.Split(new[] { separator }, count, options);
+    }
+}


### PR DESCRIPTION
Fixes #1513

Also added a test to ensure `Split(null)` calls `Split(char[])` without any compiler ambiguity and some minor test cleanup to reflect that actual overloads that we ended up with.