### PR TITLE
Exposing additional method on Activator

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -64,6 +64,9 @@ namespace System
         public static object CreateInstance(System.Type type) { throw null; }
         public static object CreateInstance(System.Type type, System.Boolean nonPublic) { throw null; }
         public static object CreateInstance(System.Type type, params object[] args) { throw null; }
+        public static object CreateInstance(System.Type type, object[] args, object[] activationAttributes) { throw null; } 
+        public static object CreateInstance(System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture) { throw null; } 
+        public static object CreateInstance(System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw null; } 
         public static T CreateInstance<T>() { throw null; }
     }
 

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -187,6 +187,7 @@
     <Compile Include="System\AppContext\AppContext.Switch.cs" />
     <Compile Include="System\AppContext\AppContext.Switch.Validation.cs" />
     <Compile Include="System\Reflection\StrongNameKeyPairTests.netstandard1.7.cs" />
+    <Compile Include="System\ActivatorTest.netstandard1.7.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Runtime/tests/System/ActivatorTest.netstandard1.7.cs
+++ b/src/System.Runtime/tests/System/ActivatorTest.netstandard1.7.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Tests
+{
+
+    public class ActivatorTestsExtended
+    {
+        class ClassWithPrivateCtor
+        {
+            static ClassWithPrivateCtor() { Flag.Reset(100); }
+            private ClassWithPrivateCtor() { Flag.Increase(200); }
+            public ClassWithPrivateCtor(int i) { Flag.Increase(300); }
+        }
+        class ClassWithPrivateCtor2
+        {
+            static ClassWithPrivateCtor2() { Flag.Reset(100); }
+            private ClassWithPrivateCtor2() { Flag.Increase(200); }
+            public ClassWithPrivateCtor2(int i) { Flag.Increase(300); }
+        }
+        class ClassWithPrivateCtor3
+        {
+            static ClassWithPrivateCtor3() { Flag.Reset(100); }
+            private ClassWithPrivateCtor3() { Flag.Increase(200); }
+            public ClassWithPrivateCtor3(int i) { Flag.Increase(300); }
+        }
+
+
+        public class IsTestedAttribute : Attribute
+        {
+            private bool flag;
+            public IsTestedAttribute(bool flag)
+            {
+                this.flag = flag;
+
+            }
+        }
+        [IsTestedAttribute(false)]
+        class ClassWithIsTestedAttribute { }
+        [Serializable]
+        class ClassWithSerializableAttribute { }
+        [IsTestedAttribute(false)]
+        class MBRWithIsTestedAttribute : MarshalByRefObject { }
+        class Flag
+        {
+            public static int cnt = 0;
+            public static void Reset(int i) { cnt = i; }
+            public static void Increase(int i) { cnt += i; }
+            public static bool Equal(int i) { return cnt == i; }
+        }
+
+        [Fact]
+        static void TestingBindingFlags()
+        {
+            Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(typeof(ClassWithPrivateCtor), BindingFlags.Public | BindingFlags.Instance, null, null, CultureInfo.CurrentCulture));
+            Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(typeof(ClassWithPrivateCtor), BindingFlags.Public | BindingFlags.Instance, null, new object[] { 1, 2, 3 }, CultureInfo.CurrentCulture));
+
+
+            Flag.Reset(0); Assert.Equal(0, Flag.cnt);
+            Activator.CreateInstance(typeof(ClassWithPrivateCtor), BindingFlags.Static | BindingFlags.NonPublic, null, null, CultureInfo.CurrentCulture);
+            Assert.Equal(300, Flag.cnt);
+            Activator.CreateInstance(typeof(ClassWithPrivateCtor), BindingFlags.Instance | BindingFlags.NonPublic, null, null, CultureInfo.CurrentCulture);
+            Assert.Equal(500, Flag.cnt);
+
+            Flag.Reset(0); Assert.Equal(0, Flag.cnt);
+            Activator.CreateInstance(typeof(ClassWithPrivateCtor2), BindingFlags.Instance | BindingFlags.NonPublic, null, null, CultureInfo.CurrentCulture);
+            Assert.Equal(300, Flag.cnt);
+            Activator.CreateInstance(typeof(ClassWithPrivateCtor2), BindingFlags.Static | BindingFlags.NonPublic, null, null, CultureInfo.CurrentCulture);
+            Assert.Equal(500, Flag.cnt);
+
+            Flag.Reset(0); Assert.Equal(0, Flag.cnt);
+            Activator.CreateInstance(typeof(ClassWithPrivateCtor3), BindingFlags.Instance | BindingFlags.Public, null, new object[] { 122 }, CultureInfo.CurrentCulture);
+            Assert.Equal(400, Flag.cnt);
+            Activator.CreateInstance(typeof(ClassWithPrivateCtor3), BindingFlags.Static | BindingFlags.NonPublic, null, null, CultureInfo.CurrentCulture);
+            Assert.Equal(600, Flag.cnt);
+            Activator.CreateInstance(typeof(ClassWithPrivateCtor3), BindingFlags.Instance | BindingFlags.Public, null, new object[] { 122 }, CultureInfo.CurrentCulture);
+            Assert.Equal(900, Flag.cnt);
+
+            Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(typeof(ClassWithPrivateCtor), BindingFlags.Public | BindingFlags.Static, null, null, CultureInfo.CurrentCulture));
+            Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(typeof(ClassWithPrivateCtor), BindingFlags.Public | BindingFlags.Static, null, new object[] { 122 }, CultureInfo.CurrentCulture));
+        }
+
+        [Fact]
+        static void TestingBindingFlags1()
+        {
+            Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(typeof(ClassWithPrivateCtor), BindingFlags.Public | BindingFlags.Instance, null, null, CultureInfo.CurrentCulture, null));
+            Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(typeof(ClassWithPrivateCtor), BindingFlags.Public | BindingFlags.Instance, null, new object[] { 1, 2, 3 }, CultureInfo.CurrentCulture, null));
+
+            Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(typeof(ClassWithPrivateCtor), BindingFlags.Public | BindingFlags.Static, null, null, CultureInfo.CurrentCulture, null));
+            Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(typeof(ClassWithPrivateCtor), BindingFlags.Public | BindingFlags.Static, null, new object[] { 122 }, CultureInfo.CurrentCulture, null));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        static void TestingActivationAttributes()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => Activator.CreateInstance(typeof(ClassWithIsTestedAttribute), null, new object[] { new Object() }));
+            Assert.Throws<PlatformNotSupportedException>(() => Activator.CreateInstance(typeof(ClassWithIsTestedAttribute), null, new object[] { new IsTestedAttribute(true) }));
+            Assert.Throws<PlatformNotSupportedException>(() => Activator.CreateInstance(typeof(ClassWithSerializableAttribute), null, new object[] { new ClassWithIsTestedAttribute() }));
+            Assert.Throws<PlatformNotSupportedException>(() => Activator.CreateInstance(typeof(MBRWithIsTestedAttribute), null, new object[] { new IsTestedAttribute(true) }));
+
+            Assert.Throws<PlatformNotSupportedException>(() => Activator.CreateInstance(typeof(ClassWithIsTestedAttribute), 0, null, null, CultureInfo.CurrentCulture, new object[] { new IsTestedAttribute(true) }));
+            Assert.Throws<PlatformNotSupportedException>(() => Activator.CreateInstance(typeof(ClassWithSerializableAttribute), 0, null, null, CultureInfo.CurrentCulture, new object[] { new ClassWithIsTestedAttribute() }));
+            Assert.Throws<PlatformNotSupportedException>(() => Activator.CreateInstance(typeof(MBRWithIsTestedAttribute), 0, null, null, CultureInfo.CurrentCulture, new object[] { new IsTestedAttribute(true) }));
+        }
+
+        [Fact]
+        static void TestingActivationAttributes1()
+        {
+            Activator.CreateInstance(typeof(ClassWithIsTestedAttribute), null, null);
+            Activator.CreateInstance(typeof(ClassWithIsTestedAttribute), null, new object[] { });
+
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/11869

@jkotas @weshaggard @stephentoub  PTAL

note The follwing 2 methods are largely useless unless we were atleast exposing a stubbed out implementation of System.Runtime.Remoting.Activation.UrlAttribute, as currently on core we can only pass null to activationAttributes which defaults to the overload without it : 
public static object CreateInstance(System.Type type, object[] args, object[] activationAttributes)  
public static object CreateInstance(System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes)