### PR TITLE
Override BufferedStream.CopyToAsync to delegate to source stream

### DIFF
--- a/src/Common/src/System/IO/StreamHelpers.ArrayPoolCopy.cs
+++ b/src/Common/src/System/IO/StreamHelpers.ArrayPoolCopy.cs
@@ -10,44 +10,8 @@ using System.Threading.Tasks;
 namespace System.IO
 {
     /// <summary>Provides methods to help in the implementation of Stream-derived types.</summary>
-    internal static class StreamHelpers
+    internal static partial class StreamHelpers
     {
-        /// <summary>Validate the arguments to CopyToAsync, as would Stream.CopyToAsync.</summary>
-        public static void ValidateCopyToAsyncArgs(Stream source, Stream destination, int bufferSize)
-        {
-            if (destination == null)
-            {
-                throw new ArgumentNullException(nameof(destination));
-            }
-
-            if (bufferSize <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(bufferSize), bufferSize, SR.ArgumentOutOfRange_NeedPosNum);
-            }
-
-            bool sourceCanRead = source.CanRead;
-            if (!sourceCanRead && !source.CanWrite)
-            {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
-            }
-
-            bool destinationCanWrite = destination.CanWrite;
-            if (!destination.CanRead && !destinationCanWrite)
-            {
-                throw new ObjectDisposedException(nameof(destination), SR.ObjectDisposed_StreamClosed);
-            }
-
-            if (!sourceCanRead)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
-            }
-
-            if (!destinationCanWrite)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
-            }
-        }
-
         /// <summary>
         /// Provides an implementation usable as an override of Stream.CopyToAsync but that uses the shared
         /// ArrayPool for the intermediate buffer rather than allocating a new buffer each time.

--- a/src/Common/src/System/IO/StreamHelpers.CopyValidation.cs
+++ b/src/Common/src/System/IO/StreamHelpers.CopyValidation.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    /// <summary>Provides methods to help in the implementation of Stream-derived types.</summary>
+    internal static partial class StreamHelpers
+    {
+        /// <summary>Validate the arguments to CopyToAsync, as would Stream.CopyToAsync.</summary>
+        public static void ValidateCopyToAsyncArgs(Stream source, Stream destination, int bufferSize)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), bufferSize, SR.ArgumentOutOfRange_NeedPosNum);
+            }
+
+            bool sourceCanRead = source.CanRead;
+            if (!sourceCanRead && !source.CanWrite)
+            {
+                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
+            }
+
+            bool destinationCanWrite = destination.CanWrite;
+            if (!destination.CanRead && !destinationCanWrite)
+            {
+                throw new ObjectDisposedException(nameof(destination), SR.ObjectDisposed_StreamClosed);
+            }
+
+            if (!sourceCanRead)
+            {
+                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
+            }
+
+            if (!destinationCanWrite)
+            {
+                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+            }
+        }
+    }
+}

--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -74,8 +74,11 @@
     <Compile Include="System\IO\Compression\DeflateZLib\Inflater.cs" />
     <Compile Include="System\IO\Compression\DeflateZLib\ZLibException.cs" />
     <Compile Include="System\IO\Compression\DeflateZLib\ZLibNative.cs" />
-    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.cs">
-      <Link>Common\System\IO\StreamHelpers.cs</Link>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.ArrayPoolCopy.cs">
+      <Link>Common\System\IO\StreamHelpers.ArrayPoolCopy.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
+      <Link>Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == '' ">

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -82,8 +82,11 @@
     <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
       <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.cs">
-      <Link>Common\System\IO\StreamHelpers.cs</Link>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.ArrayPoolCopy.cs">
+      <Link>Common\System\IO\StreamHelpers.ArrayPoolCopy.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
+      <Link>Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- .NET Standard 1.7 -->

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -42,8 +42,11 @@
     <Compile Include="System\IO\Pipes\NamedPipeServerStream.cs" />
     <Compile Include="System\IO\Pipes\PipeState.cs" />
     <Compile Include="System\IO\Pipes\PipeStream.cs" />
