### PR TITLE
Disable randomly failing SslStreamAlertsTest test

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
@@ -57,6 +57,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue(12683, TestPlatforms.Windows)]
         [ActiveIssue(12319, TestPlatforms.AnyUnix)]
         public async Task SslStream_StreamToStream_ServerInitiatedCloseNotify_Ok()
         {


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/12683
cc: @cipop