### PR TITLE
Allow for ArrayPool<T> to create buffers with a different minimum length

### DIFF
--- a/src/System.Buffers/src/System/Buffers/ArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPool.cs
@@ -22,6 +22,9 @@ namespace System.Buffers
     /// </remarks>
     public abstract class ArrayPool<T>
     {
+        // Default minimum array length for an ArrayPool
+        internal const int DefaultMinArrayLength = 16;
+
         /// <summary>The lazily-initialized shared pool instance.</summary>
         private static ArrayPool<T> s_sharedInstance = null;
 
@@ -74,7 +77,26 @@ namespace System.Buffers
         /// </remarks>
         public static ArrayPool<T> Create(int maxArrayLength, int maxArraysPerBucket)
         {
-            return new DefaultArrayPool<T>(maxArrayLength, maxArraysPerBucket);
+            return new DefaultArrayPool<T>(DefaultMinArrayLength, maxArrayLength, maxArraysPerBucket);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ArrayPool{T}"/> instance using custom configuration options.
+        /// </summary>
+        /// <param name="minArrayLength">The minimum length of array instances that may be stored in the pool.</param>
+        /// <param name="maxArrayLength">The maximum length of array instances that may be stored in the pool.</param>
+        /// <param name="maxArraysPerBucket">
+        /// The maximum number of array instances that may be stored in each bucket in the pool.  The pool
+        /// groups arrays of similar lengths into buckets for faster access.
+        /// </param>
+        /// <returns>A new <see cref="ArrayPool{T}"/> instance with the specified configuration options.</returns>
+        /// <remarks>
+        /// The created pool will group arrays into buckets, with no more than <paramref name="maxArraysPerBucket"/>
+        /// in each bucket and with those arrays not exceeding <paramref name="maxArrayLength"/> in length.
+        /// </remarks>
+        public static ArrayPool<T> Create(int minArrayLength, int maxArrayLength, int maxArraysPerBucket)
+        {
+            return new DefaultArrayPool<T>(minArrayLength, maxArrayLength, maxArraysPerBucket);
         }
 
         /// <summary>

--- a/src/System.Buffers/src/System/Buffers/Utilities.cs
+++ b/src/System.Buffers/src/System/Buffers/Utilities.cs
@@ -10,11 +10,37 @@ namespace System.Buffers
     internal static class Utilities
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int SelectBucketIndex(int bufferSize)
+        internal static int RoundUpPowerOf2(int size)
+        {
+            // From: http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+            size--;
+            size |= size >> 1;
+            size |= size >> 2;
+            size |= size >> 4;
+            size |= size >> 8;
+            size |= size >> 16;
+            return size + 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int GetShiftFromPowerOf2(int size)
+        {
+            // assuming that size is not 0 and has been computed through RoundUpPowerOf2
+            int shift = -1;
+            while (size != 0)
+            {
+                shift++;
+                size = size/2;
+            }
+            return shift;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int SelectBucketIndex(int shift, int bufferSize)
         {
             Debug.Assert(bufferSize > 0);
 
-            uint bitsRemaining = ((uint)bufferSize - 1) >> 4;
+            uint bitsRemaining = ((uint)bufferSize - 1) >> shift;
 
             int poolIndex = 0;
             if (bitsRemaining > 0xFFFF) { bitsRemaining >>= 16; poolIndex = 16; }
@@ -27,9 +53,9 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int GetMaxSizeForBucket(int binIndex)
+        internal static int GetMaxSizeForBucket(int minSize, int binIndex)
         {
-            int maxSize = 16 << binIndex;
+            int maxSize = minSize << binIndex;
             Debug.Assert(maxSize >= 0);
             return maxSize;
         }


### PR DESCRIPTION
Hi there!

## Problem

Currently, the default minimum length that can be rented from an `ArrayPool<T>` is hardcoded to 16 in a few places, in [DefaultArrayPool.cs](https://github.com/dotnet/corefx/blob/bffef76f6af208e2042a2f27bc081ee908bb390b/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs#L35) and in [Utilities.cs](https://github.com/dotnet/corefx/blob/bffef76f6af208e2042a2f27bc081ee908bb390b/src/System.Buffers/src/System/Buffers/Utilities.cs#L17). 

Typically I would like to use ArrayPool<T> for arrays allocated for a custom List type and I would like to use it for a minimum size of 4 (instead of 16), but this could go as low as 1.

## Proposal

This PR adds a new method method `ArrayPool<T>.Create(minLength, maxLength, maxArrayPerBucket)` to allow such a scenario and modify the underlying code accordingly.

Tests are not updated yet. I would like to get feedback before proceeding further.

Thanks!

cc: @stephentoub 