### PR TITLE
Lower peak memory usage in BigInteger tests

### DIFF
--- a/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
@@ -579,7 +579,7 @@ namespace System.Numerics.Tests
         [OuterLoop]
         public static void RunDoubleExplicitCastFromLargeBigIntegerTests()
         {
-            DoubleExplicitCastFromLargeBigIntegerTests(0, 5, 64, 4);
+            DoubleExplicitCastFromLargeBigIntegerTests(0, 4, 64, 3);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes issue https://github.com/dotnet/corefx/issues/12025.

This lowers the peak memory usage on my machine from ~8 GB to ~4GB (running only this test case). I think that is still plenty large to get the coverage we want from this.