### PR TITLE
[release/1.1.0] Lower peak memory usage in BigInteger tests

### DIFF
--- a/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
@@ -579,7 +579,7 @@ namespace System.Numerics.Tests
         [OuterLoop]
         public static void RunDoubleExplicitCastFromLargeBigIntegerTests()
         {
-            DoubleExplicitCastFromLargeBigIntegerTests(0, 5, 64, 4);
+            DoubleExplicitCastFromLargeBigIntegerTests(0, 4, 64, 3);
         }
 
         [Fact]


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/12663 to release/1.1.0. This is a test-only change which lowers the peak memory consumption of the BigInteger tests.

@karelz 