### PR TITLE
Remove redundant Packaging.props import from src/publish.proj

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Packaging.props))\Packaging.props" />
   <Import Project="$(ToolsDir)PublishContent.targets" />
   <Import Project="$(ToolsDir)versioning.targets" />
 


### PR DESCRIPTION
It is already unconditionally imported in `dir.props`, and this causes a warning during publish-packages. As far as I can tell looking at git history, this double-import has always been there since publish.proj was originally created (as publish.builds).

@chcosta 