### PR TITLE
Increase timeouts in several ThreadLocal tests

### DIFF
--- a/src/System.Threading/tests/ThreadLocalTests.cs
+++ b/src/System.Threading/tests/ThreadLocalTests.cs
@@ -135,7 +135,7 @@ namespace System.Threading.Tests
                 GC.WaitForPendingFinalizers();
                 GC.Collect();
                 return mres.IsSet;
-            }, 500);
+            }, 5000);
 
             Assert.True(mres.IsSet);
         }
@@ -329,7 +329,7 @@ namespace System.Threading.Tests
                     GC.WaitForPendingFinalizers();
                     GC.Collect();
                     return mres.IsSet;
-                }, 1000);
+                }, 5000);
 
                 Assert.True(mres.IsSet, "RunThreadLocalTest8_Values: Expected thread local to release the object and for it to be finalized");
             }


### PR DESCRIPTION
I'm currently assuming that https://github.com/dotnet/corefx/issues/12556 failed not because of a product bug but because 500ms was insufficient for the test to complete given the load on the machine.  For now I'm addressing this by increasing the timeouts, and we'll see if it happens again.

Fixes https://github.com/dotnet/corefx/issues/12556