### PR TITLE
Build perf

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -75,6 +75,13 @@
 
   <UsingTask TaskName="GatherDirectoriesToRestore" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
+  <!-- Create a collection of all project.json files for dependency updates. -->
+  <ItemGroup>
+    <ProjectJsonFiles Include="$(SourceDir)**/project.json" />
+    <ProjectJsonFiles Include="$(MSBuildThisFileDirectory)pkg/**/project.json" />
+    <ProjectJsonFiles Condition="'$(BuildTestsAgainstPackages)' == 'true'" Include="$(GeneratedProjectJsonDir)/**/project.json" />
+  </ItemGroup>
+  
   <Target Name="BatchRestorePackages" DependsOnTargets="VerifyDependencies">
     <MakeDir Directories="$(PackagesDir)" Condition="!Exists('$(PackagesDir)')" /> 
 

--- a/dir.props
+++ b/dir.props
@@ -126,13 +126,6 @@
     <DnuRestoreCommand Condition="'$(NuGetConfigPath)'!=''">$(DnuRestoreCommand) --configfile $(NuGetConfigPath)</DnuRestoreCommand>
   </PropertyGroup>
 
-  <!-- Create a collection of all project.json files for dependency updates. -->
-  <ItemGroup>
-    <ProjectJsonFiles Include="$(SourceDir)**/project.json" />
-    <ProjectJsonFiles Include="$(MSBuildThisFileDirectory)pkg/**/project.json" />
-    <ProjectJsonFiles Condition="'$(BuildTestsAgainstPackages)' == 'true'" Include="$(GeneratedProjectJsonDir)/**/project.json" />
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(BuildAllProjects)'=='true'">
     <!-- When we do a traversal build we get all packages up front, don't restore them again -->
     <RestorePackages>false</RestorePackages>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -199,7 +199,7 @@
           Returns="@(FilesToPackage)">
     <MSBuild Targets="GetFilesToPackage"
              Projects="@(Project)"
-             BuildInParallel="$(BuildInParallel)"
+             BuildInParallel="true"
              Properties="$(ProjectProperties)"
              ContinueOnError="ErrorAndContinue" >
       <Output TaskParameter="TargetOutputs"


### PR DESCRIPTION
When looking into build perf I noticed a couple issues that were easy fixes.

1. Every project was globbing for project.json's in the repo.
2. Pkg > Builds GetFilesToPackage was running in series rather than parallel.

Fixing the first issue cut package build time in half.  We happen to evaluate over 1000 different projects for a full package build, so that globbing really added up.

/cc @weshaggard @danmosemsft @stephentoub 