### PR TITLE
Two Socket/NetworkStream-related optimizations

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/SafeNativeOverlapped.cs
+++ b/src/Common/src/Interop/Windows/Winsock/SafeNativeOverlapped.cs
@@ -2,23 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
-
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace System.Net.Sockets
 {
-    internal class SafeNativeOverlapped : SafeHandle
+    internal sealed class SafeNativeOverlapped : SafeHandle
     {
-        private static readonly SafeNativeOverlapped s_zero = new SafeNativeOverlapped();
-        private SafeCloseSocket _safeCloseSocket;
+        internal static SafeNativeOverlapped Zero { get; } = new SafeNativeOverlapped();
 
-        internal static SafeNativeOverlapped Zero { get { return s_zero; } }
-
-        protected SafeNativeOverlapped()
+        private SafeNativeOverlapped()
             : this(IntPtr.Zero)
         {
             if (GlobalLog.IsEnabled)
@@ -27,7 +21,7 @@ namespace System.Net.Sockets
             }
         }
 
-        protected SafeNativeOverlapped(IntPtr handle)
+        private SafeNativeOverlapped(IntPtr handle)
             : base(IntPtr.Zero, true)
         {
             SetHandle(handle);
@@ -36,7 +30,7 @@ namespace System.Net.Sockets
         public unsafe SafeNativeOverlapped(SafeCloseSocket socketHandle, NativeOverlapped* handle)
             : this((IntPtr)handle)
         {
-            _safeCloseSocket = socketHandle;
+            SocketHandle = socketHandle;
 
             if (GlobalLog.IsEnabled)
             {
@@ -44,23 +38,17 @@ namespace System.Net.Sockets
             }
 
 #if DEBUG
-            _safeCloseSocket.AddRef();
+            SocketHandle.AddRef();
 #endif
         }
 
-        protected override void Dispose(bool disposing)
+        internal unsafe void ReplaceHandle(NativeOverlapped* overlapped)
         {
-            if (disposing)
-            {
-                // It is important that the boundHandle is released immediately to allow new overlapped operations.
-                if (GlobalLog.IsEnabled)
-                {
-                    GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::Dispose(true)");
-                }
-
-                FreeNativeOverlapped();
-            }
+            Debug.Assert(handle == IntPtr.Zero, "We should only be replacing the handle when it's already been freed.");
+            SetHandle((IntPtr)overlapped);
         }
+
+        internal SafeCloseSocket SocketHandle { get; }
 
         public override bool IsInvalid
         {
@@ -75,37 +63,31 @@ namespace System.Net.Sockets
             }
 
             FreeNativeOverlapped();
+
+#if DEBUG
+            SocketHandle.Release();
+#endif
             return true;
         }
 
-        private void FreeNativeOverlapped()
+        internal void FreeNativeOverlapped()
         {
-            IntPtr oldHandle = Interlocked.Exchange(ref handle, IntPtr.Zero);
-
             // Do not call free during AppDomain shutdown, there may be an outstanding operation.
             // Overlapped will take care calling free when the native callback completes.
+            IntPtr oldHandle = Interlocked.Exchange(ref handle, IntPtr.Zero);
             if (oldHandle != IntPtr.Zero && !Environment.HasShutdownStarted)
             {
                 unsafe
                 {
-                    Debug.Assert(_safeCloseSocket != null, "m_SafeCloseSocket is null.");
+                    Debug.Assert(SocketHandle != null, "SocketHandle is null.");
 
-                    ThreadPoolBoundHandle boundHandle = _safeCloseSocket.IOCPBoundHandle;
-                    Debug.Assert(boundHandle != null, "SafeNativeOverlapped::ImmediatelyFreeNativeOverlapped - boundHandle is null");
+                    ThreadPoolBoundHandle boundHandle = SocketHandle.IOCPBoundHandle;
+                    Debug.Assert(boundHandle != null, "SafeNativeOverlapped::FreeNativeOverlapped - boundHandle is null");
 
-                    if (boundHandle != null)
-                    {
-                        // FreeNativeOverlapped will be called even if boundHandle was previously disposed.
-                        boundHandle.FreeNativeOverlapped((NativeOverlapped*)oldHandle);
-                    }
-
-#if DEBUG
-                    _safeCloseSocket.Release();
-#endif
-                    _safeCloseSocket = null;
+                    // FreeNativeOverlapped will be called even if boundHandle was previously disposed.
+                    boundHandle?.FreeNativeOverlapped((NativeOverlapped*)oldHandle);
                 }
             }
-            return;
         }
     }
 }

