### PR TITLE
Fix internal build of System.Security.Cryptography.Primitives.Tests

### DIFF
--- a/src/System.Security.Cryptography.Primitives/tests/project.json
+++ b/src/System.Security.Cryptography.Primitives/tests/project.json
@@ -16,7 +16,8 @@
   },
   "frameworks": {
     "netstandard1.3": {},
-    "netstandard1.7": {}
+    "netstandard1.7": {},
+    "netcoreapp1.1" : {}
   },
   "supports": {
     "coreFx.Test.netcore50": {},


### PR DESCRIPTION
It appears to be failing due to not finding the netcoreapp1.1 frameworks section in the project.json, after such a build was added to the .builds file:
```
error : Unable to find framework section 'frameworks.['netcoreapp1.1']' in 'corefx\src\System.Security.Cryptography.Primitives\tests/project.json'
```

cc: @weshaggard, @bartonjs