### PR TITLE
Fix SpecialFolder.MyDocuments to map to XDG properly in Unix

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
@@ -193,7 +193,6 @@ namespace System
             switch (folder)
             {
                 case SpecialFolder.UserProfile:
-                case SpecialFolder.MyDocuments: // same value as Personal
                     return home;
                 case SpecialFolder.ApplicationData:
                     return GetXdgConfig(home);
@@ -207,6 +206,8 @@ namespace System
                     }
                     return data;
 
+                case SpecialFolder.MyDocuments: // same value as Personal
+                    return ReadXdgDirectory(home, "XDG_DOCUMENTS_DIR", "Documents");
                 case SpecialFolder.Desktop:
                 case SpecialFolder.DesktopDirectory:
                     return ReadXdgDirectory(home, "XDG_DESKTOP_DIR", "Desktop");

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -199,10 +199,8 @@ namespace System.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public void GetFolderPath_Unix_PersonalIsHomeAndUserProfile()
+        public void GetFolderPath_Unix_UserProfileIsHome()
         {
-            Assert.Equal(Environment.GetEnvironmentVariable("HOME"), Environment.GetFolderPath(Environment.SpecialFolder.Personal));
-            Assert.Equal(Environment.GetEnvironmentVariable("HOME"), Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
             Assert.Equal(Environment.GetEnvironmentVariable("HOME"), Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
         }
 


### PR DESCRIPTION
In Windows SpecialFolder.MyDocuments maps to "C:\Users\foo\My Documents".

The equivalent to this in Linux should be
"/home/foo/Documents", not "/home/foo".

(There's already another SpecialFolder enum member
that already maps to "/home/foo" and
"C:\Users\foo", it is the SpecialFolder.UserProfile.)