### PR TITLE
Fix DateTimeFormatInfoGetInstance.GetInstance test

### DIFF
--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetInstance.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetInstance.cs
@@ -34,22 +34,16 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(GetInstance_NotNull_TestData))]
-        public void GetInstance(IFormatProvider provider)
+        public void GetInstance_NotNull(IFormatProvider provider)
         {
             Assert.NotNull(DateTimeFormatInfo.GetInstance(provider));
         }
 
-        public static IEnumerable<object[]> GetInstance_Specific_TestData()
+        [Fact]
+        public void GetInstance_ExpectedCurrent()
         {
-            yield return new object[] { null, DateTimeFormatInfo.CurrentInfo };
-            yield return new object[] { new TestIFormatProviderClass(), DateTimeFormatInfo.CurrentInfo };
-        }
-
-        [Theory]
-        [MemberData(nameof(GetInstance_Specific_TestData))]
-        public void GetInstance(IFormatProvider provider, DateTimeFormatInfo expected)
-        {
-            Assert.Equal(expected, DateTimeFormatInfo.GetInstance(provider));
+            Assert.Same(DateTimeFormatInfo.CurrentInfo, DateTimeFormatInfo.GetInstance(null));
+            Assert.Same(DateTimeFormatInfo.CurrentInfo, DateTimeFormatInfo.GetInstance(new TestIFormatProviderClass()));
         }
     }
 }


### PR DESCRIPTION
The test was using Assert.Equal to compare the DateTimeFormatInfo returned from GetInstance with the one provided by the theory as the expected result.  Two problems with this: 1) DateTimeFormatInfo doesn't override equality testing, so Equal will end up doing an object reference comparison, and 2) xunit doesn't guarantee that the thread which enumerates a member data is the same that invokes all instances of the associated test.  As a result, we could end up in cases where the member data happened to be enumerated on one thread, the test was invoked on another, and the identity of DateTimeFormatInfo.CurrentInfo would then not match, resulting in equality failures.

Fixes https://github.com/dotnet/corefx/issues/12002
cc: @tarekgh