### PR TITLE
SwitchLevelAttribute: Use nameof and remove unneeded namespace imports

### DIFF
--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/SwitchLevelAttribute.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/SwitchLevelAttribute.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
-using System.Collections;
-
 namespace System.Diagnostics
 {
     [AttributeUsage(AttributeTargets.Class)]
@@ -24,7 +20,7 @@ namespace System.Diagnostics
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
 
                 _type = value;
             }


### PR DESCRIPTION
Fix some minor nits.

cc: @AlexGhiondea