### PR TITLE
Add a bunch of serialization implementations

### DIFF
--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryHive.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryHive.cs
@@ -2,11 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.Win32
 {
     /**
      * Registry hive values.  Useful only for GetRemoteBaseKey
      */
+    [Serializable]
 #if REGISTRY_ASSEMBLY
     public
 #else

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -476,6 +476,7 @@ namespace System.Data.SqlClient
         public string Server { get { throw null; } }
         public override string Source { get { throw null; } }
         public byte State { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo si, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
     }
     public sealed partial class SqlInfoMessageEventArgs : System.EventArgs

--- a/src/System.Data.SqlClient/src/System/Data/OperationAbortedException.cs
+++ b/src/System.Data.SqlClient/src/System/Data/OperationAbortedException.cs
@@ -6,11 +6,12 @@
 
 //------------------------------------------------------------------------------
 
+using System.Runtime.Serialization;
 using Res = System.SR;
-
 
 namespace System.Data
 {
+    [Serializable]
     public sealed class OperationAbortedException : Exception
     {
         private OperationAbortedException(string message, Exception innerException) : base(message, innerException)
@@ -18,6 +19,9 @@ namespace System.Data
             HResult = unchecked((int)0x80131936);
         }
 
+        private OperationAbortedException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
 
         static internal OperationAbortedException Aborted(Exception inner)
         {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/ApplicationIntent.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/ApplicationIntent.cs
@@ -10,6 +10,7 @@ namespace System.Data.SqlClient
     /// <summary>
     /// represents the application workload type when connecting to a server
     /// </summary>
+    [Serializable]
     public enum ApplicationIntent
     {
         ReadWrite = 0,

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlError.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlError.cs
@@ -9,6 +9,7 @@
 
 namespace System.Data.SqlClient
 {
+    [Serializable]
     public sealed class SqlError
     {
         private string _source = TdsEnums.SQL_PROVIDER_NAME;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlErrorCollection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlErrorCollection.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 
 namespace System.Data.SqlClient
 {
+    [Serializable]
     public sealed class SqlErrorCollection : ICollection
     {
         // Ideally this would be typed as List<SqlError>, but that would make the non-generic

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlException.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlException.cs
@@ -11,23 +11,45 @@ using System.ComponentModel;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.Serialization;
 using System.Text; // StringBuilder
 
 namespace System.Data.SqlClient
 {
+    [Serializable]
     public sealed class SqlException : System.Data.Common.DbException
     {
         private const string OriginalClientConnectionIdKey = "OriginalClientConnectionId";
         private const string RoutingDestinationKey = "RoutingDestination";
+        private const int SqlExceptionHResult = unchecked((int)0x80131904);
 
         private SqlErrorCollection _errors;
         private Guid _clientConnectionId = Guid.Empty;
 
         private SqlException(string message, SqlErrorCollection errorCollection, Exception innerException, Guid conId) : base(message, innerException)
         {
-            HResult = unchecked((int)0x80131904);
+            HResult = SqlExceptionHResult;
             _errors = errorCollection;
             _clientConnectionId = conId;
+        }
+
+        private SqlException(SerializationInfo si, StreamingContext sc) : base(si, sc)
+        {
+            HResult = SqlExceptionHResult;
+            _errors = (SqlErrorCollection)si.GetValue("Errors", typeof(SqlErrorCollection));
+            _clientConnectionId = (Guid)si.GetValue("ClientConnectionId", typeof(Guid));
+        }
+
+        public override void GetObjectData(SerializationInfo si, StreamingContext context)
+        {
+            if (null == si)
+            {
+                throw new ArgumentNullException(nameof(si));
+            }
+
+            si.AddValue("Errors", _errors, typeof(SqlErrorCollection));
+            si.AddValue("ClientConnectionId", _clientConnectionId, typeof(Guid));
+            base.GetObjectData(si, context);
         }
 
         // runtime will call even if private...

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ThreadState.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ThreadState.cs
@@ -7,6 +7,7 @@ namespace System.Diagnostics
     /// <devdoc>
     ///     Specifies the execution state of a thread.
     /// </devdoc>
+    [Serializable]
     public enum ThreadState
     {
         /// <devdoc>

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceLevel.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceLevel.cs
@@ -11,6 +11,7 @@ namespace System.Diagnostics
     ///    <para>Specifies what messages to output for debugging
     ///       and tracing.</para>
     /// </devdoc>
+    [Serializable]
     public enum TraceLevel
     {
         /// <devdoc>

--- a/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
+++ b/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
@@ -231,6 +231,7 @@ namespace System.Diagnostics.Tracing
         public EventSourceException() { }
         public EventSourceException(string message) { }
         public EventSourceException(string message, System.Exception innerException) { }
+        protected EventSourceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EventSourceOptions

--- a/src/System.Diagnostics.Tracing/ref/project.json
+++ b/src/System.Diagnostics.Tracing/ref/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Runtime": "4.1.0"
+    "System.Runtime": "4.4.0-beta-24615-03"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -11,7 +11,7 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)'=='netcore50aot'">
-    <DefineConstants>$(DefineConstants);PROJECTN</DefineConstants>
+    <DefineConstants>$(DefineConstants);PROJECTN;FEATURE_SERIALIZATION</DefineConstants>
     <!-- Need to remove reference to System.Reflection.TypeExtensions
     which is included transitively via System.Reflection -->
     <OmitTransitiveCompileReferences>true</OmitTransitiveCompileReferences>

--- a/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
@@ -8,6 +8,7 @@ namespace System.Drawing
     ///    Represents an ordered pair of x and y coordinates that
     ///    define a point in a two-dimensional plane.
     /// </summary>
+    [Serializable]
     public struct Point
     {
         /// <summary>

--- a/src/System.Drawing.Primitives/src/System/Drawing/PointF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/PointF.cs
@@ -8,6 +8,7 @@ namespace System.Drawing
     ///    Represents an ordered pair of x and y coordinates that
     ///    define a point in a two-dimensional plane.
     /// </summary>
+    [Serializable]
     public struct PointF
     {
         /// <summary>

--- a/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
@@ -11,6 +11,7 @@ namespace System.Drawing
     ///       Stores the location and size of a rectangular region. 
     ///    </para>
     /// </summary>
+    [Serializable]
     public struct Rectangle
     {
         public static readonly Rectangle Empty = new Rectangle();

--- a/src/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
@@ -11,6 +11,7 @@ namespace System.Drawing
     ///       Stores the location and size of a rectangular region.
     ///    </para>
     /// </summary>
+    [Serializable]
     public struct RectangleF
     {
         /// <summary>

--- a/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
@@ -11,6 +11,7 @@ namespace System.Drawing
     ///    Represents the size of a rectangular region
     ///    with an ordered pair of width and height.
     /// </summary>
+    [Serializable]
     public struct Size
     {
         /// <summary>

--- a/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
@@ -13,6 +13,7 @@ namespace System.Drawing
     ///       with an ordered pair of width and height.
     ///    </para>
     /// </summary>
+    [Serializable]
     public struct SizeF
     {
         /// <summary>

--- a/src/System.Drawing.Primitives/tests/ColorTests.cs
+++ b/src/System.Drawing.Primitives/tests/ColorTests.cs
@@ -512,21 +512,6 @@ namespace System.Drawing.Primitives.Tests
         }
 
         [Fact]
-        public void SerializationRoundTrip()
-        {
-            Color c = Color.Red;
-            CheckRed(c);
-
-            BinaryFormatter bf = new BinaryFormatter();
-            MemoryStream ms = new MemoryStream();
-            bf.Serialize(ms, c);
-
-            ms.Position = 0;
-            Color color = (Color)bf.Deserialize(ms);
-            CheckRed(color);
-        }
-
-        [Fact]
         public void DebuggerAttributesAreValid()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(Color.Aquamarine);

--- a/src/System.Drawing.Primitives/tests/SerializationTests.cs
+++ b/src/System.Drawing.Primitives/tests/SerializationTests.cs
@@ -19,45 +19,33 @@ namespace System.Drawing.Primitives.Tests
             yield return new object[] { Color.FromName("SomeName") };
         }
 
-        public static IEnumerable<object[]> Size_Roundtrip_MemberData()
-        {
-            yield return new object[] { new SizeF(123.4f, 567.8f) };
-        }
-
-        public static IEnumerable<object[]> Point_Roundtrip_MemberData()
-        {
-            yield return new object[] { new PointF(123.4f, 567.8f) };
-        }
-
-        public static IEnumerable<object[]> Rectangle_Roundtrip_MemberData()
-        {
-            yield return new object[] { new RectangleF(1.2f, 3.4f, 5.6f, 7.8f) };
-        }
-
         [Theory]
         [MemberData(nameof(Color_Roundtrip_MemberData))]
-        public void Color_Roundtrip(Color c) => Assert.Equal(c, BinaryFormatterHelpers.Clone(c));
-
-        [Theory]
-        [MemberData(nameof(Size_Roundtrip_MemberData))]
-        public void Size_Roundtrip(SizeF s)
+        public void Color_Roundtrip(Color c)
         {
+            Assert.Equal(c, BinaryFormatterHelpers.Clone(c));
+        }
+
+        [Fact]
+        public void Size_Roundtrip()
+        {
+            SizeF s = new SizeF(123.4f, 567.8f);
             Assert.Equal(s, BinaryFormatterHelpers.Clone(s));
             Assert.Equal(s.ToSize(), BinaryFormatterHelpers.Clone(s.ToSize()));
         }
 
-        [Theory]
-        [MemberData(nameof(Point_Roundtrip_MemberData))]
-        public void Point_Roundtrip(PointF p)
+        [Fact]
+        public void Point_Roundtrip()
         {
+            PointF p = new PointF(123.4f, 567.8f);
             Assert.Equal(p, BinaryFormatterHelpers.Clone(p));
             Assert.Equal(Point.Truncate(p), BinaryFormatterHelpers.Clone(Point.Truncate(p)));
         }
 
-        [Theory]
-        [MemberData(nameof(Rectangle_Roundtrip_MemberData))]
-        public void Rectangle_Roundtrip(RectangleF r)
+        [Fact]
+        public void Rectangle_Roundtrip()
         {
+            RectangleF r = new RectangleF(1.2f, 3.4f, 5.6f, 7.8f);
             Assert.Equal(r, BinaryFormatterHelpers.Clone(r));
             Assert.Equal(Rectangle.Truncate(r), BinaryFormatterHelpers.Clone(Rectangle.Truncate(r)));
         }

--- a/src/System.Drawing.Primitives/tests/SerializationTests.cs
+++ b/src/System.Drawing.Primitives/tests/SerializationTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Tests;
+using Xunit;
+
+namespace System.Drawing.Primitives.Tests
+{
+    public class SerializationTests
+    {
+        public static IEnumerable<object[]> Color_Roundtrip_MemberData()
+        {
+            yield return new object[] { default(Color) };
+            yield return new object[] { Color.FromKnownColor(KnownColor.AliceBlue) };
+            yield return new object[] { Color.AliceBlue };
+            yield return new object[] { Color.FromArgb(255, 1, 2, 3) };
+            yield return new object[] { Color.FromArgb(0, 1, 2, 3) };
+            yield return new object[] { Color.FromArgb(1, 2, 3) };
+            yield return new object[] { Color.FromName("SomeName") };
+        }
+
+        public static IEnumerable<object[]> Size_Roundtrip_MemberData()
+        {
+            yield return new object[] { new SizeF(123.4f, 567.8f) };
+        }
+
+        public static IEnumerable<object[]> Point_Roundtrip_MemberData()
+        {
+            yield return new object[] { new PointF(123.4f, 567.8f) };
+        }
+
+        public static IEnumerable<object[]> Rectangle_Roundtrip_MemberData()
+        {
+            yield return new object[] { new RectangleF(1.2f, 3.4f, 5.6f, 7.8f) };
+        }
+
+        [Theory]
+        [MemberData(nameof(Color_Roundtrip_MemberData))]
+        public void Color_Roundtrip(Color c) => Assert.Equal(c, BinaryFormatterHelpers.Clone(c));
+
+        [Theory]
+        [MemberData(nameof(Size_Roundtrip_MemberData))]
+        public void Size_Roundtrip(SizeF s)
+        {
+            Assert.Equal(s, BinaryFormatterHelpers.Clone(s));
+            Assert.Equal(s.ToSize(), BinaryFormatterHelpers.Clone(s.ToSize()));
+        }
+
+        [Theory]
+        [MemberData(nameof(Point_Roundtrip_MemberData))]
+        public void Point_Roundtrip(PointF p)
+        {
+            Assert.Equal(p, BinaryFormatterHelpers.Clone(p));
+            Assert.Equal(Point.Truncate(p), BinaryFormatterHelpers.Clone(Point.Truncate(p)));
+        }
+
+        [Theory]
+        [MemberData(nameof(Rectangle_Roundtrip_MemberData))]
+        public void Rectangle_Roundtrip(RectangleF r)
+        {
+            Assert.Equal(r, BinaryFormatterHelpers.Clone(r));
+            Assert.Equal(Rectangle.Truncate(r), BinaryFormatterHelpers.Clone(Rectangle.Truncate(r)));
+        }
+    }
+}

--- a/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.csproj
+++ b/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.csproj
@@ -37,8 +37,12 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="ColorTests.cs" />
+    <Compile Include="SerializationTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Globalization.Extensions/src/System/Globalization/Extensions.cs
+++ b/src/System.Globalization.Extensions/src/System/Globalization/Extensions.cs
@@ -36,6 +36,7 @@ namespace System.Globalization
         }
     }
 
+    [Serializable]
     internal sealed class CultureAwareComparer : StringComparer
     {
         internal const CompareOptions ValidCompareMaskOffFlags =

--- a/src/System.IO.FileSystem.Primitives/src/System/IO/FileAttributes.cs
+++ b/src/System.IO.FileSystem.Primitives/src/System/IO/FileAttributes.cs
@@ -6,6 +6,7 @@ using System;
 
 namespace System.IO
 {
+    [Serializable]
     [Flags]
     public enum FileAttributes
     {

--- a/src/System.IO.FileSystem.Primitives/src/System/IO/FileMode.cs
+++ b/src/System.IO.FileSystem.Primitives/src/System/IO/FileMode.cs
@@ -15,6 +15,7 @@ namespace System.IO
     ///   to the end of the file).  To truncate a file or create it if it doesn't
     ///   exist, use Create.
     /// </devdoc>
+    [Serializable]
     public enum FileMode
     {
         /// <devdoc>

--- a/src/System.IO.FileSystem.Primitives/src/System/IO/FileShare.cs
+++ b/src/System.IO.FileSystem.Primitives/src/System/IO/FileShare.cs
@@ -14,6 +14,7 @@ namespace System.IO
     ///   Note these values currently match the values for FILE_SHARE_READ,
     ///   FILE_SHARE_WRITE, and FILE_SHARE_DELETE in winnt.h
     /// </devdoc>
+    [Serializable]
     [Flags]
     public enum FileShare
     {

--- a/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
+++ b/src/System.IO.FileSystem/ref/System.IO.FileSystem.cs
@@ -233,12 +233,14 @@ namespace System.IO
         protected string FullPath;
         protected string OriginalPath;
         protected FileSystemInfo() { }
+        protected FileSystemInfo(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public System.IO.FileAttributes Attributes { get { throw null; } set { } }
         public System.DateTime CreationTime { get { throw null; } set { } }
         public System.DateTime CreationTimeUtc { get { throw null; } set { } }
         public abstract bool Exists { get; }
         public string Extension { get { throw null; } }
         public virtual string FullName { get { throw null; } }
+        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public System.DateTime LastAccessTime { get { throw null; } set { } }
         public System.DateTime LastAccessTimeUtc { get { throw null; } set { } }
         public System.DateTime LastWriteTime { get { throw null; } set { } }

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -6,9 +6,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Security;
+using System.Runtime.Serialization;
 
 namespace System.IO
 {
+    [Serializable]
     public sealed partial class DirectoryInfo : FileSystemInfo
     {
         [System.Security.SecuritySafeCritical]
@@ -31,6 +33,11 @@ namespace System.IO
             // Fast path when we know a DirectoryInfo exists.
             OriginalPath = originalPath ?? Path.GetFileName(fullPath);
             FullPath = fullPath;
+            DisplayPath = GetDisplayName(OriginalPath);
+        }
+
+        private DirectoryInfo(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
             DisplayPath = GetDisplayName(OriginalPath);
         }
 

--- a/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 using System.Runtime.Versioning;
 using System.Text;
 
@@ -14,6 +15,7 @@ namespace System.IO
 {
     // Class for creating FileStream objects, and some basic file management
     // routines such as Delete, etc.
+    [Serializable]
     public sealed partial class FileInfo : FileSystemInfo
     {
         private String _name;
@@ -29,6 +31,12 @@ namespace System.IO
             Contract.EndContractBlock();
 
             Init(fileName);
+        }
+
+        private FileInfo(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            _name = Path.GetFileName(OriginalPath);
+            DisplayPath = GetDisplayPath(OriginalPath);
         }
 
         [System.Security.SecurityCritical]

--- a/src/System.IO.FileSystem/src/System/IO/FileOptions.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileOptions.cs
@@ -11,10 +11,11 @@ namespace System.IO
     // We didn't expose a number of these values because we didn't believe 
     // a number of them made sense in managed code, at least not yet.
 
-    [Flags]
     /// <devdoc>
     ///   Additional options to how to create a FileStream.
     /// </devdoc>
+    [Serializable]
+    [Flags]
     public enum FileOptions
     {
         // NOTE: any change to FileOptions enum needs to be 

--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.cs
@@ -8,11 +8,13 @@ using System.Security;
 using Microsoft.Win32;
 using System.Text;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 using System.Runtime.Versioning;
 
 namespace System.IO
 {
-    public abstract partial class FileSystemInfo
+    [Serializable]
+    public abstract partial class FileSystemInfo : MarshalByRefObject, ISerializable
     {
         protected String FullPath;          // fully qualified path of the file or directory
         protected String OriginalPath;      // path passed in by the user
@@ -21,6 +23,23 @@ namespace System.IO
         [System.Security.SecurityCritical]
         protected FileSystemInfo()
         {
+        }
+
+        protected FileSystemInfo(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            FullPath = Path.GetFullPath(info.GetString(nameof(FullPath)));
+            OriginalPath = info.GetString(nameof(OriginalPath));
+        }
+
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(OriginalPath), OriginalPath, typeof(String));
+            info.AddValue(nameof(FullPath), FullPath, typeof(String));
         }
 
         // Full path of the directory/file

--- a/src/System.IO.FileSystem/src/System/IO/SearchOption.cs
+++ b/src/System.IO.FileSystem/src/System/IO/SearchOption.cs
@@ -11,6 +11,7 @@ namespace System.IO
     ///   retrieve files/directories from the current directory alone
     ///   or should include all the subdirectories also.
     /// </devdoc>
+    [Serializable]
     public enum SearchOption
     {
         /// <devdoc>

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Serialization.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Serialization.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization.Formatters.Tests;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public partial class DirectoryInfo_Serialization : FileSystemTest
+    {
+        [Fact]
+        public void SerializeDeserialize_Roundtrip()
+        {
+            var orig = new DirectoryInfo("SomePath");
+            DirectoryInfo cloned = BinaryFormatterHelpers.Clone(orig);
+            Assert.Equal(orig.Name, cloned.Name);
+            Assert.Equal(orig.FullName, cloned.FullName);
+            Assert.Equal(orig.ToString(), cloned.ToString());
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileInfo/Serialization.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Serialization.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization.Formatters.Tests;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class FileInfo_Serialization : FileSystemTest
+    {
+        [Fact]
+        public void SerializeDeserialize_Roundtrip()
+        {
+            var orig = new DirectoryInfo("SomePath");
+            DirectoryInfo cloned = BinaryFormatterHelpers.Clone(orig);
+            Assert.Equal(orig.Name, cloned.Name);
+            Assert.Equal(orig.FullName, cloned.FullName);
+            Assert.Equal(orig.ToString(), cloned.ToString());
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -35,8 +35,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'==''">
+    <Compile Include="FileInfo\Serialization.cs" />
     <Compile Include="FileStream\Handle.cs" />
     <Compile Include="Directory\GetLogicalDrives.cs" />
+    <Compile Include="DirectoryInfo\Serialization.cs" />
     <Compile Include="FileStream\BeginRead.cs" />
     <Compile Include="FileStream\EndRead.cs" />
     <Compile Include="FileStream\BeginWrite.cs" />
@@ -45,6 +47,9 @@
     <Compile Include="File\EncryptDecrypt.cs" />
     <Compile Include="File\Replace.cs" />
     <Compile Include="File\ReadWriteAllLines.netstandard1.7.cs" />
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <!-- Rewritten -->

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -35,7 +35,11 @@
   },
   "frameworks": {
     "netstandard1.3": {},
-    "netstandard1.7": {}
+    "netstandard1.7": {
+      "dependencies": {
+        "System.Runtime.Serialization.Formatters": "4.4.0-beta-24615-03"
+      }
+    }
   },
   "supports": {
     "coreFx.Test.netcoreapp1.0": {},

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFileAccess.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFileAccess.cs
@@ -4,6 +4,7 @@
 
 namespace System.IO.MemoryMappedFiles
 {
+    [Serializable]
     public enum MemoryMappedFileAccess
     {
         ReadWrite = 0,

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFileOptions.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFileOptions.cs
@@ -4,6 +4,7 @@
 
 namespace System.IO.MemoryMappedFiles
 {
+    [Serializable]
     [Flags]
     public enum MemoryMappedFileOptions
     {

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeDirection.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeDirection.cs
@@ -4,6 +4,7 @@
 
 namespace System.IO.Pipes
 {
+    [Serializable]
     public enum PipeDirection
     {
         In = 1,

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeOptions.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeOptions.cs
@@ -4,6 +4,7 @@
 
 namespace System.IO.Pipes
 {
+    [Serializable]
     [Flags]
     public enum PipeOptions
     {

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeState.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeState.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.IO.Pipes
 {
+    [Serializable]
     internal enum PipeState
     {
         // Waiting to connect is the state before a live connection has been established. For named pipes, the 

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeTransmissionMode.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeTransmissionMode.cs
@@ -4,6 +4,7 @@
 
 namespace System.IO.Pipes
 {
+    [Serializable]
     public enum PipeTransmissionMode
     {
         Byte = 0,

--- a/src/System.Net.Ping/ref/System.Net.Ping.cs
+++ b/src/System.Net.Ping/ref/System.Net.Ping.cs
@@ -76,6 +76,7 @@ namespace System.Net.NetworkInformation
     {
         public PingException(string message) { }
         public PingException(string message, System.Exception innerException) { }
+        protected PingException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
     public partial class PingOptions
     {

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/PingException.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/PingException.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
+
 namespace System.Net.NetworkInformation
 {
+    [Serializable]
     public class PingException : InvalidOperationException
     {
         public PingException(string message) :
@@ -13,6 +16,11 @@ namespace System.Net.NetworkInformation
 
         public PingException(string message, Exception innerException) :
             base(message, innerException)
+        {
+        }
+
+        protected PingException(SerializationInfo serializationInfo, StreamingContext streamingContext) :
+            base(serializationInfo, streamingContext)
         {
         }
     }

--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -71,9 +71,12 @@ namespace System.Net
         public System.Net.CookieCollection GetCookies(System.Uri uri) { throw null; }
         public void SetCookies(System.Uri uri, string cookieHeader) { }
     }
-    public partial class CookieException : System.FormatException
+    public partial class CookieException : System.FormatException, System.Runtime.Serialization.ISerializable
     {
         public CookieException() { }
+        protected CookieException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
     public partial class CredentialCache : System.Collections.IEnumerable, System.Net.ICredentials, System.Net.ICredentialsByHost
     {

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -38,6 +38,7 @@ namespace System.Net
     // Currently, only represents client-side cookies. The cookie classes know
     // how to parse a set-cookie format string, but not a cookie format string
     // (e.g. "Cookie: $Version=1; name=value; $Path=/foo; $Secure")
+    [Serializable]
     public sealed class Cookie
     {
         // NOTE: these two constants must change together.

--- a/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -10,6 +10,7 @@ namespace System.Net
     // CookieCollection
     //
     // A list of cookies maintained in Sorted order. Only one cookie with matching Name/Domain/Path
+    [Serializable]
     public class CookieCollection : ICollection
     {
         internal enum Stamp

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -87,6 +87,7 @@ namespace System.Net
     // CookieContainer
     //
     // Manage cookies for a user (implicit). Based on RFC 2965.
+    [Serializable]
     public class CookieContainer
     {
         public const int DefaultCookieLimit = 300;
@@ -977,6 +978,7 @@ namespace System.Net
         }
     }
 
+    [Serializable]
     internal struct PathList
     {
         // Usage of PathList depends on it being shallowly immutable;
@@ -1054,6 +1056,7 @@ namespace System.Net
             }
         }
 
+        [Serializable]
         private sealed class PathListComparer : IComparer<string>
         {
             internal static readonly PathListComparer StaticInstance = new PathListComparer();

--- a/src/System.Net.Primitives/src/System/Net/CookieException.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieException.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
+
 // The NETNative_SystemNetHttp #define is used in some source files to indicate we are compiling classes
 // directly into the .NET Native System.Net.Http.dll implementation assembly in order to use internal class
 // methods. Internal methods are needed in order to map cookie response headers from the WinRT Windows.Web.Http APIs.
@@ -16,7 +18,8 @@ namespace System.Net.Internal
 namespace System.Net
 #endif
 {
-    public class CookieException : FormatException
+    [Serializable]
+    public class CookieException : FormatException, ISerializable
     {
         public CookieException() : base()
         {
@@ -28,6 +31,21 @@ namespace System.Net
 
         internal CookieException(string message, Exception inner) : base(message, inner)
         {
+        }
+
+        protected CookieException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+            : base(serializationInfo, streamingContext)
+        {
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            GetObjectData(serializationInfo, streamingContext);
+        }
+
+        public override void GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            base.GetObjectData(serializationInfo, streamingContext);
         }
     }
 }

--- a/src/System.Net.Primitives/src/System/Net/EndPoint.cs
+++ b/src/System.Net.Primitives/src/System/Net/EndPoint.cs
@@ -13,6 +13,7 @@ namespace System.Net
     ///       Identifies a network address.
     ///    </para>
     /// </devdoc>
+    [Serializable]
     public abstract class EndPoint
     {
         /// <devdoc>

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -12,6 +12,7 @@ namespace System.Net
     ///     Provides an Internet Protocol (IP) address.
     ///   </para>
     /// </devdoc>
+    [Serializable]
     public class IPAddress
     {
         public static readonly IPAddress Any = new IPAddress(0x0000000000000000);
@@ -40,6 +41,7 @@ namespace System.Net
         /// <summary>
         /// A lazily initialized cache of the result of calling <see cref="ToString"/>.
         /// </summary>
+        [NonSerialized]
         private string _toString;
 
         /// <summary>

--- a/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -12,6 +12,7 @@ namespace System.Net
     ///       Provides an IP address.
     ///    </para>
     /// </devdoc>
+    [Serializable]
     public class IPEndPoint : EndPoint
     {
         /// <devdoc>

--- a/src/System.Net.Primitives/tests/FunctionalTests/SerializationTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SerializationTest.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.Serialization.Formatters.Tests;
+using Xunit;
+
+namespace System.Net.Primitives.Functional.Tests
+{
+    public static class SerializationTest
+    {
+        public static IEnumerable<object[]> SerializeDeserialize_Roundtrip_MemberData()
+        {
+            yield return new object[] { IPAddress.Parse("127.0.0.1") };
+            yield return new object[] { new IPEndPoint(IPAddress.Loopback, 12345) };
+            yield return new object[] { new Cookie("somekey", "somevalue") };
+            yield return new object[] { new CookieCollection() { new Cookie("somekey", "somevalue") } };
+        }
+
+        [Theory]
+        [MemberData(nameof(SerializeDeserialize_Roundtrip_MemberData))]
+        public static void SerializeDeserialize_Roundtrip(object obj)
+        {
+            Assert.Equal(obj, BinaryFormatterHelpers.Clone(obj));
+        }
+    }
+}

--- a/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
+++ b/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
@@ -35,6 +35,12 @@
     <Compile Include="NetworkCredentialTest.cs" />
     <Compile Include="SocketAddressTest.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
+    <Compile Include="SerializationTest.cs" />
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\pkg\System.Net.Primitives.pkgproj">
       <Project>{8772BC91-7B55-49B9-94FA-4B1BE5BEAB55}</Project>

--- a/src/System.Net.Primitives/tests/FunctionalTests/project.json
+++ b/src/System.Net.Primitives/tests/FunctionalTests/project.json
@@ -16,7 +16,11 @@
   },
   "frameworks": {
     "netstandard1.3": {},
-    "netstandard1.7": {}
+    "netstandard1.7": {
+      "dependencies": {
+        "System.Runtime.Serialization.Formatters": "4.4.0-beta-24615-03"
+      }
+    }
   },
   "supports": {
     "coreFx.Test.netcore50": {},

--- a/src/System.Net.Primitives/tests/PalTests/Fakes/Serialization.cs
+++ b/src/System.Net.Primitives/tests/PalTests/Fakes/Serialization.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = false)]
+    public sealed class SerializableAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = false)]
+    public sealed class NonSerializedAttribute : Attribute { }
+}
+
+namespace System.Runtime.Serialization
+{
+    public interface ISerializable
+    {
+        void GetObjectData(SerializationInfo info, StreamingContext context);
+    }
+
+    public class SerializationInfo
+    {
+        public void AddValue(string name, object value) { }
+    }
+
+    public struct StreamingContext { }
+}

--- a/src/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
+++ b/src/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
@@ -33,6 +33,7 @@
     <Compile Include="SocketAddressPalTest.cs" />
 
     <Compile Include="Fakes\GlobalLog.cs" />
+    <Compile Include="Fakes\Serialization.cs" Condition="'$(TargetGroup)' != ''"/>
 
     <Compile Include="..\..\src\System\Net\EndPoint.cs" >
       <Link>ProductionCode\System\Net\EndPoint.cs</Link>

--- a/src/System.Net.Primitives/tests/UnitTests/Fakes/CookieException.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/Fakes/CookieException.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net
+{
+    // Fake CookieException without serialization to enable unit tests compiling for netstandard 1.3
+    public class CookieException : FormatException
+    {
+        public CookieException() : base() { }
+        internal CookieException(string message) : base(message) { }
+        internal CookieException(string message, Exception inner) : base(message, inner) { }
+    }
+}

--- a/src/System.Net.Primitives/tests/UnitTests/Fakes/Serialization.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/Fakes/Serialization.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = false)]
+    public sealed class SerializableAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = false)]
+    public sealed class NonSerializedAttribute : Attribute { }
+}
+
+namespace System.Runtime.Serialization
+{
+    public interface ISerializable
+    {
+        void GetObjectData(SerializationInfo info, StreamingContext context);
+    }
+
+    public class SerializationInfo
+    {
+        public void AddValue(string name, object value) { }
+    }
+
+    public struct StreamingContext { }
+}

--- a/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
+++ b/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
@@ -31,6 +31,8 @@
     <Compile Include="Fakes\GlobalLog.cs" />
     <Compile Include="Fakes\HostInformation.cs" />
     <Compile Include="Fakes\IPAddressPal.cs" />
+    <Compile Include="Fakes\CookieException.cs" />
+    <Compile Include="Fakes\Serialization.cs" Condition="'$(TargetGroup)' != ''"/>
     <Compile Include="..\..\src\System\Net\Cookie.cs">
       <Link>ProductionCode\System\Net\Cookie.cs</Link>
     </Compile>
@@ -39,9 +41,6 @@
     </Compile>
     <Compile Include="..\..\src\System\Net\CookieCollection.cs">
       <Link>ProductionCode\System\Net\CookieCollection.cs</Link>
-    </Compile>
-    <Compile Include="..\..\src\System\Net\CookieException.cs">
-      <Link>ProductionCode\System\Net\CookieException.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\EndPoint.cs">
       <Link>ProductionCode\System\Net\EndPoint.cs</Link>


### PR DESCRIPTION
Most of these are just adding [Serializable].  Some also involve implementing ISerializable.

Covers the serializable types from:
- Microsoft.Win32.Registry
- System.Data.SqlClient
- System.Diagnostics.Process
- System.Diagnostics.TraceSource
- System.Diagnostics.Tracing
- System.Drawing.Primitives
- System.Globalization.Extensions
- System.IO.FileSystem.Primitives
- System.IO.FileSystem
- System.IO.MemoryMappedfiles
- System.IO.Pipes
- System.Net.Ping
- System.Net.Primitives (except for SocketException, which I'll do separately once packages are updated)

cc: @danmosemsft 
Contributes to https://github.com/dotnet/corefx/issues/12725
Contributes to https://github.com/dotnet/corefx/issues/12669
Contributes to https://github.com/dotnet/corefx/issues/12669