### PR TITLE
Expose HashSet<T> ctors with capacity in netcoreapp1.1

### DIFF
--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -171,6 +171,8 @@ namespace System.Collections.Generic
     public partial class HashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         public HashSet() { }
+        public HashSet(int capacity) { }
+        public HashSet(int capacity, System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public HashSet(System.Collections.Generic.IEnumerable<T> collection) { }
         public HashSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public HashSet(System.Collections.Generic.IEqualityComparer<T> comparer) { }

--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -171,8 +171,10 @@ namespace System.Collections.Generic
     public partial class HashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         public HashSet() { }
+#if netcoreapp11
         public HashSet(int capacity) { }
         public HashSet(int capacity, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+#endif
         public HashSet(System.Collections.Generic.IEnumerable<T> collection) { }
         public HashSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public HashSet(System.Collections.Generic.IEqualityComparer<T> comparer) { }

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -204,7 +204,7 @@ namespace System.Collections.Generic
         {
             if (capacity < 0)
             {
-                throw new ArgumentOutOfRangeException("capacity");
+                throw new ArgumentOutOfRangeException(nameof(capacity));
             }
             Contract.EndContractBlock();
 

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -98,6 +98,10 @@ namespace System.Collections.Generic
             _version = 0;
         }
 
+        public HashSet(int capacity)
+            : this(capacity, EqualityComparer<T>.Default)
+        { }
+
         public HashSet(IEnumerable<T> collection)
             : this(collection, EqualityComparer<T>.Default)
         { }
@@ -193,6 +197,21 @@ namespace System.Collections.Generic
                 _lastIndex = index;
             }
             _count = count;
+        }
+
+        public HashSet(int capacity, IEqualityComparer<T> comparer)
+            : this(comparer)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException("capacity");
+            }
+            Contract.EndContractBlock();
+
+            if (capacity > 0)
+            {
+                Initialize(capacity);
+            }
         }
 
         #endregion

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -11,7 +11,7 @@ namespace System.Collections.Tests
     /// <summary>
     /// Contains tests that ensure the correctness of the HashSet class.
     /// </summary>
-    public abstract class HashSet_Generic_Tests<T> : ISet_Generic_Tests<T>
+    public abstract partial class HashSet_Generic_Tests<T> : ISet_Generic_Tests<T>
     {
         #region ISet<T> Helper Methods
 

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.netcoreapp1.1.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.netcoreapp1.1.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public abstract partial class HashSet_Generic_Tests<T> : ISet_Generic_Tests<T>
+    {
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_Constructor_int(int capacity)
+        {
+            HashSet<T> set = new HashSet<T>(capacity);
+            Assert.Equal(0, set.Count);
+        }
+
+        [Fact]
+        public void HashSet_Generic_Constructor_int_Negative_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new HashSet<T>(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new HashSet<T>(int.MinValue));
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_Constructor_int_IEqualityComparer(int capacity)
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            HashSet<T> set = new HashSet<T>(capacity, comparer);
+            Assert.Equal(0, set.Count);
+            if (comparer == null)
+                Assert.Equal(EqualityComparer<T>.Default, set.Comparer);
+            else
+                Assert.Equal(comparer, set.Comparer);
+        }
+
+        [Fact]
+        public void HashSet_Generic_Constructor_int_IEqualityComparer_Negative_ThrowsArgumentOutOfRangeException()
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new HashSet<T>(-1, comparer));
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new HashSet<T>(int.MinValue, comparer));
+        }
+    }
+}

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Generic\Dictionary\Dictionary.Generic.Tests.Values.cs" />
     <Compile Include="Generic\HashSet\HashSet.Generic.cs" />
     <Compile Include="Generic\HashSet\HashSet.Generic.Tests.cs" />
+    <Compile Include="Generic\HashSet\HashSet.Generic.Tests.netcoreapp1.1.cs" Condition="'$(TargetGroup)'=='netcoreapp1.1'" />
     <Compile Include="Generic\HashSet\HashSet.Generic.Tests.AsNonGenericIEnumerable.cs" />
     <Compile Include="Generic\LinkedList\LinkedList.Generic.cs" />
     <Compile Include="Generic\LinkedList\LinkedList.Generic.Tests.AddAfter.cs" />


### PR DESCRIPTION
Port #2862 from Future to Master.

I cherry-picked the two relevant commits from the future branch:
 - https://github.com/dotnet/corefx/commit/38899ee55e5b8a558ee91349ab2042d26ff7a961
 - https://github.com/dotnet/corefx/commit/c92d9d4f93e089e6782c3c8a35883952d4daa63a

I then added a third commit that cleaned some things up, exposed the APIs in netcoreapp1.1, and added tests.

cc: @stephentoub, @MarkusSintonen