### PR TITLE
Remove unnecessary StringBuilder allocation

### DIFF
--- a/src/Common/tests/System/Xml/ModuleCore/cltmconsole.cs
+++ b/src/Common/tests/System/Xml/ModuleCore/cltmconsole.cs
@@ -42,9 +42,7 @@ namespace OLEDB.Test.ModuleCore
             //up to be two carriage returns!
             if (ch != null)
             {
-                StringBuilder builder = new StringBuilder(ch.Length);
-                builder.Append(ch);
-                Write(builder.ToString());
+                Write(new String(ch));
             }
         }
 

--- a/src/Common/tests/System/Xml/ModuleCore/cltmconsole.cs
+++ b/src/Common/tests/System/Xml/ModuleCore/cltmconsole.cs
@@ -42,7 +42,7 @@ namespace OLEDB.Test.ModuleCore
             //up to be two carriage returns!
             if (ch != null)
             {
-                Write(new String(ch));
+                Write(new string(ch));
             }
         }
 


### PR DESCRIPTION
Replaces unnecessary StringBuilder allocation and replaces it wiht
simple string consctruction.