### PR TITLE
Fix Alpine Linux System.Native.so build

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -1285,8 +1285,12 @@ cmsghdr* GET_CMSG_NXTHDR(msghdr* mhdr, cmsghdr* cmsg)
 // In musl-libc, CMSG_NXTHDR typecasts char* to cmsghdr* which causes
 // clang to throw cast-align warning. This is to suppress the warning
 // inline.
+// There is also a problem in the CMSG_NXTHDR macro in musl-libc.
+// It compares signed and unsigned value and clang warns about that.
+// So we suppress the warning inline too.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-align"
+#pragma clang diagnostic ignored "-Wsign-compare"
 #endif
     return CMSG_NXTHDR(mhdr, cmsg);
 #ifndef __GLIBC__


### PR DESCRIPTION
The native System.Native.so build fails on Alpine Linux with a signed to unsigned
comparison warning in the expansion of the CMSG_NXTHDR macro. The issue is in the
macro definition in the platform headers, so I am adding suppression of that warning
for the macro expansion.