--- a/src/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/System.Net.Sockets/src/Resources/Strings.resx
@@ -291,4 +291,16 @@
   <data name="net_sockets_disconnect_notsupported" xml:space="preserve">
     <value>This platform does not support disconnecting a Socket.  Instead, close the Socket and create a new one.</value>
   </data>
+  <data name="NotSupported_UnreadableStream" xml:space="preserve">
+    <value>Stream does not support reading.</value>
+  </data>
+  <data name="NotSupported_UnwritableStream" xml:space="preserve">
+    <value>Stream does not support writing.</value>
+  </data>
+  <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
+    <value>Can not access a closed Stream.</value>
+  </data>
+  <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
+    <value>Positive number required.</value>
+  </data>
 </root>

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -75,6 +75,12 @@
     <Compile Include="System\Net\Sockets\MultipleConnectAsync.cs" />
     <Compile Include="System\Net\Sockets\OverlappedAsyncResult.cs" />
     <Compile Include="System\Net\Sockets\ReceiveMessageOverlappedAsyncResult.cs" />
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.ArrayPoolCopy.cs">
+      <Link>Common\System\IO\StreamHelpers.ArrayPoolCopy.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
+      <Link>Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
+    </Compile>
     <!-- Logging -->
     <Compile Include="$(CommonPath)\System\Net\Logging\GlobalLog.cs">
       <Link>Common\System\Net\Logging\GlobalLog.cs</Link>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
+using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1025,6 +1028,63 @@ namespace System.Net.Sockets
                 this);
         }
 
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            // Validate arguments as would the base CopyToAsync
+            StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
+
+            // And bail early if cancellation has already been requested
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
+
+            // Then do additional checks as ReadAsync would.
+
+            if (_cleanedUp)
+            {
+                throw new ObjectDisposedException(this.GetType().FullName);
+            }
+
+            Socket streamSocket = _streamSocket;
+            if (streamSocket == null)
+            {
+                throw new IOException(SR.Format(SR.net_io_readfailure, SR.net_io_connectionclosed));
+            }
+
+            // Do the copy.  We get a copy buffer from the shared pool, and we pass both it and the
+            // socket into the copy as part of the event args so as to avoid additional fields in
+            // the async method's state machine.
+            return CopyToAsyncCore(
+                destination,
+                new AwaitableSocketAsyncEventArgs(streamSocket, ArrayPool<byte>.Shared.Rent(bufferSize)),
+                cancellationToken);
+        }
+
+        private static async Task CopyToAsyncCore(Stream destination, AwaitableSocketAsyncEventArgs ea, CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    int bytesRead = await ea.ReceiveAsync();
+                    if (bytesRead == 0)
+                    {
+                        break;
+                    }
+
+                    await destination.WriteAsync(ea.Buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(ea.Buffer, clearArray: true);
+                ea.Dispose();
+            }
+        }
+
         // Flushes data from the stream.  This is meaningless for us, so it does nothing.
         public override void Flush()
         {
@@ -1090,6 +1150,115 @@ namespace System.Net.Sockets
                 }
 
                 _streamSocket.DebugMembers();
