### PR TITLE
Fix a number of import errors in the rid graph.

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -188,28 +188,28 @@
             "#import": [ "rhel" ]
         },
         "rhel.7-x64": {
-            "#import": [ "rhel", "rhel-x64" ]
+            "#import": [ "rhel.7", "rhel-x64" ]
         },
 
         "rhel.7.0": {
             "#import": [ "rhel.7" ]
         },
         "rhel.7.0-x64": {
-            "#import": [ "rhel.7", "rhel.7-x64" ]
+            "#import": [ "rhel.7.0", "rhel.7-x64" ]
         },
 
         "rhel.7.1": {
             "#import": [ "rhel.7.0" ]
         },
         "rhel.7.1-x64": {
-            "#import": [ "rhel.7.0", "rhel.7.0-x64" ]
+            "#import": [ "rhel.7.1", "rhel.7.0-x64" ]
         },
 
         "rhel.7.2": {
             "#import": [ "rhel.7.1" ]
         },
         "rhel.7.2-x64": {
-            "#import": [ "rhel.7.1", "rhel.7.1-x64" ]
+            "#import": [ "rhel.7.2", "rhel.7.1-x64" ]
         },
 
         "ol": {
@@ -230,21 +230,21 @@
             "#import": [ "ol.7", "rhel.7.0" ]
         },
         "ol.7.0-x64": {
-            "#import": [ "ol.7", "ol.7-x64", "rhel.7.0-x64" ]
+            "#import": [ "ol.7.0", "ol.7-x64", "rhel.7.0-x64" ]
         },
 
         "ol.7.1": {
             "#import": [ "ol.7.0", "rhel.7.1" ]
         },
         "ol.7.1-x64": {
-            "#import": [ "ol.7.0", "ol.7.0-x64", "rhel.7.1-x64" ]
+            "#import": [ "ol.7.1", "ol.7.0-x64", "rhel.7.1-x64" ]
         },
 
         "ol.7.2": {
             "#import": [ "ol.7.1", "rhel.7.2" ]
         },
         "ol.7.2-x64": {
-            "#import": [ "ol.7.1", "ol.7.1-x64", "rhel.7.2-x64" ]
+            "#import": [ "ol.7.2", "ol.7.1-x64", "rhel.7.2-x64" ]
         },
 
         "centos": {


### PR DESCRIPTION
A number of linux distros had incorrect rid imports. These generally took the form of a version- and arch-specific rid importing a base rid, or a previous-version rid, rather than the analogous version-specific but arch-agnostic rid.

@ericstj , @ellismg 