### PR TITLE
Enable ephemeral import of private keys from a PFX on Windows

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
+++ b/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\System.Security.Cryptography.X509Certificates.csproj">
+    <ProjectReference Include="..\ref\System.Security.Cryptography.X509Certificates.builds">
       <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.X509Certificates.builds" />

--- a/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.builds
+++ b/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.builds
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Security.Cryptography.X509Certificates.csproj" />
+    <Project Include="System.Security.Cryptography.X509Certificates.csproj">
+      <TargetGroup>netcoreapp1.1</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -410,6 +410,9 @@ namespace System.Security.Cryptography.X509Certificates
     public enum X509KeyStorageFlags
     {
         DefaultKeySet = 0,
+#if netcoreapp11
+        EphemeralKeySet = 32,
+#endif
         Exportable = 4,
         MachineKeySet = 2,
         PersistKeySet = 16,

--- a/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.csproj
@@ -3,7 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp1.1'">$(DefineConstants);netcoreapp11</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.X509Certificates.cs" />

--- a/src/System.Security.Cryptography.X509Certificates/ref/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/ref/project.json
@@ -6,6 +6,7 @@
     "System.Security.Cryptography.Primitives": "4.4.0-beta-24612-03"
   },
   "frameworks": {
-    "netstandard1.7": {}
+    "netstandard1.7": {},
+    "netcoreapp1.1": {}
   }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
@@ -60,10 +60,11 @@ namespace Internal.Cryptography.Pal
 
         private T GetPrivateKey<T>(Func<CspParameters, T> createCsp, Func<CngKey, T> createCng) where T : AsymmetricAlgorithm
         {
-            SafeNCryptKeyHandle ncryptKey = TryAcquireCngPrivateKey(CertContext);
+            CngKeyHandleOpenOptions cngHandleOptions;
+            SafeNCryptKeyHandle ncryptKey = TryAcquireCngPrivateKey(CertContext, out cngHandleOptions);
             if (ncryptKey != null)
             {
-                CngKey cngKey = CngKey.Open(ncryptKey, CngKeyHandleOpenOptions.None);
+                CngKey cngKey = CngKey.Open(ncryptKey, cngHandleOptions);
                 return createCng(cngKey);
             }
  
@@ -98,46 +99,81 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        private static SafeNCryptKeyHandle TryAcquireCngPrivateKey(SafeCertContextHandle certificateContext)
+        private static SafeNCryptKeyHandle TryAcquireCngPrivateKey(
+            SafeCertContextHandle certificateContext,
+            out CngKeyHandleOpenOptions handleOptions)
         {
             Debug.Assert(certificateContext != null, "certificateContext != null");
             Debug.Assert(!certificateContext.IsClosed && !certificateContext.IsInvalid,
                          "!certificateContext.IsClosed && !certificateContext.IsInvalid");
 
+            IntPtr privateKeyPtr;
+
+            // If the certificate has a key handle instead of a key prov info, return the
+            // ephemeral key
+            {
+                int cbData = IntPtr.Size;
+
+                if (Interop.crypt32.CertGetCertificateContextProperty(
+                    certificateContext,
+                    CertContextPropId.CERT_NCRYPT_KEY_HANDLE_PROP_ID,
+                    out privateKeyPtr,
+                    ref cbData))
+                {
+                    handleOptions = CngKeyHandleOpenOptions.EphemeralKey;
+                    return new SafeNCryptKeyHandle(privateKeyPtr, certificateContext);
+                }
+            }
+
             bool freeKey = true;
             SafeNCryptKeyHandle privateKey = null;
+            handleOptions = CngKeyHandleOpenOptions.None;
             try
             {
                 int keySpec = 0;
                 if (!Interop.crypt32.CryptAcquireCertificatePrivateKey(
-                        certificateContext,
-                        CryptAcquireFlags.CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG,
-                        IntPtr.Zero,
-                        out privateKey,
-                        out keySpec,
-                        out freeKey))
+                    certificateContext,
+                    CryptAcquireFlags.CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG,
+                    IntPtr.Zero,
+                    out privateKey,
+                    out keySpec,
+                    out freeKey))
                 {
                     int dwErrorCode = Marshal.GetLastWin32Error();
+
+                    // The documentation for CryptAcquireCertificatePrivateKey says that freeKey
+                    // should already be false if "key acquisition fails", and it can be presumed
+                    // that privateKey was set to 0.  But, just in case:
+                    freeKey = false;
+                    privateKey?.SetHandleAsInvalid();
                     return null;
+                }
+
+                // It is very unlikely that Windows will tell us !freeKey other than when reporting failure,
+                // because we set neither CRYPT_ACQUIRE_CACHE_FLAG nor CRYPT_ACQUIRE_USE_PROV_INFO_FLAG, which are
+                // currently the only two success situations documented. However, any !freeKey response means the
+                // key's lifetime is tied to that of the certificate, so re-register the handle as a child handle
+                // of the certificate.
+                if (!freeKey && privateKey != null && !privateKey.IsInvalid)
+                {
+                    var newKeyHandle = new SafeNCryptKeyHandle(privateKey.DangerousGetHandle(), certificateContext);
+                    privateKey.SetHandleAsInvalid();
+                    privateKey = newKeyHandle;
+                    freeKey = true;
                 }
 
                 return privateKey;
             }
