### PR TITLE
RemoteInvoke Collections tests using DefaultThreadCurrentCulture

### DIFF
--- a/src/System.Collections.NonGeneric/tests/CaseInsentiveComparerTests.cs
+++ b/src/System.Collections.NonGeneric/tests/CaseInsentiveComparerTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.Collections.Tests
 {
-    public static class CaseInsensitiveComparerTests
+    public static class CaseInsensitiveComparerTests 
     {
         [Theory]
         [InlineData("hello", "HELLO", 0)]
@@ -130,41 +130,46 @@ namespace System.Collections.Tests
         [InlineData(null, null, 0)]
         public static void DefaultInvariant_Compare(object a, object b, int expected)
         {
-            var cultureNames = new string[]
+            CultureInfo culture1 = CultureInfo.CurrentCulture;
+            CultureInfo culture2 = CultureInfo.CurrentUICulture;
+
+            try
             {
-                "cs-CZ","da-DK","de-DE","el-GR","en-US",
-                "es-ES","fi-FI","fr-FR","hu-HU","it-IT",
-                "ja-JP","ko-KR","nb-NO","nl-NL","pl-PL",
-                "pt-BR","pt-PT","ru-RU","sv-SE","tr-TR",
-                "zh-CN","zh-HK","zh-TW"
-            };
-
-            CultureInfo culture1 = CultureInfo.DefaultThreadCurrentCulture;
-            CultureInfo culture2 = CultureInfo.DefaultThreadCurrentCulture;
-
-            foreach (string cultureName in cultureNames)
-            {
-                CultureInfo culture;
-                try
+                var cultureNames = new string[]
                 {
-                    culture = new CultureInfo(cultureName);
-                }
-                catch (CultureNotFoundException)
+                    "cs-CZ","da-DK","de-DE","el-GR","en-US",
+                    "es-ES","fi-FI","fr-FR","hu-HU","it-IT",
+                    "ja-JP","ko-KR","nb-NO","nl-NL","pl-PL",
+                    "pt-BR","pt-PT","ru-RU","sv-SE","tr-TR",
+                    "zh-CN","zh-HK","zh-TW"
+                };
+
+                foreach (string cultureName in cultureNames)
                 {
-                    continue;
+                    CultureInfo culture;
+                    try
+                    {
+                        culture = new CultureInfo(cultureName);
+                    }
+                    catch (CultureNotFoundException)
+                    {
+                        continue;
+                    }
+
+                    // Set current culture
+                    CultureInfo.CurrentCulture = culture;
+                    CultureInfo.CurrentUICulture = culture;
+
+                    // All cultures should sort the same way, irrespective of the thread's culture
+                    CaseInsensitiveComparer defaultInvComparer = CaseInsensitiveComparer.DefaultInvariant;
+                    Assert.Equal(expected, Math.Sign(defaultInvComparer.Compare(a, b)));
                 }
-
-                // Set current culture
-                CultureInfo.DefaultThreadCurrentCulture = culture;
-                CultureInfo.DefaultThreadCurrentUICulture = culture;
-
-                // All cultures should sort the same way, irrespective of the thread's culture
-                CaseInsensitiveComparer defaultInvComparer = CaseInsensitiveComparer.DefaultInvariant;
-                Assert.Equal(expected, Math.Sign(defaultInvComparer.Compare(a, b)));
             }
-
-            CultureInfo.DefaultThreadCurrentCulture = culture1;
-            CultureInfo.DefaultThreadCurrentUICulture = culture2;
+            finally
+            {
+                CultureInfo.CurrentCulture = culture1;
+                CultureInfo.CurrentUICulture = culture2;
+            }
         }
 
         [Theory]

--- a/src/System.Collections.NonGeneric/tests/ComparerTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ComparerTests.cs
@@ -37,8 +37,8 @@ namespace System.Collections.Tests
         [Fact]
         public static void DefaultInvariant_Compare()
         {
-            CultureInfo culture1 = CultureInfo.DefaultThreadCurrentCulture;
-            CultureInfo culture2 = CultureInfo.DefaultThreadCurrentUICulture;
+            CultureInfo culture1 = CultureInfo.CurrentCulture;
+            CultureInfo culture2 = CultureInfo.CurrentUICulture;
 
             try
             {
@@ -67,8 +67,8 @@ namespace System.Collections.Tests
                     }
 
                     // Set current culture
-                    CultureInfo.DefaultThreadCurrentCulture = culture;
-                    CultureInfo.DefaultThreadCurrentUICulture = culture;
+                    CultureInfo.CurrentCulture = culture;
+                    CultureInfo.CurrentUICulture = culture;
 
                     // All cultures should sort the same way, irrespective of the thread's culture
                     Comparer comp = Comparer.DefaultInvariant;
@@ -78,8 +78,8 @@ namespace System.Collections.Tests
             }
             finally
             {
-                CultureInfo.DefaultThreadCurrentCulture = culture1;
-                CultureInfo.DefaultThreadCurrentUICulture = culture2;
+                CultureInfo.CurrentCulture = culture1;
+                CultureInfo.CurrentUICulture = culture2;
             }
         }
 

