### PR TITLE
Disable TestUserCredentialsPropertiesOnWindows test failing on Windows

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -346,6 +346,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [ActiveIssue(12696)]
         [Fact, PlatformSpecific(TestPlatforms.Windows), OuterLoop] // Requires admin privileges
         public void TestUserCredentialsPropertiesOnWindows()
         {


### PR DESCRIPTION
cc: @Priya91 
https://github.com/dotnet/corefx/issues/12696