### PR TITLE
Add P2P from TypeConverter to ResourceManager

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -244,6 +244,10 @@
 
     <!-- Random pieces of code required to build  -->
     <Compile Include="System\misc.cs" />
+
+    <!-- TODO: Replace this reference with package reference -->
+    <ProjectReference Include="$(SourceDir)System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.pkgproj"/>
+
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This P2P is still needed until the next package update.

cc @stephentoub @AlexGhiondea 