### PR TITLE
Add missing members to Win32Exception

### DIFF
--- a/src/Microsoft.Win32.Primitives/ref/Microsoft.Win32.Primitives.cs
+++ b/src/Microsoft.Win32.Primitives/ref/Microsoft.Win32.Primitives.cs
@@ -8,13 +8,15 @@
 
 namespace System.ComponentModel
 {
-    public partial class Win32Exception : System.Exception
+    public partial class Win32Exception : System.Runtime.InteropServices.ExternalException
     {
         public Win32Exception() { }
         public Win32Exception(int error) { }
         public Win32Exception(int error, string message) { }
         public Win32Exception(string message) { }
         public Win32Exception(string message, System.Exception innerException) { }
+        protected Win32Exception(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public int NativeErrorCode { get { throw null; } }
     }
 }

--- a/src/Microsoft.Win32.Primitives/ref/Microsoft.Win32.Primitives.cs
+++ b/src/Microsoft.Win32.Primitives/ref/Microsoft.Win32.Primitives.cs
@@ -8,7 +8,7 @@
 
 namespace System.ComponentModel
 {
-    public partial class Win32Exception : System.Runtime.InteropServices.ExternalException
+    public partial class Win32Exception : System.Runtime.InteropServices.ExternalException, System.Runtime.Serialization.ISerializable
     {
         public Win32Exception() { }
         public Win32Exception(int error) { }

--- a/src/Microsoft.Win32.Primitives/ref/project.json
+++ b/src/Microsoft.Win32.Primitives/ref/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Runtime": "4.1.0"
+    "System.Runtime": "4.4.0-beta-24615-03"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.Unix.cs
+++ b/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.Unix.cs
@@ -2,17 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Text;
-using System.Runtime.InteropServices;
-
 namespace System.ComponentModel
 {
-    public partial class Win32Exception : Exception
+    public partial class Win32Exception
     {
-        private static string GetErrorMessage(int error)
-        {
-            return Interop.Sys.StrError(error);
-        }
+        private static string GetErrorMessage(int error) => Interop.Sys.StrError(error);
     }
 }

--- a/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.Windows.cs
+++ b/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.Windows.cs
@@ -2,15 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.ComponentModel
 {
-    public partial class Win32Exception : Exception
+    public partial class Win32Exception
     {
-        private static string GetErrorMessage(int error)
-        {
-            return Interop.mincore.GetMessage(error);
-        }
+        private static string GetErrorMessage(int error) => Interop.mincore.GetMessage(error);
     }
 }

--- a/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.cs
+++ b/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.cs
@@ -2,16 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Text;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 
 namespace System.ComponentModel
 {
     /// <devdoc>
     ///    <para>The exception that is thrown for a Win32 error code.</para>
     /// </devdoc>
-    public partial class Win32Exception : Exception
+    [Serializable]
+    public partial class Win32Exception : ExternalException, ISerializable
     {
         /// <devdoc>
         ///    <para>Represents the Win32 error code associated with this exception. This 
@@ -42,9 +42,6 @@ namespace System.ComponentModel
         : base(message)
         {
             nativeErrorCode = error;
-            // Win32Exception is not inheriting from ExternalException anymore, 
-            // so we set the HResult manually to have the exact behavior we used to have when inherited from ExternalException
-            HResult = E_FAIL;
         }
 
         /// <devdoc>
@@ -63,9 +60,22 @@ namespace System.ComponentModel
         public Win32Exception(string message, Exception innerException) : base(message, innerException)
         {
             nativeErrorCode = Marshal.GetLastWin32Error();
-            // Win32Exception is not inheriting from ExternalException anymore, 
-            // so we set the HResult manually to have the exact behavior we used to have when inherited from ExternalException
-            HResult = E_FAIL;
+        }
+
+        protected Win32Exception(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            nativeErrorCode = info.GetInt32(nameof(NativeErrorCode));
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            info.AddValue(nameof(NativeErrorCode), nativeErrorCode);
+            base.GetObjectData(info, context);
         }
 
         /// <devdoc>

--- a/src/Microsoft.Win32.Primitives/src/project.json
+++ b/src/Microsoft.Win32.Primitives/src/project.json
@@ -7,8 +7,8 @@
     },
     "netstandard1.7": {
       "dependencies": {
-        "System.Runtime": "4.1.0",
-        "System.Runtime.InteropServices": "4.1.0"
+        "System.Runtime": "4.4.0-beta-24615-03",
+        "System.Runtime.InteropServices": "4.4.0-beta-24615-03"
       }
     }
   }

--- a/src/Microsoft.Win32.Primitives/tests/Microsoft.Win32.Primitives.Tests.csproj
+++ b/src/Microsoft.Win32.Primitives/tests/Microsoft.Win32.Primitives.Tests.csproj
@@ -21,6 +21,12 @@
   <ItemGroup>
     <Compile Include="Win32Exception.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
+    <Compile Include="Win32Exception.netstandard1.7.cs" />
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\pkg\Microsoft.Win32.Primitives.pkgproj">
       <Project>{8ffe99c0-22f8-4462-b839-970eac1b3472}</Project>

--- a/src/Microsoft.Win32.Primitives/tests/Win32Exception.cs
+++ b/src/Microsoft.Win32.Primitives/tests/Win32Exception.cs
@@ -2,17 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Text;
 using Xunit;
 
-namespace Microsoft.Win32.Primitives.Tests
+namespace System.ComponentModel.Tests
 {
-    public static class Win32ExceptionTestType
+    public static partial class Win32ExceptionTestType
     {
-
         private const int FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200;
         private const int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
         private const int FORMAT_MESSAGE_ARGUMENT_ARRAY = 0x00002000;

--- a/src/Microsoft.Win32.Primitives/tests/Win32Exception.netstandard1.7.cs
+++ b/src/Microsoft.Win32.Primitives/tests/Win32Exception.netstandard1.7.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Tests;
+using Xunit;
+
+namespace System.ComponentModel.Tests
+{
+    public static partial class Win32ExceptionTestType
+    {
+        public static IEnumerable<object[]> SerializeDeserialize_MemberData()
+        {
+            yield return new object[] { new Win32Exception() };
+            yield return new object[] { new Win32Exception(42) };
+            yield return new object[] { new Win32Exception(-42) };
+            yield return new object[] { new Win32Exception("some message") };
+            yield return new object[] { new Win32Exception(42, "some message") };
+            yield return new object[] { new Win32Exception("some message", new InvalidOperationException()) };
+        }
+
+        [Theory]
+        [MemberData(nameof(SerializeDeserialize_MemberData))]
+        public static void SerializeDeserialize(Win32Exception exception)
+        {
+            BinaryFormatterHelpers.AssertRoundtrips(exception, e => e.NativeErrorCode, e => e.ErrorCode);
+        }
+
+        [Fact]
+        public static void GetObjectData_InvalidArgs_Throws()
+        {
+            var e = new Win32Exception();
+            Assert.Throws<ArgumentNullException>("info", () => e.GetObjectData(null, default(StreamingContext)));
+        }
+    }
+}

--- a/src/Microsoft.Win32.Primitives/tests/project.json
+++ b/src/Microsoft.Win32.Primitives/tests/project.json
@@ -15,7 +15,11 @@
   },
   "frameworks": {
     "netstandard1.3": {},
-    "netstandard1.7": {}
+    "netstandard1.7": {
+      "dependencies": {
+        "System.Runtime.Serialization.Formatters": "4.4.0-beta-24615-03"
+      }
+    }
   },
   "supports": {
     "coreFx.Test.netcore50": {},


### PR DESCRIPTION
It needs to derive from ExternalException and be serializable.

cc: @danmosemsft
Contributes to https://github.com/dotnet/corefx/issues/12669