### PR TITLE
Revert "Prefer exception, not assert, during helper setup - System.Net.Security "

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
@@ -46,7 +46,7 @@ namespace System.Net.Security.Tests
                         Dispose();
                     }
 
-                    throw new InvalidOperationException("KDC setup failure");
+                    Assert.True(false, "KDC setup failure");
                 }
             }
             else


### PR DESCRIPTION
Reverts dotnet/corefx#12488

We started to see these NegotiateStream tests fail consistently on certain OSes a few days ago.  I don't know why this change would have caused it, but I'm testing reverting it to see if it's related.