### PR TITLE
Re-Enable some ActiveIssue'd Compression tests

### DIFF
--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -216,7 +216,6 @@ namespace System.IO.Compression.Tests
         /// cause any bytes to be left in ZLib's buffer. 
         /// </summary>
         [Fact]
-        [ActiveIssue(11685)]
         public static void ZipWithLargeSparseFile()
         {
             string zipname = strange("largetrailingwhitespacedeflation.zip");

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ManualAndCompatibilityTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ManualAndCompatibilityTests.cs
@@ -10,7 +10,6 @@ namespace System.IO.Compression.Tests
     public class zip_ManualAndCompatabilityTests : ZipFileTestBase
     {
         [Theory]
-        [ActiveIssue(11685)]
         [InlineData("7zip.zip", "normal", true, true)]
         [InlineData("deflate64.zip", "normal", true, true)]
         [InlineData("windows.zip", "normalWithoutEmptyDir", false, true)]


### PR DESCRIPTION
I was unable to repro these failures on the latest master.

resolves https://github.com/dotnet/corefx/issues/11685