### PR TITLE
Port DES and RC2 in System.Security.Cryptography.Algorithms and .Csp

### DIFF
--- a/src/Common/src/Internal/Cryptography/BasicSymmetricCipherBCrypt.cs
+++ b/src/Common/src/Internal/Cryptography/BasicSymmetricCipherBCrypt.cs
@@ -16,7 +16,7 @@ namespace Internal.Cryptography
         private byte[] _currentIv;  // CNG mutates this with the updated IV for the next stage on each Encrypt/Decrypt call.
                                     // The base IV holds a copy of the original IV for Reset(), until it is cleared by Dispose().
 
-        public BasicSymmetricCipherBCrypt(SafeAlgorithmHandle algorithm, CipherMode cipherMode, int blockSizeInBytes, byte[] key, byte[] iv, bool encrypting)
+        public BasicSymmetricCipherBCrypt(SafeAlgorithmHandle algorithm, CipherMode cipherMode, int blockSizeInBytes, byte[] key, int effectiveKeyLength, byte[] iv, bool encrypting)
             : base(cipherMode.GetCipherIv(iv), blockSizeInBytes)
         {
             Debug.Assert(algorithm != null);
@@ -29,6 +29,12 @@ namespace Internal.Cryptography
             }
 
             _hKey = algorithm.BCryptImportKey(key);
+
+            if (effectiveKeyLength != 0)
+            {
+                Cng.SetEffectiveKeyLength(_hKey, effectiveKeyLength);
+            }
+
             Reset();
         }
 

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Symmetric.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Symmetric.cs
@@ -13,7 +13,9 @@ internal static partial class Interop
         internal enum PAL_SymmetricAlgorithm
         {
             AES = 0,
+            DES = 1,
             TripleDES = 2,
+            RC2 = 5,
         }
 
         internal enum PAL_SymmetricOperation

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
@@ -10,10 +10,12 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherCreate")]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherCreate2")]
         internal static extern SafeEvpCipherCtxHandle EvpCipherCreate(
             IntPtr cipher,
             byte[] key,
+            int keyLength,
+            int effectivekeyLength,
             byte[] iv,
             int enc);
 
@@ -62,10 +64,22 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpAes256Cbc")]
         internal static extern IntPtr EvpAes256Cbc();
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDes3Ecb")]
-        internal static extern IntPtr EvpDes3Ecb();
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDesCbc")]
+        internal static extern IntPtr EvpDesCbc();
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDesEcb")]
+        internal static extern IntPtr EvpDesEcb();
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDes3Cbc")]
         internal static extern IntPtr EvpDes3Cbc();
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDes3Ecb")]
+        internal static extern IntPtr EvpDes3Ecb();
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpRC2Cbc")]
+        internal static extern IntPtr EvpRC2Cbc();
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpRC2Ecb")]
+        internal static extern IntPtr EvpRC2Ecb();
     }
 }

