### PR TITLE
Update System.Data.Common project.jsons to fix a PR conflict

### DIFF
--- a/src/System.Data.Common/ref/project.json
+++ b/src/System.Data.Common/ref/project.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "System.Runtime": "4.4.0-beta-24608-01",
-    "System.Threading.Tasks": "4.4.0-beta-24608-01",
-    "System.IO": "4.4.0-beta-24608-01"
+    "System.Runtime": "4.4.0-beta-24611-02",
+    "System.Threading.Tasks": "4.4.0-beta-24611-02",
+    "System.IO": "4.4.0-beta-24611-02"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Data.Common/src/project.json
+++ b/src/System.Data.Common/src/project.json
@@ -2,17 +2,17 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.2.0-beta-24608-01",
-        "System.Collections": "4.4.0-beta-24608-01",
-        "System.Diagnostics.Debug": "4.4.0-beta-24608-01",
-        "System.Diagnostics.Tools": "4.4.0-beta-24608-01",
-        "System.Globalization": "4.4.0-beta-24608-01",
-        "System.IO": "4.4.0-beta-24608-01",
-        "System.Resources.ResourceManager": "4.4.0-beta-24608-01",
-        "System.Runtime": "4.4.0-beta-24608-01",
-        "System.Runtime.Extensions": "4.4.0-beta-24608-01",
-        "System.Text.RegularExpressions": "4.4.0-beta-24608-01",
-        "System.Threading.Tasks": "4.4.0-beta-24608-01"
+        "Microsoft.NETCore.Platforms": "1.2.0-beta-24611-02",
+        "System.Collections": "4.4.0-beta-24611-02",
+        "System.Diagnostics.Debug": "4.4.0-beta-24611-02",
+        "System.Diagnostics.Tools": "4.4.0-beta-24611-02",
+        "System.Globalization": "4.4.0-beta-24611-02",
+        "System.IO": "4.4.0-beta-24611-02",
+        "System.Resources.ResourceManager": "4.4.0-beta-24611-02",
+        "System.Runtime": "4.4.0-beta-24611-02",
+        "System.Runtime.Extensions": "4.4.0-beta-24611-02",
+        "System.Text.RegularExpressions": "4.4.0-beta-24611-02",
+        "System.Threading.Tasks": "4.4.0-beta-24611-02"
       }
     },
     "net463": {


### PR DESCRIPTION
Fixes dependency verification errors that repro when `sync`ing or building master:
```
[18:58:41.94] Verifying all auto-upgradeable dependencies...
D:\j\workspace\windows_nt_de---4526f5ff\Tools\VersionTools.targets(47,5): error : Dependency verification errors detected. To automatically fix based on dependency rules, run the msbuild target 'UpdateDependencies' [D:\j\workspace\windows_nt_de---4526f5ff\build.proj]
D:\j\workspace\windows_nt_de---4526f5ff\Tools\VersionTools.targets(47,5): error : Dependencies invalid: In 'D:\j\workspace\windows_nt_de---4526f5ff\src\System.Data.Common\ref\project.json', 'System.Runtime 4.4.0-beta-24608-01' must be '4.4.0-beta-24611-02' (CoreFx) [D:\j\workspace\windows_nt_de---4526f5ff\build.proj]
...
```

https://github.com/dotnet/corefx/pull/12514 conflicted with https://github.com/dotnet/corefx/pull/12557 (auto-update). The CI on 12514 ran before the auto-update was merged, so CI couldn't catch it.

A bit more detail: 7 hours ago, CI ran on https://github.com/dotnet/corefx/pull/12514 where stable versions were upgraded to `beta-24608-01`, the current prerelease at the time. Then (12514 not being merged yet) the auto-upgrade happened, which didn't touch those stable versions, so there was no git-level conflict. Then the auto-upgrade was merged, bringing the expected version to `beta-24611-02`. *Then* https://github.com/dotnet/corefx/pull/12514 was merged (without CI rerunning), introducing old versions into master and making verification fail.

I can't think of a way to reliably catch this kind of error until we go all the way to generating project.json files, which should eliminate them.

@weshaggard @stephentoub 