### PR TITLE
Use flags pattern to control typecasting of Count()

### DIFF
--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -28,6 +28,7 @@
     <Compile Include="System\Linq\Average.cs" />
     <Compile Include="System\Linq\Buffer.cs" />
     <Compile Include="System\Linq\Cast.cs" />
+    <Compile Include="System\Linq\Check.cs" />
     <Compile Include="System\Linq\Concat.cs" />
     <Compile Include="System\Linq\Contains.cs" />
     <Compile Include="System\Linq\Count.cs" />

--- a/src/System.Linq/src/System/Linq/AppendPrepend.cs
+++ b/src/System.Linq/src/System/Linq/AppendPrepend.cs
@@ -235,7 +235,9 @@ namespace System.Linq
                     return count == -1 ? -1 : count + 1;
                 }
 
-                return !onlyIfCheap || _source is ICollection<TSource> ? _source.Count() + 1 : -1;
+                return !onlyIfCheap || _source is ICollection<TSource> ?
+                    _source.Count(Check.All & ~Check.IIListProvider) + 1 :
+                    -1;
             }
         }
 
@@ -416,14 +418,19 @@ namespace System.Linq
 
             public override int GetCount(bool onlyIfCheap)
             {
+                int appendedCount = _appended?.Count ?? 0;
+                int prependedCount = _prepended?.Count ?? 0;
+
                 IIListProvider<TSource> listProv = _source as IIListProvider<TSource>;
                 if (listProv != null)
                 {
                     int count = listProv.GetCount(onlyIfCheap);
-                    return count == -1 ? -1 : count + (_appended == null ? 0 : _appended.Count) + (_prepended == null ? 0 : _prepended.Count);
+                    return count == -1 ? -1 : count + appendedCount + prependedCount;
                 }
 
-                return !onlyIfCheap || _source is ICollection<TSource> ? _source.Count() + (_appended == null ? 0 : _appended.Count) + (_prepended == null ? 0 : _prepended.Count) : -1;
+                return !onlyIfCheap || _source is ICollection<TSource> ?
+                    _source.Count(Check.All & ~Check.IIListProvider) + appendedCount + prependedCount :
+                    -1;
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Check.cs
+++ b/src/System.Linq/src/System/Linq/Check.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Linq
+{
+    [Flags]
+    internal enum Check
+    {
+        None = 0,
+        Array = 1,
+        ICollection = Array << 1,
+        ICollectionOfT = ICollection << 1,
+        IIListProvider = ICollectionOfT << 1,
+        IListOfT = IIListProvider << 1,
+        IPartition = IListOfT << 1,
+        List = IPartition << 1,
+        All = Array | ICollection | ICollectionOfT | IIListProvider | IListOfT | IPartition | List
+    }
+}

--- a/src/System.Linq/src/System/Linq/Count.cs
+++ b/src/System.Linq/src/System/Linq/Count.cs
@@ -4,6 +4,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Linq
 {
@@ -16,22 +17,39 @@ namespace System.Linq
                 throw Error.ArgumentNull(nameof(source));
             }
 
-            ICollection<TSource> collectionoft = source as ICollection<TSource>;
-            if (collectionoft != null)
+            return Count(source, Check.All);
+        }
+
+        internal static int Count<TSource>(this IEnumerable<TSource> source, Check flags)
+        {
+            Debug.Assert(source != null);
+            Debug.Assert((flags & Check.All) == flags);
+
+            if ((flags & Check.ICollectionOfT) != 0)
             {
-                return collectionoft.Count;
+                ICollection<TSource> collectionoft = source as ICollection<TSource>;
+                if (collectionoft != null)
+                {
+                    return collectionoft.Count;
+                }
             }
 
-            IIListProvider<TSource> listProv = source as IIListProvider<TSource>;
-            if (listProv != null)
+            if ((flags & Check.IIListProvider) != 0)
             {
-                return listProv.GetCount(onlyIfCheap: false);
+                IIListProvider<TSource> listProv = source as IIListProvider<TSource>;
+                if (listProv != null)
+                {
+                    return listProv.GetCount(onlyIfCheap: false);
+                }
             }
 
-            ICollection collection = source as ICollection;
-            if (collection != null)
+            if ((flags & Check.ICollection) != 0)
             {
-                return collection.Count;
+                ICollection collection = source as ICollection;
+                if (collection != null)
+                {
+                    return collection.Count;
+                }
             }
 
             int count = 0;

--- a/src/System.Linq/src/System/Linq/DefaultIfEmpty.cs
+++ b/src/System.Linq/src/System/Linq/DefaultIfEmpty.cs
@@ -106,9 +106,13 @@ namespace System.Linq
             public int GetCount(bool onlyIfCheap)
             {
                 int count;
-                if (!onlyIfCheap || _source is ICollection<TSource> || _source is ICollection)
+                if (!onlyIfCheap)
                 {
                     count = _source.Count();
+                }
+                else if (_source is ICollection<TSource> || _source is ICollection)
+                {
+                    count = _source.Count(Check.ICollectionOfT | Check.ICollection);
                 }
                 else
                 {

--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -79,7 +79,9 @@ namespace System.Linq
                 return listProv.GetCount(onlyIfCheap);
             }
 
-            return !onlyIfCheap || _source is ICollection<TElement> || _source is ICollection ? _source.Count() : -1;
+            return !onlyIfCheap || _source is ICollection<TElement> || _source is ICollection ?
+                _source.Count(Check.All & ~Check.IIListProvider) :
+                -1;
         }
 
         internal IEnumerator<TElement> GetEnumerator(int minIdx, int maxIdx)


### PR DESCRIPTION
`IIListProvider` is supposed to represent an iterator that has optimized `ToArray()` / `ToList()` / `Count()` paths. However, not all implementations of `IIListProvider` can optimize for all 3 of those methods. For example:

- [ConcatNEnumerableIterator.ToArray](https://github.com/dotnet/corefx/blob/master/src/System.Linq/src/System/Linq/Concat.cs#L443) cannot be optimized since we need to determine the right amount to allocate in advance, but `ToList` can.

- In my recent PR #12042 `Count` cannot be optimized for `Cast` since we might miss throwing an exception for an invalid cast, but `ToArray` / `ToList` can.

- Another example is [SelectEnumerableIterator](https://github.com/dotnet/corefx/pull/11841/files#diff-0e401ce4761b21f560293373a0a40781R150) where we can't optimize for `ToArray` or `ToList` but can for `Count`.

For providers where we can't optimize for a particular method, we just want to return `this.ToArray()` or `this.Count()`, etc. However, this leads to a stack overflow because `Enumerable.ToArray()` checks for `IIListProvider` again and calls `IIListProvider.ToArray()`.

Our solution for this thus far has been to introduce separate methods, one that checks for IIListProvider and one that doesn't. For example, places where `ToArray` can't be optimized call `EnumerableHelpers.ToArray(this)`, and places where `ToList` can't be call `new List<T>(this)`. Same for [Buffer](https://github.com/dotnet/corefx/blob/master/src/System.Linq/src/System/Linq/Buffer.cs#L16).

## What this PR is

My idea was that instead of having 2 versions of the same thing, one that does/doesn't check for a particular type, we could simply pass in flags to the method to tell it which types to cast to. The publicly exposed method (in this case `Count(IEnumerable)`) is just a wrapper around this method, telling it to try casting to all of the types. `IIListProviders` that cannot optimize their `Count` simply call

```cs
this.Count(Check.All & ~Check.IIListProvider);
```

to make `Count` not check for IIListProviders.

Another neat side-effect of using this pattern is that we can fine-tune perf in cases where we call `Count()` but we know the enumerable is not of a certain type (pass in `Check.All & ~Check.ThatType`) or is one of two types (`Check.Type1 | Check.Type2`). This PR does that in a couple of files.

cc @stephentoub, @VSadov, do you think this is a good change?