-    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.cs">
-      <Link>Common\System\IO\StreamHelpers.cs</Link>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.ArrayPoolCopy.cs">
+      <Link>Common\System\IO\StreamHelpers.ArrayPoolCopy.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
+      <Link>Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'net46' ">

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -49,6 +49,9 @@
     <Compile Include="System\IO\FileStreamHelpers.cs" />
     <Compile Include="System\IO\BufferedStream.cs" />
     <Compile Include="System\IO\InvalidDataException.cs" />
+    <Compile Include="..\..\Common\src\System\IO\StreamHelpers.cs">
+      <Link>Common\System\IO\StreamHelpers.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
       <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -49,8 +49,8 @@
     <Compile Include="System\IO\FileStreamHelpers.cs" />
     <Compile Include="System\IO\BufferedStream.cs" />
     <Compile Include="System\IO\InvalidDataException.cs" />
-    <Compile Include="..\..\Common\src\System\IO\StreamHelpers.cs">
-      <Link>Common\System\IO\StreamHelpers.cs</Link>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
+      <Link>Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
       <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>

--- a/src/System.IO/src/System/IO/BufferedStream.cs
+++ b/src/System.IO/src/System/IO/BufferedStream.cs
@@ -1096,7 +1096,7 @@ namespace System.IO
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             StreamHelpers.ValidateCopyToAsyncArgs(this, destination, bufferSize);
-            var flushTask = FlushAsync(cancellationToken);
+            Task flushTask = FlushAsync(cancellationToken);
             return flushTask.Status == TaskStatus.RanToCompletion ?
                 _stream.CopyToAsync(destination, bufferSize, cancellationToken) :
                 CopyToAsyncCore(flushTask, destination, bufferSize, cancellationToken);

--- a/src/System.IO/src/System/IO/BufferedStream.cs
+++ b/src/System.IO/src/System/IO/BufferedStream.cs
@@ -1092,5 +1092,20 @@ namespace System.IO
             Flush();
             _stream.SetLength(value);
         }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            StreamHelpers.ValidateCopyToAsyncArgs(this, destination, bufferSize);
+            var flushTask = FlushAsync(cancellationToken);
+            return flushTask.Status == TaskStatus.RanToCompletion ?
+                _stream.CopyToAsync(destination, bufferSize, cancellationToken) :
+                CopyToAsyncCore(flushTask, destination, bufferSize, cancellationToken);
+        }
+
+        private async Task CopyToAsyncCore(Task flushTask, Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            await flushTask.ConfigureAwait(false);
+            await _stream.CopyToAsync(destination, bufferSize, cancellationToken).ConfigureAwait(false);
+        }
     }  // class BufferedStream
 }  // namespace

--- a/src/System.IO/tests/Stream/Stream.AsyncTests.cs
+++ b/src/System.IO/tests/Stream/Stream.AsyncTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -10,30 +10,21 @@ namespace System.IO.Tests
 {
     public class StreamAsync
     {
-        protected virtual Stream CreateStream()
-        {
-            return new MemoryStream();
-        }
+        protected virtual Stream CreateStream() => new MemoryStream();
 
         [Fact]
-        public async Task CopyToTest()
+        public async Task CopyToAsyncTest()
         {
+            byte[] data = Enumerable.Range(0, 1000).Select(i => (byte)(i % 256)).ToArray();
+
             Stream ms = CreateStream();
-            for (int i = 0; i < 1000; i++)
-            {
-                ms.WriteByte((byte)(i % 256));
-            }
+            ms.Write(data, 0, data.Length);
             ms.Position = 0;
 
             var ms2 = new MemoryStream();
             await ms.CopyToAsync(ms2);
 
-            var buffer = ms2.ToArray();
-            for (int i = 0; i < 1000; i++)
-            {
-                Assert.Equal(i % 256, buffer[i]);
-            }
-
+            Assert.Equal(data, ms2.ToArray());
         }
     }
 }


### PR DESCRIPTION
PR https://github.com/dotnet/corefx/pull/12006 added an override of BufferedStream.CopyToAsync, but it doesn't compile because it pulls in a helper file that references types from System.Buffers.dll, which System.IO.dll doesn't currently reference.  While that may change in the future, this PR fixes that by cherry-picking the initial commit and then adding a commit that splits the helper file into two, one that does the argument validation needed by this change and one that uses ArrayPool.  I've also added a commit with additional tests for the CopyToAsync override.

cc: @ianhays, @maddin2016
Fixes https://github.com/dotnet/corefx/issues/11572