### PR TITLE
Rename ValidateCopyToAsyncArgs -> ValidateCopyToArgs

### DIFF
--- a/src/Common/src/System/IO/StreamHelpers.ArrayPoolCopy.cs
+++ b/src/Common/src/System/IO/StreamHelpers.ArrayPoolCopy.cs
@@ -27,7 +27,7 @@ namespace System.IO
         public static Task ArrayPoolCopyToAsync(Stream source, Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             Debug.Assert(source != null);
-            ValidateCopyToAsyncArgs(source, destination, bufferSize);
+            ValidateCopyToArgs(source, destination, bufferSize);
             return ArrayPoolCopyToAsyncCore(source, destination, bufferSize, cancellationToken);
         }
 

--- a/src/Common/src/System/IO/StreamHelpers.CopyValidation.cs
+++ b/src/Common/src/System/IO/StreamHelpers.CopyValidation.cs
@@ -7,8 +7,8 @@ namespace System.IO
     /// <summary>Provides methods to help in the implementation of Stream-derived types.</summary>
     internal static partial class StreamHelpers
     {
-        /// <summary>Validate the arguments to CopyToAsync, as would Stream.CopyToAsync.</summary>
-        public static void ValidateCopyToAsyncArgs(Stream source, Stream destination, int bufferSize)
+        /// <summary>Validate the arguments to CopyTo, as would Stream.CopyTo.</summary>
+        public static void ValidateCopyToArgs(Stream source, Stream destination, int bufferSize)
         {
             if (destination == null)
             {

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
@@ -1699,7 +1699,7 @@ namespace System.IO
                 return StreamHelpers.ArrayPoolCopyToAsync(_parent, destination, bufferSize, cancellationToken);
             }
 
-            StreamHelpers.ValidateCopyToAsyncArgs(_parent, destination, bufferSize);
+            StreamHelpers.ValidateCopyToArgs(_parent, destination, bufferSize);
 
             // Bail early for cancellation if cancellation has been requested
             if (cancellationToken.IsCancellationRequested)

--- a/src/System.IO/src/System/IO/BufferedStream.cs
+++ b/src/System.IO/src/System/IO/BufferedStream.cs
@@ -1095,7 +1095,8 @@ namespace System.IO
 
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            StreamHelpers.ValidateCopyToAsyncArgs(this, destination, bufferSize);
+            StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
+            
             Task flushTask = FlushAsync(cancellationToken);
             return flushTask.Status == TaskStatus.RanToCompletion ?
                 _stream.CopyToAsync(destination, bufferSize, cancellationToken) :


### PR DESCRIPTION
dotnet/coreclr#7579 copies `StreamHelpers` from corefx and renames `ValidateCopyToAsyncArgs` to `ValidateCopyToArgs`. This is the corresponding change in this repo renaming the method.

cc @stephentoub, @ianhays 