### PR TITLE
Add System.Net.IPAddress missing members

### DIFF
--- a/src/Common/src/System/Net/SocketAddress.cs
+++ b/src/Common/src/System/Net/SocketAddress.cs
@@ -108,7 +108,9 @@ namespace System.Net.Internals
             else
             {
 #if SYSTEM_NET_PRIMITIVES_DLL
+#pragma warning disable 618
                 uint address = unchecked((uint)ipAddress.Address);
+#pragma warning restore 618
 #else
                 byte[] ipAddressBytes = ipAddress.GetAddressBytes();
                 Debug.Assert(ipAddressBytes.Length == 4);

--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -205,6 +205,8 @@ namespace System.Net
         public static System.Net.IPAddress Parse(string ipString) { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse(string ipString, out System.Net.IPAddress address) { throw null; }
+        [Obsolete("This property has been deprecated. It is address family dependent. Please use IPAddress.Equals method to perform comparisons.http://go.microsoft.com/fwlink/?linkid=14202")]
+        public long Address { get { throw null; } set { } }
     }
     public partial class IPEndPoint : System.Net.EndPoint
     {

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -251,14 +251,6 @@ namespace System.Net
             }
         }
 
-        // When IPv6 support was added to the .NET Framework, the public Address property was marked as Obsolete.
-        // The public obsolete Address property has not been carried forward in .NET Core, but remains here as
-        // internal to allow internal types that understand IPv4 to still access it without obsolete warnings.
-        internal long Address
-        {
-            get { return PrivateAddress; }
-        }
-
         /// <devdoc>
         ///   <para>
         ///     IPv6 Scope identifier. This is really a uint32, but that isn't CLS compliant
@@ -441,6 +433,43 @@ namespace System.Net
                     }
                 }
                 return (_numbers[5] == 0xFFFF);
+            }
+        }
+
+        [Obsolete("This property has been deprecated. It is address family dependent. Please use IPAddress.Equals method to perform comparisons.http://go.microsoft.com/fwlink/?linkid=14202")]
+        public long Address
+        {
+            get
+            {
+                //
+                // IPv6 Changes: Can't do this for IPv6, so throw an exception.
+                //
+                //
+                if (AddressFamily == AddressFamily.InterNetworkV6)
+                {
+                    throw new SocketException(SocketError.OperationNotSupported);
+                }
+                else
+                {
+                    return PrivateAddress;
+                }
+            }
+            set
+            {
+                //
+                // IPv6 Changes: Can't do this for IPv6 addresses
+                if (AddressFamily == AddressFamily.InterNetworkV6)
+                {
+                    throw new SocketException(SocketError.OperationNotSupported);
+                }
+                else
+                {
+                    if (PrivateAddress != value)
+                    {
+                        _toString = null;
+                        PrivateAddress = (uint)value;
+                    }
+                }
             }
         }
 

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -185,7 +185,7 @@ namespace System.Net.Primitives.Functional.Tests
             int i2 = (int)0x50130000;
 
             short s1 = (short)0x1350;
-            short s2 = (short) 0x5013;
+            short s2 = (short)0x5013;
 
             Assert.Equal(l2, IPAddress.HostToNetworkOrder(l1));
             Assert.Equal(i2, IPAddress.HostToNetworkOrder(i1));
@@ -279,5 +279,26 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.True(ip4.GetHashCode().Equals(ip5.GetHashCode()));
             Assert.False(ip4.GetHashCode().Equals(ip6.GetHashCode()));
         }
+
+#if NetStandard17
+#pragma warning disable 618
+         [Fact]
+         public static void Address_Property_Failure()
+         {
+             IPAddress ip1 = IPAddress.Parse("fe80::200:f8ff:fe21:67cf");
+             Assert.Throws<SocketException>(() => ip1.Address);
+         }
+ 
+         [Fact]
+         public static void Address_Property_Success()
+         {
+             IPAddress ip1 = IPAddress.Parse("192.168.0.9");
+             //192.168.0.10
+             long newIp4Address = 192 << 24 | 168 << 16 | 0 << 8 | 10;
+             ip1.Address = newIp4Address;
+             Assert.Equal("10.0.168.192" , ip1.ToString());
+         }
+#pragma warning restore 618
+#endif //NetStandard17
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
+++ b/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
@@ -10,6 +10,9 @@
     <ProjectGuid>{4FE5ECEE-ACC5-4558-A946-573426599B73}</ProjectGuid>
     <OutputType>Library</OutputType>
     <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
+  </PropertyGroup> 
+  <PropertyGroup Condition="'$(TargetGroup)' == ''">
+     <DefineConstants>NetStandard17</DefineConstants>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />


### PR DESCRIPTION
Add back Address property , this's basically
resurrecting https://github.com/dotnet/corefx/pull/12595
since even after rebasing there's lot of merging to do.
It's easier to create a new PR then merging each file.

Fixes #12131