+            }
+        }
+
+        /// <summary>A SocketAsyncEventArgs that can be awaited to get the result of an operation.</summary>
+        internal sealed class AwaitableSocketAsyncEventArgs : SocketAsyncEventArgs, ICriticalNotifyCompletion
+        {
+            /// <summary>Sentinal object used to indicate that the operation has completed prior to OnCompleted being called.</summary>
+            private static readonly Action s_completedSentinel = () => { };
+            /// <summary>
+            /// null if the operation has not completed, <see cref="s_completedSentinel"/> if it has, and another object
+            /// if OnCompleted was called before the operation could complete, in which case it's the delegate to invoke
+            /// when the operation does complete.
+            /// </summary>
+            private Action _continuation;
+
+            /// <summary>Initializes the event args.</summary>
+            /// <param name="socket">The associated socket.</param>
+            /// <param name="buffer">The buffer to use for all operations.</param>
+            public AwaitableSocketAsyncEventArgs(Socket socket, byte[] buffer)
+            {
+                Debug.Assert(socket != null);
+                Debug.Assert(buffer != null && buffer.Length > 0);
+
+                // Store the socket into the base's UserToken.  This avoids the need for an extra field, at the expense
+                // of an object=>Socket cast when we need to access it, which is only once per operation.
+                UserToken = socket;
+
+                // Store the buffer for use by all operations with this instance.
+                SetBuffer(buffer, 0, buffer.Length);
+
+                // Hook up the completed event.
+                Completed += delegate
+                {
+                    // When the operation completes, see if OnCompleted was already called to hook up a continuation.
+                    // If it was, invoke the continuation.
+                    Action c = _continuation;
+                    if (c != null)
+                    {
+                        c();
+                    }
+                    else
+                    {
+                        // We may be racing with OnCompleted, so check with synchronization, trying to swap in our
+                        // completion sentinel.  If we lose the race and OnCompleted did hook up a continuation,
+                        // invoke it.  Otherwise, there's nothing more to be done.
+                        Interlocked.CompareExchange(ref _continuation, s_completedSentinel, null)?.Invoke();
+                    }
+                };
+            }
+
+            /// <summary>Initiates a receive operation on the associated socket.</summary>
+            /// <returns>This instance.</returns>
+            public AwaitableSocketAsyncEventArgs ReceiveAsync()
+            {
+                if (!Socket.ReceiveAsync(this))
+                {
+                    _continuation = s_completedSentinel;
+                }
+                return this;
+            }
+
+            /// <summary>Gets this instance.</summary>
+            public AwaitableSocketAsyncEventArgs GetAwaiter() => this;
+
+            /// <summary>Gets whether the operation has already completed.</summary>
+            /// <remarks>
+            /// This is not a generically usable IsCompleted operation that suggests the whole operation has completed.
+            /// Rather, it's specifically used as part of the await pattern, and is only usable to determine whether the
+            /// operation has completed by the time the instance is awaited.
+            /// </remarks>
+            public bool IsCompleted => _continuation != null;
+
+            /// <summary>Same as <see cref="OnCompleted(Action)"/> </summary>
+            public void UnsafeOnCompleted(Action continuation) => OnCompleted(continuation);
+
+            /// <summary>Queues the provided continuation to be executed once the operation has completed.</summary>
+            public void OnCompleted(Action continuation)
+            {
+                if (_continuation == s_completedSentinel || Interlocked.CompareExchange(ref _continuation, continuation, null) == s_completedSentinel)
+                {
+                    Task.Run(continuation);
+                }
+            }
+
+            /// <summary>Gets the result of the completion operation.</summary>
+            /// <returns>Number of bytes transferred.</returns>
+            /// <remarks>
+            /// Unlike Task's awaiter's GetResult, this does not block until the operation completes: it must only
+            /// be used once the operation has completed.  This is handled implicitly by await.
+            /// </remarks>
+            public int GetResult()
+            {
+                _continuation = null;
+                if (SocketError != SocketError.Success)
+                {
+                    ThrowIOSocketException();
+                }
+                return BytesTransferred;
+            }
+
+            /// <summary>Gets the associated socket.</summary>
+            internal Socket Socket => (Socket)UserToken; // stored in the base's UserToken to avoid an extra field in the object
+
+            /// <summary>Throws an IOException wrapping a SocketException using the current <see cref="SocketError"/>.</summary>
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private void ThrowIOSocketException()
+            {
+                var se = new SocketException((int)SocketError);
+                throw new IOException(SR.Format(SR.net_io_readfailure, se.Message), se);
             }
         }
     }

--- a/src/System.Net.Sockets/src/netcore50/project.json
+++ b/src/System.Net.Sockets/src/netcore50/project.json
@@ -5,6 +5,7 @@
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.NETCore.Targets": "1.0.1",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
+        "System.Buffers": "4.0.0",
         "System.Collections": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tracing": "4.0.20",

--- a/src/System.Net.Sockets/src/project.json
+++ b/src/System.Net.Sockets/src/project.json
@@ -2,6 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
+        "System.Buffers": "4.4.0-beta-24615-03",
         "System.Collections": "4.4.0-beta-24615-03",
         "System.Diagnostics.Debug": "4.4.0-beta-24615-03",
         "System.Diagnostics.Tracing": "4.4.0-beta-24615-03",

