### PR TITLE
Make string implement ICloneable in contract

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -1897,7 +1897,7 @@ namespace System
     {
         public STAThreadAttribute() { }
     }
-    public sealed partial class String : System.Collections.Generic.IEnumerable<char>, System.Collections.IEnumerable, System.IComparable, System.IComparable<string>, System.IConvertible, System.IEquatable<string>
+    public sealed partial class String : System.Collections.Generic.IEnumerable<char>, System.Collections.IEnumerable, System.IComparable, System.IComparable<string>, System.IConvertible, System.IEquatable<string>, System.ICloneable
     {
         public static readonly string Empty;
         [System.CLSCompliantAttribute(false)]


### PR DESCRIPTION
It already implements it in the implementation, and there are already tests for Clone... the interface derivation is just missing in the contract.

cc: @danmosemsft
Contributes to https://github.com/dotnet/corefx/issues/12199