--- a/src/Common/src/Interop/Windows/BCrypt/DESBCryptModes.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/DESBCryptModes.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security.Cryptography;
+using Internal.NativeCrypto;
+
+namespace Internal.Cryptography
+{
+    internal static class DesBCryptModes
+    {
+        private static readonly SafeAlgorithmHandle s_hAlgCbc = OpenDesAlgorithm(Cng.BCRYPT_CHAIN_MODE_CBC);
+        private static readonly SafeAlgorithmHandle s_hAlgEcb = OpenDesAlgorithm(Cng.BCRYPT_CHAIN_MODE_ECB);
+
+        internal static SafeAlgorithmHandle GetSharedHandle(CipherMode cipherMode)
+        {
+            // Windows 8 added support to set the CipherMode value on a key,
+            // but Windows 7 requires that it be set on the algorithm before key creation.
+            switch (cipherMode)
+            {
+                case CipherMode.CBC:
+                    return s_hAlgCbc;
+                case CipherMode.ECB:
+                    return s_hAlgEcb;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        private static SafeAlgorithmHandle OpenDesAlgorithm(string cipherMode)
+        {
+            SafeAlgorithmHandle hAlg = Cng.BCryptOpenAlgorithmProvider(Cng.BCRYPT_DES_ALGORITHM, null, Cng.OpenAlgorithmProviderFlags.NONE);
+            hAlg.SetCipherMode(cipherMode);
+
+            return hAlg;
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptPropertyStrings.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptPropertyStrings.cs
@@ -8,8 +8,10 @@ internal partial class Interop
     {
         internal static class BCryptPropertyStrings
         {
-            internal const string BCRYPT_HASH_LENGTH = "HashDigestLength";
+            internal const string BCRYPT_CHAINING_MODE = "ChainingMode";
             internal const string BCRYPT_ECC_PARAMETERS = "ECCParameters";
+            internal const string BCRYPT_EFFECTIVE_KEY_LENGTH = "EffectiveKeyLength";
+            internal const string BCRYPT_HASH_LENGTH = "HashDigestLength";
         }
     }
 }

--- a/src/Common/src/Interop/Windows/BCrypt/RC2BCryptModes.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/RC2BCryptModes.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security.Cryptography;
+using Internal.NativeCrypto;
+
+namespace Internal.Cryptography
+{
+    internal static class RC2BCryptModes
+    {
+        private static readonly SafeAlgorithmHandle s_hAlgCbc = OpenRC2Algorithm(Cng.BCRYPT_CHAIN_MODE_CBC);
+        private static readonly SafeAlgorithmHandle s_hAlgEcb = OpenRC2Algorithm(Cng.BCRYPT_CHAIN_MODE_ECB);
+
+        internal static SafeAlgorithmHandle GetSharedHandle(CipherMode cipherMode)
+        {
+            // Windows 8 added support to set the CipherMode value on a key,
+            // but Windows 7 requires that it be set on the algorithm before key creation.
+            switch (cipherMode)
+            {
+                case CipherMode.CBC:
+                    return s_hAlgCbc;
+                case CipherMode.ECB:
+                    return s_hAlgEcb;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        private static SafeAlgorithmHandle OpenRC2Algorithm(string cipherMode)
+        {
+            SafeAlgorithmHandle hAlg = Cng.BCryptOpenAlgorithmProvider(Cng.BCRYPT_RC2_ALGORITHM, null, Cng.OpenAlgorithmProviderFlags.NONE);
+            hAlg.SetCipherMode(cipherMode);
+
+            return hAlg;
+        }
+    }
+}

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherTests.cs
@@ -1,0 +1,229 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.Des.Tests
+{
+    public static class DesCipherTests
+    {
+        // These are the expected output of many decryptions. Changing these values requires re-generating test input.
+        private static readonly string s_multiBlockString = new ASCIIEncoding().GetBytes(
+            "This is a sentence that is longer than a block, it ensures that multi-block functions work.").ByteArrayToHex();
+        private static readonly string s_multiBlockStringPaddedZeros =
+             "5468697320697320612073656E74656E63652074686174206973206C6F6E676572207468616E206120626C6F636B2C20" +
+             "697420656E73757265732074686174206D756C74692D626C6F636B2066756E6374696F6E7320776F726B2E0000000000";
+        private static readonly string s_multiBlockString_8 = new ASCIIEncoding().GetBytes(
+            "This is a sentence that is longer than a block,but exactly an even block multiplier of 8").ByteArrayToHex();
+        private static readonly string s_randomKey_64 = "87FF0737F868378F";
+        private static readonly string s_randomIv_64 = "E531E789E3E1BB6F";
+
+        public static IEnumerable<object[]> DesTestData
+        {
+            get
+            {
+                // FIPS81 ECB with plaintext "Now is the time for all "
+                yield return new object[]
+                {
+                    CipherMode.ECB,
+                    PaddingMode.None,
+                    "0123456789abcdef",
+                    null,
+                    "4e6f77206973207468652074696d6520666f7220616c6c20",
+                    null,
+                    "3fa40e8a984d48156a271787ab8883f9893d51ec4b563b53"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.ECB,
+                    PaddingMode.None,
+                    s_randomKey_64,
+                    null,
+                    s_multiBlockString_8,
+                    null,
+                    "4E42A439ED50C7998CD626B8BE1ECC0A82B985EA772030E87C96BFAE1B97A7666505B8AE96745DE2921F6868897C20F2" +
+                    "BC8C7B284FD1E9A0A2E49DDAB7A3978233423377C88177CB2D92475EE4DC1FF9E6DFA135DE648E1B"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.ECB,
+                    PaddingMode.PKCS7,
+                    s_randomKey_64,
+                    null,
+                    s_multiBlockString,
+                    null,
+                    "4E42A439ED50C7998CD626B8BE1ECC0A82B985EA772030E87C96BFAE1B97A7666505B8AE96745DE249C1EC3338BBAD41" +
+                    "93A9B792205F345E22D45A9A996F21CE24697E5A45F600E8C6E71FC7114A3E96EC4EACC9F652DEBC679D22DE7141F67F"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.ECB,
+                    PaddingMode.Zeros,
+                    s_randomKey_64,
+                    null,
+                    s_multiBlockString,
+                    s_multiBlockStringPaddedZeros,
+                    "4E42A439ED50C7998CD626B8BE1ECC0A82B985EA772030E87C96BFAE1B97A7666505B8AE96745DE249C1EC3338BBAD41" +
+                    "93A9B792205F345E22D45A9A996F21CE24697E5A45F600E8C6E71FC7114A3E96EC4EACC9F652DEBC471DF9564F29C738"
+                };
+
+                // FIPS81 CBC with plaintext "Now is the time for all "
+                yield return new object[]
+                {
+                    CipherMode.CBC,
+                    PaddingMode.None,
+                    "0123456789abcdef",
+                    "1234567890abcdef",
+                    "4e6f77206973207468652074696d6520666f7220616c6c20",
+                    null,
+                    "e5c7cdde872bf27c43e934008c389c0f683788499a7c05f6"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.CBC,
+                    PaddingMode.None,
+                    s_randomKey_64,
+                    s_randomIv_64,
+                    s_multiBlockString_8,
+                    null,
+                    "7264319AE3C504148CD4A19B4FDC7D2ACCCB0A08D60CBE2B885DCB2C1A86ED9CA51006E33859B03EEB61CF5219D769C1" +
+                    "ABF1A1FDE0EF87D3B3C4D567D9C8960DDA55DBE13341928FEF38B938E1F62FAD1D05E355E440E012"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.CBC,
+                    PaddingMode.Zeros,
+                    s_randomKey_64,
+                    s_randomIv_64,
+                    s_multiBlockString,
+                    s_multiBlockStringPaddedZeros,
+                    "7264319AE3C504148CD4A19B4FDC7D2ACCCB0A08D60CBE2B885DCB2C1A86ED9CA51006E33859B03E00F5B57801EFF745" +
+                    "F7A577842461CF39AC143505EC326233E66343A46FEADE9E8456D8AC6A84A1C32E6792857F062400740CB21A333D334D"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.CBC,
+                    PaddingMode.PKCS7,
+                    s_randomKey_64,
+                    s_randomIv_64,
+                    s_multiBlockString,
+                    null,
+                    "7264319AE3C504148CD4A19B4FDC7D2ACCCB0A08D60CBE2B885DCB2C1A86ED9CA51006E33859B03E00F5B57801EFF745" +
+                    "F7A577842461CF39AC143505EC326233E66343A46FEADE9E8456D8AC6A84A1C32E6792857F062400EA9053D17AD3C35D"
+                };
+            }
+        }
+
+        [Theory, MemberData(nameof(DesTestData))]
+        public static void DesRoundTrip(CipherMode cipherMode, PaddingMode paddingMode, string key, string iv, string textHex, string expectedDecrypted, string expectedEncrypted)
+        {
+            byte[] expectedDecryptedBytes = expectedDecrypted == null ? textHex.HexToByteArray() : expectedDecrypted.HexToByteArray();
+            byte[] expectedEncryptedBytes = expectedEncrypted.HexToByteArray();
+            byte[] keyBytes = key.HexToByteArray();
+
+            using (DES alg = DESFactory.Create())
+            {
+                alg.Key = keyBytes;
+                alg.Padding = paddingMode;
+                alg.Mode = cipherMode;
+                if (iv != null)
+                    alg.IV = iv.HexToByteArray();
+
+                byte[] cipher = alg.Encrypt(textHex.HexToByteArray());
+                Assert.Equal<byte>(expectedEncryptedBytes, cipher);
+
+                byte[] decrypted = alg.Decrypt(cipher);
+                Assert.Equal<byte>(expectedDecryptedBytes, decrypted);
+            }
+        }
+
+        [Fact]
+        public static void DesReuseEncryptorDecryptor()
+        {
+            using (DES alg = DESFactory.Create())
+            {
+                alg.Key = s_randomKey_64.HexToByteArray();
+                alg.IV = s_randomIv_64.HexToByteArray();
+                alg.Padding = PaddingMode.PKCS7;
+                alg.Mode = CipherMode.CBC;
+
+                using (ICryptoTransform encryptor = alg.CreateEncryptor())
+                using (ICryptoTransform decryptor = alg.CreateDecryptor())
+                {
+                    for (int i = 0; i < 2; i++)
+                    {
+                        byte[] plainText1 = s_multiBlockString.HexToByteArray();
+                        byte[] cipher1 = encryptor.Transform(plainText1);
+                        byte[] expectedCipher1 = (
+                            "7264319AE3C504148CD4A19B4FDC7D2ACCCB0A08D60CBE2B885DCB2C1A86ED9CA51006E33859B03E00F5B57801EFF745" +
+                            "F7A577842461CF39AC143505EC326233E66343A46FEADE9E8456D8AC6A84A1C32E6792857F062400EA9053D17AD3C35D").HexToByteArray();
+                        Assert.Equal<byte>(expectedCipher1, cipher1);
+
+                        byte[] decrypted1 = decryptor.Transform(cipher1);
+                        byte[] expectedDecrypted1 = s_multiBlockString.HexToByteArray();
+                        Assert.Equal<byte>(expectedDecrypted1, decrypted1);
+
+                        byte[] plainText2 = s_multiBlockString_8.HexToByteArray();
+                        byte[] cipher2 = encryptor.Transform(plainText2);
+                        byte[] expectedCipher2 = (
+                            "7264319AE3C504148CD4A19B4FDC7D2ACCCB0A08D60CBE2B885DCB2C1A86ED9CA51006E33859B03EEB61CF5219D769C1" +
+                            "ABF1A1FDE0EF87D3B3C4D567D9C8960DDA55DBE13341928FEF38B938E1F62FAD1D05E355E440E012A0FFAB00B7AEE64D").HexToByteArray();
+                        Assert.Equal<byte>(expectedCipher2, cipher2);
+
+                        byte[] decrypted2 = decryptor.Transform(cipher2);
+                        byte[] expectedDecrypted2 = s_multiBlockString_8.HexToByteArray();
+                        Assert.Equal<byte>(expectedDecrypted2, decrypted2);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public static void DesExplicitEncryptorDecryptor_WithIV()
+        {
+            using (DES alg = DESFactory.Create())
+            {
+                alg.Padding = PaddingMode.PKCS7;
+                alg.Mode = CipherMode.CBC;
+                using (ICryptoTransform encryptor = alg.CreateEncryptor(s_randomKey_64.HexToByteArray(), s_randomIv_64.HexToByteArray()))
+                {
+                    byte[] plainText1 = s_multiBlockString.HexToByteArray();
+                    byte[] cipher1 = encryptor.Transform(plainText1);
+                    byte[] expectedCipher1 = (
+                        "7264319AE3C504148CD4A19B4FDC7D2ACCCB0A08D60CBE2B885DCB2C1A86ED9CA51006E33859B03E00F5B57801EFF745" +
+                        "F7A577842461CF39AC143505EC326233E66343A46FEADE9E8456D8AC6A84A1C32E6792857F062400EA9053D17AD3C35D").HexToByteArray();
+                    Assert.Equal<byte>(expectedCipher1, cipher1);
+                }
+            }
+        }
+
+        [Fact]
+        public static void DesExplicitEncryptorDecryptor_NoIV()
+        {
+            using (DES alg = DESFactory.Create())
+            {
+                alg.Padding = PaddingMode.PKCS7;
+                alg.Mode = CipherMode.ECB;
+                using (ICryptoTransform encryptor = alg.CreateEncryptor(s_randomKey_64.HexToByteArray(), null))
+                {
+                    byte[] plainText1 = s_multiBlockString.HexToByteArray();
+                    byte[] cipher1 = encryptor.Transform(plainText1);
+                    byte[] expectedCipher1 = (
+                        "4E42A439ED50C7998CD626B8BE1ECC0A82B985EA772030E87C96BFAE1B97A7666505B8AE96745DE249C1EC3338BBAD41" +
+                        "93A9B792205F345E22D45A9A996F21CE24697E5A45F600E8C6E71FC7114A3E96EC4EACC9F652DEBC679D22DE7141F67F").HexToByteArray();
+                    Assert.Equal<byte>(expectedCipher1, cipher1);
+                }
+            }
+        }
+    }
+}

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESFactory.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Encryption.Des.Tests
+{
+    public interface IDESProvider
+    {
+        DES Create();
+    }
+
+    public static partial class DESFactory
+    {
+        public static DES Create()
+        {
+            return s_provider.Create();
+        }
+    }
+}

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DesTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DesTests.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.Des.Tests
+{
+    public static partial class DesTests
+    {
+        private static readonly byte[] KnownWeakKey = "e0e0e0e0f1f1f1f1".HexToByteArray();
+        private static readonly byte[] KnownSemiWeakKey = "1f011f010e010e01".HexToByteArray();
+        private static readonly byte[] KnownGoodKey = "87FF0737F868378F".HexToByteArray();
+        private static readonly byte[] KnownShortKey = "00".HexToByteArray();
+
+        [Fact]
+        public static void DesDefaultCtor()
+        {
+            using (DES des = DESFactory.Create())
+            {
+                Assert.Equal(64, des.KeySize);
+                Assert.Equal(64, des.BlockSize);
+                Assert.Equal(CipherMode.CBC, des.Mode);
+                Assert.Equal(PaddingMode.PKCS7, des.Padding);
+            }
+        }
+
+        [Fact]
+        public static void DesKeysValidation()
+        {
+            Assert.True(DES.IsWeakKey(KnownWeakKey));
+            Assert.False(DES.IsWeakKey(KnownGoodKey));
+            Assert.Throws<CryptographicException>(() => DES.IsWeakKey(null));
+            Assert.Throws<CryptographicException>(() => DES.IsWeakKey(KnownShortKey));
+
+            Assert.True(DES.IsSemiWeakKey(KnownSemiWeakKey));
+            Assert.False(DES.IsSemiWeakKey(KnownGoodKey));
+            Assert.Throws<CryptographicException>(() => DES.IsSemiWeakKey(null));
+            Assert.Throws<CryptographicException>(() => DES.IsSemiWeakKey(KnownShortKey));
+
+            using (DES des = DESFactory.Create())
+            {
+                Assert.Throws<ArgumentException>(() => des.Key = KnownShortKey);
+                Assert.Throws<CryptographicException>(() => des.Key = KnownSemiWeakKey);
+                Assert.Throws<ArgumentNullException>("value", () => des.Key = null);
+
+                des.Key = KnownGoodKey;
+                Assert.Equal(KnownGoodKey, des.Key);
+            }
+        }
+
+        [Fact]
+        public static void DESKeySizeValidation()
+        {
+            using (DES des = DESFactory.Create())
+            {
+                des.KeySize = 64;
+                Assert.Equal(64, des.KeySize);
+
+                Assert.Throws<CryptographicException>(() => des.KeySize = 64 - 8);
+                Assert.Throws<CryptographicException>(() => des.KeySize = 64 + 8);
+            }
+        }
+
+        [Fact]
+        public static void DESBlockSizeValidation()
+        {
+            using (DES des = DESFactory.Create())
+            {
+                des.BlockSize = 64;
+                Assert.Equal(64, des.BlockSize);
+
+                Assert.Throws<CryptographicException>(() => des.BlockSize = 63);
+                Assert.Throws<CryptographicException>(() => des.BlockSize = 65);
+            }
+        }
+
+        [Fact]
+        public static void DesTransformBlockValidation()
+        {
+            using (DES des = DESFactory.Create())
+            {
+                Assert.Throws<ArgumentException>("rgbKey", () => des.CreateDecryptor(KnownShortKey, des.IV));
+                Assert.Throws<ArgumentNullException>("rgbKey", () => des.CreateDecryptor(null, des.IV));
+                Assert.Throws<CryptographicException>(() => des.CreateDecryptor(KnownWeakKey, des.IV));
+                Assert.Throws<CryptographicException>(() => des.CreateDecryptor(KnownSemiWeakKey, des.IV));
+
+                Assert.Throws<ArgumentException>("rgbKey", () => des.CreateEncryptor(KnownShortKey, des.IV));
+                Assert.Throws<ArgumentNullException>("rgbKey", () => des.CreateEncryptor(null, des.IV));
+                Assert.Throws<CryptographicException>(() => des.CreateEncryptor(KnownWeakKey, des.IV));
+                Assert.Throws<CryptographicException>(() => des.CreateEncryptor(KnownSemiWeakKey, des.IV));
+            }
+        }
+    }
+}

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
@@ -1,0 +1,245 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.RC2.Tests
+{
+    using RC2 = System.Security.Cryptography.RC2;
+
+    public static class RC2CipherTests
+    {
+        // These are the expected output of many decryptions. Changing these values requires re-generating test input.
+        private static readonly string s_multiBlockString = new ASCIIEncoding().GetBytes(
+            "This is a sentence that is longer than a block, it ensures that multi-block functions work.").ByteArrayToHex();
+        private static readonly string s_multiBlockString_8 = new ASCIIEncoding().GetBytes(
+            "This is a sentence that is longer than a block,but exactly an even block multiplier of 8").ByteArrayToHex();
+        private static readonly string s_multiBlockStringPaddedZeros =
+            "5468697320697320612073656E74656E63652074686174206973206C6F6E676572207468616E206120626C6F636B2C20" +
+            "697420656E73757265732074686174206D756C74692D626C6F636B2066756E6374696F6E7320776F726B2E0000000000";
+
+        private static readonly string s_randomKey_64 = "87FF0737F868378F";
+        private static readonly string s_randomIv_64 = "E531E789E3E1BB6F";
+
+        public static IEnumerable<object[]> RC2TestData
+        {
+            get
+            {
+                // RFC 2268 test
+                yield return new object[]
+                {
+                    CipherMode.ECB,
+                    PaddingMode.None,
+                    "3000000000000000",
+                    null,
+                    "1000000000000001",
+                    null,
+                    "30649EDF9BE7D2C2"
+                };
+
+                // RFC 2268 test
+                yield return new object[]
+                {
+                    CipherMode.ECB,
+                    PaddingMode.None,
+                    "FFFFFFFFFFFFFFFF",
+                    null,
+                    "FFFFFFFFFFFFFFFF",
+                    null,
+                    "278B27E42E2F0D49"
+                };
+
+                // RFC 2268 test
+                yield return new object[]
+                {
+                    CipherMode.ECB,
+                    PaddingMode.None,
+                    "88bca90e90875a7f0f79c384627bafb2",
+                    null,
+                    "0000000000000000",
+                    null,
+                    "2269552ab0f85ca6"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.ECB,
+                    PaddingMode.None,
+                    s_randomKey_64,
+                    null,
+                    s_multiBlockString_8,
+                    null,
+                    "F6DF2E83811D6CB0C8A5830069D16F6A51C985D7003852539051FABC3C6EA7CF46BD3DBD5527003A13BC850E32BB598F" +
+                    "1AC96E96401EBBCDAEEF21D6C05B8DF2637B938CFDB8814B3CC47E30640BD0396B2AC6D7D9977499"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.ECB,
+                    PaddingMode.PKCS7,
+                    s_randomKey_64,
+                    null,
+                    s_multiBlockString,
+                    null,
+                    "F6DF2E83811D6CB0C8A5830069D16F6A51C985D7003852539051FABC3C6EA7CF46BD3DBD5527003A789B76CBE4D40A73" +
+                    "620F04ED9F0AA1AEC7FEC90E7934F69E0568F6DF1F38B2198821D0A771D68A3F8220C8822E387721AEB21E183555CE07"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.ECB,
+                    PaddingMode.Zeros,
+                    s_randomKey_64,
+                    null,
+                    s_multiBlockString,
+                    s_multiBlockStringPaddedZeros,
+                    "F6DF2E83811D6CB0C8A5830069D16F6A51C985D7003852539051FABC3C6EA7CF46BD3DBD5527003A789B76CBE4D40A73" +
+                    "620F04ED9F0AA1AEC7FEC90E7934F69E0568F6DF1F38B2198821D0A771D68A3F8220C8822E387721C669B2B62A6BF492"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.CBC,
+                    PaddingMode.None,
+                    s_randomKey_64,
+                    s_randomIv_64,
+                    s_multiBlockString_8,
+                    null,
+                    "85B5D998F35ECD98DB886798170F64BA2DBA4FE902791CDE900EEB0B35728FEE35FB6CADC41DF67F6056044F15B5C7ED" +
+                    "4FAB086053D7DC458C206145AE9655F1590C590FBDE76365FA488CADBCDA67B325A35E7CCBC1B9A1"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.CBC,
+                    PaddingMode.PKCS7,
+                    s_randomKey_64,
+                    s_randomIv_64,
+                    s_multiBlockString,
+                    null,
+                    "85B5D998F35ECD98DB886798170F64BA2DBA4FE902791CDE900EEB0B35728FEE35FB6CADC41DF67FBB691B45D92B876A" +
+                    "13FD18229E5ACB797D21D7B257520910360E00FEECDE3433FDC6F15233AE6B5CAC01289AC8B57A9A6B5DA734C2E7E733"
+                };
+
+                yield return new object[]
+                {
+                    CipherMode.CBC,
+                    PaddingMode.Zeros,
+                    s_randomKey_64,
+                    s_randomIv_64,
+                    s_multiBlockString,
+                    s_multiBlockStringPaddedZeros,
+                    "85B5D998F35ECD98DB886798170F64BA2DBA4FE902791CDE900EEB0B35728FEE35FB6CADC41DF67FBB691B45D92B876A" +
+                    "13FD18229E5ACB797D21D7B257520910360E00FEECDE3433FDC6F15233AE6B5CAC01289AC8B57A9A6A1BB012ED20DADA"
+                };
+
+            }
+        }
+
+        [Theory, MemberData(nameof(RC2TestData))]
+        public static void RC2RoundTrip(CipherMode cipherMode, PaddingMode paddingMode, string key, string iv, string textHex, string expectedDecrypted, string expectedEncrypted)
+        {
+            byte[] expectedDecryptedBytes = expectedDecrypted == null ? textHex.HexToByteArray() : expectedDecrypted.HexToByteArray();
+            byte[] expectedEncryptedBytes = expectedEncrypted.HexToByteArray();
+            byte[] keyBytes = key.HexToByteArray();
+
+            using (RC2 alg = RC2Factory.Create())
+            {
+                alg.Key = keyBytes;
+                alg.Padding = paddingMode;
+                alg.Mode = cipherMode;
+                if (iv != null)
+                    alg.IV = iv.HexToByteArray();
+
+                byte[] cipher = alg.Encrypt(textHex.HexToByteArray());
+                Assert.Equal<byte>(expectedEncryptedBytes, cipher);
+
+                byte[] decrypted = alg.Decrypt(cipher);
+                Assert.Equal<byte>(expectedDecryptedBytes, decrypted);
+            }
+        }
+
+        [Fact]
+        public static void RC2ReuseEncryptorDecryptor()
+        {
+            using (RC2 alg = RC2Factory.Create())
+            {
+                alg.Key = s_randomKey_64.HexToByteArray();
+                alg.IV = s_randomIv_64.HexToByteArray();
+                alg.Padding = PaddingMode.PKCS7;
+                alg.Mode = CipherMode.CBC;
+
+                using (ICryptoTransform encryptor = alg.CreateEncryptor())
+                using (ICryptoTransform decryptor = alg.CreateDecryptor())
+                {
+                    for (int i = 0; i < 2; i++)
+                    {
+                        byte[] plainText1 = s_multiBlockString.HexToByteArray();
+                        byte[] cipher1 = encryptor.Transform(plainText1);
+                        byte[] expectedCipher1 = (
+                            "85B5D998F35ECD98DB886798170F64BA2DBA4FE902791CDE900EEB0B35728FEE35FB6CADC41DF67FBB691B45D92B876A" +
+                            "13FD18229E5ACB797D21D7B257520910360E00FEECDE3433FDC6F15233AE6B5CAC01289AC8B57A9A6B5DA734C2E7E733").HexToByteArray();
+                        Assert.Equal<byte>(expectedCipher1, cipher1);
+
+                        byte[] decrypted1 = decryptor.Transform(cipher1);
+                        byte[] expectedDecrypted1 = s_multiBlockString.HexToByteArray();
+                        Assert.Equal<byte>(expectedDecrypted1, decrypted1);
+
+                        byte[] plainText2 = s_multiBlockString_8.HexToByteArray();
+                        byte[] cipher2 = encryptor.Transform(plainText2);
+                        byte[] expectedCipher2 = (
+                            "85B5D998F35ECD98DB886798170F64BA2DBA4FE902791CDE900EEB0B35728FEE35FB6CADC41DF67F6056044F15B5C7ED" +
+                            "4FAB086053D7DC458C206145AE9655F1590C590FBDE76365FA488CADBCDA67B325A35E7CCBC1B9A15E5EBE2879C7AEC2").HexToByteArray();
+                        Assert.Equal<byte>(expectedCipher2, cipher2);
+
+                        byte[] decrypted2 = decryptor.Transform(cipher2);
+                        byte[] expectedDecrypted2 = s_multiBlockString_8.HexToByteArray();
+                        Assert.Equal<byte>(expectedDecrypted2, decrypted2);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public static void RC2ExplicitEncryptorDecryptor_WithIV()
+        {
+            using (RC2 alg = RC2Factory.Create())
+            {
+                alg.Padding = PaddingMode.PKCS7;
+                alg.Mode = CipherMode.CBC;
+                using (ICryptoTransform encryptor = alg.CreateEncryptor(s_randomKey_64.HexToByteArray(), s_randomIv_64.HexToByteArray()))
+                {
+                    byte[] plainText1 = s_multiBlockString.HexToByteArray();
+                    byte[] cipher1 = encryptor.Transform(plainText1);
+                    byte[] expectedCipher1 = (
+                        "85B5D998F35ECD98DB886798170F64BA2DBA4FE902791CDE900EEB0B35728FEE35FB6CADC41DF67FBB691B45D92B876A" +
+                        "13FD18229E5ACB797D21D7B257520910360E00FEECDE3433FDC6F15233AE6B5CAC01289AC8B57A9A6B5DA734C2E7E733").HexToByteArray();
+                    Assert.Equal<byte>(expectedCipher1, cipher1);
+                }
+            }
+        }
+
+        [Fact]
+        public static void RC2ExplicitEncryptorDecryptor_NoIV()
+        {
+            using (RC2 alg = RC2Factory.Create())
+            {
+                alg.Padding = PaddingMode.PKCS7;
+                alg.Mode = CipherMode.ECB;
+                using (ICryptoTransform encryptor = alg.CreateEncryptor(s_randomKey_64.HexToByteArray(), null))
+                {
+                    byte[] plainText1 = s_multiBlockString.HexToByteArray();
+                    byte[] cipher1 = encryptor.Transform(plainText1);
+                    byte[] expectedCipher1 = (
+                        "F6DF2E83811D6CB0C8A5830069D16F6A51C985D7003852539051FABC3C6EA7CF46BD3DBD5527003A789B76CBE4D40A73" +
+                        "620F04ED9F0AA1AEC7FEC90E7934F69E0568F6DF1F38B2198821D0A771D68A3F8220C8822E387721AEB21E183555CE07").HexToByteArray();
+                    Assert.Equal<byte>(expectedCipher1, cipher1);
+                }
+            }
+        }
+    }
+}

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2Factory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2Factory.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Encryption.RC2.Tests
+{
+    using RC2 = System.Security.Cryptography.RC2;
+
+    public interface IRC2Provider
+    {
+        RC2 Create();
+    }
+
+    public static partial class RC2Factory
+    {
+        public static RC2 Create()
+        {
+            return s_provider.Create();
+        }
+    }
+}

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2Tests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2Tests.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.RC2.Tests
+{
+    using RC2 = System.Security.Cryptography.RC2;
+
+    public static partial class RC2Tests
+    {
+        [Fact]
+        public static void RC2DefaultCtor()
+        {
+            using (RC2 rc2 = RC2Factory.Create())
+            {
+                Assert.Equal(128, rc2.KeySize);
+                Assert.Equal(64, rc2.BlockSize);
+                Assert.Equal(CipherMode.CBC, rc2.Mode);
+                Assert.Equal(PaddingMode.PKCS7, rc2.Padding);
+            }
+        }
+
+        [Fact]
+        public static void RC2Blockize()
+        {
+            using (RC2 rc2 = RC2Factory.Create())
+            {
+                rc2.BlockSize = 64;
+                Assert.Equal(64, rc2.BlockSize);
+
+                Assert.Throws<CryptographicException>(() => rc2.BlockSize = 64 - 1);
+                Assert.Throws<CryptographicException>(() => rc2.BlockSize = 64 + 1);
+            }
+        }
+
+        [Fact]
+        public static void RC2EffectiveKeySize()
+        {
+            using (RC2 rc2 = RC2Factory.Create())
+            {
+                rc2.KeySize = 40;
+                Assert.Equal(40, rc2.EffectiveKeySize);
+                rc2.EffectiveKeySize = 40;
+
+                // KeySize must equal EffectiveKeySize
+                rc2.KeySize = 48;
+                Assert.Throws<CryptographicUnexpectedOperationException>(() => rc2.EffectiveKeySize = 48 + 8);
+                Assert.Throws<CryptographicUnexpectedOperationException>(() => rc2.EffectiveKeySize = 48 - 8);
+                Assert.Throws<CryptographicUnexpectedOperationException>(() => rc2.EffectiveKeySize = 0);
+            }
+        }
+    }
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.cpp
@@ -10,7 +10,9 @@ static_assert(PAL_OperationEncrypt == kCCEncrypt, "");
 static_assert(PAL_OperationDecrypt == kCCDecrypt, "");
 
 static_assert(PAL_AlgorithmAES == kCCAlgorithmAES128, "");
+static_assert(PAL_AlgorithmDES == kCCAlgorithmDES, "");
 static_assert(PAL_Algorithm3DES == kCCAlgorithm3DES, "");
+static_assert(PAL_AlgorithmRC2 == kCCAlgorithmRC2, "");
 
 static_assert(PAL_ChainingModeECB == kCCModeECB, "");
 static_assert(PAL_ChainingModeCBC == kCCModeCBC, "");
@@ -51,7 +53,8 @@ extern "C" int AppleCryptoNative_CryptorCreate(PAL_SymmetricOperation operation,
 
     // Ensure we aren't passing through things we don't understand
     assert(operation == PAL_OperationEncrypt || operation == PAL_OperationDecrypt);
-    assert(algorithm == PAL_AlgorithmAES || algorithm == PAL_Algorithm3DES);
+    assert(algorithm == PAL_AlgorithmAES || algorithm == PAL_AlgorithmDES ||
+           algorithm == PAL_Algorithm3DES || algorithm == PAL_AlgorithmRC2);
     assert(chainingMode == PAL_ChainingModeECB || chainingMode == PAL_ChainingModeCBC);
     assert(paddingMode == PAL_PaddingModeNone || paddingMode == PAL_PaddingModePkcs7);
     assert(options == 0);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.h
@@ -19,7 +19,9 @@ typedef uint32_t PAL_SymmetricOperation;
 enum
 {
     PAL_AlgorithmAES = 0,
+    PAL_AlgorithmDES = 1,
     PAL_Algorithm3DES = 2,
+    PAL_AlgorithmRC2 = 5,
 };
 typedef uint32_t PAL_SymmetricAlgorithm;
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.h
@@ -18,6 +18,8 @@ Returns new EVP_CIPHER_CTX on success, nullptr on failure.
 extern "C" EVP_CIPHER_CTX*
 CryptoNative_EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char* iv, int32_t enc);
 
+extern "C" EVP_CIPHER_CTX*
+CryptoNative_EvpCipherCreate2(const EVP_CIPHER* type, uint8_t* key, int32_t keyLength, int32_t effectiveKeyLength, unsigned char* iv, int32_t enc);
 /*
 Cleans up and deletes an EVP_CIPHER_CTX instance created by EvpCipherCreate.
 
@@ -127,3 +129,35 @@ EvpDes3Cbc
 Direct shim to EVP_des_ede3_cbc.
 */
 extern "C" const EVP_CIPHER* CryptoNative_EvpDes3Cbc();
+
+/*
+Function:
+EvpDesEcb
+
+Direct shim to EVP_des_ecb.
+*/
+extern "C" const EVP_CIPHER* CryptoNative_EvpDesEcb();
+
+/*
+Function:
+EvpDesCbc
+
+Direct shim to EVP_des_ede_cbc.
+*/
+extern "C" const EVP_CIPHER* CryptoNative_EvpDesCbc();
+
+/*
+Function:
+EvpRC2Ecb
+
+Direct shim to EVP_rc2_ecb.
+*/
+extern "C" const EVP_CIPHER* CryptoNative_EvpRC2Ecb();
+
+/*
+Function:
+EvpRC2Cbc
+
+Direct shim to EVP_des_rc2_cbc.
+*/
+extern "C" const EVP_CIPHER* CryptoNative_EvpRC2Cbc();

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -54,6 +54,15 @@ namespace System.Security.Cryptography
         public abstract byte[] GetBytes(int cb);
         public abstract void Reset();
     }
+    [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+    public abstract partial class DES : System.Security.Cryptography.SymmetricAlgorithm
+    {
+        protected DES() { }
+        public override byte[] Key { get { return default(byte[]); } set { } }
+        public static System.Security.Cryptography.DES Create() { return default(System.Security.Cryptography.DES); }
+        public static bool IsSemiWeakKey(byte[] rgbKey) { return default(bool); }
+        public static bool IsWeakKey(byte[] rgbKey) { return default(bool); }
+    }
     public abstract partial class DSA : System.Security.Cryptography.AsymmetricAlgorithm
     {
         protected DSA() { }
@@ -274,6 +283,15 @@ namespace System.Security.Cryptography
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public abstract void GetBytes(byte[] data);
+    }
+    [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+    public abstract partial class RC2 : System.Security.Cryptography.SymmetricAlgorithm
+    {
+        protected int EffectiveKeySizeValue;
+        protected RC2() { }
+        public virtual int EffectiveKeySize { get { return default(int); } set { } }
+        public override int KeySize { get { return default(int); } set { } }
+        public static System.Security.Cryptography.RC2 Create() { return default(System.Security.Cryptography.RC2); }
     }
     public partial class Rfc2898DeriveBytes : System.Security.Cryptography.DeriveBytes
     {

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.Unix.cs
@@ -20,7 +20,7 @@ namespace Internal.Cryptography
             // The algorithm pointer is a static pointer, so not having any cleanup code is correct.
             IntPtr algorithm = GetAlgorithm(key.Length * 8, cipherMode);
 
-            BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, key, iv, encrypting);
+            BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, key, 0, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
 

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.OSX.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.OSX.cs
@@ -3,11 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Security.Cryptography;
-using Internal.NativeCrypto;
 
 namespace Internal.Cryptography
 {
-    internal partial class AesImplementation
+    partial class DesImplementation
     {
         private static ICryptoTransform CreateTransformCore(
             CipherMode cipherMode,
@@ -17,14 +16,15 @@ namespace Internal.Cryptography
             int blockSize,
             bool encrypting)
         {
-            SafeAlgorithmHandle algorithm = AesBCryptModes.GetSharedHandle(cipherMode);
+            BasicSymmetricCipher cipher = new AppleCCCryptor(
+                Interop.AppleCrypto.PAL_SymmetricAlgorithm.DES,
+                cipherMode,
+                blockSize,
+                key,
+                iv,
+                encrypting);
 
-            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, 0, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
-
-        // -----------------------------
-        // ---- PAL layer ends here ----
-        // -----------------------------
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Unix.cs
@@ -7,7 +7,7 @@ using System.Security.Cryptography;
 
 namespace Internal.Cryptography
 {
-    partial class TripleDesImplementation
+    partial class DesImplementation
     {
         private static ICryptoTransform CreateTransformCore(
             CipherMode cipherMode,
@@ -22,10 +22,10 @@ namespace Internal.Cryptography
             switch (cipherMode)
             {
                 case CipherMode.CBC:
-                    algorithm = Interop.Crypto.EvpDes3Cbc();
+                    algorithm = Interop.Crypto.EvpDesCbc();
                     break;
                 case CipherMode.ECB:
-                    algorithm = Interop.Crypto.EvpDes3Ecb();
+                    algorithm = Interop.Crypto.EvpDesEcb();
                     break;
                 default:
                     throw new NotSupportedException();
@@ -34,9 +34,5 @@ namespace Internal.Cryptography
             BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, key, 0, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
-
-        // -----------------------------
-        // ---- PAL layer ends here ----
-        // -----------------------------    
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Windows.cs
@@ -7,7 +7,7 @@ using Internal.NativeCrypto;
 
 namespace Internal.Cryptography
 {
-    internal partial class AesImplementation
+    partial class DesImplementation
     {
         private static ICryptoTransform CreateTransformCore(
             CipherMode cipherMode,
@@ -17,14 +17,10 @@ namespace Internal.Cryptography
             int blockSize,
             bool encrypting)
         {
-            SafeAlgorithmHandle algorithm = AesBCryptModes.GetSharedHandle(cipherMode);
+            SafeAlgorithmHandle algorithm = DesBCryptModes.GetSharedHandle(cipherMode);
 
             BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, 0, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
-
-        // -----------------------------
-        // ---- PAL layer ends here ----
-        // -----------------------------
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/OpenSslCipher.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/OpenSslCipher.cs
@@ -14,14 +14,14 @@ namespace Internal.Cryptography
         private readonly bool _encrypting;
         private SafeEvpCipherCtxHandle _ctx;
 
-        public OpenSslCipher(IntPtr algorithm, CipherMode cipherMode, int blockSizeInBytes, byte[] key, byte[] iv, bool encrypting)
+        public OpenSslCipher(IntPtr algorithm, CipherMode cipherMode, int blockSizeInBytes, byte[] key, int effectiveKeyLength, byte[] iv, bool encrypting)
             : base(cipherMode.GetCipherIv(iv), blockSizeInBytes)
         {
             Debug.Assert(algorithm != IntPtr.Zero);
 
             _encrypting = encrypting;
 
-            OpenKey(algorithm, key);
+            OpenKey(algorithm, key, effectiveKeyLength);
         }
 
         protected override void Dispose(bool disposing)
@@ -117,11 +117,13 @@ namespace Internal.Cryptography
             return bytesWritten;
         }
 
-        private void OpenKey(IntPtr algorithm, byte[] key)
+        private void OpenKey(IntPtr algorithm, byte[] key, int effectiveKeyLength)
         {
             _ctx = Interop.Crypto.EvpCipherCreate(
                 algorithm,
                 key,
+                key.Length * 8,
+                effectiveKeyLength,
                 IV,
                 _encrypting ? 1 : 0);
 

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.OSX.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.OSX.cs
@@ -3,28 +3,29 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Security.Cryptography;
-using Internal.NativeCrypto;
 
 namespace Internal.Cryptography
 {
-    internal partial class AesImplementation
+    partial class RC2Implementation
     {
         private static ICryptoTransform CreateTransformCore(
             CipherMode cipherMode,
             PaddingMode paddingMode,
             byte[] key,
+            int effectiveKeyLength,
             byte[] iv,
             int blockSize,
             bool encrypting)
         {
-            SafeAlgorithmHandle algorithm = AesBCryptModes.GetSharedHandle(cipherMode);
+            BasicSymmetricCipher cipher = new AppleCCCryptor(
+                Interop.AppleCrypto.PAL_SymmetricAlgorithm.RC2,
+                cipherMode,
+                blockSize,
+                key,
+                iv,
+                encrypting);
 
-            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, 0, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
-
-        // -----------------------------
-        // ---- PAL layer ends here ----
-        // -----------------------------
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.Unix.cs
@@ -3,16 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Security.Cryptography;
 
 namespace Internal.Cryptography
 {
-    partial class TripleDesImplementation
+    partial class RC2Implementation
     {
         private static ICryptoTransform CreateTransformCore(
             CipherMode cipherMode,
             PaddingMode paddingMode,
             byte[] key,
+            int effectiveKeyLength,
             byte[] iv,
             int blockSize,
             bool encrypting)
@@ -22,21 +24,17 @@ namespace Internal.Cryptography
             switch (cipherMode)
             {
                 case CipherMode.CBC:
-                    algorithm = Interop.Crypto.EvpDes3Cbc();
+                    algorithm = Interop.Crypto.EvpRC2Cbc();
                     break;
                 case CipherMode.ECB:
-                    algorithm = Interop.Crypto.EvpDes3Ecb();
+                    algorithm = Interop.Crypto.EvpRC2Ecb();
                     break;
                 default:
                     throw new NotSupportedException();
             }
 
-            BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, key, 0, iv, encrypting);
+            BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, key, effectiveKeyLength, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
-
-        // -----------------------------
-        // ---- PAL layer ends here ----
-        // -----------------------------    
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.Windows.cs
@@ -7,24 +7,21 @@ using Internal.NativeCrypto;
 
 namespace Internal.Cryptography
 {
-    internal partial class AesImplementation
+    partial class RC2Implementation
     {
         private static ICryptoTransform CreateTransformCore(
             CipherMode cipherMode,
             PaddingMode paddingMode,
             byte[] key,
+            int effectiveKeyLength,
             byte[] iv,
             int blockSize,
             bool encrypting)
         {
-            SafeAlgorithmHandle algorithm = AesBCryptModes.GetSharedHandle(cipherMode);
+            SafeAlgorithmHandle algorithm = RC2BCryptModes.GetSharedHandle(cipherMode);
 
-            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, 0, iv, encrypting);
+            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, effectiveKeyLength, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
-
-        // -----------------------------
-        // ---- PAL layer ends here ----
-        // -----------------------------
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.cs
@@ -8,18 +8,21 @@ using System.Security.Cryptography;
 namespace Internal.Cryptography
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350")]
-    internal sealed partial class TripleDesImplementation : TripleDES
+    internal sealed partial class RC2Implementation : RC2
     {
         private const int BitsPerByte = 8;
         private static readonly RandomNumberGenerator s_rng = RandomNumberGenerator.Create();
 
-        public override KeySizes[] LegalKeySizes
+        public override int EffectiveKeySize
         {
             get
             {
-                // CNG does not support 128-bit keys.
-                // Only support 192-bit keys on all platforms for simplicity.
-                return new KeySizes[] { new KeySizes(minSize: 3 * 64, maxSize: 3 * 64, skipSize: 0) };
+                return KeySizeValue;
+            }
+            set
+            {
+                if (value != KeySizeValue)
+                    throw new CryptographicUnexpectedOperationException(SR.Cryptography_RC2_EKSKS2);
             }
         }
 
@@ -75,7 +78,8 @@ namespace Internal.Cryptography
                     throw new ArgumentException(SR.Cryptography_InvalidIVSize, nameof(rgbIV));
             }
 
-            return CreateTransformCore(Mode, Padding, rgbKey, rgbIV, BlockSize / BitsPerByte, encrypting);
+            int effectiveKeySize = EffectiveKeySizeValue == 0 ? (int)keySize : EffectiveKeySize;
+            return CreateTransformCore(Mode, Padding, rgbKey, effectiveKeySize, rgbIV, BlockSize / BitsPerByte, encrypting);
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Windows.cs
@@ -19,7 +19,7 @@ namespace Internal.Cryptography
         {
             SafeAlgorithmHandle algorithm = TripleDesBCryptModes.GetSharedHandle(cipherMode);
 
-            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, iv, encrypting);
+            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, 0, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
 

--- a/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -249,6 +249,9 @@
   <data name="Cryptography_RC2_EKSKS" xml:space="preserve">
     <value>KeySize value must be at least as large as the EffectiveKeySize value.</value>
   </data>
+  <data name="Cryptography_RC2_EKSKS2" xml:space="preserve">
+    <value>EffectiveKeySize must be the same as KeySize in this implementation.</value>
+  </data>
   <data name="Cryptography_TransformBeyondEndOfBuffer" xml:space="preserve">
     <value>Attempt to transform beyond end of buffer.</value>
   </data>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -24,6 +24,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
+    <Compile Include="Internal\Cryptography\AesImplementation.cs" />
+    <Compile Include="Internal\Cryptography\DesImplementation.cs" />
+    <Compile Include="Internal\Cryptography\Helpers.cs" />
+    <Compile Include="Internal\Cryptography\HMACCommon.cs" />
+    <Compile Include="Internal\Cryptography\HashAlgorithmNames.cs" />
+    <Compile Include="Internal\Cryptography\RC2Implementation.cs" />
     <Compile Include="Internal\Cryptography\TripleDesImplementation.cs" />
     <Compile Include="System\Security\Cryptography\Aes.cs" />
     <Compile Include="System\Security\Cryptography\AsymmetricKeyExchangeDeformatter.cs" />
@@ -31,6 +37,7 @@
     <Compile Include="System\Security\Cryptography\AsymmetricSignatureDeformatter.cs" />
     <Compile Include="System\Security\Cryptography\AsymmetricSignatureFormatter.cs" />
     <Compile Include="System\Security\Cryptography\DeriveBytes.cs" />
+    <Compile Include="System\Security\Cryptography\DES.cs" />
     <Compile Include="System\Security\Cryptography\DSA.cs" />
     <Compile Include="System\Security\Cryptography\DSAParameters.cs" />
     <Compile Include="System\Security\Cryptography\DSASignatureDeformatter.cs" />
@@ -54,6 +61,7 @@
     <Compile Include="System\Security\Cryptography\HMACSHA512.cs" />
     <Compile Include="System\Security\Cryptography\IncrementalHash.cs" />
     <Compile Include="System\Security\Cryptography\RandomNumberGenerator.cs" />
+    <Compile Include="System\Security\Cryptography\RC2.cs" />
     <Compile Include="System\Security\Cryptography\Rfc2898DeriveBytes.cs" />
     <Compile Include="System\Security\Cryptography\RSA.cs" />
     <Compile Include="System\Security\Cryptography\RSAEncryptionPadding.cs" />
@@ -68,10 +76,6 @@
     <Compile Include="System\Security\Cryptography\RSASignaturePadding.cs" />
     <Compile Include="System\Security\Cryptography\RSASignaturePaddingMode.cs" />
     <Compile Include="System\Security\Cryptography\TripleDES.cs" />
-    <Compile Include="Internal\Cryptography\AesImplementation.cs" />
-    <Compile Include="Internal\Cryptography\Helpers.cs" />
-    <Compile Include="Internal\Cryptography\HMACCommon.cs" />
-    <Compile Include="Internal\Cryptography\HashAlgorithmNames.cs" />
     <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipher.cs">
       <Link>Internal\Cryptography\BasicSymmetricCipher.cs</Link>
     </Compile>
@@ -96,11 +100,13 @@
     <Compile Include="System\Security\Cryptography\RNGCryptoServiceProvider.Windows.cs" />
     <Compile Include="System\Security\Cryptography\RSACng.cs" />
     <Compile Include="Internal\Cryptography\AesImplementation.Windows.cs" />
+    <Compile Include="Internal\Cryptography\DesImplementation.Windows.cs" />
+    <Compile Include="Internal\Cryptography\HashProviderDispenser.Windows.cs" />
+    <Compile Include="Internal\Cryptography\RC2Implementation.Windows.cs" />
+    <Compile Include="Internal\Cryptography\TripleDesImplementation.Windows.cs" />
     <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipherBCrypt.cs">
       <Link>Internal\Cryptography\BasicSymmetricCipherBCrypt.cs</Link>
     </Compile>
-    <Compile Include="Internal\Cryptography\HashProviderDispenser.Windows.cs" />
-    <Compile Include="Internal\Cryptography\TripleDesImplementation.Windows.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
@@ -151,6 +157,12 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\BCryptAlgorithmCache.cs">
       <Link>Internal\Windows\BCrypt\BCryptAlgorithmCache.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\DESBCryptModes.cs">
+      <Link>Common\Interop\Windows\BCrypt\DESBCryptModes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\RC2BCryptModes.cs">
+      <Link>Common\Interop\Windows\BCrypt\RC2BCryptModes.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\TripleDesBCryptModes.cs">
       <Link>Common\Interop\Windows\BCrypt\TripleDesBCryptModes.cs</Link>
@@ -275,8 +287,10 @@
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs</Link>
     </Compile>
     <Compile Include="Internal\Cryptography\AesImplementation.Unix.cs" />
+    <Compile Include="Internal\Cryptography\DesImplementation.Unix.cs" />
     <Compile Include="Internal\Cryptography\HashProviderDispenser.Unix.cs" />
     <Compile Include="Internal\Cryptography\OpenSslCipher.cs" />
+    <Compile Include="Internal\Cryptography\RC2Implementation.Unix.cs" />
     <Compile Include="Internal\Cryptography\TripleDesImplementation.Unix.cs" />
     <Compile Include="System\Security\Cryptography\RNGCryptoServiceProvider.Unix.cs" />
   </ItemGroup>
@@ -304,7 +318,9 @@
     </Compile>
     <Compile Include="Internal\Cryptography\AesImplementation.OSX.cs" />
     <Compile Include="Internal\Cryptography\AppleCCCryptor.cs" />
+    <Compile Include="Internal\Cryptography\DesImplementation.OSX.cs" />
     <Compile Include="Internal\Cryptography\HashProviderDispenser.OSX.cs" />
+    <Compile Include="Internal\Cryptography\RC2Implementation.OSX.cs" />
     <Compile Include="Internal\Cryptography\TripleDesImplementation.OSX.cs" />
     <Compile Include="System\Security\Cryptography\RNGCryptoServiceProvider.OSX.cs" />
   </ItemGroup>

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DES.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DES.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Cryptography;
+using System.ComponentModel;
+
+namespace System.Security.Cryptography
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class DES : SymmetricAlgorithm
+    {
+        protected DES()
+        {
+            LegalBlockSizesValue = s_legalBlockSizes.CloneKeySizesArray();
+            LegalKeySizesValue = s_legalKeySizes.CloneKeySizesArray();
+            KeySizeValue = 64;
+            BlockSizeValue = 64;
+        }
+
+        public static DES Create()
+        {
+            return new DesImplementation();
+        }
+
+        public override byte[] Key
+        {
+            get
+            {
+                byte[] key = base.Key;
+                while (IsWeakKey(key) || IsSemiWeakKey(key))
+                {
+                    GenerateKey();
+                    key = base.Key;
+                }
+                return key;
+            }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                if (!(value.Length * 8).IsLegalSize(s_legalKeySizes))
+                    throw new ArgumentException(SR.Cryptography_InvalidKeySize);
+
+                if (IsWeakKey(value))
+                    throw new CryptographicException(SR.Cryptography_InvalidKey_Weak, "DES");
+
+                if (IsSemiWeakKey(value))
+                    throw new CryptographicException(SR.Cryptography_InvalidKey_SemiWeak, "DES");
+
+                base.Key = value;
+            }
+        }
+
+        public static bool IsWeakKey(byte[] rgbKey)
+        {
+            if (!IsLegalKeySize(rgbKey)) // Also checks for null; same exception
+                throw new CryptographicException(SR.Cryptography_InvalidKeySize);
+
+            byte[] rgbOddParityKey = rgbKey.FixupKeyParity();
+            UInt64 key = QuadWordFromBigEndian(rgbOddParityKey);
+            if ((key == 0x0101010101010101) ||
+                (key == 0xfefefefefefefefe) ||
+                (key == 0x1f1f1f1f0e0e0e0e) ||
+                (key == 0xe0e0e0e0f1f1f1f1))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsSemiWeakKey(byte[] rgbKey)
+        {
+            if (!IsLegalKeySize(rgbKey)) // Also checks for null; same exception
+                throw new CryptographicException(SR.Cryptography_InvalidKeySize);
+
+            byte[] rgbOddParityKey = rgbKey.FixupKeyParity();
+            UInt64 key = QuadWordFromBigEndian(rgbOddParityKey);
+            if ((key == 0x01fe01fe01fe01fe) ||
+                (key == 0xfe01fe01fe01fe01) ||
+                (key == 0x1fe01fe00ef10ef1) ||
+                (key == 0xe01fe01ff10ef10e) ||
+                (key == 0x01e001e001f101f1) ||
+                (key == 0xe001e001f101f101) ||
+                (key == 0x1ffe1ffe0efe0efe) ||
+                (key == 0xfe1ffe1ffe0efe0e) ||
+                (key == 0x011f011f010e010e) ||
+                (key == 0x1f011f010e010e01) ||
+                (key == 0xe0fee0fef1fef1fe) ||
+                (key == 0xfee0fee0fef1fef1))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsLegalKeySize(byte[] rgbKey)
+        {
+            if (rgbKey != null && rgbKey.Length == 8)
+                return true;
+
+            return false;
+        }
+
+        private static UInt64 QuadWordFromBigEndian(byte[] block)
+        {
+            UInt64 x = (
+                (((UInt64)block[0]) << 56) | (((UInt64)block[1]) << 48) |
+                (((UInt64)block[2]) << 40) | (((UInt64)block[3]) << 32) |
+                (((UInt64)block[4]) << 24) | (((UInt64)block[5]) << 16) |
+                (((UInt64)block[6]) << 8) | ((UInt64)block[7])
+                );
+            return x;
+        }
+
+        private static KeySizes[] s_legalBlockSizes =
+        {
+            new KeySizes(minSize: 64, maxSize: 64, skipSize: 0)
+        };
+
+        private static KeySizes[] s_legalKeySizes =
+        {
+            new KeySizes(minSize: 64, maxSize: 64, skipSize: 0)
+        };
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RC2.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RC2.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Cryptography;
+using System.ComponentModel;
+
+namespace System.Security.Cryptography
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class RC2 : SymmetricAlgorithm
+    {
+        protected int EffectiveKeySizeValue;
+
+        protected RC2()
+        {
+            LegalBlockSizesValue = s_legalBlockSizes.CloneKeySizesArray();
+            LegalKeySizesValue = s_legalKeySizes.CloneKeySizesArray();
+            KeySizeValue = 128;
+            BlockSizeValue = 64;
+        }
+
+        public static RC2 Create()
+        {
+            return new RC2Implementation();
+        }
+
+        public override int KeySize
+        {
+            get { return KeySizeValue; }
+            set
+            {
+                if (value < EffectiveKeySizeValue)
+                    throw new CryptographicException(SR.Cryptography_RC2_EKSKS);
+
+                base.KeySize = value;
+            }
+        }
+
+        public virtual int EffectiveKeySize
+        {
+            get
+            {
+                if (EffectiveKeySizeValue == 0)
+                    return KeySizeValue;
+
+                return EffectiveKeySizeValue;
+            }
+            set
+            {
+                if (value > KeySizeValue)
+                    throw new CryptographicException(SR.Cryptography_RC2_EKSKS);
+                else if (value == 0)
+                    EffectiveKeySizeValue = value;
+                else if (value < 40)
+                    throw new CryptographicException(SR.Cryptography_RC2_EKS40);
+                else
+                {
+                    if (value.IsLegalSize(s_legalKeySizes))
+                        EffectiveKeySizeValue = value;
+                    else
+                        throw new CryptographicException(SR.Cryptography_InvalidKeySize);
+                }
+            }
+        }
+
+        private static readonly KeySizes[] s_legalBlockSizes =
+        {
+            new KeySizes(minSize: 64, maxSize: 64, skipSize: 0)
+        };
+
+        private static readonly KeySizes[] s_legalKeySizes =
+        {
+            new KeySizes(minSize: 40, maxSize: 1024, skipSize: 8) // 1024 bits is theoretical max according to the RFC
+        };
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/DESProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DESProvider.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Encryption.Des.Tests
+{
+    internal class DesProvider : IDESProvider
+    {
+        public DES Create()
+        {
+            return DES.Create();
+        }
+    }
+
+    public partial class DESFactory
+    {
+        private static readonly IDESProvider s_provider = new DesProvider();
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/DESTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DESTests.cs
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.Des.Tests
+{
+    public static partial class DesTests
+    {
+        [Fact]
+        public static void EnsureLegalSizesValuesIsolated()
+        {
+            new DESLegalSizesBreaker().Dispose();
+
+            using (DES des = DES.Create())
+            {
+                Assert.Equal(64, des.LegalKeySizes[0].MinSize);
+                Assert.Equal(64, des.LegalBlockSizes[0].MinSize);
+            }
+        }
+
+        private class DESLegalSizesBreaker : DESMinimal
+        {
+            public DESLegalSizesBreaker()
+            {
+                LegalKeySizesValue[0] = new KeySizes(1, 1, 0);
+                LegalBlockSizesValue[0] = new KeySizes(1, 1, 0);
+            }
+        }
+
+        private class DESMinimal : DES
+        {
+            // If the constructor uses a virtual call to any of the property setters
+            // they will fail.
+            private readonly bool _ready;
+
+            public DESMinimal()
+            {
+                // Don't set this as a field initializer, otherwise it runs before the base ctor.
+                _ready = true;
+            }
+
+            public override int KeySize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.KeySize = value;
+                }
+            }
+
+            public override int BlockSize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.BlockSize = value;
+                }
+            }
+
+            public override byte[] IV
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.IV = value;
+                }
+            }
+
+            public override byte[] Key
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Key = value;
+                }
+            }
+
+            public override CipherMode Mode
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Mode = value;
+                }
+            }
+
+            public override PaddingMode Padding
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Padding = value;
+                }
+            }
+
+            public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateIV()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateKey()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/RC2Provider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RC2Provider.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Encryption.RC2.Tests
+{
+    using RC2 = System.Security.Cryptography.RC2;
+
+    internal class RC2Provider : IRC2Provider
+    {
+        public RC2 Create()
+        {
+            return RC2.Create();
+        }
+    }
+
+    public partial class RC2Factory
+    {
+        private static readonly IRC2Provider s_provider = new RC2Provider();
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/RC2Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RC2Tests.cs
@@ -1,0 +1,185 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.RC2.Tests
+{
+    using RC2 = System.Security.Cryptography.RC2;
+
+    public static partial class RC2Tests
+    {
+        [Fact]
+        public static void RC2KeySize()
+        {
+            using (RC2 rc2 = RC2.Create())
+            {
+                rc2.KeySize = 40;
+                Assert.Equal(40 / 8, rc2.Key.Length);
+                Assert.Equal(40, rc2.KeySize);
+
+                rc2.KeySize = 1024;
+                Assert.Equal(1024 / 8, rc2.Key.Length);
+                Assert.Equal(1024, rc2.KeySize);
+
+                Assert.Throws<CryptographicException>(() => rc2.KeySize = 40 - 8);
+                Assert.Throws<CryptographicException>(() => rc2.KeySize = 1024 + 8);
+            }
+        }
+
+        [Fact]
+        public static void RC2EffectiveKeySize_BaseClass()
+        {
+            using (RC2 rc2 = new RC2Minimal())
+            {
+                rc2.KeySize = 40;
+                Assert.Equal(40, rc2.EffectiveKeySize);
+                rc2.EffectiveKeySize = 40;
+
+                // Setting to 0 uses KeySize
+                rc2.EffectiveKeySize = 0;
+                Assert.Equal(40, rc2.EffectiveKeySize);
+
+                Assert.Throws<CryptographicException>(() => rc2.EffectiveKeySize = 40 - 8);
+                Assert.Throws<CryptographicException>(() => rc2.EffectiveKeySize = 40 + 8);
+                Assert.Throws<CryptographicException>(() => rc2.EffectiveKeySize = 35);
+                Assert.Throws<CryptographicException>(() => rc2.EffectiveKeySize = 41);
+            }
+        }
+
+        [Fact]
+        public static void EnsureLegalSizesValuesIsolated()
+        {
+            new RC2LegalSizesBreaker().Dispose();
+
+            using (RC2 rc2 = RC2.Create())
+            {
+                Assert.Equal(40, rc2.LegalKeySizes[0].MinSize);
+                Assert.Equal(64, rc2.LegalBlockSizes[0].MinSize);
+
+                rc2.Key = new byte[8];
+            }
+        }
+
+        private class RC2LegalSizesBreaker : RC2Minimal
+        {
+            public RC2LegalSizesBreaker()
+            {
+                LegalKeySizesValue[0] = new KeySizes(1, 1, 0);
+                LegalBlockSizesValue[0] = new KeySizes(1, 1, 0);
+            }
+        }
+
+        private class RC2Minimal : RC2
+        {
+            // If the constructor uses a virtual call to any of the property setters
+            // they will fail.
+            private readonly bool _ready;
+
+            public RC2Minimal()
+            {
+                // Don't set this as a field initializer, otherwise it runs before the base ctor.
+                _ready = true;
+            }
+
+            public override int KeySize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.KeySize = value;
+                }
+            }
+
+            public override int BlockSize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.BlockSize = value;
+                }
+            }
+
+            public override byte[] IV
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.IV = value;
+                }
+            }
+
+            public override byte[] Key
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Key = value;
+                }
+            }
+
+            public override CipherMode Mode
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Mode = value;
+                }
+            }
+
+            public override PaddingMode Padding
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Padding = value;
+                }
+            }
+
+            public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateIV()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateKey()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -26,20 +26,23 @@
     <Compile Include="$(CommonTestPath)\System\IO\PositionValueStream.cs">
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
+      <Link>CommonTest\System\RandomDataGenerator.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.Data.cs">
-      <Link>CommonTest\AlgorithmImplementations\AES\AesCipherTests.Data.cs</Link>
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.Data.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.cs">
-      <Link>CommonTest\AlgorithmImplementations\AES\AesCipherTests.cs</Link>
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesContractTests.cs">
-      <Link>CommonTest\AlgorithmImplementations\AES\AesContractTests.cs</Link>
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesContractTests.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesCornerTests.cs">
-      <Link>CommonTest\AlgorithmImplementations\AES\AesCornerTests.cs</Link>
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesCornerTests.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesModeTests.cs">
-      <Link>CommonTest\AlgorithmImplementations\AES\AesModeTests.cs</Link>
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesModeTests.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
@@ -48,10 +51,10 @@
       <Link>CommonTest\System\Security\Cryptography\CryptoUtils.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\DecryptorReusability.cs">
-      <Link>CommonTest\AlgorithmImplementations\AES\DecryptorReusability.cs</Link>
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\DecryptorReusability.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesFactory.cs">
-      <Link>CommonTest\AlgorithmImplementations\AES\AesFactory.cs</Link>
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesFactory.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs</Link>
@@ -96,16 +99,13 @@
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs">
-      <Link>CommonTest\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs</Link>
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs">
-      <Link>CommonTest\AlgorithmImplementations\TripleDES\TripleDESFactory.cs</Link>
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs">
-      <Link>CommonTest\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
-      <Link>CommonTest\System\RandomDataGenerator.cs</Link>
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs</Link>
     </Compile>
     <Compile Include="AesProvider.cs" />
     <Compile Include="DefaultECDsaProvider.cs" />
@@ -134,13 +134,26 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="AsymmetricSignatureFormatterTests.cs" />
+    <Compile Include="DefaultDSAProvider.cs" />
+    <Compile Include="DESProvider.cs" />
+    <Compile Include="DESTests.cs" />
     <Compile Include="DSASignatureFormatterTests.cs" />
     <Compile Include="ECDiffieHellmanPublicKeyTests.cs" />
+    <Compile Include="RC2Provider.cs" />
+    <Compile Include="RC2Tests.cs" />
     <Compile Include="RSAKeyExchangeFormatterTests.cs" />
     <Compile Include="RSASignatureFormatterTests.cs" />
-    <Compile Include="DefaultDSAProvider.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AsymmetricSignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AsymmetricSignatureFormatter.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DESFactory.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DESFactory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs</Link>
@@ -159,6 +172,15 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs</Link>

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
@@ -164,6 +164,7 @@ namespace Internal.Cryptography
                 _outer.Mode,
                 blockSizeInBytes,
                 key,
+                0,
                 iv,
                 encrypting);
 

--- a/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.cs
+++ b/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.cs
@@ -49,6 +49,17 @@ namespace System.Security.Cryptography
         UseNonExportableKey = 4,
         UseUserProtectedKey = 32,
     }
+    [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+    public sealed partial class DESCryptoServiceProvider : System.Security.Cryptography.DES
+    {
+        public DESCryptoServiceProvider() { }
+        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor() { return default(System.Security.Cryptography.ICryptoTransform); }
+        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) { return default(System.Security.Cryptography.ICryptoTransform); }
+        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor() { return default(System.Security.Cryptography.ICryptoTransform); }
+        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) { return default(System.Security.Cryptography.ICryptoTransform); }
+        public override void GenerateIV() { }
+        public override void GenerateKey() { }
+    }
     public sealed partial class DSACryptoServiceProvider : System.Security.Cryptography.DSA, System.Security.Cryptography.ICspAsymmetricAlgorithm
     {
         public DSACryptoServiceProvider() { }
@@ -87,6 +98,17 @@ namespace System.Security.Cryptography
     {
         Exchange = 1,
         Signature = 2,
+    }
+    [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+    public sealed partial class RC2CryptoServiceProvider : System.Security.Cryptography.RC2
+    {
+        public RC2CryptoServiceProvider() { }
+        public override int EffectiveKeySize { get { return default(int); } set { } }
+        public bool UseSalt { get { return default(bool); } set { } }
+        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) { return default(System.Security.Cryptography.ICryptoTransform); }
+        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) { return default(System.Security.Cryptography.ICryptoTransform); }
+        public override void GenerateIV() { }
+        public override void GenerateKey() { }
     }
     public sealed partial class RSACryptoServiceProvider : System.Security.Cryptography.RSA, System.Security.Cryptography.ICspAsymmetricAlgorithm
     {

--- a/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.Csp.cs" />
+    <!-- ToDo: Remove once prerelease gets updated again -->
+    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\ref\System.Security.Cryptography.Algorithms.csproj">
+      <Name>System.Security.Cryptography.Algorithms</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Security.Cryptography.Csp/src/Internal/Cryptography/BasicSymmetricCipherCsp.cs
+++ b/src/System.Security.Cryptography.Csp/src/Internal/Cryptography/BasicSymmetricCipherCsp.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.NativeCrypto;
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using static Internal.NativeCrypto.CapiHelper;
+
+namespace Internal.Cryptography
+{
+    internal sealed class BasicSymmetricCipherCsp : BasicSymmetricCipher
+    {
+        private readonly bool _encrypting;
+        private SafeProvHandle _hProvider;
+        private SafeKeyHandle _hKey;
+
+        public BasicSymmetricCipherCsp(int algId, CipherMode cipherMode, int blockSizeInBytes, byte[] key, int effectiveKeyLength, bool addNoSaltFlag, byte[] iv, bool encrypting)
+            : base(cipherMode.GetCipherIv(iv), blockSizeInBytes)
+        {
+            _encrypting = encrypting;
+
+            _hProvider = AcquireSafeProviderHandle();
+            _hKey = ImportCspBlob(_hProvider, algId, key, addNoSaltFlag);
+
+            SetKeyParameter(_hKey, CryptGetKeyParamQueryType.KP_MODE, (int)cipherMode);
+
+            byte[] currentIv = cipherMode.GetCipherIv(iv);
+            if (currentIv != null)
+            {
+                SetKeyParameter(_hKey, CryptGetKeyParamQueryType.KP_IV, currentIv);
+            }
+
+            if (effectiveKeyLength != 0)
+            {
+                SetKeyParameter(_hKey, CryptGetKeyParamQueryType.KP_EFFECTIVE_KEYLEN, effectiveKeyLength);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                SafeKeyHandle hKey = _hKey;
+                _hKey = null;
+                if (hKey != null)
+                {
+                    hKey.Dispose();
+                }
+
+                SafeProvHandle hProvider = _hProvider;
+                _hProvider = null;
+                if (hProvider != null)
+                {
+                    hProvider.Dispose();
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset)
+        {
+            return Transform(input, inputOffset, count, output, outputOffset, false);
+        }
+
+        public override byte[] TransformFinal(byte[] input, int inputOffset, int count)
+        {
+            Debug.Assert(input != null);
+            Debug.Assert(inputOffset >= 0);
+            Debug.Assert(count >= 0);
+            Debug.Assert((count % BlockSizeInBytes) == 0);
+            Debug.Assert(input.Length - inputOffset >= count);
+
+            byte[] output = new byte[count];
+            if (count != 0)
+            {
+                int numBytesWritten = Transform(input, inputOffset, count, output, 0, true);
+                Debug.Assert(numBytesWritten == count);  // Our implementation of Transform() guarantees this.
+            }
+
+            Reset();
+
+            return output;
+        }
+
+        private void Reset()
+        {
+            // Ensure we've called CryptEncrypt with the final=true flag so the handle is reset property
+            EncryptData(_hKey, Array.Empty<Byte>(), 0, 0, Array.Empty<Byte>(), 0, 0, true);
+        }
+
+        private int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset, bool isFinal)
+        {
+            Debug.Assert(input != null);
+            Debug.Assert(inputOffset >= 0);
+            Debug.Assert(count > 0);
+            Debug.Assert((count % BlockSizeInBytes) == 0);
+            Debug.Assert(input.Length - inputOffset >= count);
+            Debug.Assert(output != null);
+            Debug.Assert(outputOffset >= 0);
+            Debug.Assert(output.Length - outputOffset >= count);
+
+            int numBytesWritten;
+            if (_encrypting)
+            {
+                numBytesWritten = EncryptData(_hKey, input, inputOffset, count, output, outputOffset, output.Length - outputOffset, isFinal);
+            }
+            else
+            {
+                numBytesWritten = DecryptData(_hKey, input, inputOffset, count, output, outputOffset, output.Length - outputOffset);
+            }
+
+            return numBytesWritten;
+        }
+
+        private static SafeKeyHandle ImportCspBlob(SafeProvHandle safeProvHandle, int algId, byte[] rawKey, bool addNoSaltFlag)
+        {
+            SafeKeyHandle safeKeyHandle;
+            byte[] keyBlob = ToPlainTextKeyBlob(algId, rawKey);
+            ImportKeyBlob(safeProvHandle, (CspProviderFlags)0, addNoSaltFlag, keyBlob, out safeKeyHandle);
+            // Note if plain text import fails, desktop falls back to "ExponentOfOneImport" which is not handled here
+            return safeKeyHandle;
+        }
+
+        private static SafeProvHandle AcquireSafeProviderHandle()
+        {
+            SafeProvHandle safeProvHandle = null;
+            var cspParams = new CspParameters((int)ProviderType.PROV_RSA_FULL);
+            CapiHelper.AcquireCsp(cspParams, out safeProvHandle);
+            return safeProvHandle;
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Csp/src/Internal/Cryptography/Helpers.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
 using System.Security.Cryptography;
 
 namespace Internal.Cryptography
@@ -19,7 +18,58 @@ namespace Internal.Cryptography
 
             return (byte[])(src.Clone());
         }
+
+        public static KeySizes[] CloneKeySizesArray(this KeySizes[] src)
+        {
+            return (KeySizes[])(src.Clone());
+        }
+
+        public static bool UsesIv(this CipherMode cipherMode)
+        {
+            return cipherMode != CipherMode.ECB;
+        }
+
+        public static byte[] GetCipherIv(this CipherMode cipherMode, byte[] iv)
+        {
+            if (cipherMode.UsesIv())
+            {
+                if (iv == null)
+                {
+                    throw new CryptographicException(SR.Cryptography_MissingIV);
+                }
+
+                return iv;
+            }
+
+            return null;
+        }
+
+        public static bool IsLegalSize(this int size, KeySizes[] legalSizes)
+        {
+            for (int i = 0; i < legalSizes.Length; i++)
+            {
+                KeySizes currentSizes = legalSizes[i];
+
+                // If a cipher has only one valid key size, MinSize == MaxSize and SkipSize will be 0
+                if (currentSizes.SkipSize == 0)
+                {
+                    if (currentSizes.MinSize == size)
+                        return true;
+                }
+                else if (size >= currentSizes.MinSize && size <= currentSizes.MaxSize)
+                {
+                    // If the number is in range, check to see if it's a legal increment above MinSize
+                    int delta = size - currentSizes.MinSize;
+
+                    // While it would be unusual to see KeySizes { 10, 20, 5 } and { 11, 14, 1 }, it could happen.
+                    // So don't return false just because this one doesn't match.
+                    if (delta % currentSizes.SkipSize == 0)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
     }
 }
-
-

--- a/src/System.Security.Cryptography.Csp/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Csp/src/Resources/Strings.resx
@@ -195,14 +195,29 @@
   <data name="Cryptography_InvalidIVSize" xml:space="preserve">
     <value>Specified initialization vector (IV) does not match the block size for this algorithm.</value>
   </data>
+  <data name="Cryptography_InvalidKey_Weak" xml:space="preserve">
+    <value>Specified key is a known weak key for '{0}' and cannot be used.</value>
+  </data>
+  <data name="Cryptography_InvalidKey_SemiWeak" xml:space="preserve">
+    <value>Specified key is a known semi-weak key for '{0}' and cannot be used.</value>
+  </data>
   <data name="Cryptography_InvalidKeySize" xml:space="preserve">
     <value>Specified key is not a valid size for this algorithm.</value>
   </data>
   <data name="Cryptography_InvalidOID" xml:space="preserve">
     <value>Object identifier (OID) is unknown.</value>
   </data>
+  <data name="Cryptography_InvalidPadding" xml:space="preserve">
+    <value>Specified padding mode is not valid for this algorithm.</value>
+  </data>
   <data name="Cryptography_InvalidPaddingMode" xml:space="preserve">
     <value>Specified padding mode is not valid for this algorithm.</value>
+  </data>
+  <data name="Cryptography_MissingIV" xml:space="preserve">
+    <value>The cipher mode specified requires that an initialization vector (IV) be used.</value>
+  </data>
+  <data name="Cryptography_MustTransformWholeBlock" xml:space="preserve">
+    <value>TransformBlock may only process bytes in block sized increments.</value>
   </data>
   <data name="Cryptography_OpenInvalidHandle" xml:space="preserve">
     <value>Cannot open an invalid handle.</value>
@@ -210,8 +225,23 @@
   <data name="Cryptography_Padding_DecDataTooBig" xml:space="preserve">
     <value>Cryptographic padding data is too big</value>
   </data>
+  <data name="Cryptography_PartialBlock" xml:space="preserve">
+    <value>The input data is not a complete block.</value>
+  </data>
+  <data name="Cryptography_RC2_EKSKS2" xml:space="preserve">
+    <value>EffectiveKeySize must be the same as KeySize in this implementation.</value>
+  </data>
+  <data name="Cryptography_TransformBeyondEndOfBuffer" xml:space="preserve">
+    <value>Attempt to transform beyond end of buffer.</value>
+  </data>
   <data name="Cryptography_UnknownHashAlgorithm" xml:space="preserve">
     <value>'{0}' is not a known hash algorithm.</value>
+  </data>
+  <data name="Cryptography_UnknownPaddingMode" xml:space="preserve">
+    <value>Unknown padding mode used.</value>
+  </data>
+  <data name="CryptSetKeyParam_Failed" xml:space="preserve">
+    <value>CryptSetKeyParam failed with error code {0}</value>
   </data>
   <data name="CspParameter_invalid" xml:space="preserve">
     <value>CSPParameters cannot be null</value>

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -25,13 +25,29 @@
     </Compile>
     <Compile Include="System\Security\Cryptography\CapiHelper.cs" />
     <Compile Include="System\Security\Cryptography\CapiHelper.DSA.cs" />
+    <Compile Include="System\Security\Cryptography\CapiHelper.SymmetricKey.cs" />
     <Compile Include="System\Security\Cryptography\CspKeyContainerInfo.cs" />
     <Compile Include="System\Security\Cryptography\CspParameters.cs" />
+    <Compile Include="System\Security\Cryptography\DESCryptoServiceProvider.cs" />
     <Compile Include="System\Security\Cryptography\DSACryptoServiceProvider.cs" />
+    <Compile Include="System\Security\Cryptography\RC2CryptoServiceProvider.cs" />
     <Compile Include="System\Security\Cryptography\RSACryptoServiceProvider.cs" />
     <Compile Include="System\Security\Cryptography\SafeCryptoHandles.cs" />
     <Compile Include="System\Security\Cryptography\Utils.cs" />
+    <Compile Include="Internal\Cryptography\BasicSymmetricCipherCsp.cs" />
     <Compile Include="Internal\Cryptography\Helpers.cs" />
+    <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipher.cs">
+      <Link>Internal\Cryptography\BasicSymmetricCipher.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoTransform.cs">
+      <Link>Internal\Cryptography\UniversalCryptoTransform.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoEncryptor.cs">
+      <Link>Internal\Cryptography\UniversalCryptoEncryptor.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoDecryptor.cs">
+      <Link>Internal\Cryptography\UniversalCryptoDecryptor.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
       <Link>Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
     </Compile>
@@ -47,6 +63,12 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- ToDo: Remove once prerelease gets updated again -->
+    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\pkg\System.Security.Cryptography.Algorithms.pkgproj">
+      <Name>System.Security.Cryptography.Algorithms</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.SymmetricKey.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.SymmetricKey.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+
+namespace Internal.NativeCrypto
+{
+    internal static partial class CapiHelper
+    {
+        /// <summary>
+        /// Helper for RC2CryptoServiceProvider and DESCryptoServiceProvider
+        /// </summary>
+        internal static byte[] ToPlainTextKeyBlob(int algId, byte[] rawKey)
+        {
+            using (var ms = new MemoryStream())
+            using (var bw = new BinaryWriter(ms))
+            {
+                // Write out the BLOBHEADER
+                WriteKeyBlobHeader(algId, bw);
+
+                // Write out the size + key contents
+                bw.Write((int)rawKey.Length);
+                bw.Write(rawKey);
+
+                bw.Flush();
+                byte[] key = ms.ToArray();
+                return key;
+            }
+        }
+
+        private static void WriteKeyBlobHeader(int algId, BinaryWriter bw)
+        {
+            // Write out the BLOBHEADER.
+            bw.Write((byte)PLAINTEXTKEYBLOB);               // BLOBHEADER.bType
+            bw.Write((byte)BLOBHEADER_CURRENT_BVERSION);    // BLOBHEADER.bVersion
+            bw.Write((ushort)0);                            // BLOBHEADER.wReserved
+            bw.Write(algId);                                // BLOBHEADER.aiKeyAlg
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -569,6 +569,54 @@ namespace Internal.NativeCrypto
         }
 
         /// <summary>
+        /// Set a key property which is based on byte[]
+        /// </summary>
+        /// <param name="safeKeyHandle">Key handle</param>
+        /// <param name="keyParam"> Key property you want to set</param>
+        /// <param name="value"> Key property value you want to set</param>
+        internal static void SetKeyParameter(SafeKeyHandle safeKeyHandle, CryptGetKeyParamQueryType keyParam, byte[] value)
+        {
+            VerifyValidHandle(safeKeyHandle); //This will throw if handle is invalid
+
+            switch (keyParam)
+            {
+                case CryptGetKeyParamQueryType.KP_IV:
+                    if (!Interop.CryptSetKeyParam(safeKeyHandle, (int)keyParam, value, 0))
+                        throw new CryptographicException(SR.CryptSetKeyParam_Failed, Convert.ToString(GetErrorCode()));
+
+                    break;
+                default:
+                    Debug.Fail("Unkown param in SetKeyParameter");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Set a key property which is based on int
+        /// </summary>
+        /// <param name="safeKeyHandle">Key handle</param>
+        /// <param name="keyParam"> Key property you want to set</param>
+        /// <param name="value"> Key property value you want to set</param>
+        internal static void SetKeyParameter(SafeKeyHandle safeKeyHandle, CryptGetKeyParamQueryType keyParam, int value)
+        {
+            VerifyValidHandle(safeKeyHandle); //This will throw if handle is invalid
+
+            switch (keyParam)
+            {
+                case CryptGetKeyParamQueryType.KP_MODE:
+                case CryptGetKeyParamQueryType.KP_MODE_BITS:
+                case CryptGetKeyParamQueryType.KP_EFFECTIVE_KEYLEN:
+                    if (! Interop.CryptSetKeyParamInt(safeKeyHandle, (int)keyParam, ref value, 0))
+                        throw new CryptographicException(SR.CryptSetKeyParam_Failed, Convert.ToString(GetErrorCode()));
+
+                    break;
+                default:
+                    Debug.Fail("Unkown param in SetKeyParameter");
+                    break;
+            }
+        }
+
+        /// <summary>
         /// Helper method to save the CSP parameters. 
         /// </summary>
         /// <param name="keyType">CSP algorithm type</param>
@@ -830,10 +878,99 @@ namespace Internal.NativeCrypto
             Array.Reverse(pbEncryptedKey);
         }
 
+        internal static int EncryptData(
+            SafeKeyHandle hKey,
+            byte[] input,
+            int inputOffset,
+            int inputCount,
+            byte[] output,
+            int outputOffset,
+            int outputCount,
+            bool isFinal)
+        {
+            VerifyValidHandle(hKey);
+            Debug.Assert(input != null);
+            Debug.Assert(inputOffset >= 0);
+            Debug.Assert(inputCount >= 0);
+            Debug.Assert(inputCount <= input.Length - inputOffset);
+            Debug.Assert(output != null);
+            Debug.Assert(outputOffset >= 0);
+            Debug.Assert(outputCount >= 0);
+            Debug.Assert(outputCount <= output.Length - outputOffset);
+            Debug.Assert((inputCount % 8) == 0);
+            Debug.Assert((outputCount % 8) == 0);
+
+            // Figure out how big the encrypted data will be
+            int cbEncryptedData = inputCount;
+            if (!Interop.CryptEncrypt(hKey, SafeHashHandle.InvalidHandle, isFinal, 0, null, ref cbEncryptedData, cbEncryptedData))
+            {
+                throw new CryptographicException(SR.Format(SR.CryptEncrypt_Failed, Convert.ToString(GetErrorCode())));
+            }
+
+            // encryptedData is an in/out buffer for CryptEncrypt. Allocate space for the encrypted data, and copy the
+            // plaintext data into that space.  Since encrypted data will have padding applied, the size of the encrypted
+            // data should always be larger than the plaintext key, so use that to determine the buffer size.
+            Debug.Assert(cbEncryptedData >= inputCount);
+            var encryptedData = new byte[cbEncryptedData];
+            Buffer.BlockCopy(input, inputOffset, encryptedData, 0, inputCount);
+
+            // Encrypt for real - the last parameter is the total size of the in/out buffer, while the second to last
+            // parameter specifies the size of the plaintext to encrypt.
+            int encryptedDataLength = inputCount;
+            if (!Interop.CryptEncrypt(hKey, SafeHashHandle.InvalidHandle, isFinal, 0, encryptedData, ref encryptedDataLength, cbEncryptedData))
+            {
+                int errCode = GetErrorCode();
+                throw new CryptographicException(SR.CryptEncrypt_Failed, Convert.ToString(errCode));
+            }
+            Debug.Assert(encryptedDataLength == cbEncryptedData);
+
+            // If isFinal, padding was added so ignore it by using outputCount as size
+            Buffer.BlockCopy(encryptedData, 0, output, outputOffset, outputCount);
+
+            return outputCount;
+        }
+
+        internal static int DecryptData(
+            SafeKeyHandle hKey,
+            byte[] input,
+            int inputOffset,
+            int inputCount,
+            byte[] output,
+            int outputOffset,
+            int outputCount)
+        {
+            VerifyValidHandle(hKey);
+            Debug.Assert(input != null);
+            Debug.Assert(inputOffset >= 0);
+            Debug.Assert(inputCount >= 0);
+            Debug.Assert(inputCount <= input.Length - inputOffset);
+            Debug.Assert(output != null);
+            Debug.Assert(outputOffset >= 0);
+            Debug.Assert(outputCount >= 0);
+            Debug.Assert(outputCount <= output.Length - outputOffset);
+            Debug.Assert((inputCount % 8) == 0);
+            Debug.Assert((outputCount % 8) == 0);
+
+            byte[] dataTobeDecrypted = new byte[inputCount];
+            Buffer.BlockCopy(input, inputOffset, dataTobeDecrypted, 0, inputCount);
+
+            int decryptedDataLength = inputCount;
+            // Always call decryption with false (not final); deal with padding manually
+            if (!Interop.CryptDecrypt(hKey, SafeHashHandle.InvalidHandle, false, 0, dataTobeDecrypted, ref decryptedDataLength))
+            {
+                int errCode = GetErrorCode();
+                throw new CryptographicException(SR.CryptDecrypt_Failed, Convert.ToString(errCode));
+            }
+
+            Buffer.BlockCopy(dataTobeDecrypted, 0, output, outputOffset, outputCount);
+
+            return decryptedDataLength;
+        }
+
         /// <summary>
         /// Helper for Import CSP
         /// </summary>
-        internal static void ImportKeyBlob(SafeProvHandle saveProvHandle, CspProviderFlags flags, byte[] keyBlob, out SafeKeyHandle safeKeyHandle)
+        internal static void ImportKeyBlob(SafeProvHandle saveProvHandle, CspProviderFlags flags, bool addNoSaltFlag, byte[] keyBlob, out SafeKeyHandle safeKeyHandle)
         {
             // Compat note: This isn't the same check as the one done by the CLR _ImportCspBlob QCall,
             // but this does match the desktop CLR behavior and the only scenarios it
@@ -844,6 +981,13 @@ namespace Internal.NativeCrypto
             if (isPublic)
             {
                 dwCapiFlags &= ~(int)(CryptGenKeyFlags.CRYPT_EXPORTABLE);
+            }
+
+            if (addNoSaltFlag)
+            {
+                // For RC2 running in rsabase.dll compatibility mode, make sure 11 bytes of
+                // zero salt are generated when using a 40 bit RC2 key.
+                dwCapiFlags |= (int)CryptGenKeyFlags.CRYPT_NO_SALT;
             }
 
             SafeKeyHandle hKey;
@@ -1340,9 +1484,6 @@ namespace Internal.NativeCrypto
         }
     }//End of class CapiHelper : Wrappers
 
-
-
-
     //
     /// <summary>
     /// All the PInvoke are captured in following part of CapiHelper class 
@@ -1378,6 +1519,14 @@ namespace Internal.NativeCrypto
             [return: MarshalAs(UnmanagedType.Bool)]
             public static extern bool CryptGetKeyParam(SafeKeyHandle safeKeyHandle, int dwParam, byte[] pbData,
                                                         ref int pdwDataLen, int dwFlags);
+
+            [DllImport(Libraries.SecurityCryptoApi, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool CryptSetKeyParam(SafeKeyHandle safeKeyHandle, int dwParam, byte[] pbData, int dwFlags);
+
+            [DllImport(Libraries.SecurityCryptoApi, SetLastError = true, EntryPoint = "CryptSetKeyParam")]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool CryptSetKeyParamInt(SafeKeyHandle safeKeyHandle, int dwParam, ref int pdw, int dwFlags);
 
             [DllImport(Libraries.SecurityCryptoApi, SetLastError = true, EntryPoint = "CryptGenKey")]
             private static extern bool _CryptGenKey(SafeProvHandle safeProvHandle, int Algid, int dwFlags, out SafeKeyHandle safeKeyHandle);
@@ -1500,9 +1649,11 @@ namespace Internal.NativeCrypto
         // since it enables access to SHA-2 operations. All currently supported OSes support RSA-AES.
         internal const int DefaultRsaProviderType = (int)ProviderType.PROV_RSA_AES;
         //Leaving these constants same as they are defined in Windows
-        internal const int ALG_TYPE_RSA = (2 << 9);
         internal const int ALG_TYPE_DSS = (1 << 9);
+        internal const int ALG_TYPE_RSA = (2 << 9);
+        internal const int ALG_TYPE_BLOCK = (3 << 9);
         internal const int ALG_CLASS_SIGNATURE = (1 << 13);
+        internal const int ALG_CLASS_DATA_ENCRYPT = (3 << 13);
         internal const int ALG_CLASS_KEY_EXCHANGE = (5 << 13);
         internal const int CALG_RSA_SIGN = (ALG_CLASS_SIGNATURE | ALG_TYPE_RSA | 0);
         internal const int CALG_DSS_SIGN = (ALG_CLASS_SIGNATURE | ALG_TYPE_DSS | 0);
@@ -1511,6 +1662,8 @@ namespace Internal.NativeCrypto
         internal const int ALG_CLASS_HASH = (4 << 13);
         internal const int ALG_TYPE_ANY = (0);
 
+        internal const int CALG_DES = (ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | 1);
+        internal const int CALG_RC2 = (ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | 2);
         internal const int CALG_MD5 = (ALG_CLASS_HASH | ALG_TYPE_ANY | 3);
         internal const int CALG_SHA1 = (ALG_CLASS_HASH | ALG_TYPE_ANY | 4);
         internal const int CALG_SHA_256 = (ALG_CLASS_HASH | ALG_TYPE_ANY | 12);
@@ -1523,6 +1676,7 @@ namespace Internal.NativeCrypto
 
         internal const int PUBLICKEYBLOB = 0x6;
         internal const int PRIVATEKEYBLOB = 0x7;
+        internal const int PLAINTEXTKEYBLOB = 0x8;
         internal const byte BLOBHEADER_CURRENT_BVERSION = 0x2;
         internal const int CRYPT_BLOB_VER3 = 0x00000080; // export version 3 of a blob type
         internal const int RSA_PUB_MAGIC = 0x31415352;

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DESCryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DESCryptoServiceProvider.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using Internal.Cryptography;
+using Internal.NativeCrypto;
+
+namespace System.Security.Cryptography
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class DESCryptoServiceProvider : DES
+    {
+        private const int BitsPerByte = 8;
+        private static readonly RandomNumberGenerator s_rng = RandomNumberGenerator.Create();
+
+        public DESCryptoServiceProvider() { }
+
+        public override void GenerateKey()
+        {
+            var key = new byte[8];
+            s_rng.GetBytes(key);
+            // Never hand back a weak or semi-weak key
+            while (IsWeakKey(key) || IsSemiWeakKey(key))
+            {
+                s_rng.GetBytes(key);
+            }
+            KeyValue = key;
+        }
+
+        public override void GenerateIV()
+        {
+            var iv = new byte[8];
+            s_rng.GetBytes(iv);
+            IVValue = iv;
+        }
+
+        public override ICryptoTransform CreateDecryptor()
+        {
+            return CreateTransform(Key, IV, encrypting: false);
+        }
+
+        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return CreateTransform(rgbKey, rgbIV == null ? null : rgbIV.CloneByteArray(), encrypting: false);
+        }
+
+        public override ICryptoTransform CreateEncryptor()
+        {
+            return CreateTransform(Key, IV, encrypting: true);
+        }
+
+        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return CreateTransform(rgbKey, rgbIV == null ? null : rgbIV.CloneByteArray(), encrypting: true);
+        }
+
+        private ICryptoTransform CreateTransform(byte[] rgbKey, byte[] rgbIV, bool encrypting)
+        {
+            // note: rgbIV is guaranteed to be cloned before this method, so no need to clone it again
+
+            if (rgbKey == null)
+                throw new ArgumentNullException(nameof(rgbKey));
+
+            long keySize = rgbKey.Length * (long)BitsPerByte;
+            if (keySize > int.MaxValue || !((int)keySize).IsLegalSize(LegalKeySizes))
+                throw new ArgumentException(SR.Cryptography_InvalidKeySize, nameof(rgbKey));
+
+            if (IsWeakKey(rgbKey))
+                throw new CryptographicException(SR.Cryptography_InvalidKey_Weak, "DES");
+            if (IsSemiWeakKey(rgbKey))
+                throw new CryptographicException(SR.Cryptography_InvalidKey_SemiWeak, "DES");
+
+            if (rgbIV == null)
+            {
+                if (Mode.UsesIv())
+                {
+                    rgbIV = new byte[8];
+                    s_rng.GetBytes(rgbIV);
+                }
+            }
+            else
+            {
+
+                // We truncate IV's that are longer than the block size to 8 bytes : this is
+                // done to maintain backward desktop compatibility with the behavior shipped in V1.x.
+                // The call to set the IV in CryptoAPI will ignore any bytes after the first 8
+                // bytes. We'll still reject IV's that are shorter than the block size though.
+                if (rgbIV.Length < 8)
+                    throw new CryptographicException(SR.Cryptography_InvalidIVSize);
+            }
+
+            BasicSymmetricCipher cipher = new BasicSymmetricCipherCsp(CapiHelper.CALG_DES, Mode, BlockSize / BitsPerByte, rgbKey, 0, false, rgbIV, encrypting);
+            return UniversalCryptoTransform.Create(Padding, cipher, encrypting);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.cs
@@ -312,14 +312,14 @@ namespace System.Security.Cryptography
             if (IsPublic(keyBlob))
             {
                 SafeProvHandle safeProvHandleTemp = AcquireSafeProviderHandle();
-                CapiHelper.ImportKeyBlob(safeProvHandleTemp, (CspProviderFlags)0, keyBlob, out safeKeyHandle);
+                CapiHelper.ImportKeyBlob(safeProvHandleTemp, (CspProviderFlags)0, false, keyBlob, out safeKeyHandle);
 
                 // The property set will take care of releasing any already-existing resources.
                 SafeProvHandle = safeProvHandleTemp;
             }
             else
             {
-                CapiHelper.ImportKeyBlob(SafeProvHandle, _parameters.Flags, keyBlob, out safeKeyHandle);
+                CapiHelper.ImportKeyBlob(SafeProvHandle, _parameters.Flags, false, keyBlob, out safeKeyHandle);
             }
 
             // The property set will take care of releasing any already-existing resources.

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RC2CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RC2CryptoServiceProvider.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Cryptography;
+using Internal.NativeCrypto;
+using System.ComponentModel;
+
+namespace System.Security.Cryptography
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class RC2CryptoServiceProvider : RC2 
+    {
+        private bool _use40bitSalt = false;
+        private const int BitsPerByte = 8;
+        private static readonly RandomNumberGenerator s_rng = RandomNumberGenerator.Create();
+
+        private static KeySizes[] s_legalKeySizes =
+        {
+            new KeySizes(40, 128, 8)  // csp implementation only goes up to 128
+        };
+
+        public RC2CryptoServiceProvider()
+        {
+            LegalKeySizesValue = s_legalKeySizes.CloneKeySizesArray();
+        }
+
+        public override int EffectiveKeySize
+        {
+            get
+            {
+                return KeySizeValue;
+            }
+            set
+            {
+                if (value != KeySizeValue)
+                    throw new CryptographicUnexpectedOperationException(SR.Cryptography_RC2_EKSKS2);
+            }
+        }
+
+        public bool UseSalt
+        {
+            get
+            {
+                return _use40bitSalt;
+            }
+            set
+            {
+                _use40bitSalt = value;
+            }
+        }
+
+        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return CreateTransform(rgbKey, rgbIV == null ? null : rgbIV.CloneByteArray(), encrypting: true);
+        }
+
+        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return CreateTransform(rgbKey, rgbIV == null ? null : rgbIV.CloneByteArray(), encrypting: false);
+        }
+
+        public override void GenerateKey()
+        {
+            var key = new byte[KeySizeValue / 8];
+            s_rng.GetBytes(key);
+            KeyValue = key;
+        }
+
+        public override void GenerateIV()
+        {
+            // Block size is always 64 bits so IV is always 64 bits == 8 bytes
+            var iv = new byte[8];
+            s_rng.GetBytes(iv);
+            IVValue = iv;
+        }
+
+        private ICryptoTransform CreateTransform(byte[] rgbKey, byte[] rgbIV, bool encrypting)
+        {
+            // note: rgbIV is guaranteed to be cloned before this method, so no need to clone it again
+
+            long keySize = rgbKey.Length * (long)BitsPerByte;
+            if (keySize > int.MaxValue || !((int)keySize).IsLegalSize(this.LegalKeySizes))
+                throw new ArgumentException(SR.Cryptography_InvalidKeySize, nameof(rgbKey));
+
+            if (rgbIV == null)
+            {
+                if (Mode.UsesIv())
+                {
+                    rgbIV = new byte[8];
+                    s_rng.GetBytes(rgbIV);
+                }
+            }
+            else
+            {
+                // We truncate IV's that are longer than the block size to 8 bytes : this is
+                // done to maintain backward desktop compatibility with the behavior shipped in V1.x.
+                // The call to set the IV in CryptoAPI will ignore any bytes after the first 8
+                // bytes. We'll still reject IV's that are shorter than the block size though.
+                if (rgbIV.Length < 8)
+                    throw new CryptographicException(SR.Cryptography_InvalidIVSize);
+            }
+
+            int effectiveKeySize = EffectiveKeySizeValue == 0 ? (int)keySize : EffectiveKeySize;
+            BasicSymmetricCipher cipher = new BasicSymmetricCipherCsp(CapiHelper.CALG_RC2, Mode, BlockSize / BitsPerByte, rgbKey, effectiveKeySize, !UseSalt, rgbIV, encrypting);
+            return UniversalCryptoTransform.Create(Padding, cipher, encrypting);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.cs
@@ -355,14 +355,14 @@ namespace System.Security.Cryptography
             if (IsPublic(keyBlob))
             {
                 SafeProvHandle safeProvHandleTemp = AcquireSafeProviderHandle();
-                CapiHelper.ImportKeyBlob(safeProvHandleTemp, (CspProviderFlags)0, keyBlob, out safeKeyHandle);
+                CapiHelper.ImportKeyBlob(safeProvHandleTemp, (CspProviderFlags)0, false, keyBlob, out safeKeyHandle);
 
                 // The property set will take care of releasing any already-existing resources.
                 SafeProvHandle = safeProvHandleTemp;
             }
             else
             {
-                CapiHelper.ImportKeyBlob(SafeProvHandle, _parameters.Flags, keyBlob, out safeKeyHandle);
+                CapiHelper.ImportKeyBlob(SafeProvHandle, _parameters.Flags, false, keyBlob, out safeKeyHandle);
             }
 
             // The property set will take care of releasing any already-existing resources.

--- a/src/System.Security.Cryptography.Csp/tests/DESCryptoServiceProviderProvider.cs
+++ b/src/System.Security.Cryptography.Csp/tests/DESCryptoServiceProviderProvider.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Encryption.Des.Tests
+{
+    public class DESCryptoServiceProviderProvider : IDESProvider
+    {
+        public DES Create()
+        {
+            return new DESCryptoServiceProvider();
+        }
+    }
+
+    public partial class DESFactory
+    {
+        private static readonly IDESProvider s_provider = new DESCryptoServiceProviderProvider();
+    }
+}

--- a/src/System.Security.Cryptography.Csp/tests/RC2CryptoServiceProviderProvider.cs
+++ b/src/System.Security.Cryptography.Csp/tests/RC2CryptoServiceProviderProvider.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Encryption.RC2.Tests
+{
+    using RC2 = System.Security.Cryptography.RC2;
+
+    public class RC2CryptoServiceProviderProvider : IRC2Provider
+    {
+        public RC2 Create()
+        {
+            return new RC2CryptoServiceProvider();
+        }
+    }
+
+    public partial class RC2Factory
+    {
+        private static readonly IRC2Provider s_provider = new RC2CryptoServiceProviderProvider();
+    }
+}

--- a/src/System.Security.Cryptography.Csp/tests/RC2CryptoServiceProviderTests.cs
+++ b/src/System.Security.Cryptography.Csp/tests/RC2CryptoServiceProviderTests.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.RC2.Tests
+{
+    using RC2 = System.Security.Cryptography.RC2;
+
+    public static partial class RC2CryptoServiceProviderTests
+    {
+        [Fact]
+        public static void RC2KeySize()
+        {
+            using (RC2 rc2 = new RC2CryptoServiceProvider())
+            {
+                rc2.KeySize = 40;
+                Assert.Equal(40 / 8, rc2.Key.Length);
+                Assert.Equal(40, rc2.KeySize);
+
+                rc2.KeySize = 128;
+                Assert.Equal(128 / 8, rc2.Key.Length);
+                Assert.Equal(128, rc2.KeySize);
+
+                Assert.Throws<CryptographicException>(() => rc2.KeySize = 40 - 8);
+                Assert.Throws<CryptographicException>(() => rc2.KeySize = 128 + 8);
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_NT_Debug</Configuration>
@@ -30,6 +30,9 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\CryptoUtils.cs">
+      <Link>CommonTest\System\Security\Cryptography\CryptoUtils.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs</Link>
     </Compile>
@@ -53,10 +56,22 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'==''">
+    <Compile Include="DESCryptoServiceProviderProvider.cs" />
     <Compile Include="DSACryptoServiceProviderProvider.cs" />
     <Compile Include="DSACryptoServiceProviderTests.cs" />
+    <Compile Include="RC2CryptoServiceProviderProvider.cs" />
+    <Compile Include="RC2CryptoServiceProviderTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AsymmetricSignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AsymmetricSignatureFormatter.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DESFactory.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DESFactory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs</Link>
@@ -76,12 +91,30 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- ToDo: Remove once prerelease gets updated again -->
+    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\pkg\System.Security.Cryptography.Algorithms.pkgproj">
+      <Name>System.Security.Cryptography.Algorithms</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -38,6 +38,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Cng.cs">
       <Link>Common\Interop\Windows\BCrypt\Cng.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs">
+      <Link>Common\Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.FindOidInfo.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -21,8 +21,12 @@ namespace System.Security.Cryptography
     public enum CipherMode
     {
         CBC = 1,
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        CFB = 4,
         CTS = 5,
         ECB = 2,
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        OFB = 3,
     }
     public partial class CryptographicException : System.SystemException
     {

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CipherMode.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CipherMode.cs
@@ -2,19 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
+using System.ComponentModel;
 
 namespace System.Security.Cryptography
 {
-    // This enum represents cipher chaining modes: cipher block chaining (CBC), 
-    // electronic code book (ECB), and ciphertext-stealing (CTS).  Not all implementations 
-    // will support all modes.
+    // This enum represents supported cipher chaining modes:
+    //  cipher block chaining (CBC),
+    //  electronic code book (ECB),
+    //  ciphertext-stealing (CTS).
+    // Not all implementations will support all modes.
     [Serializable]
     public enum CipherMode
     {
         CBC = 1,
-        CTS = 5,
         ECB = 2,
+        [EditorBrowsable(EditorBrowsableState.Never)]OFB = 3,
+        [EditorBrowsable(EditorBrowsableState.Never)]CFB = 4,
+        CTS = 5
     }
 }


### PR DESCRIPTION
Add support for RC2 and DES
Issues addressed:
#11117 Port T:System.Security.Cryptography.RC2xx
#11116 Port T:System.Security.Cryptography.DESxx
#12313 Port System.Security.Cryptography.CipherMode.CFB and .OFB

RC2\DES support is enabled for S.S.C.Csp via CAPI, and S.S.C.Algorithms for Windows (via Cng), Linux (via OpenSsl) and Apple.

In .Csp, support for ICryptoTransform was achieved by extending the UniversalCryptoTransform pattern which is much cleaner than porting the netfx CryptoAPITransform.

Note that there is no RC2\DES support in S.S.C.Cng as there is no netfx support for Cng RC2\DES.

For RC2, there was a lot of code that needed to be touched to set the effective key length property.

@bartonjs please review