### PR TITLE
Update CoreClr to beta-24610-01 (master)

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -2,7 +2,7 @@
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
   <PropertyGroup>
     <CoreFxCurrentRef>037fb445d7ca0f4d3948d4e845595c425d230834</CoreFxCurrentRef>
-    <CoreClrCurrentRef>8350fff66448a8f7beade608f963626900f55e91</CoreClrCurrentRef>
+    <CoreClrCurrentRef>c167f856809c7a9c099694d3359899aed920dc35</CoreClrCurrentRef>
     <ExternalCurrentRef>0db1f9d8996a6a05960f79712299652a4b04147f</ExternalCurrentRef>
     <ProjectNTfsCurrentRef>1270b41004b96ba37f34415e730e766e5965da00</ProjectNTfsCurrentRef>
   </PropertyGroup>
@@ -10,7 +10,7 @@
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
     <CoreFxExpectedPrerelease>beta-24608-01</CoreFxExpectedPrerelease>
-    <CoreClrExpectedPrerelease>beta-24609-02</CoreClrExpectedPrerelease>
+    <CoreClrExpectedPrerelease>beta-24610-01</CoreClrExpectedPrerelease>
     <ExternalExpectedPrerelease>beta-24523-00</ExternalExpectedPrerelease>
     <ProjectNTfsExpectedPrerelease>beta-24604-01</ProjectNTfsExpectedPrerelease>
   </PropertyGroup>

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "NETStandard.Library": "1.6.2-beta-24608-01",
-    "Microsoft.NETCore.TestHost": "1.2.0-beta-24609-02",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24609-02",
+    "Microsoft.NETCore.TestHost": "1.2.0-beta-24610-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24610-01",
     "System.Diagnostics.Contracts": "4.4.0-beta-24608-01",
     "System.Linq.Parallel": "4.4.0-beta-24608-01",
     "coveralls.io": "1.4",

