### PR TITLE
Add leaveOpen ctor to CryptoStream

### DIFF
--- a/src/System.Security.Cryptography.Primitives/pkg/System.Security.Cryptography.Primitives.pkgproj
+++ b/src/System.Security.Cryptography.Primitives/pkg/System.Security.Cryptography.Primitives.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\System.Security.Cryptography.Primitives.csproj">
+    <ProjectReference Include="..\ref\System.Security.Cryptography.Primitives.builds">
       <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Primitives.builds" />

--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.builds
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.builds
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Security.Cryptography.Primitives.csproj" />
+    <Project Include="System.Security.Cryptography.Primitives.csproj">
+      <TargetGroup>netcoreapp1.1</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -44,7 +44,9 @@ namespace System.Security.Cryptography
     public partial class CryptoStream : System.IO.Stream, System.IDisposable
     {
         public CryptoStream(System.IO.Stream stream, System.Security.Cryptography.ICryptoTransform transform, System.Security.Cryptography.CryptoStreamMode mode) { }
+#if netcoreapp11
         public CryptoStream(System.IO.Stream stream, System.Security.Cryptography.ICryptoTransform transform, System.Security.Cryptography.CryptoStreamMode mode, bool leaveOpen) { }
+#endif
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanWrite { get { throw null; } }

--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -44,6 +44,7 @@ namespace System.Security.Cryptography
     public partial class CryptoStream : System.IO.Stream, System.IDisposable
     {
         public CryptoStream(System.IO.Stream stream, System.Security.Cryptography.ICryptoTransform transform, System.Security.Cryptography.CryptoStreamMode mode) { }
+        public CryptoStream(System.IO.Stream stream, System.Security.Cryptography.ICryptoTransform transform, System.Security.Cryptography.CryptoStreamMode mode, bool leaveOpen) { }
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanWrite { get { throw null; } }

--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.csproj
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.csproj
@@ -3,7 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp1.1'">$(DefineConstants);netcoreapp11</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.Primitives.cs" />

--- a/src/System.Security.Cryptography.Primitives/ref/project.json
+++ b/src/System.Security.Cryptography.Primitives/ref/project.json
@@ -5,10 +5,7 @@
     "System.Threading.Tasks": "4.4.0-beta-24615-03"
   },
   "frameworks": {
-    "netstandard1.7": {
-      "imports": [
-        "dotnet5.8"
-      ]
-    }
+    "netstandard1.7": {},
+    "netcoreapp1.1": {}
   }
 }

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
@@ -25,15 +25,22 @@ namespace System.Security.Cryptography
         private bool _canWrite;
         private bool _finalBlockTransformed;
         private SemaphoreSlim _lazyAsyncActiveSemaphore;
-        
+        private readonly bool _leaveOpen;
+
         // Constructors
 
         public CryptoStream(Stream stream, ICryptoTransform transform, CryptoStreamMode mode)
+            : this(stream, transform, mode, false)
+        {
+        }
+
+        public CryptoStream(Stream stream, ICryptoTransform transform, CryptoStreamMode mode, bool leaveOpen)
         {
 
             _stream = stream;
             _transformMode = mode;
             _transform = transform;
+            _leaveOpen = leaveOpen;
             switch (_transformMode)
             {
                 case CryptoStreamMode.Read:
@@ -523,7 +530,10 @@ namespace System.Security.Cryptography
                     {
                         FlushFinalBlock();
                     }
-                    _stream.Dispose();
+                    if (!_leaveOpen)
+                    {
+                        _stream.Dispose();
+                    }
                 }
             }
             finally

--- a/src/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
@@ -162,10 +162,35 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
         public static void MultipleDispose()
         {
             ICryptoTransform encryptor = new IdentityTransform(1, 1, true);
+
             using (MemoryStream output = new MemoryStream())
-            using (CryptoStream encryptStream = new CryptoStream(output, encryptor, CryptoStreamMode.Write))
             {
-                encryptStream.Dispose();
+                using (CryptoStream encryptStream = new CryptoStream(output, encryptor, CryptoStreamMode.Write))
+                {
+                    encryptStream.Dispose();
+                }
+
+                Assert.Equal(false, output.CanRead);
+            }
+
+            using (MemoryStream output = new MemoryStream())
+            {
+                using (CryptoStream encryptStream = new CryptoStream(output, encryptor, CryptoStreamMode.Write, leaveOpen: false))
+                {
+                    encryptStream.Dispose();
+                }
+
+                Assert.Equal(false, output.CanRead);
+            }
+
+            using (MemoryStream output = new MemoryStream())
+            {
+                using (CryptoStream encryptStream = new CryptoStream(output, encryptor, CryptoStreamMode.Write, leaveOpen: true))
+                {
+                    encryptStream.Dispose();
+                }
+
+                Assert.Equal(true, output.CanRead);
             }
         }
 

--- a/src/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
@@ -173,6 +173,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
                 Assert.Equal(false, output.CanRead);
             }
 
+#if netcoreapp11
             using (MemoryStream output = new MemoryStream())
             {
                 using (CryptoStream encryptStream = new CryptoStream(output, encryptor, CryptoStreamMode.Write, leaveOpen: false))
@@ -192,6 +193,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
 
                 Assert.Equal(true, output.CanRead);
             }
+#endif
         }
 
         private const string LoremText =

--- a/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.builds
+++ b/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.builds
@@ -8,6 +8,10 @@
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
+    <Project Include="System.Security.Cryptography.Primitives.Tests.csproj">
+      <TargetGroup>netcoreapp1.1</TargetGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
+++ b/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
@@ -10,6 +10,7 @@
     <AssemblyName>System.Security.Cryptography.Primitives.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Primitives.Tests</RootNamespace>
     <NugetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp1.1'">$(DefineConstants);netcoreapp11</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Security.Cryptography.Primitives.pkgproj">


### PR DESCRIPTION
This adds `public CryptoStream(Stream, ICryptoTransform, CryptoStreamMode, bool leaveOpen)` to the netcoreapp1.1 contract (which will be bumped to 1.2 once support for that version exists).

Fixes #1079.
Replaces PR #11587 (thanks, @bbowyersmyth).
cc: @stephentoub @steveharter 