### PR TITLE
Add some "manual" System.Console tests

### DIFF
--- a/src/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/System.Console/tests/ManualTests/ManualTests.cs
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System
+{
+    public class ConsoleManualTests
+    {
+        public static bool ManualTestsEnabled => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MANUAL_TESTS"));
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void ReadLine()
+        {
+            const string ExpectedLine = "This is a test of ReadLine.";
+            Console.WriteLine($"Please type the sentence (without the quotes): \"{ExpectedLine}\"");
+            string result = Console.ReadLine();
+            Assert.Equal(ExpectedLine, result);
+            AssertUserExpectedResults("the characters you typed properly echoed as you typed");
+        }
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void ReadKey()
+        {
+            Console.WriteLine("Please type \"console\" (without the quotes). You shouldn't see it as you type:");
+            foreach (ConsoleKey k in new[] { ConsoleKey.C, ConsoleKey.O, ConsoleKey.N, ConsoleKey.S, ConsoleKey.O, ConsoleKey.L, ConsoleKey.E })
+            {
+                Assert.Equal(k, Console.ReadKey(intercept: true).Key);
+            }
+            AssertUserExpectedResults("\"console\" correctly not echoed as you typed it");
+        }
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void KeyAvailable()
+        {
+            Console.WriteLine("Wait a few seconds, then press any key...");
+            while (Console.KeyAvailable)
+            {
+                Console.ReadKey();
+            }
+            while (!Console.KeyAvailable)
+            {
+                Task.Delay(500).Wait();
+                Console.WriteLine("\t...waiting...");
+            }
+            Console.ReadKey();
+            AssertUserExpectedResults("several wait messages get printed out");
+        }
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void Clear()
+        {
+            Console.Clear();
+            AssertUserExpectedResults("the screen get cleared");
+        }
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void Colors()
+        {
+            const int squareSize = 20;
+            var colors = new[] { ConsoleColor.Red, ConsoleColor.Green, ConsoleColor.Blue, ConsoleColor.Yellow };
+            for (int row = 0; row < 2; row++)
+            {
+                for (int i = 0; i < squareSize / 2; i++)
+                {
+                    Console.WriteLine();
+                    Console.Write("  ");
+                    for (int col = 0; col < 2; col++)
+                    {
+                        Console.BackgroundColor = colors[row * 2 + col];
+                        Console.ForegroundColor = colors[row * 2 + col];
+                        for (int j = 0; j < squareSize; j++) Console.Write('@');
+                        Console.ResetColor();
+                    }
+                }
+            }
+            Console.WriteLine();
+
+            AssertUserExpectedResults("a Microsoft flag in solid color");
+        }
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void CursorPositionAndArrowKeys()
+        {
+            Console.WriteLine("Use the up, down, left, and right arrow keys to move around.  When done, press enter.");
+
+            while (true)
+            {
+                ConsoleKeyInfo k = Console.ReadKey(intercept: true);
+                if (k.Key == ConsoleKey.Enter)
+                {
+                    break;
+                }
+
+                int left = Console.CursorLeft, top = Console.CursorTop;
+                switch (k.Key)
+                {
+                    case ConsoleKey.UpArrow:
+                        if (top > 0) Console.CursorTop = top - 1;
+                        break;
+                    case ConsoleKey.LeftArrow:
+                        if (left > 0) Console.CursorLeft = left - 1;
+                        break;
+                    case ConsoleKey.RightArrow:
+                        Console.CursorLeft = left + 1;
+                        break;
+                    case ConsoleKey.DownArrow:
+                        Console.CursorTop = top + 1;
+                        break;
+                }
+            }
+
+            AssertUserExpectedResults("the arrow keys move around the screen as expected with no other bad artificts");
+        }
+
+        private static void AssertUserExpectedResults(string expected)
+        {
+            Console.Write($"Did you see {expected}? [y/n] ");
+            Assert.Equal(ConsoleKey.Y, Console.ReadKey().Key);
+            Console.WriteLine();
+        }
+    }
+}

--- a/src/System.Console/tests/ManualTests/System.Console.Manual.Tests.builds
+++ b/src/System.Console/tests/ManualTests/System.Console.Manual.Tests.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Console.Manual.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Console/tests/ManualTests/System.Console.Manual.Tests.csproj
+++ b/src/System.Console/tests/ManualTests/System.Console.Manual.Tests.csproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{99E5069D-241F-48A6-8F29-404B4AED72BF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Console.Manual.Tests</AssemblyName>
+    <RootNamespace>System.Console.Manual.Tests</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="ManualTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\pkg\System.Console.pkgproj">
+      <Project>{F9DF2357-81B4-4317-908E-512DA9395583}</Project>
+      <Name>System.Console</Name>
+      <OSGroup>$(InputOSGroup)</OSGroup>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Console/tests/ManualTests/project.json
+++ b/src/System.Console/tests/ManualTests/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.2.0-beta-24608-01",
+    "System.Diagnostics.Process": "4.4.0-beta-24608-01",
+    "System.IO": "4.4.0-beta-24608-01",
+    "System.Runtime": "4.4.0-beta-24608-01",
+    "System.Runtime.Extensions": "4.4.0-beta-24608-01",
+    "System.Text.Encoding": "4.4.0-beta-24608-01",
+    "System.Threading.Tasks": "4.4.0-beta-24608-01",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00830-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00830-02",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
+  },
+  "frameworks": {
+    "netstandard1.3": {}
+  },
+  "supports": {
+    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.net46": {},
+    "coreFx.Test.net461": {},
+    "coreFx.Test.net462": {},
+    "coreFx.Test.net463": {}
+  }
+}


### PR DESCRIPTION
Today our test suite for System.Console is significantly lacking, due to our current inability to handle reading, verification of output to the terminal, etc.  Until we are better at such things, this PR adds a manual test suite, that instructs the user to do something and to then verify specific visual results and behaviors.

I'm submitting this as its own PR, but added it as part of validating a bug fix I'm submitting separately.

cc: @ianhays