### PR TITLE
Update DbCommand.cs

### DIFF
--- a/src/System.Data.Common/src/System/Data/Common/DbCommand.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbCommand.cs
@@ -198,18 +198,12 @@ namespace System.Data.Common
                     registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
                 }
 
-                try
+                return Task.Factory.StartNew<int>(s =>
                 {
-                    return Task.Run<int>(() => ExecuteNonQuery());
-                }
-                catch (Exception e)
-                {
-                    return TaskHelpers.FromException<int>(e);
-                }
-                finally
-                {
-                    registration.Dispose();
-                }
+                    var t = (Tuple<DbCommand, CancellationTokenRegistration>)s;
+                    try { return t.Item1.ExecuteNonQuery(); }
+                    finally { t.Item2.Dispose(); }
+                }, Tuple.Create(this, registration), CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
             }
         }
 
@@ -247,18 +241,12 @@ namespace System.Data.Common
                     registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
                 }
 
-                try
+                return Task.Factory.StartNew<DbDataReader>(s =>
                 {
-                    return Task.Run<DbDataReader>(() => ExecuteReader(behavior));
-                }
-                catch (Exception e)
-                {
-                    return TaskHelpers.FromException<DbDataReader>(e);
-                }
-                finally
-                {
-                    registration.Dispose();
-                }
+                    var t = (Tuple<DbCommand, CancellationTokenRegistration, CommandBehavior>)s;
+                    try { return t.Item1.ExecuteReader(t.Item3); }
+                    finally { t.Item2.Dispose(); }
+                }, Tuple.Create(this, registration, behavior), CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
             }
         }
 
@@ -281,18 +269,12 @@ namespace System.Data.Common
                     registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
                 }
 
-                try
+                return Task.Factory.StartNew<object>(s =>
                 {
-                    return Task.Run<object>(() => ExecuteScalar());
-                }
-                catch (Exception e)
-                {
-                    return TaskHelpers.FromException<object>(e);
-                }
-                finally
-                {
-                    registration.Dispose();
-                }
+                    var t = (Tuple<DbCommand, CancellationTokenRegistration>)s;
+                    try { return t.Item1.ExecuteScalar(); }
+                    finally { t.Item2.Dispose(); }
+                }, Tuple.Create(this, registration), CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
             }
         }
 

--- a/src/System.Data.Common/src/System/Data/Common/DbCommand.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbCommand.cs
@@ -200,7 +200,7 @@ namespace System.Data.Common
 
                 try
                 {
-                    return Task.FromResult<int>(ExecuteNonQuery());
+                    return Task.Run<int>(() => ExecuteNonQuery());
                 }
                 catch (Exception e)
                 {
@@ -249,7 +249,7 @@ namespace System.Data.Common
 
                 try
                 {
-                    return Task.FromResult<DbDataReader>(ExecuteReader(behavior));
+                    return Task.Run<DbDataReader>(() => ExecuteReader(behavior));
                 }
                 catch (Exception e)
                 {
@@ -283,7 +283,7 @@ namespace System.Data.Common
 
                 try
                 {
-                    return Task.FromResult<object>(ExecuteScalar());
+                    return Task.Run<object>(() => ExecuteScalar());
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Since base implementation of the asynchronous methods is provided, i think that they should at least run in a worker thread so that they won't block. Drivers that extend this class could then override the asynchronous methods and implement them in their own way (probably with Asynchronous I/O).

The MySQL Driver for instance doesn't override any of the asynchronous methods in this class so every attempt to run a query asynchronous ends up with a blocking code.