### PR TITLE
ObservableCollection: Ensure passed-in collection is copied

### DIFF
--- a/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_ConstructorAndPropertyTests.cs
+++ b/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_ConstructorAndPropertyTests.cs
@@ -36,6 +36,15 @@ namespace System.Collections.ObjectModel.Tests
             Assert.Equal(collection, actual);
         }
 
+        [Theory]
+        [MemberData(nameof(Collections))]
+        public static void IEnumerableConstructorTest_MakesCopy(IEnumerable<string> collection)
+        {
+            var oc = new ObservableCollectionSubclass<string>(collection);
+            Assert.NotNull(oc.InnerList);
+            Assert.NotSame(collection, oc.InnerList);
+        }
+
         public static readonly object[][] Collections =
         {
             new object[] { new string[] { "one", "two", "three" } },
@@ -113,6 +122,13 @@ namespace System.Collections.ObjectModel.Tests
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new ObservableCollection<int>());
             DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ObservableCollection<int>());
+        }
+
+        private partial class ObservableCollectionSubclass<T> : ObservableCollection<T>
+        {
+            public ObservableCollectionSubclass(IEnumerable<T> collection) : base(collection) { }
+
+            public List<T> InnerList => (List<T>)base.Items;
         }
     }
 }

--- a/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_ConstructorAndPropertyTests.netstandard1.7.cs
+++ b/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_ConstructorAndPropertyTests.netstandard1.7.cs
@@ -30,5 +30,19 @@ namespace System.Collections.ObjectModel.Tests
             var actual = new ObservableCollection<string>(collection);
             Assert.Equal(collection, actual);
         }
+
+        [Fact]
+        public static void ListConstructorTest_MakesCopy()
+        {
+            List<string> collection = new List<string> { "one", "two", "three" };
+            var oc = new ObservableCollectionSubclass<string>(collection);
+            Assert.NotNull(oc.InnerList);
+            Assert.NotSame(collection, oc.InnerList);
+        }
+
+        private partial class ObservableCollectionSubclass<T> : ObservableCollection<T>
+        {
+            public ObservableCollectionSubclass(List<T> list) : base(list) { }
+        }
     }
 }


### PR DESCRIPTION
Ensure the passed-in collection/list is copied to a new `List<T>`.