-            finally
+            catch
             {
-                // If we're not supposed to release the key handle, then we need to bump the reference count
-                // on the safe handle to correspond to the reference that Windows is holding on to.  This will
-                // prevent the CLR from freeing the object handle.
-                // 
-                // This is certainly not the ideal way to solve this problem - it would be better for
-                // SafeNCryptKeyHandle to maintain an internal bool field that we could toggle here and
-                // have that suppress the release when the CLR calls the ReleaseHandle override.  However, that
-                // field does not currently exist, so we'll use this hack instead.
+                // If we aren't supposed to free the key, and we're not returning it,
+                // just tell the SafeHandle to not free itself.
                 if (privateKey != null && !freeKey)
                 {
-                    bool addedRef = false;
-                    privateKey.DangerousAddRef(ref addedRef);
+                    privateKey.SetHandleAsInvalid();
                 }
+
+                throw;
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -409,7 +409,6 @@ namespace Internal.Cryptography.Pal
 
         public void AppendPrivateKeyInfo(StringBuilder sb)
         {
-#if NETNATIVE
             if (HasPrivateKey)
             {
                 // Similar to the Unix implementation, in UWP merely acknowledge that there -is- a private key.
@@ -417,6 +416,9 @@ namespace Internal.Cryptography.Pal
                 sb.AppendLine();
                 sb.AppendLine("[Private Key]");
             }
+
+#if NETNATIVE
+            // Similar to the Unix implementation, in UWP merely acknowledge that there -is- a private key.
 #else
             CspKeyContainerInfo cspKeyContainerInfo = null;
             try
@@ -430,10 +432,10 @@ namespace Internal.Cryptography.Pal
             // We could not access the key container. Just return.
             catch (CryptographicException) { }
 
+            // Ephemeral keys will not have container information.
             if (cspKeyContainerInfo == null)
                 return;
 
-            sb.Append(Environment.NewLine + Environment.NewLine + "[Private Key]");
             sb.Append(Environment.NewLine + "  Key Store: ");
             sb.Append(cspKeyContainerInfo.MachineKeyStore ? "Machine" : "User");
             sb.Append(Environment.NewLine + "  Provider Name: ");

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
@@ -73,6 +73,9 @@ internal static partial class Interop
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern bool CertGetCertificateContextProperty(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, [Out] out CRYPTOAPI_BLOB pvData, [In, Out] ref int pcbData);
 
+        [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool CertGetCertificateContextProperty(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, [Out] out IntPtr pvData, [In, Out] ref int pcbData);
+
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertGetCertificateContextProperty")]
         public static extern bool CertGetCertificateContextPropertyString(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, [Out] StringBuilder pvData, [In, Out] ref int pcbData);
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
@@ -163,10 +163,12 @@ namespace Internal.Cryptography.Pal.Native
     {
         CERT_KEY_PROV_INFO_PROP_ID   = 2,
         CERT_SHA1_HASH_PROP_ID       = 3,
+        CERT_KEY_CONTEXT_PROP_ID     = 5,
         CERT_FRIENDLY_NAME_PROP_ID   = 11,
         CERT_ARCHIVED_PROP_ID        = 19,
         CERT_KEY_IDENTIFIER_PROP_ID  = 20,
         CERT_PUBKEY_ALG_PARA_PROP_ID = 22,
+        CERT_NCRYPT_KEY_HANDLE_PROP_ID = 78,
 
         // CERT_DELETE_KEYSET_PROP_ID is not defined by Windows. It's a custom property set by the framework
         // as a backchannel message from the portion of X509Certificate2Collection.Import() that loads up the PFX
@@ -394,6 +396,21 @@ namespace Internal.Cryptography.Pal.Native
         REPORT_NOT_ABLE_TO_EXPORT_PRIVATE_KEY = 0x00000002,
         EXPORT_PRIVATE_KEYS                   = 0x00000004,
         None                                  = 0x00000000,
+    }
+
+    internal enum KeyContextSpec : uint
+    {
+        AT_KEYEXCHANGE = 1,
+        AT_SIGNATURE = 2,
+        CERT_NCRYPT_KEY_SPEC = 0xFFFFFFFF,
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct CERT_KEY_CONTEXT
+    {
+        public int cbSize;
+        public IntPtr hProvOrNcryptKey;
+        public KeyContextSpec dwKeySpec;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
@@ -63,19 +63,36 @@ namespace Internal.Cryptography.Pal.Native
             return pCertContext;
         }
 
+        public bool HasPersistedPrivateKey
+        {
+            get { return CertHasProperty(CertContextPropId.CERT_KEY_PROV_INFO_PROP_ID); }
+        }
+
+        public bool HasEphemeralPrivateKey
+        {
+            get { return CertHasProperty(CertContextPropId.CERT_KEY_CONTEXT_PROP_ID); }
+        }
+
         public bool ContainsPrivateKey
         {
-            get
-            {
-                int cb = 0;
-                bool containsPrivateKey = Interop.crypt32.CertGetCertificateContextProperty(this, CertContextPropId.CERT_KEY_PROV_INFO_PROP_ID, null, ref cb);
-                return containsPrivateKey;
-            }
+            get { return HasPersistedPrivateKey || HasEphemeralPrivateKey; }
         }
 
         public SafeCertContextHandle Duplicate()
         {
             return Interop.crypt32.CertDuplicateCertificateContext(handle);
+        }
+
+        private bool CertHasProperty(CertContextPropId propertyId)
+        {
+            int cb = 0;
+            bool hasProperty = Interop.crypt32.CertGetCertificateContextProperty(
+                this,
+                propertyId,
+                null,
+                ref cb);
+
+            return hasProperty;
         }
     }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Import.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Import.cs
@@ -109,7 +109,7 @@ namespace Internal.Cryptography.Pal
                 null);
             if (certStore.IsInvalid)
                 throw Marshal.GetHRForLastWin32Error().ToCryptographicException();;
-            if (!Interop.crypt32.CertAddCertificateContextToStore(certStore, certificatePal.CertContext, CertStoreAddDisposition.CERT_STORE_ADD_ALWAYS, IntPtr.Zero))
+            if (!Interop.crypt32.CertAddCertificateLinkToStore(certStore, certificatePal.CertContext, CertStoreAddDisposition.CERT_STORE_ADD_ALWAYS, IntPtr.Zero))
                 throw Marshal.GetHRForLastWin32Error().ToCryptographicException();;
             return new StorePal(certStore);
         }
@@ -139,7 +139,7 @@ namespace Internal.Cryptography.Pal
 
             foreach (X509Certificate2 certificate in certificates)
             {
-                SafeCertContextHandle certContext = Interop.crypt32.CertDuplicateCertificateContext(certificate.Handle);
+                SafeCertContextHandle certContext = ((CertificatePal)certificate.Pal).CertContext;
                 if (!Interop.crypt32.CertAddCertificateLinkToStore(certStore, certContext, CertStoreAddDisposition.CERT_STORE_ADD_ALWAYS, IntPtr.Zero))
                     throw Marshal.GetLastWin32Error().ToCryptographicException();
             }
@@ -179,6 +179,9 @@ namespace Internal.Cryptography.Pal
                 dwFlags |= PfxCertStoreFlags.CRYPT_EXPORTABLE;
             if ((keyStorageFlags & X509KeyStorageFlags.UserProtected) == X509KeyStorageFlags.UserProtected)
                 dwFlags |= PfxCertStoreFlags.CRYPT_USER_PROTECTED;
+
+            if ((keyStorageFlags & X509KeyStorageFlags.EphemeralKeySet) == X509KeyStorageFlags.EphemeralKeySet)
+                dwFlags |= PfxCertStoreFlags.PKCS12_NO_PERSIST_KEY | PfxCertStoreFlags.PKCS12_ALWAYS_CNG_KSP;
 
             return dwFlags;
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -195,6 +195,9 @@
   <data name="Cryptography_X509_InvalidFindValue" xml:space="preserve">
     <value>Invalid find value.</value>
   </data>
+  <data name="Cryptography_X509_InvalidFlagCombination" xml:space="preserve">
+    <value>The flags '{0}' may not be specified together.</value>
+  </data>
   <data name="Cryptography_X509_KeyMismatch" xml:space="preserve">
     <value>The public key of the certificate does not match the value specified.</value>
   </data>

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.builds
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.builds
@@ -9,6 +9,14 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.Security.Cryptography.X509Certificates.csproj">
+      <OSGroup>Unix</OSGroup>
+      <TargetGroup>netcoreapp1.1</TargetGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.X509Certificates.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcoreapp1.1</TargetGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.X509Certificates.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>net463</TargetGroup>
     </Project>

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
@@ -138,6 +138,8 @@ namespace System.Security.Cryptography.X509Certificates
             if (rawData == null)
                 throw new ArgumentNullException(nameof(rawData));
 
+            X509Certificate.ValidateKeyStorageFlags(keyStorageFlags);
+
             using (ILoaderPal storePal = StorePal.FromBlob(rawData, password, keyStorageFlags))
             {
                 storePal.MoveTo(this);
@@ -153,6 +155,8 @@ namespace System.Security.Cryptography.X509Certificates
         {
             if (fileName == null)
                 throw new ArgumentNullException(nameof(fileName));
+
+            X509Certificate.ValidateKeyStorageFlags(keyStorageFlags);
 
             using (ILoaderPal storePal = StorePal.FromFile(fileName, password, keyStorageFlags))
             {

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509KeyStorageFlags.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509KeyStorageFlags.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-
 namespace System.Security.Cryptography.X509Certificates
 {
     // DefaultKeySet, UserKeySet and MachineKeySet are mutually exclusive
+    // PersistKeySet and EphemeralKeySet are mutually exclusive
     [Flags]
     public enum X509KeyStorageFlags
     {
@@ -17,6 +15,7 @@ namespace System.Security.Cryptography.X509Certificates
         Exportable = 0x04,
         UserProtected = 0x08,
         PersistKeySet = 0x10,
+        EphemeralKeySet = 0x20,
     }
 }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/unix/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/unix/project.json
@@ -22,6 +22,7 @@
     "System.Threading.Tasks": "4.4.0-beta-24612-03"
   },
   "frameworks": {
-    "netstandard1.7": {}
+    "netstandard1.7": {},
+    "netcoreapp1.1": {}
   }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/win/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/win/project.json
@@ -24,6 +24,7 @@
     "System.Threading.Tasks": "4.4.0-beta-24612-03"
   },
   "frameworks": {
-    "netstandard1.7": {}
+    "netstandard1.7": {},
+    "netcoreapp1.1": {}
   }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/Cert.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/Cert.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using Xunit;
-
 namespace System.Security.Cryptography.X509Certificates.Tests
 {
     //
@@ -16,6 +11,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     //
     internal static class Cert
     {
+        internal const X509KeyStorageFlags EphemeralIfPossible =
+#if netcoreapp11
+            X509KeyStorageFlags.EphemeralKeySet;
+#else
+            X509KeyStorageFlags.DefaultKeySet;
+#endif
         //
         // The Import() methods have an overload for each X509Certificate2Collection.Import() overload.
         //

--- a/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
@@ -320,5 +320,57 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal("error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error", ex.Message);
             }
         }
+
+        [Fact]
+        public static void InvalidStorageFlags()
+        {
+            byte[] nonEmptyBytes = new byte[1];
+
+            Assert.Throws<ArgumentException>(
+                "keyStorageFlags",
+                () => new X509Certificate(nonEmptyBytes, string.Empty, (X509KeyStorageFlags)0xFF));
+
+            Assert.Throws<ArgumentException>(
+                "keyStorageFlags",
+                () => new X509Certificate(string.Empty, string.Empty, (X509KeyStorageFlags)0xFF));
+
+            Assert.Throws<ArgumentException>(
+                "keyStorageFlags",
+                () => new X509Certificate2(nonEmptyBytes, string.Empty, (X509KeyStorageFlags)0xFF));
+
+            Assert.Throws<ArgumentException>(
+                "keyStorageFlags",
+                () => new X509Certificate2(string.Empty, string.Empty, (X509KeyStorageFlags)0xFF));
+
+            // No test is performed here for the ephemeral flag failing downlevel, because the live
+            // binary is always used by default, meaning it doesn't know EphemeralKeySet doesn't exist.
+        }
+
+#if netcoreapp11
+        [Fact]
+        public static void InvalidStorageFlags_PersistedEphemeral()
+        {
+            const X509KeyStorageFlags PersistedEphemeral =
+                X509KeyStorageFlags.EphemeralKeySet | X509KeyStorageFlags.PersistKeySet;
+
+            byte[] nonEmptyBytes = new byte[1];
+
+            Assert.Throws<ArgumentException>(
+                "keyStorageFlags",
+                () => new X509Certificate(nonEmptyBytes, string.Empty, PersistedEphemeral));
+
+            Assert.Throws<ArgumentException>(
+                "keyStorageFlags",
+                () => new X509Certificate(string.Empty, string.Empty, PersistedEphemeral));
+
+            Assert.Throws<ArgumentException>(
+                "keyStorageFlags",
+                () => new X509Certificate2(nonEmptyBytes, string.Empty, PersistedEphemeral));
+
+            Assert.Throws<ArgumentException>(
+                "keyStorageFlags",
+                () => new X509Certificate2(string.Empty, string.Empty, PersistedEphemeral));
+        }
+#endif
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.builds
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.builds
@@ -3,21 +3,29 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Security.Cryptography.X509Certificates.Tests.csproj">
-      <OSGroup>Unix</OSGroup>
       <TargetGroup>netstandard1.6</TargetGroup>
+      <OSGroup>Unix</OSGroup>
       <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Security.Cryptography.X509Certificates.Tests.csproj">
       <OSGroup>Unix</OSGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.X509Certificates.Tests.csproj">
+      <TargetGroup>netcoreapp1.1</TargetGroup>
+      <OSGroup>Unix</OSGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.X509Certificates.Tests.csproj">
+      <TargetGroup>netstandard1.6</TargetGroup>
+      <OSGroup>Windows_NT</OSGroup>
+      <TestTFMs>netcoreapp1.0</TestTFMs>
+    </Project>
+    <Project Include="System.Security.Cryptography.X509Certificates.Tests.csproj">
+      <TargetGroup>netcoreapp1.1</TargetGroup>
+      <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.Security.Cryptography.X509Certificates.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TargetGroup>netstandard1.6</TargetGroup>
-      <TestTFMs>netcoreapp1.0</TestTFMs>
-    </Project>
-    <Project Include="System.Security.Cryptography.X509Certificates.Tests.csproj">
       <TestTFMs>netcoreapp1.1;net463</TestTFMs>
-      <OSGroup>Windows_NT</OSGroup>
     </Project>
     </ItemGroup>
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -14,6 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
     <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netstandard17</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp1.1'">$(DefineConstants);netstandard17;netcoreapp11</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.json
@@ -26,7 +26,8 @@
   },
   "frameworks": {
     "netstandard1.6": {},
-    "netstandard1.7": {}
+    "netstandard1.7": {},
+    "netcoreapp1.1": {}
   },
   "supports": {
     "coreFx.Test.net463": {},


### PR DESCRIPTION
The classic behavior on Windows is when importing a PFX the private key
material gets written to a file on disk (as an implementation detail of the
software key provider), and the .NET behavior is to delete that private key
when it is detected as no longer being needed (unless the import was
performed with a request to persist the key material, such as when loading
the certificate into a persisted store).

This change enables callers to request an import with the new
EphemeralKeySet flag, which uses the PKCS12_NO_PERSIST_KEY flag to
PFXImportCertStore.  For callers who do not do any interop with Win32
directly everything should be invisible and work. Libraries which pass
PCERT_CONTEXT values to Win32, or replicate the work of
GetRSAPrivateKey, may not function as expected when passed an
X509Certificate(2) object with an ephemeral key.  This situation is already
possible if someone were to have done a P/Invoke into PFXImportCertStore
manually and constructed an X509Certificate(2) object over the pointer,
the addition of this functionality just makes it easier to get into that state.
Since ephemeral is not the default behavior the onus of compatibility rests
with the code which specified the flag on the call to load the PFX.

At this point the Windows implementation of EnvelopedCms is known to
not work with ephemeral private keys, and that will be addressed in a later
change.

This feature has no impact on Linux builds, since the private keys there
are always ephemeral.

Before this change callers to X509Certificate2Collection.Import could
specify unknown flags without an error, but due to Ephemeral and
Persisted being incompatible flags the Import method has been aligned
with the X509Certificate(2) constructors in terms of keyStorageFlag
validation.

Change 2/3 for #8186.
cc: @stephentoub @steveharter @AtsushiKan 
cc for packaging/contracts: @ericstj 