### PR TITLE
Add netcoreapp1.1 target framework to System.IO test project.json

### DIFF
--- a/src/System.IO/tests/project.json
+++ b/src/System.IO/tests/project.json
@@ -19,29 +19,13 @@
   },
   "frameworks": {
     "netstandard1.5": {},
-    "netstandard1.7": {}
+    "netstandard1.7": {},
+    "netcoreapp1.1": {}
   },
   "supports": {
     "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net462": {},
-    "coreFx.Test.net463": {},
-    "coreFx.Test.netcoreapp1.1-ns17": {
-      "netstandard1.7": [
-        "win7-x86",
-        "win7-x64",
-        "win10-arm64",
-        "osx.10.10-x64",
-        "centos.7-x64",
-        "debian.8-x64",
-        "rhel.7-x64",
-        "ubuntu.14.04-x64",
-        "ubuntu.16.04-x64",
-        "ubuntu.16.10-x64",
-        "fedora.23-x64",
-        "linux-x64",
-        "opensuse.13.2-x64",
-        "opensuse.42.1-x64"
-      ]
-    }
+    "coreFx.Test.net463": {}
   }
 }


### PR DESCRIPTION
This should fix the official build process for restoring the IO test packages correctly, introduced by https://github.com/dotnet/corefx/pull/12569.

FYI @jkotas