### PR TITLE
Make GetEnumerator a no-op

### DIFF
--- a/src/System.IO.IsolatedStorage/System.IO.IsolatedStorage.sln
+++ b/src/System.IO.IsolatedStorage/System.IO.IsolatedStorage.sln
@@ -80,8 +80,8 @@ Global
 		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
 		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
 		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Unix_Release|Any CPU.Build.0 = Unix_Release|Any CPU
-		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
 	EndGlobalSection

--- a/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -478,7 +478,30 @@ namespace System.IO.IsolatedStorage
             // (say, for a particular StrongName). You could iterate any store opened at least once by NetFX on
             // NetFX as it would create the needed identity file. You wouldn't be able to iterate if it was only
             // ever opened by CoreFX, as the needed file isn't there yet.
-            throw new PlatformNotSupportedException();
+            return new IsolatedStorageFileEnumerator();
+        }
+
+        internal sealed class IsolatedStorageFileEnumerator : IEnumerator
+        {
+            public object Current
+            {
+                get
+                {
+                    // Getting current throws on NetFX if there is no current item.
+                    throw new InvalidOperationException();
+                }
+            }
+
+            public bool MoveNext()
+            {
+                // Nothing to return
+                return false;
+            }
+
+            public void Reset()
+            {
+                // Do nothing
+            }
         }
 
         public static IsolatedStorageFile GetUserStoreForApplication()

--- a/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -19,6 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap101_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetFileNamesTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetFileNamesTests.cs
@@ -59,7 +59,7 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [Theory MemberData("ValidStores")]
+        [Theory MemberData(nameof(ValidStores))]
         public void GetFileNames_GetsFileNames(PresetScopes scope)
         {
             TestHelper.WipeStores();

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetStoreTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetStoreTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Reflection;
 using Xunit;
 
@@ -17,7 +18,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory
-            MemberData("ValidScopes")
+            MemberData(nameof(ValidScopes))
             ]
         public void InitStore_ValidScopes(IsolatedStorageScope scope)
         {
@@ -82,6 +83,25 @@ namespace System.IO.IsolatedStorage
             Assert.Throws<PlatformNotSupportedException>(() => IsolatedStorageFile.GetStore(IsolatedStorageScope.User, typeof(object), typeof(object)));
             Assert.Throws<PlatformNotSupportedException>(() => IsolatedStorageFile.GetStore(IsolatedStorageScope.User, new object()));
             Assert.Throws<PlatformNotSupportedException>(() => IsolatedStorageFile.GetStore(IsolatedStorageScope.User, new object(), new object()));
+        }
+
+        [Fact]
+        public void GetEnumerator_NoOp()
+        {
+            IEnumerator e = IsolatedStorageFile.GetEnumerator(IsolatedStorageScope.Assembly);
+            Assert.False(e.MoveNext(), "should have no items");
+
+            // Reset shouldn't throw
+            e.Reset();
+        }
+
+        [Fact]
+        public void GetEnumerator_ThrowsForCurrent()
+        {
+            IEnumerator e = IsolatedStorageFile.GetEnumerator(IsolatedStorageScope.Assembly);
+            Assert.Throws<InvalidOperationException>(() => e.Current);
+            e.MoveNext();
+            Assert.Throws<InvalidOperationException>(() => e.Current);
         }
     }
 }


### PR DESCRIPTION
Makes GetEnumerator() return an empty enumerator.
Tweak configs so types resolve in test project.
Fix some nits.

@weshaggard, @ianhays 