### PR TITLE
Regex cleanup

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -400,9 +400,11 @@ namespace System.Text.RegularExpressions
             {
                 result = new int[caps.Count];
 
-                foreach (DictionaryEntry kvp in caps)
+                // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+                IDictionaryEnumerator de = caps.GetEnumerator();
+                while (de.MoveNext())
                 {
-                    result[(int) kvp.Value] = (int) kvp.Key;
+                    result[(int)de.Value] = (int)de.Key;
                 }
             }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -9,8 +9,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Threading;
 using System.Runtime.Serialization;
+using System.Threading;
 
 namespace System.Text.RegularExpressions
 {
@@ -29,7 +29,7 @@ namespace System.Text.RegularExpressions
 
         // We need this because time is queried using Environment.TickCount for performance reasons
         // (Environment.TickCount returns milliseconds as an int and cycles):
-        private static readonly TimeSpan MaximumMatchTimeout = TimeSpan.FromMilliseconds(Int32.MaxValue - 1);
+        private static readonly TimeSpan MaximumMatchTimeout = TimeSpan.FromMilliseconds(int.MaxValue - 1);
 
         // InfiniteMatchTimeout specifies that match timeout is switched OFF. It allows for faster code paths
         // compared to simply having a very large timeout.
@@ -51,8 +51,8 @@ namespace System.Text.RegularExpressions
 
         protected internal RegexRunnerFactory factory;
 
-        protected internal Hashtable caps;            // if captures are sparse, this is the hashtable capnum->index
-        protected internal Hashtable capnames;     // if named captures are used, this maps names->index
+        protected internal Hashtable caps;          // if captures are sparse, this is the hashtable capnum->index
+        protected internal Hashtable capnames;      // if named captures are used, this maps names->index
 
         protected internal string[] capslist;              // if captures are sparse or named captures are used, this is the sorted list of names
         protected internal int capsize;                    // the size of the capture array
@@ -68,7 +68,7 @@ namespace System.Text.RegularExpressions
             {
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                
+
                 caps = value as Hashtable;
                 if (caps == null)
                 {
@@ -88,7 +88,7 @@ namespace System.Text.RegularExpressions
             {
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                
+
                 capnames = value as Hashtable;
                 if (capnames == null)
                 {
@@ -137,7 +137,7 @@ namespace System.Text.RegularExpressions
         }
 
         protected Regex(SerializationInfo info, StreamingContext context)
-            : this(info.GetString("pattern"), (RegexOptions) info.GetInt32("options"))
+            : this(info.GetString("pattern"), (RegexOptions)info.GetInt32("options"))
         {
             try
             {
@@ -236,7 +236,7 @@ namespace System.Text.RegularExpressions
         /// The valid range is <code>TimeSpan.Zero &lt; matchTimeout &lt;= Regex.MaximumMatchTimeout</code>.
         /// </summary>
         /// <param name="matchTimeout">The timeout value to validate.</param>
-        /// <exception cref="System.ArgumentOutOfRangeException">If the specified timeout is not within a valid range.
+        /// <exception cref="ArgumentOutOfRangeException">If the specified timeout is not within a valid range.
         /// </exception>
         protected internal static void ValidateMatchTimeout(TimeSpan matchTimeout)
         {
@@ -367,7 +367,7 @@ namespace System.Text.RegularExpressions
             {
                 result = new string[capslist.Length];
 
-                System.Array.Copy(capslist, 0, result, 0, capslist.Length);
+                Array.Copy(capslist, 0, result, 0, capslist.Length);
             }
 
             return result;
@@ -1105,7 +1105,7 @@ namespace System.Text.RegularExpressions
     internal sealed class ExclusiveReference
     {
         private RegexRunner _ref;
-        private Object _obj;
+        private object _obj;
         private int _locked;
 
         /*
@@ -1115,7 +1115,7 @@ namespace System.Text.RegularExpressions
          * if the object can't be returned, the lock is released.
          *
          */
-        internal Object Get()
+        internal object Get()
         {
             // try to obtain the lock
 
@@ -1124,7 +1124,7 @@ namespace System.Text.RegularExpressions
                 // grab reference
 
 
-                Object obj = _ref;
+                object obj = _ref;
 
                 // release the lock and return null if no reference
 
@@ -1153,7 +1153,7 @@ namespace System.Text.RegularExpressions
          * and the object is placed in the cache.
          *
          */
-        internal void Release(Object obj)
+        internal void Release(object obj)
         {
             if (obj == null)
                 throw new ArgumentNullException(nameof(obj));
@@ -1205,11 +1205,11 @@ namespace System.Text.RegularExpressions
          * Note that _ref.Target is referenced only under the protection
          * of the lock. (Is this necessary?)
          */
-        internal Object Get()
+        internal object Get()
         {
             if (0 == Interlocked.Exchange(ref _locked, 1))
             {
-                Object obj = _ref.Target;
+                object obj = _ref.Target;
                 _locked = 0;
                 return obj;
             }
@@ -1223,7 +1223,7 @@ namespace System.Text.RegularExpressions
          * Note that _ref.Target is referenced only under the protection
          * of the lock. (Is this necessary?)
          */
-        internal void Cache(Object obj)
+        internal void Cache(object obj)
         {
             if (0 == Interlocked.Exchange(ref _locked, 1))
             {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -898,7 +898,7 @@ namespace System.Text.RegularExpressions
             RegexRunner runner = null;
 
             if (startat < 0 || startat > input.Length)
-                throw new ArgumentOutOfRangeException("start", SR.BeginIndexNotNegative);
+                throw new ArgumentOutOfRangeException(nameof(startat), SR.BeginIndexNotNegative);
 
             if (length < 0 || length > input.Length)
                 throw new ArgumentOutOfRangeException(nameof(length), SR.LengthNotNegative);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -22,7 +22,7 @@ namespace System.Text.RegularExpressions
         private readonly int[] _positive;
         private readonly int[] _negativeASCII;
         private readonly int[][] _negativeUnicode;
-        private readonly String _pattern;
+        private readonly string _pattern;
         private readonly int _lowASCII;
         private readonly int _highASCII;
         private readonly bool _rightToLeft;
@@ -33,7 +33,7 @@ namespace System.Text.RegularExpressions
         /// Constructs a Boyer-Moore state machine for searching for the string
         /// pattern. The string must not be zero-length.
         /// </summary>
-        internal RegexBoyerMoore(String pattern, bool caseInsensitive, bool rightToLeft, CultureInfo culture)
+        internal RegexBoyerMoore(string pattern, bool caseInsensitive, bool rightToLeft, CultureInfo culture)
         {
             // Sorry, you just can't use Boyer-Moore to find an empty pattern.
             // We're doing this for your own protection. (Really, for speed.)
@@ -206,7 +206,7 @@ namespace System.Text.RegularExpressions
 
                         if (i == 0)
                         {
-                            System.Array.Copy(_negativeASCII, 0, newarray, 0, 128);
+                            Array.Copy(_negativeASCII, 0, newarray, 0, 128);
                             _negativeASCII = newarray;
                         }
 
@@ -241,14 +241,14 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                return (0 == String.CompareOrdinal(_pattern, 0, text, index, _pattern.Length));
+                return (0 == string.CompareOrdinal(_pattern, 0, text, index, _pattern.Length));
             }
         }
 
         /// <summary>
         /// When a regex is anchored, we can do a quick IsMatch test instead of a Scan
         /// </summary>
-        internal bool IsMatch(String text, int index, int beglimit, int endlimit)
+        internal bool IsMatch(string text, int index, int beglimit, int endlimit)
         {
             if (!_rightToLeft)
             {
@@ -274,7 +274,7 @@ namespace System.Text.RegularExpressions
         /// The direction and case-sensitivity of the match is determined
         /// by the arguments to the RegexBoyerMoore constructor.
         /// </summary>
-        internal int Scan(String text, int index, int beglimit, int endlimit)
+        internal int Scan(string text, int index, int beglimit, int endlimit)
         {
             int test;
             int test2;
@@ -373,13 +373,13 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Used when dumping for debugging.
         /// </summary>
-        public override String ToString()
+        public override string ToString()
         {
             return _pattern;
         }
 
 #if DEBUG
-        public String Dump(String indent)
+        public string Dump(string indent)
         {
             StringBuilder sb = new StringBuilder();
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCapture.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCapture.cs
@@ -15,11 +15,11 @@ namespace System.Text.RegularExpressions
     /// </summary>
     public class Capture
     {
-        internal String _text;
+        internal string _text;
         internal int _index;
         internal int _length;
 
-        internal Capture(String text, int i, int l)
+        internal Capture(string text, int i, int l)
         {
             _text = text;
             _index = i;
@@ -72,7 +72,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Returns the substring that was matched.
         /// </summary>
-        override public String ToString()
+        override public string ToString()
         {
             return Value;
         }
@@ -80,7 +80,7 @@ namespace System.Text.RegularExpressions
         /*
          * The original string
          */
-        internal String GetOriginalString()
+        internal string GetOriginalString()
         {
             return _text;
         }
@@ -88,7 +88,7 @@ namespace System.Text.RegularExpressions
         /*
          * The substring to the left of the capture
          */
-        internal String GetLeftSubstring()
+        internal string GetLeftSubstring()
         {
             return _text.Substring(0, _index);
         }
@@ -96,13 +96,13 @@ namespace System.Text.RegularExpressions
         /*
          * The substring to the right of the capture
          */
-        internal String GetRightSubstring()
+        internal string GetRightSubstring()
         {
             return _text.Substring(_index + _length, _text.Length - _index - _length);
         }
 
 #if DEBUG
-        internal virtual String Description()
+        internal virtual string Description()
         {
             StringBuilder Sb = new StringBuilder();
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -42,7 +42,7 @@ namespace System.Text.RegularExpressions
         private const int CATEGORYLENGTH = 2;
         private const int SETSTART = 3;
 
-        private const String NullCharString = "\0";
+        private const string NullCharString = "\0";
 
         private const char NullChar = '\0';
         private const char LastChar = '\uFFFF';
@@ -57,39 +57,39 @@ namespace System.Text.RegularExpressions
         private const char ZeroWidthNonJoiner = '\u200C';
 
 
-        private static readonly String s_internalRegexIgnoreCase = "__InternalRegexIgnoreCase__";
-        private static readonly String s_space = "\x64";
-        private static readonly String s_notSpace = "\uFF9C";
-        private static readonly String s_word = "\u0000\u0002\u0004\u0005\u0003\u0001\u0006\u0009\u0013\u0000";
-        private static readonly String s_notWord = "\u0000\uFFFE\uFFFC\uFFFB\uFFFD\uFFFF\uFFFA\uFFF7\uFFED\u0000";
+        private static readonly string s_internalRegexIgnoreCase = "__InternalRegexIgnoreCase__";
+        private static readonly string s_space = "\x64";
+        private static readonly string s_notSpace = "\uFF9C";
+        private static readonly string s_word = "\u0000\u0002\u0004\u0005\u0003\u0001\u0006\u0009\u0013\u0000";
+        private static readonly string s_notWord = "\u0000\uFFFE\uFFFC\uFFFB\uFFFD\uFFFF\uFFFA\uFFF7\uFFED\u0000";
 
-        internal static readonly String SpaceClass = "\u0000\u0000\u0001\u0064";
-        internal static readonly String NotSpaceClass = "\u0001\u0000\u0001\u0064";
-        internal static readonly String WordClass = "\u0000\u0000\u000A\u0000\u0002\u0004\u0005\u0003\u0001\u0006\u0009\u0013\u0000";
-        internal static readonly String NotWordClass = "\u0001\u0000\u000A\u0000\u0002\u0004\u0005\u0003\u0001\u0006\u0009\u0013\u0000";
-        internal static readonly String DigitClass = "\u0000\u0000\u0001\u0009";
-        internal static readonly String NotDigitClass = "\u0000\u0000\u0001\uFFF7";
+        internal static readonly string SpaceClass = "\u0000\u0000\u0001\u0064";
+        internal static readonly string NotSpaceClass = "\u0001\u0000\u0001\u0064";
+        internal static readonly string WordClass = "\u0000\u0000\u000A\u0000\u0002\u0004\u0005\u0003\u0001\u0006\u0009\u0013\u0000";
+        internal static readonly string NotWordClass = "\u0001\u0000\u000A\u0000\u0002\u0004\u0005\u0003\u0001\u0006\u0009\u0013\u0000";
+        internal static readonly string DigitClass = "\u0000\u0000\u0001\u0009";
+        internal static readonly string NotDigitClass = "\u0000\u0000\u0001\uFFF7";
 
-        private const String ECMASpaceSet = "\u0009\u000E\u0020\u0021";
-        private const String NotECMASpaceSet = "\0\u0009\u000E\u0020\u0021";
-        private const String ECMAWordSet = "\u0030\u003A\u0041\u005B\u005F\u0060\u0061\u007B\u0130\u0131";
-        private const String NotECMAWordSet = "\0\u0030\u003A\u0041\u005B\u005F\u0060\u0061\u007B\u0130\u0131";
-        private const String ECMADigitSet = "\u0030\u003A";
-        private const String NotECMADigitSet = "\0\u0030\u003A";
+        private const string ECMASpaceSet = "\u0009\u000E\u0020\u0021";
+        private const string NotECMASpaceSet = "\0\u0009\u000E\u0020\u0021";
+        private const string ECMAWordSet = "\u0030\u003A\u0041\u005B\u005F\u0060\u0061\u007B\u0130\u0131";
+        private const string NotECMAWordSet = "\0\u0030\u003A\u0041\u005B\u005F\u0060\u0061\u007B\u0130\u0131";
+        private const string ECMADigitSet = "\u0030\u003A";
+        private const string NotECMADigitSet = "\0\u0030\u003A";
 
-        internal const String ECMASpaceClass = "\x00\x04\x00" + ECMASpaceSet;
-        internal const String NotECMASpaceClass = "\x01\x04\x00" + ECMASpaceSet;
-        internal const String ECMAWordClass = "\x00\x0A\x00" + ECMAWordSet;
-        internal const String NotECMAWordClass = "\x01\x0A\x00" + ECMAWordSet;
-        internal const String ECMADigitClass = "\x00\x02\x00" + ECMADigitSet;
-        internal const String NotECMADigitClass = "\x01\x02\x00" + ECMADigitSet;
+        internal const string ECMASpaceClass = "\x00\x04\x00" + ECMASpaceSet;
+        internal const string NotECMASpaceClass = "\x01\x04\x00" + ECMASpaceSet;
+        internal const string ECMAWordClass = "\x00\x0A\x00" + ECMAWordSet;
+        internal const string NotECMAWordClass = "\x01\x0A\x00" + ECMAWordSet;
+        internal const string ECMADigitClass = "\x00\x02\x00" + ECMADigitSet;
+        internal const string NotECMADigitClass = "\x01\x02\x00" + ECMADigitSet;
 
-        internal const String AnyClass = "\x00\x01\x00\x00";
-        internal const String EmptyClass = "\x00\x00\x00";
+        internal const string AnyClass = "\x00\x01\x00\x00";
+        internal const string EmptyClass = "\x00\x00\x00";
 
         // UnicodeCategory is zero based, so we add one to each value and subtract it off later
         private const int DefinedCategoriesCapacity = 38;
-        private static readonly Dictionary<String, String> s_definedCategories = new Dictionary<String, String>(DefinedCategoriesCapacity)
+        private static readonly Dictionary<string, string> s_definedCategories = new Dictionary<string, string>(DefinedCategoriesCapacity)
         {
             // Others
             { "Cc", "\u000F" }, // UnicodeCategory.Control + 1
@@ -155,7 +155,7 @@ namespace System.Text.RegularExpressions
          *
         **/
         // Has to be sorted by the first column
-        private static readonly String[][] s_propTable = {
+        private static readonly string[][] s_propTable = {
             new [] {"IsAlphabeticPresentationForms",       "\uFB00\uFB50"},
             new [] {"IsArabic",                            "\u0600\u0700"},
             new [] {"IsArabicPresentationForms-A",         "\uFB50\uFE00"},
@@ -425,7 +425,7 @@ namespace System.Text.RegularExpressions
             // Make sure the s_propTable is correctly ordered
             int len = s_propTable.Length;
             for (int i = 0; i < len - 1; i++)
-                Debug.Assert(String.Compare(s_propTable[i][0], s_propTable[i + 1][0], StringComparison.Ordinal) < 0, "RegexCharClass s_propTable is out of order at (" + s_propTable[i][0] + ", " + s_propTable[i + 1][0] + ")");
+                Debug.Assert(string.Compare(s_propTable[i][0], s_propTable[i + 1][0], StringComparison.Ordinal) < 0, "RegexCharClass s_propTable is out of order at (" + s_propTable[i][0] + ", " + s_propTable[i + 1][0] + ")");
         }
 #endif
 
@@ -473,7 +473,7 @@ namespace System.Text.RegularExpressions
         {
             int i;
 
-            Debug.Assert(cc.CanMerge && this.CanMerge, "Both character classes added together must be able to merge");
+            Debug.Assert(cc.CanMerge && CanMerge, "Both character classes added together must be able to merge");
 
             if (!cc._canonical)
             {
@@ -494,7 +494,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Adds a set (specified by its string representation) to the class.
         /// </summary>
-        private void AddSet(String set)
+        private void AddSet(string set)
         {
             int i;
 
@@ -642,16 +642,16 @@ namespace System.Text.RegularExpressions
             if (negate)
             {
                 if (ecma)
-                    AddSet(RegexCharClass.NotECMAWordSet);
+                    AddSet(NotECMAWordSet);
                 else
-                    AddCategory(RegexCharClass.s_notWord);
+                    AddCategory(s_notWord);
             }
             else
             {
                 if (ecma)
-                    AddSet(RegexCharClass.ECMAWordSet);
+                    AddSet(ECMAWordSet);
                 else
-                    AddCategory(RegexCharClass.s_word);
+                    AddCategory(s_word);
             }
         }
 
@@ -660,16 +660,16 @@ namespace System.Text.RegularExpressions
             if (negate)
             {
                 if (ecma)
-                    AddSet(RegexCharClass.NotECMASpaceSet);
+                    AddSet(NotECMASpaceSet);
                 else
-                    AddCategory(RegexCharClass.s_notSpace);
+                    AddCategory(s_notSpace);
             }
             else
             {
                 if (ecma)
-                    AddSet(RegexCharClass.ECMASpaceSet);
+                    AddSet(ECMASpaceSet);
                 else
-                    AddCategory(RegexCharClass.s_space);
+                    AddCategory(s_space);
             }
         }
 
@@ -678,9 +678,9 @@ namespace System.Text.RegularExpressions
             if (ecma)
             {
                 if (negate)
-                    AddSet(RegexCharClass.NotECMADigitSet);
+                    AddSet(NotECMADigitSet);
                 else
-                    AddSet(RegexCharClass.ECMADigitSet);
+                    AddSet(ECMADigitSet);
             }
             else
                 AddCategoryFromName("Nd", negate, false, pattern);
@@ -712,7 +712,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Returns the char
         /// </summary>
-        internal static char SingletonChar(String set)
+        internal static char SingletonChar(string set)
         {
             Debug.Assert(IsSingleton(set) || IsSingletonInverse(set), "Tried to get the singleton char out of a non singleton character class");
             return set[SETSTART];
@@ -723,7 +723,7 @@ namespace System.Text.RegularExpressions
             return (!IsNegated(charClass) && !IsSubtraction(charClass));
         }
 
-        internal static bool IsEmpty(String charClass)
+        internal static bool IsEmpty(string charClass)
         {
             if (charClass[CATEGORYLENGTH] == 0 && charClass[FLAGS] == 0 && charClass[SETLENGTH] == 0 && !IsSubtraction(charClass))
                 return true;
@@ -734,7 +734,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// <c>true</c> if the set contains a single character only
         /// </summary>
-        internal static bool IsSingleton(String set)
+        internal static bool IsSingleton(string set)
         {
             if (set[FLAGS] == 0 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 2 && !IsSubtraction(set) &&
                 (set[SETSTART] == LastChar || set[SETSTART] + 1 == set[SETSTART + 1]))
@@ -743,7 +743,7 @@ namespace System.Text.RegularExpressions
                 return false;
         }
 
-        internal static bool IsSingletonInverse(String set)
+        internal static bool IsSingletonInverse(string set)
         {
             if (set[FLAGS] == 1 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 2 && !IsSubtraction(set) &&
                 (set[SETSTART] == LastChar || set[SETSTART] + 1 == set[SETSTART + 1]))
@@ -781,13 +781,13 @@ namespace System.Text.RegularExpressions
             return CharInClass(ch, WordClass) || ch == ZeroWidthJoiner || ch == ZeroWidthNonJoiner;
         }
 
-        internal static bool CharInClass(char ch, String set)
+        internal static bool CharInClass(char ch, string set)
         {
             return CharInClassRecursive(ch, set, 0);
         }
 
 
-        internal static bool CharInClassRecursive(char ch, String set, int start)
+        internal static bool CharInClassRecursive(char ch, string set, int start)
         {
             int mySetLength = set[start + SETLENGTH];
             int myCategoryLength = set[start + CATEGORYLENGTH];
@@ -871,7 +871,7 @@ namespace System.Text.RegularExpressions
 
                     if (curcat == SpaceConst)
                     {
-                        if (Char.IsWhiteSpace(ch))
+                        if (char.IsWhiteSpace(ch))
                             return true;
                         else
                         {
@@ -889,7 +889,7 @@ namespace System.Text.RegularExpressions
                     // less than zero is a negative case
                     if (curcat == NotSpaceConst)
                     {
-                        if (!Char.IsWhiteSpace(ch))
+                        if (!char.IsWhiteSpace(ch))
                             return true;
                         else
                         {
@@ -1020,7 +1020,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Constructs the string representation of the class.
         /// </summary>
-        internal String ToStringClass()
+        internal string ToStringClass()
         {
             if (!_canonical)
                 Canonicalize();
@@ -1121,22 +1121,22 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        private static String SetFromProperty(String capname, bool invert, string pattern)
+        private static string SetFromProperty(string capname, bool invert, string pattern)
         {
             int min = 0;
             int max = s_propTable.Length;
             while (min != max)
             {
                 int mid = (min + max) / 2;
-                int res = String.Compare(capname, s_propTable[mid][0], StringComparison.Ordinal);
+                int res = string.Compare(capname, s_propTable[mid][0], StringComparison.Ordinal);
                 if (res < 0)
                     max = mid;
                 else if (res > 0)
                     min = mid + 1;
                 else
                 {
-                    String set = s_propTable[mid][1];
-                    Debug.Assert(!String.IsNullOrEmpty(set), "Found a null/empty element in RegexCharClass prop table");
+                    string set = s_propTable[mid][1];
+                    Debug.Assert(!string.IsNullOrEmpty(set), "Found a null/empty element in RegexCharClass prop table");
                     if (invert)
                     {
                         if (set[0] == NullChar)
@@ -1159,7 +1159,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Produces a human-readable description for a set string.
         /// </summary>
-        internal static String SetDescription(String set)
+        internal static string SetDescription(string set)
         {
             int mySetLength = set[SETLENGTH];
             int myCategoryLength = set[CATEGORYLENGTH];
@@ -1266,7 +1266,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Produces a human-readable description for a single character.
         /// </summary>
-        internal static String CharDescription(char ch)
+        internal static string CharDescription(char ch)
         {
             if (ch == '\\')
                 return "\\\\";
@@ -1299,7 +1299,7 @@ namespace System.Text.RegularExpressions
             return sb.ToString();
         }
 
-        private static String CategoryDescription(char ch)
+        private static string CategoryDescription(char ch)
         {
             if (ch == SpaceConst)
                 return "\\s";

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -90,16 +90,16 @@ namespace System.Text.RegularExpressions
         internal const int Ci = 512;    // bit to indicate that we're case-insensitive.
 
         internal readonly int[] _codes;                     // the code
-        internal readonly String[] _strings;                // the string/set table
+        internal readonly string[] _strings;                // the string/set table
         internal readonly int _trackcount;                  // how many instructions use backtracking
-        internal readonly Hashtable _caps;   // mapping of user group numbers -> impl group slots
+        internal readonly Hashtable _caps;                  // mapping of user group numbers -> impl group slots
         internal readonly int _capsize;                     // number of impl group slots
         internal readonly RegexPrefix _fcPrefix;            // the set of candidate first characters (may be null)
         internal readonly RegexBoyerMoore _bmPrefix;        // the fixed prefix string as a Boyer-Moore machine (may be null)
         internal readonly int _anchors;                     // the set of zero-length start anchors (RegexFCD.Bol, etc)
         internal readonly bool _rightToLeft;                // true if right to left
 
-        internal RegexCode(int[] codes, List<String> stringlist, int trackcount,
+        internal RegexCode(int[] codes, List<string> stringlist, int trackcount,
                            Hashtable caps, int capsize,
                            RegexBoyerMoore bmPrefix, RegexPrefix fcPrefix,
                            int anchors, bool rightToLeft)
@@ -212,7 +212,7 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        private static readonly String[] CodeStr = new String[]
+        private static readonly string[] CodeStr = new string[]
         {
             "Onerep", "Notonerep", "Setrep",
             "Oneloop", "Notoneloop", "Setloop",
@@ -231,7 +231,7 @@ namespace System.Text.RegularExpressions
 #endif
         };
 
-        internal static String OperatorDescription(int Opcode)
+        internal static string OperatorDescription(int Opcode)
         {
             bool isCi = ((Opcode & Ci) != 0);
             bool isRtl = ((Opcode & Rtl) != 0);
@@ -242,7 +242,7 @@ namespace System.Text.RegularExpressions
             (isCi ? "-Ci" : "") + (isRtl ? "-Rtl" : "") + (isBack ? "-Back" : "") + (isBack2 ? "-Back2" : "");
         }
 
-        internal String OpcodeDescription(int offset)
+        internal string OpcodeDescription(int offset)
         {
             StringBuilder sb = new StringBuilder();
             int opcode = _codes[offset];
@@ -326,7 +326,7 @@ namespace System.Text.RegularExpressions
                 case Setloop:
                 case Setlazy:
                     sb.Append(", Rep = ");
-                    if (_codes[offset + 2] == Int32.MaxValue)
+                    if (_codes[offset + 2] == int.MaxValue)
                         sb.Append("inf");
                     else
                         sb.Append(_codes[offset + 2]);
@@ -335,7 +335,7 @@ namespace System.Text.RegularExpressions
                 case Branchcount:
                 case Lazybranchcount:
                     sb.Append(", Limit = ");
-                    if (_codes[offset + 2] == Int32.MaxValue)
+                    if (_codes[offset + 2] == int.MaxValue)
                         sb.Append("inf");
                     else
                         sb.Append(_codes[offset + 2]);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
@@ -89,7 +89,7 @@ namespace System.Text.RegularExpressions
                     case RegexNode.Onelazy:
                         if (curNode._m > 0)
                         {
-                            string pref = String.Empty.PadRight(curNode._m, curNode._ch);
+                            string pref = string.Empty.PadRight(curNode._m, curNode._ch);
                             return new RegexPrefix(pref, 0 != (curNode._options & RegexOptions.IgnoreCase));
                         }
                         else
@@ -202,7 +202,7 @@ namespace System.Text.RegularExpressions
         }
 
 #if DEBUG
-        internal static String AnchorDescription(int anchors)
+        internal static string AnchorDescription(int anchors)
         {
             StringBuilder sb = new StringBuilder();
 
@@ -241,7 +241,7 @@ namespace System.Text.RegularExpressions
             {
                 int[] expanded = new int[_intDepth * 2];
 
-                System.Array.Copy(_intStack, 0, expanded, 0, _intDepth);
+                Array.Copy(_intStack, 0, expanded, 0, _intDepth);
 
                 _intStack = expanded;
             }
@@ -275,7 +275,7 @@ namespace System.Text.RegularExpressions
             {
                 RegexFC[] expanded = new RegexFC[_fcDepth * 2];
 
-                System.Array.Copy(_fcStack, 0, expanded, 0, _fcDepth);
+                Array.Copy(_fcStack, 0, expanded, 0, _fcDepth);
                 _fcStack = expanded;
             }
 
@@ -333,7 +333,7 @@ namespace System.Text.RegularExpressions
 
                     if (!_skipchild)
                     {
-                        curNode = (RegexNode)curNode._children[curChild];
+                        curNode = curNode._children[curChild];
                         // this stack is how we get a depth first walk of the tree.
                         PushInt(curChild);
                         curChild = 0;
@@ -558,7 +558,7 @@ namespace System.Text.RegularExpressions
             _nullable = nullable;
         }
 
-        internal RegexFC(String charClass, bool nullable, bool caseInsensitive)
+        internal RegexFC(string charClass, bool nullable, bool caseInsensitive)
         {
             _cc = RegexCharClass.Parse(charClass);
 
@@ -608,18 +608,18 @@ namespace System.Text.RegularExpressions
 
     internal sealed class RegexPrefix
     {
-        internal String _prefix;
+        internal string _prefix;
         internal bool _caseInsensitive;
 
-        internal static RegexPrefix _empty = new RegexPrefix(String.Empty, false);
+        internal static RegexPrefix _empty = new RegexPrefix(string.Empty, false);
 
-        internal RegexPrefix(String prefix, bool ci)
+        internal RegexPrefix(string prefix, bool ci)
         {
             _prefix = prefix;
             _caseInsensitive = ci;
         }
 
-        internal String Prefix
+        internal string Prefix
         {
             get
             {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroup.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroup.cs
@@ -16,14 +16,14 @@ namespace System.Text.RegularExpressions
     public class Group : Capture
     {
         // the empty group object
-        internal static Group s_emptyGroup = new Group(string.Empty, Array.Empty<int>(), 0, string.Empty);
+        internal static readonly Group s_emptyGroup = new Group(string.Empty, Array.Empty<int>(), 0, string.Empty);
 
         internal readonly int[] _caps;
         internal int _capcount;
         internal CaptureCollection _capcoll;
         internal readonly string _name;
 
-        internal Group(String text, int[] caps, int capcount, string name)
+        internal Group(string text, int[] caps, int capcount, string name)
 
         : base(text, capcount == 0 ? 0 : caps[(capcount - 1) * 2],
                capcount == 0 ? 0 : caps[(capcount * 2) - 1])

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -258,7 +258,7 @@ namespace System.Text.RegularExpressions
             return (_caseInsensitive ? _culture.TextInfo.ToLower(ch) : ch);
         }
 
-        private bool Stringmatch(String str)
+        private bool Stringmatch(string str)
         {
             int c;
             int pos;
@@ -361,7 +361,7 @@ namespace System.Text.RegularExpressions
         protected override bool FindFirstChar()
         {
             int i;
-            String set;
+            string set;
 
             if (0 != (_code._anchors & (RegexFCD.Beginning | RegexFCD.Start | RegexFCD.EndZ | RegexFCD.End)))
             {
@@ -961,7 +961,7 @@ namespace System.Text.RegularExpressions
                             if (Forwardchars() < c)
                                 break;
 
-                            String set = _code._strings[Operand(0)];
+                            string set = _code._strings[Operand(0)];
 
                             while (c-- > 0)
                                 if (!RegexCharClass.CharInClass(Forwardcharnext(), set))
@@ -1030,7 +1030,7 @@ namespace System.Text.RegularExpressions
                             if (c > Forwardchars())
                                 c = Forwardchars();
 
-                            String set = _code._strings[Operand(0)];
+                            string set = _code._strings[Operand(0)];
                             int i;
 
                             for (i = c; i > 0; i--)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatch.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatch.cs
@@ -26,7 +26,6 @@
 //
 
 using System.Collections;
-using System.Collections.Generic;
 using System.Globalization;
 
 namespace System.Text.RegularExpressions
@@ -36,7 +35,7 @@ namespace System.Text.RegularExpressions
     /// </summary>
     public class Match : Group
     {
-        internal static Match s_empty = new Match(null, 1, String.Empty, 0, 0, 0);
+        internal static readonly Match s_empty = new Match(null, 1, string.Empty, 0, 0, 0);
         internal GroupCollection _groupcoll;
 
         // input to the match
@@ -63,7 +62,7 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        internal Match(Regex regex, int capcount, String text, int begpos, int len, int startpos)
+        internal Match(Regex regex, int capcount, string text, int begpos, int len, int startpos)
             : base(text, new int[2], 0, "0")
         {
             _regex = regex;
@@ -84,7 +83,7 @@ namespace System.Text.RegularExpressions
         /*
          * Nonpublic set-text method
          */
-        internal virtual void Reset(Regex regex, String text, int textbeg, int textend, int textstart)
+        internal virtual void Reset(Regex regex, string text, int textbeg, int textend, int textstart)
         {
             _regex = regex;
             _text = text;
@@ -129,7 +128,7 @@ namespace System.Text.RegularExpressions
         /// example, if the replacement pattern is ?$1$2?, Result returns the concatenation
         /// of Group(1).ToString() and Group(2).ToString().
         /// </summary>
-        public virtual String Result(String replacement)
+        public virtual string Result(string replacement)
         {
             RegexReplacement repl;
 
@@ -153,11 +152,11 @@ namespace System.Text.RegularExpressions
         /*
          * Used by the replacement code
          */
-        internal virtual String GroupToStringImpl(int groupnum)
+        internal virtual string GroupToStringImpl(int groupnum)
         {
             int c = _matchcount[groupnum];
             if (c == 0)
-                return String.Empty;
+                return string.Empty;
 
             int[] matches = _matches[groupnum];
 
@@ -167,7 +166,7 @@ namespace System.Text.RegularExpressions
         /*
          * Used by the replacement code
          */
-        internal String LastGroupToStringImpl()
+        internal string LastGroupToStringImpl()
         {
             return GroupToStringImpl(_matchcount.Length - 1);
         }
@@ -195,7 +194,7 @@ namespace System.Text.RegularExpressions
 
                 // Depends on the fact that Group.Synchronized just
                 // operates on and returns the same instance
-                System.Text.RegularExpressions.Group.Synchronized(group);
+                Group.Synchronized(group);
             }
 
             return inner;
@@ -384,7 +383,7 @@ namespace System.Text.RegularExpressions
 
                 for (j = 0; j < _matchcount[i]; j++)
                 {
-                    String text = "";
+                    string text = "";
 
                     if (_matches[i][j * 2] >= 0)
                         text = _text.Substring(_matches[i][j * 2], _matches[i][j * 2 + 1]);
@@ -410,7 +409,7 @@ namespace System.Text.RegularExpressions
          * Nonpublic constructor
          */
         internal MatchSparse(Regex regex, Hashtable caps, int capcount,
-                             String text, int begpos, int len, int startpos)
+                             string text, int begpos, int len, int startpos)
 
         : base(regex, capcount, text, begpos, len, startpos)
         {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchTimeoutException.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchTimeoutException.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Security;
 using System.Runtime.Serialization;
 
 namespace System.Text.RegularExpressions
@@ -14,37 +12,26 @@ namespace System.Text.RegularExpressions
     [Serializable]
     public class RegexMatchTimeoutException : TimeoutException, ISerializable
     {
-        private string _regexInput = null;
-
-        private string _regexPattern = null;
-
-        private TimeSpan _matchTimeout = TimeSpan.FromTicks(-1);
-
-
         /// <summary>
         /// Constructs a new RegexMatchTimeoutException.
         /// </summary>
         /// <param name="regexInput">Matching timeout occurred during matching within the specified input.</param>
         /// <param name="regexPattern">Matching timeout occurred during matching to the specified pattern.</param>
         /// <param name="matchTimeout">Matching timeout occurred because matching took longer than the specified timeout.</param>
-        public RegexMatchTimeoutException(string regexInput, string regexPattern, TimeSpan matchTimeout) :
-            base(SR.RegexMatchTimeoutException_Occurred)
+        public RegexMatchTimeoutException(string regexInput, string regexPattern, TimeSpan matchTimeout)
+            : base(SR.RegexMatchTimeoutException_Occurred)
         {
-            Init(regexInput, regexPattern, matchTimeout);
+            Input = regexInput;
+            Pattern = regexPattern;
+            MatchTimeout = matchTimeout;
         }
-
 
         /// <summary>
         /// This constructor is provided in compliance with common NetFx design patterns;
         /// developers should prefer using the constructor
         /// <code>public RegexMatchTimeoutException(string input, string pattern, TimeSpan matchTimeout)</code>.
         /// </summary>
-        public RegexMatchTimeoutException()
-            : base()
-        {
-            Init();
-        }
-
+        public RegexMatchTimeoutException() { }
 
         /// <summary>
         /// This constructor is provided in compliance with common NetFx design patterns;
@@ -52,12 +39,7 @@ namespace System.Text.RegularExpressions
         /// <code>public RegexMatchTimeoutException(string input, string pattern, TimeSpan matchTimeout)</code>.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
-        public RegexMatchTimeoutException(string message)
-            : base(message)
-        {
-            Init();
-        }
-
+        public RegexMatchTimeoutException(string message) : base(message) { }
 
         /// <summary>
         /// This constructor is provided in compliance with common NetFx design patterns;
@@ -66,61 +48,28 @@ namespace System.Text.RegularExpressions
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="inner">The exception that is the cause of the current exception, or a <code>null</code>.</param>
-        public RegexMatchTimeoutException(string message, Exception inner)
-            : base(message, inner)
-        {
-            Init();
-        }
-
-        private void Init()
-        {
-            Init("", "", TimeSpan.FromTicks(-1));
-        }
-
-        private void Init(string input, string pattern, TimeSpan timeout)
-        {
-            _regexInput = input;
-            _regexPattern = pattern;
-            _matchTimeout = timeout;
-        }
-
-        public string Pattern
-        {
-            [SecurityCritical]
-            get
-            { return _regexPattern; }
-        }
-
-        public string Input
-        {
-            [SecurityCritical]
-            get
-            { return _regexInput; }
-        }
-
-
-        public TimeSpan MatchTimeout
-        {
-            [SecurityCritical]
-            get
-            { return _matchTimeout; }
-        }
+        public RegexMatchTimeoutException(string message, Exception inner) : base(message, inner) { }
 
         protected RegexMatchTimeoutException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            string input = info.GetString("regexInput");
-            string pattern = info.GetString("regexPattern");
-            TimeSpan timeout = new TimeSpan(info.GetInt64("timeoutTicks"));
-            Init(input, pattern, timeout);
+            Input = info.GetString("regexInput");
+            Pattern = info.GetString("regexPattern");
+            MatchTimeout = new TimeSpan(info.GetInt64("timeoutTicks"));
         }
 
-        void ISerializable.GetObjectData(SerializationInfo si, StreamingContext context)
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            base.GetObjectData(si, context);
-            si.AddValue("regexInput", _regexInput);
-            si.AddValue("regexPattern", _regexPattern);
-            si.AddValue("timeoutTicks", _matchTimeout.Ticks);
+            base.GetObjectData(info, context);
+            info.AddValue("regexInput", Input);
+            info.AddValue("regexPattern", Pattern);
+            info.AddValue("timeoutTicks", MatchTimeout.Ticks);
         }
+
+        public string Input { get; } = string.Empty;
+
+        public string Pattern { get; } = string.Empty;
+
+        public TimeSpan MatchTimeout { get; } = TimeSpan.FromTicks(-1);
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -105,7 +105,7 @@ namespace System.Text.RegularExpressions
 
         internal List<RegexNode> _children;
 
-        internal String _str;
+        internal string _str;
         internal char _ch;
         internal int _m;
         internal int _n;
@@ -126,7 +126,7 @@ namespace System.Text.RegularExpressions
             _ch = ch;
         }
 
-        internal RegexNode(int type, RegexOptions options, String str)
+        internal RegexNode(int type, RegexOptions options, string str)
         {
             _type = type;
             _options = options;
@@ -285,12 +285,12 @@ namespace System.Text.RegularExpressions
 
                 u = child;
                 if (u._m > 0)
-                    u._m = min = ((Int32.MaxValue - 1) / u._m < min) ? Int32.MaxValue : u._m * min;
+                    u._m = min = ((int.MaxValue - 1) / u._m < min) ? int.MaxValue : u._m * min;
                 if (u._n > 0)
-                    u._n = max = ((Int32.MaxValue - 1) / u._n < max) ? Int32.MaxValue : u._n * max;
+                    u._n = max = ((int.MaxValue - 1) / u._n < max) ? int.MaxValue : u._n * max;
             }
 
-            return min == Int32.MaxValue ? new RegexNode(Nothing, _options) : u;
+            return min == int.MaxValue ? new RegexNode(Nothing, _options) : u;
         }
 
         /// <summary>
@@ -344,7 +344,7 @@ namespace System.Text.RegularExpressions
             RegexNode prev;
 
             if (_children == null)
-                return new RegexNode(RegexNode.Nothing, _options);
+                return new RegexNode(Nothing, _options);
 
             wasLastSet = false;
             lastNodeCannotMerge = false;
@@ -398,7 +398,7 @@ namespace System.Text.RegularExpressions
                         prev = _children[j];
 
                         RegexCharClass prevCharClass;
-                        if (prev._type == RegexNode.One)
+                        if (prev._type == One)
                         {
                             prevCharClass = new RegexCharClass();
                             prevCharClass.AddChar(prev._ch);
@@ -408,7 +408,7 @@ namespace System.Text.RegularExpressions
                             prevCharClass = RegexCharClass.Parse(prev._str);
                         }
 
-                        if (at._type == RegexNode.One)
+                        if (at._type == One)
                         {
                             prevCharClass.AddChar(at._ch);
                         }
@@ -418,10 +418,10 @@ namespace System.Text.RegularExpressions
                             prevCharClass.AddCharClass(atCharClass);
                         }
 
-                        prev._type = RegexNode.Set;
+                        prev._type = Set;
                         prev._str = prevCharClass.ToStringClass();
                     }
-                    else if (at._type == RegexNode.Nothing)
+                    else if (at._type == Nothing)
                     {
                         j--;
                     }
@@ -437,7 +437,7 @@ namespace System.Text.RegularExpressions
             if (j < i)
                 _children.RemoveRange(j, i - j);
 
-            return StripEnation(RegexNode.Nothing);
+            return StripEnation(Nothing);
         }
 
         /// <summary>
@@ -456,7 +456,7 @@ namespace System.Text.RegularExpressions
             int j;
 
             if (_children == null)
-                return new RegexNode(RegexNode.Empty, _options);
+                return new RegexNode(Empty, _options);
 
             wasLastString = false;
             optionsLast = 0;
@@ -471,7 +471,7 @@ namespace System.Text.RegularExpressions
                 if (j < i)
                     _children[j] = at;
 
-                if (at._type == RegexNode.Concatenate &&
+                if (at._type == Concatenate &&
                     ((at._options & RegexOptions.RightToLeft) == (_options & RegexOptions.RightToLeft)))
                 {
                     for (int k = 0; k < at._children.Count; k++)
@@ -480,8 +480,8 @@ namespace System.Text.RegularExpressions
                     _children.InsertRange(i + 1, at._children);
                     j--;
                 }
-                else if (at._type == RegexNode.Multi ||
-                         at._type == RegexNode.One)
+                else if (at._type == Multi ||
+                         at._type == One)
                 {
                     // Cannot merge strings if L or I options differ
                     optionsAt = at._options & (RegexOptions.RightToLeft | RegexOptions.IgnoreCase);
@@ -495,28 +495,28 @@ namespace System.Text.RegularExpressions
 
                     prev = _children[--j];
 
-                    if (prev._type == RegexNode.One)
+                    if (prev._type == One)
                     {
-                        prev._type = RegexNode.Multi;
+                        prev._type = Multi;
                         prev._str = Convert.ToString(prev._ch, CultureInfo.InvariantCulture);
                     }
 
                     if ((optionsAt & RegexOptions.RightToLeft) == 0)
                     {
-                        if (at._type == RegexNode.One)
+                        if (at._type == One)
                             prev._str += at._ch.ToString();
                         else
                             prev._str += at._str;
                     }
                     else
                     {
-                        if (at._type == RegexNode.One)
+                        if (at._type == One)
                             prev._str = at._ch.ToString() + prev._str;
                         else
                             prev._str = at._str + prev._str;
                     }
                 }
-                else if (at._type == RegexNode.Empty)
+                else if (at._type == Empty)
                 {
                     j--;
                 }
@@ -529,7 +529,7 @@ namespace System.Text.RegularExpressions
             if (j < i)
                 _children.RemoveRange(j, i - j);
 
-            return StripEnation(RegexNode.Empty);
+            return StripEnation(Empty);
         }
 
         internal RegexNode MakeQuantifier(bool lazy, int min, int max)
@@ -537,22 +537,22 @@ namespace System.Text.RegularExpressions
             RegexNode result;
 
             if (min == 0 && max == 0)
-                return new RegexNode(RegexNode.Empty, _options);
+                return new RegexNode(Empty, _options);
 
             if (min == 1 && max == 1)
                 return this;
 
             switch (_type)
             {
-                case RegexNode.One:
-                case RegexNode.Notone:
-                case RegexNode.Set:
+                case One:
+                case Notone:
+                case Set:
 
-                    MakeRep(lazy ? RegexNode.Onelazy : RegexNode.Oneloop, min, max);
+                    MakeRep(lazy ? Onelazy : Oneloop, min, max);
                     return this;
 
                 default:
-                    result = new RegexNode(lazy ? RegexNode.Lazyloop : RegexNode.Loop, _options, min, max);
+                    result = new RegexNode(lazy ? Lazyloop : Loop, _options, min, max);
                     result.AddChild(this);
                     return result;
             }
@@ -586,7 +586,7 @@ namespace System.Text.RegularExpressions
         }
 
 #if DEBUG
-        internal static String[] TypeStr = new String[] {
+        internal static readonly string[] TypeStr = new string[] {
             "Onerep", "Notonerep", "Setrep",
             "Oneloop", "Notoneloop", "Setloop",
             "Onelazy", "Notonelazy", "Setlazy",
@@ -601,7 +601,7 @@ namespace System.Text.RegularExpressions
             "Capture", "Group", "Require", "Prevent", "Greedy",
             "Testref", "Testgroup"};
 
-        internal String Description()
+        internal string Description()
         {
             StringBuilder ArgSb = new StringBuilder();
 
@@ -659,14 +659,14 @@ namespace System.Text.RegularExpressions
                 case Setlazy:
                 case Loop:
                 case Lazyloop:
-                    ArgSb.Append("(Min = " + _m.ToString(CultureInfo.InvariantCulture) + ", Max = " + (_n == Int32.MaxValue ? "inf" : Convert.ToString(_n, CultureInfo.InvariantCulture)) + ")");
+                    ArgSb.Append("(Min = " + _m.ToString(CultureInfo.InvariantCulture) + ", Max = " + (_n == int.MaxValue ? "inf" : Convert.ToString(_n, CultureInfo.InvariantCulture)) + ")");
                     break;
             }
 
             return ArgSb.ToString();
         }
 
-        internal const String Space = "                                ";
+        internal const string Space = "                                ";
 
         internal void Dump()
         {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -25,7 +25,7 @@ namespace System.Text.RegularExpressions
         internal RegexNode _concatenation;
         internal RegexNode _unit;
 
-        internal String _pattern;
+        internal string _pattern;
         internal int _currentPos;
         internal CultureInfo _culture;
 
@@ -37,16 +37,16 @@ namespace System.Text.RegularExpressions
         internal Hashtable _caps;
         internal Hashtable _capnames;
 
-        internal Int32[] _capnumlist;
-        internal List<String> _capnamelist;
+        internal int[] _capnumlist;
+        internal List<string> _capnamelist;
 
         internal RegexOptions _options;
         internal List<RegexOptions> _optionsStack;
 
         internal bool _ignoreNextParen = false;
 
-        internal const int MaxValueDiv10 = Int32.MaxValue / 10;
-        internal const int MaxValueMod10 = Int32.MaxValue % 10;
+        internal const int MaxValueDiv10 = int.MaxValue / 10;
+        internal const int MaxValueMod10 = int.MaxValue % 10;
 
         /*
          * This static call constructs a RegexTree from a regular expression
@@ -54,11 +54,11 @@ namespace System.Text.RegularExpressions
          *
          * The method creates, drives, and drops a parser instance.
          */
-        internal static RegexTree Parse(String re, RegexOptions op)
+        internal static RegexTree Parse(string re, RegexOptions op)
         {
             RegexParser p;
             RegexNode root;
-            String[] capnamelist;
+            string[] capnamelist;
 
             p = new RegexParser((op & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture);
 
@@ -81,7 +81,7 @@ namespace System.Text.RegularExpressions
          * This static call constructs a flat concatenation node given
          * a replacement pattern.
          */
-        internal static RegexReplacement ParseReplacement(String rep, Hashtable caps, int capsize, Hashtable capnames, RegexOptions op)
+        internal static RegexReplacement ParseReplacement(string rep, Hashtable caps, int capsize, Hashtable capnames, RegexOptions op)
         {
             RegexParser p;
             RegexNode root;
@@ -100,7 +100,7 @@ namespace System.Text.RegularExpressions
         /*
          * Escapes all metacharacters (including |,(,),[,{,|,^,$,*,+,?,\, spaces and #)
          */
-        internal static String Escape(String input)
+        internal static string Escape(string input)
         {
             for (int i = 0; i < input.Length; i++)
             {
@@ -155,7 +155,7 @@ namespace System.Text.RegularExpressions
         /*
          * Escapes all metacharacters (including (,),[,],{,},|,^,$,*,+,?,\, spaces and #)
          */
-        internal static String Unescape(String input)
+        internal static string Unescape(string input)
         {
             for (int i = 0; i < input.Length; i++)
             {
@@ -200,10 +200,10 @@ namespace System.Text.RegularExpressions
         /*
          * Drops a string into the pattern buffer.
          */
-        internal void SetPattern(String Re)
+        internal void SetPattern(string Re)
         {
             if (Re == null)
-                Re = String.Empty;
+                Re = string.Empty;
             _pattern = Re;
             _currentPos = 0;
         }
@@ -380,7 +380,7 @@ namespace System.Text.RegularExpressions
                     {
                         case '*':
                             min = 0;
-                            max = Int32.MaxValue;
+                            max = int.MaxValue;
                             break;
 
                         case '?':
@@ -390,7 +390,7 @@ namespace System.Text.RegularExpressions
 
                         case '+':
                             min = 1;
-                            max = Int32.MaxValue;
+                            max = int.MaxValue;
                             break;
 
                         case '{':
@@ -403,7 +403,7 @@ namespace System.Text.RegularExpressions
                                     {
                                         MoveRight();
                                         if (CharsRight() == 0 || RightChar() == '}')
-                                            max = Int32.MaxValue;
+                                            max = int.MaxValue;
                                         else
                                             max = ScanDecimal();
                                     }
@@ -601,7 +601,7 @@ namespace System.Text.RegularExpressions
                     // It currently doesn't do anything other than skip the whole thing!
                     if (CharsRight() > 0 && RightChar() == ':' && !inRange)
                     {
-                        String name;
+                        string name;
                         int savePos = Textpos();
 
                         MoveRight();
@@ -783,7 +783,7 @@ namespace System.Text.RegularExpressions
                                 }
                                 else if (RegexCharClass.IsWordChar(ch))
                                 {
-                                    String capname = ScanCapname();
+                                    string capname = ScanCapname();
 
                                     if (IsCaptureName(capname))
                                         capnum = CaptureSlotFromName(capname);
@@ -822,7 +822,7 @@ namespace System.Text.RegularExpressions
                                     }
                                     else if (RegexCharClass.IsWordChar(ch))
                                     {
-                                        String uncapname = ScanCapname();
+                                        string uncapname = ScanCapname();
 
                                         if (IsCaptureName(uncapname))
                                             uncapnum = CaptureSlotFromName(uncapname);
@@ -874,7 +874,7 @@ namespace System.Text.RegularExpressions
                             }
                             else if (RegexCharClass.IsWordChar(ch))
                             {
-                                String capname = ScanCapname();
+                                string capname = ScanCapname();
 
                                 if (IsCaptureName(capname) && CharsRight() > 0 && MoveRightGetChar() == ')')
                                     return new RegexNode(RegexNode.Testref, _options, CaptureSlotFromName(capname));
@@ -1153,7 +1153,7 @@ namespace System.Text.RegularExpressions
 
             else if (angled && RegexCharClass.IsWordChar(ch))
             {
-                String capname = ScanCapname();
+                string capname = ScanCapname();
 
                 if (CharsRight() > 0 && MoveRightGetChar() == close)
                 {
@@ -1247,7 +1247,7 @@ namespace System.Text.RegularExpressions
             }
             else if (angled && RegexCharClass.IsWordChar(ch))
             {
-                String capname = ScanCapname();
+                string capname = ScanCapname();
 
                 if (CharsRight() > 0 && MoveRightGetChar() == '}')
                 {
@@ -1302,7 +1302,7 @@ namespace System.Text.RegularExpressions
         /*
          * Scans a capture name: consumes word chars
          */
-        internal String ScanCapname()
+        internal string ScanCapname()
         {
             int startpos = Textpos();
 
@@ -1535,7 +1535,7 @@ namespace System.Text.RegularExpressions
         /*
          * Scans X for \p{X} or \P{X}
          */
-        internal String ParseProperty()
+        internal string ParseProperty()
         {
             if (CharsRight() < 3)
             {
@@ -1557,7 +1557,7 @@ namespace System.Text.RegularExpressions
                     break;
                 }
             }
-            String capname = _pattern.Substring(startpos, Textpos() - startpos);
+            string capname = _pattern.Substring(startpos, Textpos() - startpos);
 
             if (CharsRight() == 0 || MoveRightGetChar() != '}')
                 throw MakeException(SR.IncompleteSlashP);
@@ -1750,7 +1750,7 @@ namespace System.Text.RegularExpressions
 
                 if (_captop <= i)
                 {
-                    if (i == Int32.MaxValue)
+                    if (i == int.MaxValue)
                         _captop = i;
                     else
                         _captop = i + 1;
@@ -1761,12 +1761,12 @@ namespace System.Text.RegularExpressions
         /*
          * Notes a used capture slot
          */
-        internal void NoteCaptureName(String name, int pos)
+        internal void NoteCaptureName(string name, int pos)
         {
             if (_capnames == null)
             {
                 _capnames = new Hashtable();
-                _capnamelist = new List<String>();
+                _capnamelist = new List<string>();
             }
 
             if (!_capnames.ContainsKey(name))
@@ -1810,7 +1810,7 @@ namespace System.Text.RegularExpressions
 
             if (_capcount < _captop)
             {
-                _capnumlist = new Int32[_capcount];
+                _capnumlist = new int[_capcount];
                 int i = 0;
 
                 // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
@@ -1820,14 +1820,14 @@ namespace System.Text.RegularExpressions
                     _capnumlist[i++] = (int)de.Key;
                 }
 
-                System.Array.Sort(_capnumlist, Comparer<Int32>.Default);
+                Array.Sort(_capnumlist, Comparer<int>.Default);
             }
 
             // merge capsnumlist into capnamelist
 
             if (_capnames != null || _capnumlist != null)
             {
-                List<String> oldcapnamelist;
+                List<string> oldcapnamelist;
                 int next;
                 int k = 0;
 
@@ -1835,13 +1835,13 @@ namespace System.Text.RegularExpressions
                 {
                     oldcapnamelist = null;
                     _capnames = new Hashtable();
-                    _capnamelist = new List<String>();
+                    _capnamelist = new List<string>();
                     next = -1;
                 }
                 else
                 {
                     oldcapnamelist = _capnamelist;
-                    _capnamelist = new List<String>();
+                    _capnamelist = new List<string>();
                     next = (int)_capnames[oldcapnamelist[0]];
                 }
 
@@ -1856,7 +1856,7 @@ namespace System.Text.RegularExpressions
                     }
                     else
                     {
-                        String str = Convert.ToString(j, _culture);
+                        string str = Convert.ToString(j, _culture);
                         _capnamelist.Add(str);
                         _capnames[str] = j;
                     }
@@ -1867,7 +1867,7 @@ namespace System.Text.RegularExpressions
         /*
          * Looks up the slot number for a given name
          */
-        internal int CaptureSlotFromName(String capname)
+        internal int CaptureSlotFromName(string capname)
         {
             return (int)_capnames[capname];
         }
@@ -1886,7 +1886,7 @@ namespace System.Text.RegularExpressions
         /*
          * Looks up the slot number for a given name
          */
-        internal bool IsCaptureName(String capname)
+        internal bool IsCaptureName(string capname)
         {
             if (_capnames == null)
                 return false;
@@ -2035,7 +2035,7 @@ namespace System.Text.RegularExpressions
 
             if (cch > 1)
             {
-                String str = _pattern.Substring(pos, cch);
+                string str = _pattern.Substring(pos, cch);
 
                 if (UseOptionI() && !isReplacement)
                 {
@@ -2264,7 +2264,7 @@ namespace System.Text.RegularExpressions
         /*
          * Fills in an ArgumentException
          */
-        internal ArgumentException MakeException(String message)
+        internal ArgumentException MakeException(string message)
         {
             return new ArgumentException(SR.Format(SR.MakeException, _pattern, message));
         }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1813,9 +1813,11 @@ namespace System.Text.RegularExpressions
                 _capnumlist = new Int32[_capcount];
                 int i = 0;
 
-                foreach (DictionaryEntry kvp in _caps)
+                // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+                IDictionaryEnumerator de = _caps.GetEnumerator();
+                while (de.MoveNext())
                 {
-                    _capnumlist[i++] = (int) kvp.Key;
+                    _capnumlist[i++] = (int)de.Key;
                 }
 
                 System.Array.Sort(_capnumlist, Comparer<Int32>.Default);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -21,23 +21,23 @@ namespace System.Text.RegularExpressions
         internal const int LastGroup = -3;
         internal const int WholeString = -4;
 
-        private readonly String _rep;
-        private readonly List<String> _strings; // table of string constants
-        private readonly List<Int32> _rules;    // negative -> group #, positive -> string #
+        private readonly string _rep;
+        private readonly List<string> _strings; // table of string constants
+        private readonly List<int> _rules;      // negative -> group #, positive -> string #
 
         /// <summary>
         /// Since RegexReplacement shares the same parser as Regex,
         /// the constructor takes a RegexNode which is a concatenation
         /// of constant strings and backreferences.
         /// </summary>
-        internal RegexReplacement(String rep, RegexNode concat, Hashtable _caps)
+        internal RegexReplacement(string rep, RegexNode concat, Hashtable _caps)
         {
             if (concat.Type() != RegexNode.Concatenate)
                 throw new ArgumentException(SR.ReplacementError);
 
             StringBuilder sb = StringBuilderCache.Acquire();
-            List<String> strings = new List<String>();
-            List<Int32> rules = new List<Int32>();
+            List<string> strings = new List<string>();
+            List<int> rules = new List<int>();
 
             for (int i = 0; i < concat.ChildCount(); i++)
             {
@@ -121,10 +121,10 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Given a Match, emits into the List<String> the evaluated
+        /// Given a Match, emits into the List<string> the evaluated
         /// Right-to-Left substitution pattern.
         /// </summary>
-        private void ReplacementImplRTL(List<String> al, Match match)
+        private void ReplacementImplRTL(List<string> al, Match match)
         {
             for (int i = _rules.Count - 1; i >= 0; i--)
             {
@@ -157,7 +157,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// The original pattern string
         /// </summary>
-        internal String Pattern
+        internal string Pattern
         {
             get { return _rep; }
         }
@@ -165,7 +165,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Returns the replacement result for a single match
         /// </summary>
-        internal String Replacement(Match match)
+        internal string Replacement(Match match)
         {
             StringBuilder sb = StringBuilderCache.Acquire();
 
@@ -186,7 +186,7 @@ namespace System.Text.RegularExpressions
         /// The right-to-left case is split out because StringBuilder
         /// doesn't handle right-to-left string building directly very well.
         /// </summary>
-        internal String Replace(Regex regex, String input, int count, int startat)
+        internal string Replace(Regex regex, string input, int count, int startat)
         {
             if (count < -1)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.CountTooSmall);
@@ -227,7 +227,7 @@ namespace System.Text.RegularExpressions
                 }
                 else
                 {
-                    List<String> al = new List<String>();
+                    List<string> al = new List<string>();
                     int prevat = input.Length;
 
                     do
@@ -265,8 +265,8 @@ namespace System.Text.RegularExpressions
         /// The right-to-left case is split out because StringBuilder
         /// doesn't handle right-to-left string building directly very well.
         /// </summary>
-        internal static String Replace(MatchEvaluator evaluator, Regex regex,
-                                       String input, int count, int startat)
+        internal static string Replace(MatchEvaluator evaluator, Regex regex,
+                                       string input, int count, int startat)
         {
             if (evaluator == null)
                 throw new ArgumentNullException(nameof(evaluator));
@@ -312,7 +312,7 @@ namespace System.Text.RegularExpressions
                 }
                 else
                 {
-                    List<String> al = new List<String>();
+                    List<string> al = new List<string>();
                     int prevat = input.Length;
 
                     do
@@ -347,18 +347,18 @@ namespace System.Text.RegularExpressions
         /// Does a split. In the right-to-left case we reorder the
         /// array to be forwards.
         /// </summary>
-        internal static String[] Split(Regex regex, String input, int count, int startat)
+        internal static string[] Split(Regex regex, string input, int count, int startat)
         {
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.CountTooSmall);
             if (startat < 0 || startat > input.Length)
                 throw new ArgumentOutOfRangeException(nameof(startat), SR.BeginIndexNotNegative);
 
-            String[] result;
+            string[] result;
 
             if (count == 1)
             {
-                result = new String[1];
+                result = new string[1];
                 result[0] = input;
                 return result;
             }
@@ -369,13 +369,13 @@ namespace System.Text.RegularExpressions
 
             if (!match.Success)
             {
-                result = new String[1];
+                result = new string[1];
                 result[0] = input;
                 return result;
             }
             else
             {
-                List<String> al = new List<String>();
+                List<string> al = new List<string>();
 
                 if (!regex.RightToLeft)
                 {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -25,42 +25,42 @@ namespace System.Text.RegularExpressions
         protected internal int runtextend;         // end of text to search
         protected internal int runtextstart;       // starting point for search
 
-        protected internal String runtext;         // text to search
+        protected internal string runtext;         // text to search
         protected internal int runtextpos;         // current position in text
 
-        protected internal int[] runtrack;         // The backtracking stack.  Opcodes use this to store data regarding 
-        protected internal int runtrackpos;        // what they have matched and where to backtrack to.  Each "frame" on 
-                                           // the stack takes the form of [CodePosition Data1 Data2...], where 
-                                           // CodePosition is the position of the current opcode and 
+        protected internal int[] runtrack;         // The backtracking stack.  Opcodes use this to store data regarding
+        protected internal int runtrackpos;        // what they have matched and where to backtrack to.  Each "frame" on
+                                           // the stack takes the form of [CodePosition Data1 Data2...], where
+                                           // CodePosition is the position of the current opcode and
                                            // the data values are all optional.  The CodePosition can be negative, and
                                            // these values (also called "back2") are used by the BranchMark family of opcodes
                                            // to indicate whether they are backtracking after a successful or failed
-                                           // match.  
+                                           // match.
                                            // When we backtrack, we pop the CodePosition off the stack, set the current
-                                           // instruction pointer to that code position, and mark the opcode 
-                                           // with a backtracking flag ("Back").  Each opcode then knows how to 
-                                           // handle its own data. 
+                                           // instruction pointer to that code position, and mark the opcode
+                                           // with a backtracking flag ("Back").  Each opcode then knows how to
+                                           // handle its own data.
 
-        protected internal int[] runstack;         // This stack is used to track text positions across different opcodes. 
-        protected internal int runstackpos;        // For example, in /(a*b)+/, the parentheses result in a SetMark/CaptureMark 
+        protected internal int[] runstack;         // This stack is used to track text positions across different opcodes.
+        protected internal int runstackpos;        // For example, in /(a*b)+/, the parentheses result in a SetMark/CaptureMark
                                            // pair. SetMark records the text position before we match a*b.  Then
                                            // CaptureMark uses that position to figure out where the capture starts.
                                            // Opcodes which push onto this stack are always paired with other opcodes
                                            // which will pop the value from it later.  A successful match should mean
-                                           // that this stack is empty. 
+                                           // that this stack is empty.
 
-        protected internal int[] runcrawl;         // The crawl stack is used to keep track of captures.  Every time a group 
-        protected internal int runcrawlpos;        // has a capture, we push its group number onto the runcrawl stack.  In 
-                                           // the case of a balanced match, we push BOTH groups onto the stack. 
+        protected internal int[] runcrawl;         // The crawl stack is used to keep track of captures.  Every time a group
+        protected internal int runcrawlpos;        // has a capture, we push its group number onto the runcrawl stack.  In
+                                           // the case of a balanced match, we push BOTH groups onto the stack.
 
         protected internal int runtrackcount;      // count of states that may do backtracking
 
         protected internal Match runmatch;         // result object
         protected internal Regex runregex;         // regex object
 
-        private Int32 _timeout;            // timeout in milliseconds (needed for actual)        
+        private int _timeout;              // timeout in milliseconds (needed for actual)
         private bool _ignoreTimeout;
-        private Int32 _timeoutOccursAt;
+        private int _timeoutOccursAt;
 
 
         // We have determined this value in a series of experiments where x86 retail
@@ -84,12 +84,12 @@ namespace System.Text.RegularExpressions
         /// and we could use a separate method Skip() that will quickly scan past
         /// any characters that we know can't match.
         /// </summary>
-        protected internal Match Scan(Regex regex, String text, int textbeg, int textend, int textstart, int prevlen, bool quick)
+        protected internal Match Scan(Regex regex, string text, int textbeg, int textend, int textstart, int prevlen, bool quick)
         {
             return Scan(regex, text, textbeg, textend, textstart, prevlen, quick, regex.MatchTimeout);
         }
 
-        protected internal Match Scan(Regex regex, String text, int textbeg, int textend, int textstart, int prevlen, bool quick, TimeSpan timeout)
+        protected internal Match Scan(Regex regex, string text, int textbeg, int textend, int textstart, int prevlen, bool quick, TimeSpan timeout)
         {
             int bump;
             int stoppos;
@@ -101,8 +101,8 @@ namespace System.Text.RegularExpressions
 
             _ignoreTimeout = (Regex.InfiniteMatchTimeout == timeout);
             _timeout = _ignoreTimeout
-                                    ? (Int32)Regex.InfiniteMatchTimeout.TotalMilliseconds
-                                    : (Int32)(timeout.TotalMilliseconds + 0.5); // Round
+                                    ? (int)Regex.InfiniteMatchTimeout.TotalMilliseconds
+                                    : (int)(timeout.TotalMilliseconds + 0.5); // Round
 
             runregex = regex;
             runtext = text;
@@ -367,13 +367,13 @@ namespace System.Text.RegularExpressions
                    (index < endpos && RegexCharClass.IsECMAWordChar(runtext[index]));
         }
 
-        protected static bool CharInSet(char ch, String set, String category)
+        protected static bool CharInSet(char ch, string set, string category)
         {
             string charClass = RegexCharClass.ConvertOldStringsToClass(set, category);
             return RegexCharClass.CharInClass(ch, charClass);
         }
 
-        protected static bool CharInClass(char ch, String charClass)
+        protected static bool CharInClass(char ch, string charClass)
         {
             return RegexCharClass.CharInClass(ch, charClass);
         }
@@ -388,7 +388,7 @@ namespace System.Text.RegularExpressions
 
             newtrack = new int[runtrack.Length * 2];
 
-            System.Array.Copy(runtrack, 0, newtrack, runtrack.Length, runtrack.Length);
+            Array.Copy(runtrack, 0, newtrack, runtrack.Length, runtrack.Length);
             runtrackpos += runtrack.Length;
             runtrack = newtrack;
         }
@@ -403,7 +403,7 @@ namespace System.Text.RegularExpressions
 
             newstack = new int[runstack.Length * 2];
 
-            System.Array.Copy(runstack, 0, newstack, runstack.Length, runstack.Length);
+            Array.Copy(runstack, 0, newstack, runstack.Length, runstack.Length);
             runstackpos += runstack.Length;
             runstack = newstack;
         }
@@ -417,7 +417,7 @@ namespace System.Text.RegularExpressions
 
             newcrawl = new int[runcrawl.Length * 2];
 
-            System.Array.Copy(runcrawl, 0, newcrawl, runcrawl.Length, runcrawl.Length);
+            Array.Copy(runcrawl, 0, newcrawl, runcrawl.Length, runcrawl.Length);
             runcrawlpos += runcrawl.Length;
             runcrawl = newcrawl;
         }
@@ -566,7 +566,7 @@ namespace System.Text.RegularExpressions
             Debug.WriteLine("Stack: " + StackDescription(runstack, runstackpos));
         }
 
-        internal static String StackDescription(int[] a, int index)
+        internal static string StackDescription(int[] a, int index)
         {
             var sb = new StringBuilder();
 
@@ -591,7 +591,7 @@ namespace System.Text.RegularExpressions
             return sb.ToString();
         }
 
-        internal virtual String TextposDescription()
+        internal virtual string TextposDescription()
         {
             var sb = new StringBuilder();
             int remaining;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunnerFactory.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunnerFactory.cs
@@ -11,6 +11,4 @@ namespace System.Text.RegularExpressions
         protected RegexRunnerFactory() { }
         protected internal abstract RegexRunner CreateInstance();
     }
-
 }
-

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
@@ -6,13 +6,12 @@
 // global information attached.
 
 using System.Collections;
-using System.Collections.Generic;
 
 namespace System.Text.RegularExpressions
 {
     internal sealed class RegexTree
     {
-        internal RegexTree(RegexNode root, Hashtable caps, Int32[] capnumlist, int captop, Hashtable capnames, String[] capslist, RegexOptions opts)
+        internal RegexTree(RegexNode root, Hashtable caps, int[] capnumlist, int captop, Hashtable capnames, string[] capslist, RegexOptions opts)
         {
             _root = root;
             _caps = caps;
@@ -25,9 +24,9 @@ namespace System.Text.RegularExpressions
 
         internal readonly RegexNode _root;
         internal readonly Hashtable _caps;
-        internal readonly Int32[] _capnumlist;
+        internal readonly int[] _capnumlist;
         internal readonly Hashtable _capnames;
-        internal readonly String[] _capslist;
+        internal readonly string[] _capslist;
         internal readonly RegexOptions _options;
         internal readonly int _captop;
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
@@ -25,7 +25,7 @@ namespace System.Text.RegularExpressions
         private int[] _emitted;
         private int _curpos;
         private readonly Dictionary<string, int> _stringhash;
-        private readonly List<String> _stringtable;
+        private readonly List<string> _stringtable;
         private bool _counting;
         private int _count;
         private int _trackcount;
@@ -58,7 +58,7 @@ namespace System.Text.RegularExpressions
             _intStack = new int[32];
             _emitted = new int[32];
             _stringhash = new Dictionary<string, int>();
-            _stringtable = new List<String>();
+            _stringtable = new List<string>();
         }
 
         /// <summary>
@@ -166,15 +166,15 @@ namespace System.Text.RegularExpressions
         /// Returns an index in the string table for a string;
         /// uses a hashtable to eliminate duplicates.
         /// </summary>
-        private int StringCode(String str)
+        private int StringCode(string str)
         {
             if (_counting)
                 return 0;
 
             if (str == null)
-                str = String.Empty;
+                str = string.Empty;
 
-            Int32 i;
+            int i;
             if (!_stringhash.TryGetValue(str, out i))
             {
                 i = _stringtable.Count;
@@ -261,7 +261,7 @@ namespace System.Text.RegularExpressions
                     {
                         EmitFragment(curNode._type | BeforeChild, curNode, curChild);
 
-                        curNode = (RegexNode)curNode._children[curChild];
+                        curNode = curNode._children[curChild];
                         PushInt(curChild);
                         curChild = 0;
                         continue;
@@ -428,7 +428,7 @@ namespace System.Text.RegularExpressions
                 case RegexNode.Loop | BeforeChild:
                 case RegexNode.Lazyloop | BeforeChild:
 
-                    if (node._n < Int32.MaxValue || node._m > 1)
+                    if (node._n < int.MaxValue || node._m > 1)
                         Emit(node._m == 0 ? RegexCode.Nullcount : RegexCode.Setcount, node._m == 0 ? 0 : 1 - node._m);
                     else
                         Emit(node._m == 0 ? RegexCode.Nullmark : RegexCode.Setmark);
@@ -447,8 +447,8 @@ namespace System.Text.RegularExpressions
                         int StartJumpPos = CurPos();
                         int Lazy = (nodetype - (RegexNode.Loop | AfterChild));
 
-                        if (node._n < Int32.MaxValue || node._m > 1)
-                            Emit(RegexCode.Branchcount + Lazy, PopInt(), node._n == Int32.MaxValue ? Int32.MaxValue : node._n - node._m);
+                        if (node._n < int.MaxValue || node._m > 1)
+                            Emit(RegexCode.Branchcount + Lazy, PopInt(), node._n == int.MaxValue ? int.MaxValue : node._n - node._m);
                         else
                             Emit(RegexCode.Branchmark + Lazy, PopInt());
 
@@ -509,7 +509,7 @@ namespace System.Text.RegularExpressions
 
                 case RegexNode.One:
                 case RegexNode.Notone:
-                    Emit(node._type | bits, (int)node._ch);
+                    Emit(node._type | bits, node._ch);
                     break;
 
                 case RegexNode.Notoneloop:
@@ -518,10 +518,10 @@ namespace System.Text.RegularExpressions
                 case RegexNode.Onelazy:
                     if (node._m > 0)
                         Emit(((node._type == RegexNode.Oneloop || node._type == RegexNode.Onelazy) ?
-                              RegexCode.Onerep : RegexCode.Notonerep) | bits, (int)node._ch, node._m);
+                              RegexCode.Onerep : RegexCode.Notonerep) | bits, node._ch, node._m);
                     if (node._n > node._m)
-                        Emit(node._type | bits, (int)node._ch, node._n == Int32.MaxValue ?
-                             Int32.MaxValue : node._n - node._m);
+                        Emit(node._type | bits, node._ch, node._n == int.MaxValue ?
+                             int.MaxValue : node._n - node._m);
                     break;
 
                 case RegexNode.Setloop:
@@ -530,7 +530,7 @@ namespace System.Text.RegularExpressions
                         Emit(RegexCode.Setrep | bits, StringCode(node._str), node._m);
                     if (node._n > node._m)
                         Emit(node._type | bits, StringCode(node._str),
-                             (node._n == Int32.MaxValue) ? Int32.MaxValue : node._n - node._m);
+                             (node._n == int.MaxValue) ? int.MaxValue : node._n - node._m);
                     break;
 
                 case RegexNode.Multi:

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -720,12 +720,12 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Throws<ArgumentNullException>("pattern", () => Regex.Match("input", null));
             Assert.Throws<ArgumentNullException>("pattern", () => Regex.Match("input", null, RegexOptions.None));
             Assert.Throws<ArgumentNullException>("pattern", () => Regex.Match("input", null, RegexOptions.None, TimeSpan.FromSeconds(1)));
-            
+
             // Start is invalid
-            Assert.Throws<ArgumentOutOfRangeException>("start", () => new Regex("pattern").Match("input", -1));
-            Assert.Throws<ArgumentOutOfRangeException>("start", () => new Regex("pattern").Match("input", -1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("start", () => new Regex("pattern").Match("input", 6));
-            Assert.Throws<ArgumentOutOfRangeException>("start", () => new Regex("pattern").Match("input", 6, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").Match("input", -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").Match("input", -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").Match("input", 6));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").Match("input", 6, 0));
 
             // Length is invalid
             Assert.Throws<ArgumentOutOfRangeException>("length", () => new Regex("pattern").Match("input", 0, -1));
@@ -767,8 +767,8 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Throws<ArgumentNullException>("pattern", () => Regex.IsMatch("input", null, RegexOptions.None, TimeSpan.FromSeconds(1)));
 
             // Start is invalid
-            Assert.Throws<ArgumentOutOfRangeException>("start", () => new Regex("pattern").IsMatch("input", -1));
-            Assert.Throws<ArgumentOutOfRangeException>("start", () => new Regex("pattern").IsMatch("input", 6));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").IsMatch("input", -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").IsMatch("input", 6));
         }
     }
 }


### PR DESCRIPTION
While working in the regex codebase again yesterday, I noticed some minor cleanup opportunities.

Broken up into four commits for easier review, preferably merged as separate commits:

 1. **Avoid box allocations when enumerating `Hashtable`.** Enumerating `Hashtable` using `foreach` results in box allocations for each entry in the `Hashtable` because `Current` returns a `DictionaryEntry` struct but `Current` is typed as object. The allocations can be avoided by using `IDictionaryEnumerator` directly. The original `Hashtable`-based code in the desktop implementation actually does exactly this, so this change essentially just moves the implementation back to what it was in desktop.
- Previous similar changes: #7539, #9050, #10247
- Desktop implementation: [Regex.cs](https://github.com/Microsoft/referencesource/blob/cf5e702dcbf0fd1f5f5df75b3166345591a5e98a/System/regex/system/text/regularexpressions/Regex.cs#L568-L571), [RegexParser.cs](https://github.com/Microsoft/referencesource/blob/cf5e702dcbf0fd1f5f5df75b3166345591a5e98a/System/regex/system/text/regularexpressions/RegexParser.cs#L1680-L1681)

 2. **Use nameof.** There was one remaining place in the codebase that wasn't using `nameof` because it was specifying an incorrect param name. The actual parameter is `startat` not `start`. It's named `startat` in all the public APIs that call this internal method. I updated the tests to remove the param name check so the tests don't fail if run against desktop, which still specifies the incorrect param name.

 3. **Simplify `RegexMatchTimeoutException`.** Use getter-only properties to simplify the code a bit. Removes unnecessary security attributes, `Init` methods, and fields.

 4. **Regex code formatting cleanup**. General minor formatting cleanup.
- BCL type names to language keywords (e.g. `Object` -> `object`, `String` -> `string`, etc.).
- Makes some static fields readonly.
- Remove some unnecessary casts/prefixes.
- Remove and sort namespaces.
- Remove trailing whitespace.