--- a/src/System.Net.Sockets/src/win/project.json
+++ b/src/System.Net.Sockets/src/win/project.json
@@ -2,6 +2,7 @@
   "frameworks": {
     "netstandard1.7": {
       "dependencies": {
+        "System.Buffers": "4.4.0-beta-24615-03",
         "System.Collections": "4.4.0-beta-24615-03",
         "System.Diagnostics.Debug": "4.4.0-beta-24615-03",
         "System.Diagnostics.Tracing": "4.4.0-beta-24615-03",

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    public class SocketAsyncEventArgsTest
+    {
+        [Fact]
+        public async Task ReuseSocketAsyncEventArgs_SameInstance_MultipleSockets()
+        {
+            using (var listen = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                listen.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listen.Listen(1);
+
+                Task<Socket> acceptTask = listen.AcceptAsync();
+                await Task.WhenAll(
+                    acceptTask,
+                    client.ConnectAsync(new IPEndPoint(IPAddress.Loopback, ((IPEndPoint)listen.LocalEndPoint).Port)));
+
+                using (Socket server = await acceptTask)
+                {
+                    TaskCompletionSource<bool> tcs = null;
+
+                    var args = new SocketAsyncEventArgs();
+                    args.SetBuffer(new byte[1024], 0, 1024);
+                    args.Completed += (_,__) => tcs.SetResult(true);
+
+                    for (int i = 1; i <= 10; i++)
+                    {
+                        tcs = new TaskCompletionSource<bool>();
+                        args.Buffer[0] = (byte)i;
+                        args.SetBuffer(0, 1);
+                        if (server.SendAsync(args))
+                        {
+                            await tcs.Task;
+                        }
+
+                        args.Buffer[0] = 0;
+                        tcs = new TaskCompletionSource<bool>();
+                        if (client.ReceiveAsync(args))
+                        {
+                            await tcs.Task;
+                        }
+                        Assert.Equal(1, args.BytesTransferred);
+                        Assert.Equal(i, args.Buffer[0]);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -39,6 +39,7 @@
     <Compile Include="TcpClientTest.cs" />
     <Compile Include="Shutdown.cs" />
     <Compile Include="SocketAPMExtensions.cs" />
+    <Compile Include="SocketAsyncEventArgsTest.cs" />
     <Compile Include="SocketAsyncExtensions.cs" />
     <Compile Include="SocketOptionNameTest.cs" />
     <Compile Include="UdpClientTest.cs" />


### PR DESCRIPTION
This PR provides two independent but related optimizations, one for NetworkStream and one for Socket.  The latter was done as it showed up as a significant source of allocations once the former was done.

1. Add NetworkStream.CopyToAsync override.  This does several custom things.  First, it uses ArrayPool for the buffer used in the copy operation.  Second, it uses a SocketAsyncEventArgs to avoid per-operation costs related to the socket.  And third, it then uses a custom awaitable to avoid async/Task-related overheads that would otherwise occur per-ReadAsync.

2. Removes a per-operation SafeHandle allocation from any operation on a SocketAsyncEventArgs.

I wrote a little benchmark that connects a socket to a localhost server which serves up 10MB of data.  It then creates a NetworkStream and does a CopyToAsync on it to copy all of the data to Stream.Null.  And it does all of this 10 times. Prior to the changes, there are lots of allocations (I'm only showing line items with > 10K of impact):
![image](https://cloud.githubusercontent.com/assets/2642209/19401974/4f2f50e4-922c-11e6-87a8-443ce672736f.png)

After adding CopyToAsync, most of the allocations go away, but we end up with a significant number of SafeNativeOverlapped SafeHandles:
![image](https://cloud.githubusercontent.com/assets/2642209/19401991/6bd3d68e-922c-11e6-90c8-2be3bc82844f.png)

After the second fix to address the SafeHandles, our memory usage is much more reasonable:
![image](https://cloud.githubusercontent.com/assets/2642209/19402007/8f10b5cc-922c-11e6-89c3-56f951f835c6.png)

(Most of what remains is unrelated to the actual operation being tested, and is coming from things elsewhere in the test app, e.g. strings created at startup.)

cc: @ericeil, @davidsh, @cipop, @davidfowl, @benaadams 
Fixes #11573 
Fixes #12659 
