### PR TITLE
Disable SslStream_StreamToStream_DataAfterShutdown_Fail test failing in CI

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
@@ -124,6 +124,7 @@ namespace System.Net.Security.Tests
         }
         
         [Fact]
+        [ActiveIssue(12706, TestPlatforms.Windows)]
         [ActiveIssue(12319, TestPlatforms.AnyUnix)]
         public async Task SslStream_StreamToStream_DataAfterShutdown_Fail()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
@@ -22,6 +22,7 @@ namespace System.Net.Security.Tests
         private const uint SEC_E_CERT_UNKNOWN = 0x80090327;
 
         [Fact]
+        [ActiveIssue(12706, TestPlatforms.Windows)]
         [ActiveIssue(12319, TestPlatforms.AnyUnix)]
         public async Task SslStream_StreamToStream_HandshakeAlert_Ok()
         {


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/12706
cc: @CIPop 