### PR TITLE
Avoid using DefaultThreadCurrentCulture in tests

### DIFF
--- a/src/Common/tests/System/ThreadCultureChange.cs
+++ b/src/Common/tests/System/ThreadCultureChange.cs
@@ -8,26 +8,26 @@ namespace System.Common.Tests
 {
     public sealed class ThreadCultureChange : IDisposable
     {
-        private CultureInfo _originalDefaultCultureInfo;
-        private CultureInfo _originalDefaultUICultureInfo;
+        private readonly CultureInfo _originalCultureInfo;
+        private readonly CultureInfo _originalUICultureInfo;
 
         public ThreadCultureChange()
         {
-            _originalDefaultCultureInfo = CultureInfo.DefaultThreadCurrentCulture;
-            _originalDefaultUICultureInfo = CultureInfo.DefaultThreadCurrentUICulture;
+            _originalCultureInfo = CultureInfo.CurrentCulture;
+            _originalUICultureInfo = CultureInfo.CurrentUICulture;
         }
 
         public void ChangeCultureInfo(string culture)
         {
-            CultureInfo newCulture = new CultureInfo(culture);
-            CultureInfo.DefaultThreadCurrentCulture = newCulture;
-            CultureInfo.DefaultThreadCurrentUICulture = newCulture;
+            var newCulture = new CultureInfo(culture);
+            CultureInfo.CurrentCulture = newCulture;
+            CultureInfo.CurrentUICulture = newCulture;
         }
 
         public void Dispose()
         {
-            CultureInfo.DefaultThreadCurrentCulture = _originalDefaultCultureInfo;
-            CultureInfo.DefaultThreadCurrentUICulture = _originalDefaultUICultureInfo;
+            CultureInfo.CurrentCulture = _originalCultureInfo;
+            CultureInfo.CurrentUICulture = _originalUICultureInfo;
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -1229,7 +1229,7 @@ namespace System.Collections.Tests
             CultureInfo currentCulture = CultureInfo.CurrentCulture;
             try
             {
-                    CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
+                    CultureInfo.CurrentCulture = new CultureInfo("en-US");
                     var cultureNames = new string[]
                     {
                         "cs-CZ","da-DK","de-DE","el-GR","en-US",


### PR DESCRIPTION
We still have some tests that use DefaultThreadCurrent{UI}Culture in the current process.  All usage of DefaultThreadCurrent{UI}Culture needs to either be done in a separate process or changed to Current{UI}Culture, as the former affects not only the current thread, but also the default used for any new threads created in the process, which leads to non-deterministic failures in our test suites.

This PR fixes all remaining usage in our existing tests.

cc: @tarekgh, @ianhays