### PR TITLE
Remove some workarounds from BinaryFormatter

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatter.cs
@@ -155,7 +155,7 @@ namespace System.Runtime.Serialization
             {
                 WriteArray(data, memberName, varType);
             }
-            else if (varType.GetTypeInfo().IsValueType)
+            else if (varType.IsValueType)
             {
                 WriteValueType(data, memberName, varType);
             }

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
@@ -19,18 +19,18 @@ namespace System.Runtime.Serialization
 
         private static FieldInfo[] GetSerializableFields(Type type)
         {
-            if (type.GetTypeInfo().IsInterface)
+            if (type.IsInterface)
             {
                 return Array.Empty<FieldInfo>();
             }
 
-            if (!type.GetTypeInfo().IsSerializable)
+            if (!type.IsSerializable)
             {
-                throw new SerializationException(SR.Format(SR.Serialization_NonSerType, type.GetTypeInfo().FullName, type.GetTypeInfo().Assembly.FullName));
+                throw new SerializationException(SR.Format(SR.Serialization_NonSerType, type.FullName, type.Assembly.FullName));
             }
 
             var results = new List<FieldInfo>();
-            for (Type t = type; t != typeof(object); t = t.GetTypeInfo().BaseType)
+            for (Type t = type; t != typeof(object); t = t.BaseType)
             {
                 foreach (FieldInfo field in t.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
                 {
@@ -69,7 +69,7 @@ namespace System.Runtime.Serialization
 
         // TODO #8133: Fix this to avoid reflection
         private static readonly Func<Type, object> s_getUninitializedObjectDelegate = (Func<Type, object>)
-            typeof(string).GetTypeInfo().Assembly
+            typeof(string).Assembly
             .GetType("System.Runtime.Serialization.FormatterServices")
             .GetMethod("GetUninitializedObject", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
             .CreateDelegate(typeof(Func<Type, object>));
@@ -222,14 +222,14 @@ namespace System.Runtime.Serialization
                 throw new ArgumentNullException(nameof(type));
             }
 
-            foreach (Attribute first in type.GetTypeInfo().GetCustomAttributes(typeof(TypeForwardedFromAttribute), false))
+            foreach (Attribute first in type.GetCustomAttributes(typeof(TypeForwardedFromAttribute), false))
             {
                 hasTypeForwardedFrom = true;
                 return ((TypeForwardedFromAttribute)first).AssemblyFullName;
             }
 
             hasTypeForwardedFrom = false;
-            return type.GetTypeInfo().Assembly.FullName;
+            return type.Assembly.FullName;
         }
 
         internal static string GetClrTypeFullName(Type type)
@@ -251,7 +251,7 @@ namespace System.Runtime.Serialization
 
         private static string GetClrTypeFullNameForNonArrayTypes(Type type)
         {
-            if (!type.GetTypeInfo().IsGenericType)
+            if (!type.IsGenericType)
             {
                 return type.FullName;
             }

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectInfo.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectInfo.cs
@@ -93,7 +93,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             if (surrogateSelector != null && (_serializationSurrogate = surrogateSelector.GetSurrogate(_objectType, context, out surrogateSelectorTemp)) != null)
             {
                 _si = new SerializationInfo(_objectType, converter);
-                if (!_objectType.GetTypeInfo().IsPrimitive)
+                if (!_objectType.IsPrimitive)
                 {
                     _serializationSurrogate.GetObjectData(obj, _si, context);
                 }
@@ -101,9 +101,9 @@ namespace System.Runtime.Serialization.Formatters.Binary
             }
             else if (obj is ISerializable)
             {
-                if (!_objectType.GetTypeInfo().IsSerializable)
+                if (!_objectType.IsSerializable)
                 {
-                    throw new SerializationException(SR.Format(SR.Serialization_NonSerType, _objectType.FullName, _objectType.GetTypeInfo().Assembly.FullName));
+                    throw new SerializationException(SR.Format(SR.Serialization_NonSerType, _objectType.FullName, _objectType.Assembly.FullName));
                 }
                 _si = new SerializationInfo(_objectType, converter);
                 ((ISerializable)obj).GetObjectData(_si, context);

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
@@ -148,9 +148,9 @@ namespace System.Runtime.Serialization.Formatters.Binary
 
         private void CheckSerializable(Type t)
         {
-            if (!t.GetTypeInfo().IsSerializable && !HasSurrogate(t))
+            if (!t.IsSerializable && !HasSurrogate(t))
             {
-                throw new SerializationException(string.Format(CultureInfo.InvariantCulture, SR.Serialization_NonSerType, t.FullName, t.GetTypeInfo().Assembly.FullName));
+                throw new SerializationException(string.Format(CultureInfo.InvariantCulture, SR.Serialization_NonSerType, t.FullName, t.Assembly.FullName));
             }
         }
 
@@ -443,7 +443,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                     }
                     else if (couldBeValueType && pr._arrayElementType != null)
                     {
-                        if (!pr._arrayElementType.GetTypeInfo().IsValueType && !pr._isLowerBound)
+                        if (!pr._arrayElementType.IsValueType && !pr._isLowerBound)
                         {
                             pr._objectA = (object[])pr._newObj;
                         }
@@ -598,7 +598,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
 
                 if (objectPr._arrayElementType != null)
                 {
-                    if ((objectPr._arrayElementType.GetTypeInfo().IsValueType) && (pr._arrayElementTypeCode == InternalPrimitiveTypeE.Invalid))
+                    if ((objectPr._arrayElementType.IsValueType) && (pr._arrayElementTypeCode == InternalPrimitiveTypeE.Invalid))
                     {
                         pr._isValueTypeFixup = true; //Valuefixup
                         ValueFixupStack.Push(new ValueFixup((Array)objectPr._newObj, objectPr._indexMap)); //valuefixup
@@ -748,7 +748,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                 ParseObject(pr);
                 _stack.Push(pr);
 
-                if ((pr._objectInfo != null) && pr._objectInfo._objectType != null && (pr._objectInfo._objectType.GetTypeInfo().IsValueType))
+                if ((pr._objectInfo != null) && pr._objectInfo._objectType != null && (pr._objectInfo._objectType.IsValueType))
                 {
                     pr._isValueTypeFixup = true; //Valuefixup
                     ValueFixupStack.Push(new ValueFixup(objectPr._newObj, pr._name, objectPr._objectInfo));//valuefixup
@@ -988,7 +988,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                 }
 
                 // before adding it to cache, let us do the security check 
-                CheckTypeForwardedTo(assm, type.GetTypeInfo().Assembly, type);
+                CheckTypeForwardedTo(assm, type.Assembly, type);
 
                 entry = new TypeNAssembly();
                 entry.Type = type;
@@ -1044,7 +1044,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                     // here let us do the security check 
                     if (objectType != null)
                     {
-                        CheckTypeForwardedTo(sourceAssembly, objectType.GetTypeInfo().Assembly, objectType);
+                        CheckTypeForwardedTo(sourceAssembly, objectType.Assembly, objectType);
                     }
                 }
 

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectWriter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectWriter.cs
@@ -450,7 +450,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             // Get type of array element 
             Type arrayElemType = arrayType.GetElementType();
             WriteObjectInfo arrayElemObjectInfo = null;
-            if (!arrayElemType.GetTypeInfo().IsPrimitive)
+            if (!arrayElemType.IsPrimitive)
             {
                 arrayElemObjectInfo = WriteObjectInfo.Serialize(arrayElemType, _surrogates, _context, _serObjectInfoInit, _formatterConverter, _binder);
                 arrayElemObjectInfo._assemId = GetAssemblyId(arrayElemObjectInfo);
@@ -526,7 +526,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                 if (!(Converter.IsWriteAsByteArray(arrayElemTypeNameInfo._primitiveTypeEnum) && (lowerBoundA[0] == 0)))
                 {
                     object[] objectA = null;
-                    if (!arrayElemType.GetTypeInfo().IsValueType)
+                    if (!arrayElemType.IsValueType)
                     {
                         // Non-primitive type array                 
                         objectA = (object[])array;
@@ -781,7 +781,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                 return _previousId;
             }
             _idGenerator._currentCount = _currentId;
-            if (type != null && type.GetTypeInfo().IsValueType)
+            if (type != null && type.IsValueType)
             {
                 if (!assignUniqueIdToValueType)
                 {

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryTypeConverter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryTypeConverter.cs
@@ -48,7 +48,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                         string assembly = null;
                         if (objectInfo == null)
                         {
-                            assembly = type.GetTypeInfo().Assembly.FullName;
+                            assembly = type.Assembly.FullName;
                             typeInformation = type.FullName;
                         }
                         else
@@ -115,7 +115,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                 switch (primitiveTypeEnum)
                 {
                     case InternalPrimitiveTypeE.Invalid:
-                        binaryTypeEnum = type.GetTypeInfo().Assembly == Converter.s_urtAssembly ?
+                        binaryTypeEnum = type.Assembly == Converter.s_urtAssembly ?
                             BinaryTypeEnum.ObjectUrt :
                             BinaryTypeEnum.ObjectUser;
                         typeInformation = type.FullName;

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryUtilClasses.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryUtilClasses.cs
@@ -491,7 +491,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             {
                 if (!_sealedStatusChecked)
                 {
-                    _isSealed = _type.GetTypeInfo().IsSealed;
+                    _isSealed = _type.IsSealed;
                     _sealedStatusChecked = true;
                 }
                 return _isSealed;

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/Converter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/Converter.cs
@@ -64,7 +64,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
 
         internal static InternalPrimitiveTypeE ToCode(Type type) =>
                 type == null ? ToPrimitiveTypeEnum(TypeCode.Empty) :
-                type.GetTypeInfo().IsPrimitive ? ToPrimitiveTypeEnum(type.GetTypeCode()) :
+                type.GetTypeInfo().IsPrimitive ? ToPrimitiveTypeEnum(Type.GetTypeCode(type)) :
                 ReferenceEquals(type, s_typeofDateTime) ? InternalPrimitiveTypeE.DateTime :
                 ReferenceEquals(type, s_typeofTimeSpan) ? InternalPrimitiveTypeE.TimeSpan :
                 ReferenceEquals(type, s_typeofDecimal) ? InternalPrimitiveTypeE.Decimal :

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/Converter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/Converter.cs
@@ -30,7 +30,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
         internal static readonly Type s_typeofUInt64 = typeof(ulong);
         internal static readonly Type s_typeofObject = typeof(object);
         internal static readonly Type s_typeofSystemVoid = typeof(void);
-        internal static readonly Assembly s_urtAssembly = s_typeofString.GetTypeInfo().Assembly;
+        internal static readonly Assembly s_urtAssembly = s_typeofString.Assembly;
         internal static readonly string s_urtAssemblyString = s_urtAssembly.FullName;
 
         // Arrays
@@ -64,7 +64,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
 
         internal static InternalPrimitiveTypeE ToCode(Type type) =>
                 type == null ? ToPrimitiveTypeEnum(TypeCode.Empty) :
-                type.GetTypeInfo().IsPrimitive ? ToPrimitiveTypeEnum(Type.GetTypeCode(type)) :
+                type.IsPrimitive ? ToPrimitiveTypeEnum(Type.GetTypeCode(type)) :
                 ReferenceEquals(type, s_typeofDateTime) ? InternalPrimitiveTypeE.DateTime :
                 ReferenceEquals(type, s_typeofTimeSpan) ? InternalPrimitiveTypeE.TimeSpan :
                 ReferenceEquals(type, s_typeofDecimal) ? InternalPrimitiveTypeE.Decimal :
@@ -157,7 +157,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                     if (objectInfo == null)
                     {
                         typeName = type.FullName;
-                        nameSpaceEnum = type.GetTypeInfo().Assembly == s_urtAssembly ? InternalNameSpaceE.UrtSystem : InternalNameSpaceE.UrtUser;
+                        nameSpaceEnum = type.Assembly == s_urtAssembly ? InternalNameSpaceE.UrtSystem : InternalNameSpaceE.UrtUser;
                     }
                     else
                     {

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
@@ -1054,7 +1054,7 @@ namespace System.Runtime.Serialization
                 _typeLoad = (TypeLoadExceptionHolder)obj;
             }
 
-            if (idOfContainingObj != 0 && ((field != null && field.FieldType.GetTypeInfo().IsValueType) || arrayIndex != null))
+            if (idOfContainingObj != 0 && ((field != null && field.FieldType.IsValueType) || arrayIndex != null))
             {
                 if (idOfContainingObj == objID)
                 {
@@ -1204,7 +1204,7 @@ namespace System.Runtime.Serialization
             _serInfo = info;
             _surrogate = surrogate;
 
-            if (idOfContainer != 0 && ((field != null && field.FieldType.GetTypeInfo().IsValueType) || arrayIndex != null))
+            if (idOfContainer != 0 && ((field != null && field.FieldType.IsValueType) || arrayIndex != null))
             {
                 if (idOfContainer == _id)
                 {

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/SafeSerializationEventArgs.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/SafeSerializationEventArgs.cs
@@ -21,9 +21,9 @@ namespace System.Runtime.Serialization
             {
                 throw new ArgumentNullException(nameof(serializedState));
             }
-            if (!serializedState.GetType().GetTypeInfo().IsSerializable)
+            if (!serializedState.GetType().IsSerializable)
             {
-                throw new ArgumentException(SR.Format(SR.Serialization_NonSerType, serializedState.GetType(), serializedState.GetType().GetTypeInfo().Assembly.FullName));
+                throw new ArgumentException(SR.Format(SR.Serialization_NonSerType, serializedState.GetType(), serializedState.GetType().Assembly.FullName));
             }
 
             // nop

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/SerializationEventsCache.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/SerializationEventsCache.cs
@@ -43,7 +43,7 @@ namespace System.Runtime.Serialization
                         mi.Add(m);
                     }
                 }
-                baseType = baseType.GetTypeInfo().BaseType;
+                baseType = baseType.BaseType;
             }
             mi?.Reverse(); // We should invoke the methods starting from base
 

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ValueTypeFixupInfo.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ValueTypeFixupInfo.cs
@@ -54,7 +54,7 @@ namespace System.Runtime.Serialization
                     throw new ArgumentException(SR.Argument_MemberAndArray);
                 }
 
-                if (member.FieldType.GetTypeInfo().IsValueType && containerID == 0)
+                if (member.FieldType.IsValueType && containerID == 0)
                 {
                     throw new ArgumentException(SR.Argument_MustSupplyContainer);
                 }

--- a/src/System.Runtime.Serialization.Formatters/src/System/TemporaryStubs.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/TemporaryStubs.cs
@@ -69,28 +69,6 @@ namespace System.Reflection
                 obj._fields[i].SetValue(values[i], values[i + 1]);
             }
         }
-
-        internal static TypeCode GetTypeCode(this Type type) // TODO: Replace with Type.TypeCode when it's available
-        {
-            if (type == null) return TypeCode.Empty;
-            else if (type == typeof(bool)) return TypeCode.Boolean;
-            else if (type == typeof(char)) return TypeCode.Char;
-            else if (type == typeof(sbyte)) return TypeCode.SByte;
-            else if (type == typeof(byte)) return TypeCode.Byte;
-            else if (type == typeof(short)) return TypeCode.Int16;
-            else if (type == typeof(ushort)) return TypeCode.UInt16;
-            else if (type == typeof(int)) return TypeCode.Int32;
-            else if (type == typeof(uint)) return TypeCode.UInt32;
-            else if (type == typeof(long)) return TypeCode.Int64;
-            else if (type == typeof(ulong)) return TypeCode.UInt64;
-            else if (type == typeof(float)) return TypeCode.Single;
-            else if (type == typeof(double)) return TypeCode.Double;
-            else if (type == typeof(decimal)) return TypeCode.Decimal;
-            else if (type == typeof(System.DateTime)) return TypeCode.DateTime;
-            else if (type == typeof(string)) return TypeCode.String;
-            else if (type.GetTypeInfo().IsEnum) return GetTypeCode(Enum.GetUnderlyingType(type));
-            return TypeCode.Object;
-        }
     }
 }
 

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -467,7 +467,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         public void SerializeNonSerializableTypeWithSurrogate()
         {
             var p = new NonSerializablePair<int, string>() { Value1 = 1, Value2 = "2" };
-            Assert.False(p.GetType().GetTypeInfo().IsSerializable);
+            Assert.False(p.GetType().IsSerializable);
             Assert.Throws<SerializationException>(() => FormatterClone(p));
 
             NonSerializablePair<int, string> result = FormatterClone(p, new NonSerializablePairSurrogate());

--- a/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
@@ -87,7 +87,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         public void GetTypeFromAssembly_InvalidArguments_ThrowsException()
         {
             Assert.Throws<ArgumentNullException>("assem", () => FormatterServices.GetTypeFromAssembly(null, "name"));
-            Assert.Null(FormatterServices.GetTypeFromAssembly(GetType().GetTypeInfo().Assembly, Guid.NewGuid().ToString("N"))); // non-existing type doesn't throw
+            Assert.Null(FormatterServices.GetTypeFromAssembly(GetType().Assembly, Guid.NewGuid().ToString("N"))); // non-existing type doesn't throw
         }
     }
 }

--- a/src/System.Runtime.Serialization.Formatters/tests/SerializationInfoTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/SerializationInfoTests.cs
@@ -19,7 +19,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
 
             Assert.Equal(typeof(Serializable), si.ObjectType);
             Assert.Equal(typeof(Serializable).FullName, si.FullTypeName);
-            Assert.Equal(typeof(Serializable).GetTypeInfo().Assembly.FullName, si.AssemblyName);
+            Assert.Equal(typeof(Serializable).Assembly.FullName, si.AssemblyName);
 
             Assert.Equal(15, si.MemberCount);
 


### PR DESCRIPTION
- We no longer need our own custom GetTypeCode implementation, as Type.GetTypeCode is exposed.
- We no longer need GetTypeInfo calls sprinkled all around, as Type exposes the various members like IsValueType that we needed.

cc: @danmosemsft 