### PR TITLE
Remove ExtraParameters and add defaults for clean and sync

### DIFF
--- a/config.json
+++ b/config.json
@@ -192,12 +192,6 @@
       "values": [],
       "defaultValue": ""
     },
-    "ExtraParameters": {
-      "description": "Extra parameters will be passed to the selected command.",
-      "valueType": "passThrough",
-      "values": [],
-      "defaultValue": ""
-    },
     "BatchGenerateTestProjectJsons": {
       "description": "MsBuild target that generates the project.json files to build tests against packages.",
       "valueType": "target",
@@ -402,6 +396,7 @@
         }
       },
       "defaultValues": {
+	    "defaultAlias": "b",
         "toolName": "msbuild",
         "settings": {
           "MsBuildLogging":"/flp:v=normal;LogFile=clean.log"
@@ -515,6 +510,7 @@
         }
       },
       "defaultValues": {
+	  	"defaultAlias": "p",
         "toolName": "msbuild",
         "settings": {
           "MsBuildLogging":"/flp:v=normal;LogFile=sync.log"


### PR DESCRIPTION
From discussion with @maririos I'm not sure all other commands will have defaults but clean and sync having them (which guards against weird parsing errors in their respective script files).

Related issues:
https://github.com/dotnet/buildtools/issues/1080
https://github.com/dotnet/buildtools/issues/928 
https://github.com/dotnet/buildtools/issues/910

@weshaggard 