### PR TITLE
Add support for building native packages on Alpine 3.4.3

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -39,6 +39,9 @@ get_current_linux_name() {
     elif [ "$(cat /etc/*-release | grep -cim1 debian)" -eq 1 ]; then
         echo "debian"
         return 0
+    elif [ "$(cat /etc/*-release | grep -cim1 alpine)" -eq 1 ]; then
+        echo "alpine"
+        return 0
     elif [ "$(cat /etc/*-release | grep -cim1 fedora)" -eq 1 ]; then
         if [ "$(cat /etc/*-release | grep -cim1 23)" -eq 1 ]; then
             echo "fedora.23"

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -400,7 +400,28 @@
         },
         "opensuse.42.1-x64": {
             "#import": [ "opensuse.42.1", "opensuse-x64" ]
-        }
+        },
+
+        "alpine": {
+            "#import": [ "linux" ]
+        },
+        "alpine-x64": {
+            "#import": [ "alpine", "linux-x64" ]
+        },
+
+        "alpine.3": {
+            "#import": [ "alpine" ]
+        },
+        "alpine.3-x64": {
+            "#import": [ "alpine.3", "alpine-x64" ]
+        },
+
+        "alpine.3.4.3": {
+            "#import": [ "alpine.3" ]
+        },
+        "alpine.3.4.3-x64": {
+            "#import": [ "alpine.3.4.3", "alpine.3-x64" ]
+        },
     }
  }
 

--- a/src/Native/pkg/dir.props
+++ b/src/Native/pkg/dir.props
@@ -10,6 +10,7 @@
     <OSGroupPath Condition="$(OSGroup.StartsWith('rhel'))">Linux</OSGroupPath>
     <OSGroupPath Condition="$(OSGroup.StartsWith('ubuntu'))">Linux</OSGroupPath>
     <OSGroupPath Condition="$(OSGroup.StartsWith('opensuse'))">Linux</OSGroupPath>
+    <OSGroupPath Condition="$(OSGroup.StartsWith('alpine'))">Linux</OSGroupPath>
   </PropertyGroup>
 
   <!-- Determine extensions of binary and symbol files on this OS. -->
@@ -37,6 +38,7 @@
     <Ubuntu1404NativePath Condition="'$(Ubuntu1404NativePath)' == ''">$(BuildNativePath)</Ubuntu1404NativePath>
     <Ubuntu1604NativePath Condition="'$(Ubuntu1604NativePath)' == ''">$(BuildNativePath)</Ubuntu1604NativePath>
     <Ubuntu1610NativePath Condition="'$(Ubuntu1610NativePath)' == ''">$(BuildNativePath)</Ubuntu1610NativePath>
+    <Alpine343NativePath Condition="'$(Alpine343NativePath)' == ''">$(BuildNativePath)</Alpine343NativePath>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
   </PropertyGroup>
 

--- a/src/Native/pkg/runtime.native.System.IO.Compression/alpine/3.4.3/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/alpine/3.4.3/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>alpine.3.4.3-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Alpine343NativePath)System.IO.Compression.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -43,6 +43,10 @@
       <OSGroup>opensuse.42.1</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="alpine\3.4.3\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>alpine.3.4.3</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>x86</Platform>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -57,6 +57,9 @@
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="alpine\3.4.3\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
       <Platform>x86</Platform>
     </ProjectReference>

--- a/src/Native/pkg/runtime.native.System.Net.Http/alpine/3.4.3/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/alpine/3.4.3/runtime.native.System.Net.Http.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>alpine.3.4.3-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Alpine343NativePath)System.Net.Http.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
@@ -43,6 +43,10 @@
       <OSGroup>opensuse.42.1</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="alpine\3.4.3\runtime.native.System.Net.Http.pkgproj">
+      <OSGroup>alpine.3.4.3</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
@@ -40,6 +40,9 @@
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Net.Http.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="alpine\3.4.3\runtime.native.System.Net.Http.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Net.Security/alpine/3.4.3/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/alpine/3.4.3/runtime.native.System.Net.Security.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>alpine.3.4.3-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Alpine343NativePath)\System.Net.Security.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.builds
@@ -43,6 +43,10 @@
       <OSGroup>opensuse.42.1</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="alpine\3.4.3\runtime.native.System.Net.Security.pkgproj">
+      <OSGroup>alpine.3.4.3</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.pkgproj
@@ -40,6 +40,9 @@
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Net.Security.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="alpine\3.4.3\runtime.native.System.Net.Security.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/alpine/3.4.3/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/alpine/3.4.3/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>alpine.3.4.3-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Alpine343NativePath)System.Security.Cryptography.Native.OpenSsl.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.builds
@@ -43,6 +43,10 @@
       <OSGroup>opensuse.42.1</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="alpine\3.4.3\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>alpine.3.4.3</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -40,6 +40,9 @@
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="alpine\3.4.3\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/alpine/3.4.3/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/alpine/3.4.3/runtime.native.System.Security.Cryptography.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>alpine.3.4.3-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Alpine343NativePath)System.Security.Cryptography.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
@@ -43,6 +43,10 @@
       <OSGroup>opensuse.42.1</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="alpine\3.4.3\runtime.native.System.Security.Cryptography.pkgproj">
+      <OSGroup>alpine.3.4.3</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
@@ -40,6 +40,9 @@
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Security.Cryptography.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="alpine\3.4.3\runtime.native.System.Security.Cryptography.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System/alpine/3.4.3/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/alpine/3.4.3/runtime.native.System.pkgproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>alpine.3.4.3-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(Alpine343NativePath)System.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+    <File Include="$(Alpine343NativePath)System.Native.a">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System/runtime.native.System.builds
+++ b/src/Native/pkg/runtime.native.System/runtime.native.System.builds
@@ -43,6 +43,10 @@
       <OSGroup>opensuse.42.1</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Include="alpine\3.4.3\runtime.native.System.pkgproj">
+      <OSGroup>alpine.3.4.3</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/runtime.native.System.pkgproj
@@ -40,6 +40,9 @@
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="alpine\3.4.3\runtime.native.System.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
* Adds pkgproj files for each native package.
* Allows init-tools to be run on Alpine. Note: __PUBLISH_RID still needs to be set to something other than Alpine (like `ubuntu.14.04-x64`) for init-tools to complete successfully.

I've chosen to include only `alpine.3.4.3-x64` (and its parents) in the rid graph right now. We might find that these packages can be used for the entire alpine.3.x family, or perhaps just alpine.3.4.x. We can adjust the rid graph and package identities if that makes sense.

@ellismg @ericstj 