### PR TITLE
EmailAddressAttribute validation returns true on empty string

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
@@ -28,6 +28,10 @@ namespace System.ComponentModel.DataAnnotations
             {
                 return false;
             }
+            else if (valueAsString.Length == 0)
+            {
+                return true;
+            }
 
             // only return true if there is only 1 '@' character
             // and it is neither the first nor the last character

--- a/src/System.ComponentModel.Annotations/tests/EmailAddressAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/EmailAddressAttributeTests.cs
@@ -12,6 +12,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
         protected override IEnumerable<TestCase> ValidValues()
         {
             yield return new TestCase(new EmailAddressAttribute(), null);
+            yield return new TestCase(new EmailAddressAttribute(), "");
             yield return new TestCase(new EmailAddressAttribute(), "someName@someDomain.com");
             yield return new TestCase(new EmailAddressAttribute(), "1234@someDomain.com");
             yield return new TestCase(new EmailAddressAttribute(), "firstName.lastName@someDomain.com");
@@ -28,7 +29,6 @@ namespace System.ComponentModel.DataAnnotations.Tests
         protected override IEnumerable<TestCase> InvalidValues()
         {
             yield return new TestCase(new EmailAddressAttribute(), 0);
-            yield return new TestCase(new EmailAddressAttribute(), "");
             yield return new TestCase(new EmailAddressAttribute(), " \r \t \n" );
             yield return new TestCase(new EmailAddressAttribute(), "@someDomain.com");
             yield return new TestCase(new EmailAddressAttribute(), "@someDomain@abc.com");


### PR DESCRIPTION
System.ComponentModel.Annotations.EmailAddressAttribute IsValid returns true on empty string, so that it is aligned with other validators. And Required attribute validates non-empty string.

Fixing issue #11142
