### PR TITLE
Add IWebProxyScript to System.Net.WebProxy

### DIFF
--- a/src/System.Net.WebProxy/ref/System.Net.WebProxy.cs
+++ b/src/System.Net.WebProxy/ref/System.Net.WebProxy.cs
@@ -7,6 +7,12 @@
 
 namespace System.Net
 {
+    public interface IWebProxyScript
+    {
+        void Close();
+        bool Load(System.Uri scriptLocation, string script, System.Type helperType);
+        string Run(string url, string host);
+    }
     public class WebProxy : System.Net.IWebProxy, System.Runtime.Serialization.ISerializable
     {
         public WebProxy() { }

--- a/src/System.Net.WebProxy/src/System.Net.WebProxy.csproj
+++ b/src/System.Net.WebProxy/src/System.Net.WebProxy.csproj
@@ -13,6 +13,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
+    <Compile Include="System\Net\IWebProxyScript.cs" />
     <Compile Include="System\Net\WebProxy.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net463'">

--- a/src/System.Net.WebProxy/src/System/Net/IWebProxyScript.cs
+++ b/src/System.Net.WebProxy/src/System/Net/IWebProxyScript.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net
+{
+    public interface IWebProxyScript
+    {
+        void Close();
+        bool Load(Uri scriptLocation, string script, Type helperType);
+        string Run(string url, string host);
+    }
+}


### PR DESCRIPTION
It's just an interface.  Nothing in netstandard implements it.

Fixes https://github.com/dotnet/corefx/issues/12132
cc: @ericeil