--- a/src/System.Collections.NonGeneric/tests/Helpers.cs
+++ b/src/System.Collections.NonGeneric/tests/Helpers.cs
@@ -201,14 +201,14 @@ namespace System.Collections.Tests
 
         public static void PerformActionOnCustomCulture(Action action, CultureInfo customCulture = null)
         {
-            CultureInfo currentCulture = CultureInfo.DefaultThreadCurrentCulture;
+            CultureInfo currentCulture = CultureInfo.CurrentCulture;
             try
             {
                 if (customCulture == null)
                 {
                     customCulture = new CultureInfo("de-DE");
                 }
-                CultureInfo.DefaultThreadCurrentCulture = customCulture;
+                CultureInfo.CurrentCulture = customCulture;
                 action();
             }
             catch (CultureNotFoundException)
@@ -216,7 +216,7 @@ namespace System.Collections.Tests
             }
             finally
             {
-                CultureInfo.DefaultThreadCurrentCulture = currentCulture;
+                CultureInfo.CurrentCulture = currentCulture;
             }
         }
     }

--- a/src/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -1226,50 +1226,50 @@ namespace System.Collections.Tests
         {
             var sortList = new SortedList();
 
-            CultureInfo currentCulture = CultureInfo.DefaultThreadCurrentCulture;
+            CultureInfo currentCulture = CultureInfo.CurrentCulture;
             try
             {
-                CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
-                var cultureNames = new string[]
-                {
-                    "cs-CZ","da-DK","de-DE","el-GR","en-US",
-                    "es-ES","fi-FI","fr-FR","hu-HU","it-IT",
-                    "ja-JP","ko-KR","nb-NO","nl-NL","pl-PL",
-                    "pt-BR","pt-PT","ru-RU","sv-SE","tr-TR",
-                    "zh-CN","zh-HK","zh-TW"
-                };
+                    CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
+                    var cultureNames = new string[]
+                    {
+                        "cs-CZ","da-DK","de-DE","el-GR","en-US",
+                        "es-ES","fi-FI","fr-FR","hu-HU","it-IT",
+                        "ja-JP","ko-KR","nb-NO","nl-NL","pl-PL",
+                        "pt-BR","pt-PT","ru-RU","sv-SE","tr-TR",
+                        "zh-CN","zh-HK","zh-TW"
+                    };
 
-                var installedCultures = new CultureInfo[cultureNames.Length];
-                var cultureDisplayNames = new string[installedCultures.Length];
-                int uniqueDisplayNameCount = 0;
+                    var installedCultures = new CultureInfo[cultureNames.Length];
+                    var cultureDisplayNames = new string[installedCultures.Length];
+                    int uniqueDisplayNameCount = 0;
 
-                foreach (string cultureName in cultureNames)
-                {
-                    var culture = new CultureInfo(cultureName);
-                    installedCultures[uniqueDisplayNameCount] = culture;
-                    cultureDisplayNames[uniqueDisplayNameCount] = culture.DisplayName;
-                    sortList.Add(cultureDisplayNames[uniqueDisplayNameCount], culture);
+                    foreach (string cultureName in cultureNames)
+                    {
+                        var culture = new CultureInfo(cultureName);
+                        installedCultures[uniqueDisplayNameCount] = culture;
+                        cultureDisplayNames[uniqueDisplayNameCount] = culture.DisplayName;
+                        sortList.Add(cultureDisplayNames[uniqueDisplayNameCount], culture);
 
-                    uniqueDisplayNameCount++;
+                        uniqueDisplayNameCount++;
+                    }
+
+                    // In Czech ch comes after h if the comparer changes based on the current culture of the thread
+                    // we will not be able to find some items
+                    CultureInfo.CurrentCulture = new CultureInfo("cs-CZ");
+
+                    for (int i = 0; i < uniqueDisplayNameCount; i++)
+                    {
+                        Assert.Equal(installedCultures[i], sortList[installedCultures[i].DisplayName]);
+                    }
                 }
-
-                // In Czech ch comes after h if the comparer changes based on the current culture of the thread
-                // we will not be able to find some items
-                CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("cs-CZ");
-
-                for (int i = 0; i < uniqueDisplayNameCount; i++)
+                catch (CultureNotFoundException)
                 {
-                    Assert.Equal(installedCultures[i], sortList[installedCultures[i].DisplayName]);
+                }
+                finally
+                {
+                    CultureInfo.CurrentCulture = currentCulture;
                 }
             }
-            catch (CultureNotFoundException)
-            {
-            }
-            finally
-            {
-                CultureInfo.DefaultThreadCurrentCulture = currentCulture;
-            }
-        }
 
         [Fact]
         public static void Item_Set()


### PR DESCRIPTION
Modify these tests to use RemoteInvoke and modify the CurrentCulture/CurrentUICulture so they won't fail intermittently when running in parallel.

resolves https://github.com/dotnet/corefx/issues/12242