### PR TITLE
Add XML docs to IPartition

### DIFF
--- a/src/System.Linq/src/System/Linq/Partition.cs
+++ b/src/System.Linq/src/System/Linq/Partition.cs
@@ -35,16 +35,45 @@ namespace System.Linq
         int GetCount(bool onlyIfCheap);
     }
 
+    /// <summary>
+    /// An iterator that supports random access and can produce a partial sequence of its items through an optimized path.
+    /// </summary>
     internal interface IPartition<TElement> : IIListProvider<TElement>
     {
+        /// <summary>
+        /// Skips the specified number of elements in this sequence.
+        /// </summary>
+        /// <param name="count">The number of elements to skip.</param>
+        /// <returns>An <see cref="IPartition{TElement}"/> with the first <paramref name="count"/> items removed.</returns>
         IPartition<TElement> Skip(int count);
 
+        /// <summary>
+        /// Takes the specified number of elements from this sequence.
+        /// </summary>
+        /// <param name="count">The number of elements to take.</param>
+        /// <returns>An <see cref="IPartition{TElement}"/> with only the first <paramref name="count"/> items.</returns>
         IPartition<TElement> Take(int count);
 
+        /// <summary>
+        /// Gets the item associated with a 0-based index in this sequence.
+        /// </summary>
+        /// <param name="index">The 0-based index to access.</param>
+        /// <param name="found"><c>true</c> if the sequence contains an element at that index, <c>false</c> otherwise.</param>
+        /// <returns>The element if <paramref name="found"/> is <c>true</c>, otherwise, the default value of <see cref="TElement"/>.</returns>
         TElement TryGetElementAt(int index, out bool found);
 
+        /// <summary>
+        /// Gets the first item in this sequence.
+        /// </summary>
+        /// <param name="found"><c>true</c> if the sequence contains a first element, <c>false</c> otherwise.</param>
+        /// <returns>The element if <paramref name="found"/> is <c>true</c>, otherwise, the default value of <see cref="TElement"/>.</returns>
         TElement TryGetFirst(out bool found);
 
+        /// <summary>
+        /// Gets the last item in this sequence.
+        /// </summary>
+        /// <param name="found"><c>true</c> if the sequence contains a last element, <c>false</c> otherwise.</param>
+        /// <returns>The element if <paramref name="found"/> is <c>true</c>, otherwise, the default value of <see cref="TElement"/>.</returns>
         TElement TryGetLast(out bool found);
     }
 

--- a/src/System.Linq/src/System/Linq/Partition.cs
+++ b/src/System.Linq/src/System/Linq/Partition.cs
@@ -41,14 +41,14 @@ namespace System.Linq
     internal interface IPartition<TElement> : IIListProvider<TElement>
     {
         /// <summary>
-        /// Skips the specified number of elements in this sequence.
+        /// Creates a new partition that skips the specified number of elements from this sequence.
         /// </summary>
         /// <param name="count">The number of elements to skip.</param>
         /// <returns>An <see cref="IPartition{TElement}"/> with the first <paramref name="count"/> items removed.</returns>
         IPartition<TElement> Skip(int count);
 
         /// <summary>
-        /// Takes the specified number of elements from this sequence.
+        /// Creates a new partition that takes the specified number of elements from this sequence.
         /// </summary>
         /// <param name="count">The number of elements to take.</param>
         /// <returns>An <see cref="IPartition{TElement}"/> with only the first <paramref name="count"/> items.</returns>
@@ -65,14 +65,14 @@ namespace System.Linq
         /// <summary>
         /// Gets the first item in this sequence.
         /// </summary>
-        /// <param name="found"><c>true</c> if the sequence contains a first element, <c>false</c> otherwise.</param>
+        /// <param name="found"><c>true</c> if the sequence contains an element, <c>false</c> otherwise.</param>
         /// <returns>The element if <paramref name="found"/> is <c>true</c>, otherwise, the default value of <see cref="TElement"/>.</returns>
         TElement TryGetFirst(out bool found);
 
         /// <summary>
         /// Gets the last item in this sequence.
         /// </summary>
-        /// <param name="found"><c>true</c> if the sequence contains a last element, <c>false</c> otherwise.</param>
+        /// <param name="found"><c>true</c> if the sequence contains an element, <c>false</c> otherwise.</param>
         /// <returns>The element if <paramref name="found"/> is <c>true</c>, otherwise, the default value of <see cref="TElement"/>.</returns>
         TElement TryGetLast(out bool found);
     }


### PR DESCRIPTION
This PR adds XML docs to IPartition. `TryGetFirst` / `TryGetLast` / `TryGetElementAt` are kind of confusing since there's an ambiguity whether we should only return the value if it's cheap vs. if the sequence contains a first / last / element at that index, so this clarifies that for future readers.

@stephentoub @VSadov 