--- a/src/System.AppContext/src/project.json
+++ b/src/System.AppContext/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "net463": {

--- a/src/System.Collections/src/project.json
+++ b/src/System.Collections/src/project.json
@@ -3,7 +3,7 @@
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.8"

--- a/src/System.Diagnostics.Contracts/src/project.json
+++ b/src/System.Diagnostics.Contracts/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.0": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.1"

--- a/src/System.Diagnostics.Debug/src/project.json
+++ b/src/System.Diagnostics.Debug/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "netcore50": {

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.2.0-beta-24608-01",
-    "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02",
+    "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01",
     "System.Linq.Expressions": "4.4.0-beta-24608-01",
     "System.ObjectModel": "4.4.0-beta-24608-01",
     "System.Text.RegularExpressions": "4.4.0-beta-24608-01",

--- a/src/System.Diagnostics.StackTrace/src/project.json
+++ b/src/System.Diagnostics.StackTrace/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02",
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01",
         "System.IO.FileSystem": "4.0.1",
         "System.Reflection.Metadata": "1.5.0-beta-24608-01",
         "System.Collections.Immutable": "1.2.0"

--- a/src/System.Diagnostics.Tools/src/project.json
+++ b/src/System.Diagnostics.Tools/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "net463": {

--- a/src/System.Diagnostics.Tracing/src/project.json
+++ b/src/System.Diagnostics.Tracing/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "netcore50": {

--- a/src/System.Globalization.Calendars/src/project.json
+++ b/src/System.Globalization.Calendars/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "net463": {

--- a/src/System.Globalization/src/project.json
+++ b/src/System.Globalization/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.8"

--- a/src/System.IO.FileSystem.Primitives/src/project.json
+++ b/src/System.IO.FileSystem.Primitives/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "net463": {

--- a/src/System.IO.UnmanagedMemoryStream/src/project.json
+++ b/src/System.IO.UnmanagedMemoryStream/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "net463": {

--- a/src/System.IO/src/project.json
+++ b/src/System.IO/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.8"

--- a/src/System.Private.Uri/src/project.json
+++ b/src/System.Private.Uri/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.0": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.1"

--- a/src/System.Private.Xml/src/project.json
+++ b/src/System.Private.Xml/src/project.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "Microsoft.CSharp": "4.4.0-beta-24608-01",
         "Microsoft.NETCore.Platforms": "1.2.0-beta-24608-01",
-        "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24609-02",
+        "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24610-01",
         "Microsoft.Win32.Registry": "4.4.0-beta-24608-01",
         "System.Collections": "4.4.0-beta-24608-01",
         "System.Collections.NonGeneric": "4.4.0-beta-24608-01",
@@ -57,7 +57,7 @@
       "dependencies": {
         "Microsoft.CSharp": "4.4.0-beta-24608-01",
         "Microsoft.NETCore.Platforms": "1.2.0-beta-24608-01",
-        "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24609-02",
+        "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24610-01",
         "Microsoft.Win32.Registry": "4.4.0-beta-24608-01",
         "System.Collections": "4.4.0-beta-24608-01",
         "System.Collections.NonGeneric": "4.4.0-beta-24608-01",

--- a/src/System.Reflection.Emit.ILGeneration/src/project.json
+++ b/src/System.Reflection.Emit.ILGeneration/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Reflection.Emit.Lightweight/src/project.json
+++ b/src/System.Reflection.Emit.Lightweight/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Reflection.Emit/src/project.json
+++ b/src/System.Reflection.Emit/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Reflection.Primitives/src/project.json
+++ b/src/System.Reflection.Primitives/src/project.json
@@ -3,7 +3,7 @@
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.8"

--- a/src/System.Reflection.TypeExtensions/src/project.json
+++ b/src/System.Reflection.TypeExtensions/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "net462": {

--- a/src/System.Reflection/src/project.json
+++ b/src/System.Reflection/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.8"

--- a/src/System.Resources.ResourceManager/src/project.json
+++ b/src/System.Resources.ResourceManager/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dnxcore50"
@@ -10,7 +10,7 @@
     },
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dnxcore50"

--- a/src/System.Runtime.Handles/src/project.json
+++ b/src/System.Runtime.Handles/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.8"

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Runtime.InteropServices/src/project.json
+++ b/src/System.Runtime.InteropServices/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.8"

--- a/src/System.Runtime.Loader/src/project.json
+++ b/src/System.Runtime.Loader/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.6"

--- a/src/System.Runtime.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.WindowsRuntime/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02",
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1"
       },
       "imports": [

--- a/src/System.Runtime/src/project.json
+++ b/src/System.Runtime/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.6"

--- a/src/System.Security.Cryptography.X509Certificates/src/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/project.json
@@ -3,7 +3,7 @@
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.8"

--- a/src/System.Text.Encoding.Extensions/src/project.json
+++ b/src/System.Text.Encoding.Extensions/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Text.Encoding/src/project.json
+++ b/src/System.Text.Encoding/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Threading.Overlapped/src/project.json
+++ b/src/System.Threading.Overlapped/src/project.json
@@ -3,7 +3,7 @@
     "netstandard1.3": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.2.0-beta-24608-01",
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "netcore50": {

--- a/src/System.Threading.Tasks/src/project.json
+++ b/src/System.Threading.Tasks/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.8"

--- a/src/System.Threading.Thread/src/project.json
+++ b/src/System.Threading.Thread/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Threading.ThreadPool/src/project.json
+++ b/src/System.Threading.ThreadPool/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Threading.Timer/src/project.json
+++ b/src/System.Threading.Timer/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Threading/src/project.json
+++ b/src/System.Threading/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24609-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24610-01"
       }
     },
     "netcore50": {


### PR DESCRIPTION
Replacing https://github.com/dotnet/corefx/pull/12497 which is broken due to the ProjectNTfs update.