### PR TITLE
Disable SslStreamAlertTests by making them netcoreapp1.1 specific

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -9,7 +9,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -43,7 +43,7 @@
     <Compile Include="ServerAsyncAuthenticateTest.cs" />
     <Compile Include="ServerNoEncryptionTest.cs" />
     <Compile Include="ServerRequireEncryptionTest.cs" />
-    <Compile Include="SslStreamAlertsTest.cs" />
+    <Compile Include="SslStreamAlertsTest.cs" Condition="'$(TargetGroup)'=='netcoreapp1.1'" />
     <Compile Include="SslStreamSchSendAuxRecordTest.cs" />
     <Compile Include="SslStreamStreamToStreamTest.cs" />
     <Compile Include="SslStreamNetworkStreamTest.cs" />


### PR DESCRIPTION
After https://github.com/dotnet/corefx/pull/11489

This error shows up after trying to consume the new packages.
 SslStreamAlertsTest.cs(81,30): error CS1061: 'SslStream' does not contain a definition for 'ShutdownAsync' and no extension method 'ShutdownAsync' accepting a first argument of type 'SslStream' could be found (are you missing a using directive or an assembly reference?) [D:\A\_work\55\s\corefx\src\System.Net.Security\tests\FunctionalTests\System.Net.Security.Tests.csproj]

For now disabling these tests by conditioning them on netcoreapp1.1.

@CIPop you will need to fix the issue with your PR to create a netcoreapp1.1 build configuration for the ref and these tests in order to re-enable them.

FYI @sepidehMS @joperezr 