### PR TITLE
Fix for ZipArchive depending on Position for Create streams

### DIFF
--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -61,8 +61,9 @@
       <Link>Common\System\IO\PathInternal.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
-       <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
-     </Compile>
+      <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
+    </Compile>
+    <Compile Include="System\IO\Compression\PositionPreservingWriteOnlyStreamWrapper.cs" />
   </ItemGroup>
   <!-- Files exclusive to Core -->
   <ItemGroup Condition="'$(TargetGroup)' != 'net46' And '$(TargetGroup)' != 'net463'">

--- a/src/System.IO.Compression/src/System/IO/Compression/PositionPreservingWriteOnlyStreamWrapper.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/PositionPreservingWriteOnlyStreamWrapper.cs
@@ -1,0 +1,107 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO.Compression
+{
+    internal sealed class PositionPreservingWriteOnlyStreamWrapper : Stream
+    {
+        private readonly Stream _stream;
+        private long _position;
+
+        /// <summary>
+        /// Creates a wrapper for write-only (non-readable, non-seekable) streams that keeps track of <see cref="Position"/> and allows it to be read.
+        /// </summary>
+        /// <param name="stream">The underlying stream, which handles all actual writes.</param>
+        public PositionPreservingWriteOnlyStreamWrapper(Stream stream)
+        {
+            _stream = stream;
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+
+        public override long Position
+        {
+            get { return _position; }
+            set
+            {
+                throw new NotSupportedException(SR.NotSupported);
+            }
+        }
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _position += count;
+            _stream.Write(buffer, offset, count);
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            _position += offset;
+            return _stream.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult) => _stream.EndWrite(asyncResult);
+
+        public override void WriteByte(byte value)
+        {
+            _position += 1;
+            _stream.WriteByte(value);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            _position += offset;
+            return _stream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override bool CanTimeout => _stream.CanTimeout;
+        public override int ReadTimeout
+        {
+            get { return _stream.ReadTimeout; }
+            set { _stream.ReadTimeout = value; }
+        }
+        public override int WriteTimeout
+        {
+            get { return _stream.WriteTimeout; }
+            set { _stream.WriteTimeout = value; }
+        }
+
+        public override void Flush() => _stream.Flush();
+        public override Task FlushAsync(CancellationToken cancellationToken) => _stream.FlushAsync(cancellationToken);
+
+        public override void Close()
+        {
+            _stream.Close();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _stream.Dispose();
+        }
+
+        public override long Length
+        {
+            get
+            {
+                throw new NotSupportedException(SR.NotSupported);
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException(SR.NotSupported);
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException(SR.NotSupported);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException(SR.NotSupported);
+        }
+    }
+}

--- a/src/System.IO.Compression/src/System/IO/Compression/PositionPreservingWriteOnlyStreamWrapper.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/PositionPreservingWriteOnlyStreamWrapper.cs
@@ -37,7 +37,7 @@ namespace System.IO.Compression
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {
-            _position += offset;
+            _position += count;
             return _stream.BeginWrite(buffer, offset, count, callback, state);
         }
 
@@ -51,7 +51,7 @@ namespace System.IO.Compression
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            _position += offset;
+            _position += count;
             return _stream.WriteAsync(buffer, offset, count, cancellationToken);
         }
 

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -491,12 +491,15 @@ namespace System.IO.Compression
                 }
 
                 _mode = mode;
-                _archiveStream = stream;
+                if (mode == ZipArchiveMode.Create && !stream.CanSeek)
+                    _archiveStream = new PositionPreservingWriteOnlyStreamWrapper(stream);
+                else
+                    _archiveStream = stream;
                 _archiveStreamOwner = null;
                 if (mode == ZipArchiveMode.Create)
                     _archiveReader = null;
                 else
-                    _archiveReader = new BinaryReader(stream);
+                    _archiveReader = new BinaryReader(_archiveStream);
                 _entries = new List<ZipArchiveEntry>();
                 _entriesCollection = new ReadOnlyCollection<ZipArchiveEntry>(_entries);
                 _entriesDictionary = new Dictionary<String, ZipArchiveEntry>();

--- a/src/System.IO.Compression/tests/Utilities/WrappedStream.cs
+++ b/src/System.IO.Compression/tests/Utilities/WrappedStream.cs
@@ -83,7 +83,12 @@ internal class WrappedStream : Stream
 
     public override long Position
     {
-        get { return _baseStream.Position; }
+        get
+        {
+            if (CanSeek)
+                return _baseStream.Position;
+            throw new NotSupportedException("This stream does not support seeking");
+        }
         set
         {
             if (CanSeek)


### PR DESCRIPTION
This is a fix for #11497, using the stream wrapper technique suggested by @svick.

The stream wrapper is only applied when necessary (if the `ZipArchive` is opened in `Create` mode and the underlying stream does not support seeking).

The wrapper forwards all (non-reading) methods to its base stream, *including asynchronous methods*. This is important to prevent the wrapper from forcing synchrony.

The existing unit tests (once fixed) were sufficient to detect this bug.