### PR TITLE
Fix SelectArrayIterator.MoveNext after Dispose

### DIFF
--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -168,16 +168,10 @@ namespace System.Linq
             {
                 return new SelectArrayIterator<TSource, TResult>(_source, _selector);
             }
-            
-            public override void Dispose()
-            {
-                // Don't touch _state
-                _current = default(TResult);
-            }
 
             public override bool MoveNext()
             {
-                if (_state == 0 | _state == _source.Length + 1)
+                if (_state < 1 | _state == _source.Length + 1)
                 {
                     Dispose();
                     return false;

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -168,6 +168,12 @@ namespace System.Linq
             {
                 return new SelectArrayIterator<TSource, TResult>(_source, _selector);
             }
+            
+            public override void Dispose()
+            {
+                // Don't touch _state
+                _current = default(TResult);
+            }
 
             public override bool MoveNext()
             {

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -1146,14 +1146,11 @@ namespace System.Linq.Tests
             }
         }
 
-        public static TheoryData<IEnumerable<int>> MoveNextAfterDisposeData()
+        public static IEnumerable<object[]> MoveNextAfterDisposeData()
         {
-            return new TheoryData<IEnumerable<int>>
-            {
-                { Array.Empty<int>() },
-                { new int[1] },
-                { Enumerable.Range(1, 30) }
-            };
+            yield return new object[] { Array.Empty<int>() };
+            yield return new object[] { new int[1] };
+            yield return new object[] { Enumerable.Range(1, 30) };
         }
     }
 }

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -1141,7 +1141,7 @@ namespace System.Linq.Tests
                 using (IEnumerator<int> e = result.GetEnumerator())
                 {
                     while (e.MoveNext()) ; // Loop until we reach the end of the iterator, @ which pt it gets disposed.
-                    e.MoveNext(); // MoveNext should not throw an exception after Dispose.
+                    Assert.False(e.MoveNext()); // MoveNext should not throw an exception after Dispose.
                 }
             }
         }

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -1118,5 +1118,42 @@ namespace System.Linq.Tests
             Assert.Equal(new[] { 6, 8 }, new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Skip(2).ToList());
             Assert.Empty(new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Skip(8).ToList());
         }
+
+        [Theory]
+        [MemberData(nameof(MoveNextAfterDisposeData))]
+        public void MoveNextAfterDispose(IEnumerable<int> source)
+        {
+            // Select is specialized for a bunch of different types, so we want
+            // to make sure this holds true for all of them.
+            var identityTransforms = new List<Func<IEnumerable<int>, IEnumerable<int>>>
+            {
+                e => e,
+                e => ForceNotCollection(e),
+                e => e.ToArray(),
+                e => e.ToList(),
+                e => new LinkedList<int>(e), // IList<T> that's not a List
+                e => e.Select(i => i) // Multiple Select() chains are optimized
+            };
+
+            foreach (IEnumerable<int> equivalentSource in identityTransforms.Select(t => t(source)))
+            {
+                IEnumerable<int> result = equivalentSource.Select(i => i);
+                using (IEnumerator<int> e = result.GetEnumerator())
+                {
+                    while (e.MoveNext()) ; // Loop until we reach the end of the iterator, @ which pt it gets disposed.
+                    e.MoveNext(); // MoveNext should not throw an exception after Dispose.
+                }
+            }
+        }
+
+        public static TheoryData<IEnumerable<int>> MoveNextAfterDisposeData()
+        {
+            return new TheoryData<IEnumerable<int>>
+            {
+                { Array.Empty<int>() },
+                { new int[1] },
+                { Enumerable.Range(1, 30) }
+            };
+        }
     }
 }


### PR DESCRIPTION
Just realized that there was a small issue with my changes in #11841: if someone tries to `MoveNext` on a `SelectArrayIterator` after it's Disposed, then an IOOR exception will be generated because we try to access index -2. This is the fix.

Repro:

```cs
var s = new int[1].Select(a => a);
using (var e = s.GetEnumerator())
{
    e.MoveNext();
    e.MoveNext(); // Disposes
    e.MoveNext(); // before called SelectArrayIterator.Dispose again, now throws
}
```

cc @stephentoub, @VSadov 