### PR TITLE
Enable support of ephemeral certificates with EnvelopedCms

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.Decrypt.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.Decrypt.cs
@@ -66,6 +66,17 @@ namespace Internal.Cryptography.Pal.Windows
             using (SafeCertContextHandle hCertContext = cert.CreateCertContextHandle())
             {
                 int cbSize = 0;
+
+                if (Interop.Crypt32.CertGetCertificateContextProperty(
+                    hCertContext,
+                    CertContextPropId.CERT_NCRYPT_KEY_HANDLE_PROP_ID,
+                    null,
+                    ref cbSize))
+                {
+                    keySpec = CryptKeySpec.CERT_NCRYPT_KEY_SPEC;
+                    return null;
+                }
+
                 if (!Interop.Crypt32.CertGetCertificateContextProperty(hCertContext, CertContextPropId.CERT_KEY_PROV_INFO_PROP_ID, null, ref cbSize))
                 {
                     ErrorCode errorCode = (ErrorCode)(Marshal.GetLastWin32Error());
@@ -110,7 +121,20 @@ namespace Internal.Cryptography.Pal.Windows
             using (SafeCertContextHandle hCertContext = cert.CreateCertContextHandle())
             {
                 IntPtr hKey;
+                int cbSize = IntPtr.Size;
+
+                if (Interop.Crypt32.CertGetCertificateContextProperty(
+                    hCertContext,
+                    CertContextPropId.CERT_NCRYPT_KEY_HANDLE_PROP_ID,
+                    out hKey,
+                    ref cbSize))
+                {
+                    exception = null;
+                    return new SafeProvOrNCryptKeyHandleUwp(hKey, hCertContext);
+                }
+
                 CryptKeySpec keySpec;
+
                 if (!Interop.Crypt32.CryptAcquireCertificatePrivateKey(hCertContext, flags, IntPtr.Zero, out hKey, out keySpec, out mustFree))
                 {
                     exception = Marshal.GetHRForLastWin32Error().ToCryptographicException();

--- a/src/System.Security.Cryptography.Pkcs/src/Interop/Windows/Crypt32/Interop.CertContextPropId.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Interop/Windows/Crypt32/Interop.CertContextPropId.cs
@@ -21,6 +21,7 @@ internal static partial class Interop
             CERT_ARCHIVED_PROP_ID = 19,
             CERT_KEY_IDENTIFIER_PROP_ID = 20,
             CERT_PUBKEY_ALG_PARA_PROP_ID = 22,
+            CERT_NCRYPT_KEY_HANDLE_PROP_ID = 78,
             CERT_DELETE_KEYSET_PROP_ID = 101,
         }
     }

--- a/src/System.Security.Cryptography.Pkcs/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextProperty.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextProperty.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 using Microsoft.Win32.SafeHandles;
@@ -15,6 +13,9 @@ internal static partial class Interop
     {
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern bool CertGetCertificateContextProperty(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, [Out] byte[] pvData, [In, Out] ref int pcbData);
+
+        [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern bool CertGetCertificateContextProperty(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, out IntPtr pvData, [In, Out] ref int pcbData);
     }
 }
 

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.KeyPersistence.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.KeyPersistence.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+using System.Security.Cryptography.Pkcs.Tests;
+
+namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
+{
+    public static partial class DecryptTests
+    {
+        [Theory]
+        [InlineData(Oids.Aes128)]
+        [InlineData(Oids.Aes192)]
+        [InlineData(Oids.Aes256)]
+        [InlineData(Oids.Rc2)]
+        [InlineData(Oids.Des)]
+        [InlineData(Oids.TripleDesCbc)]
+        // RC4 is not supported for CNG keys (the key provider for this cert)
+        public static void Decrypt_256_Ephemeral(string algOid)
+        {
+            byte[] content = { 1, 1, 2, 3, 5, 8, 13, 21 };
+            ContentInfo contentInfo = new ContentInfo(content);
+            TestSimpleDecrypt_RoundTrip(
+                Certificates.RSASha256KeyTransfer1.CloneAsEphemeralLoader(),
+                contentInfo,
+                algOid,
+                SubjectIdentifierType.IssuerAndSerialNumber);
+        }
+
+        [Theory]
+        [InlineData(Oids.Aes128)]
+        [InlineData(Oids.Aes192)]
+        [InlineData(Oids.Aes256)]
+        [InlineData(Oids.Rc2)]
+        [InlineData(Oids.Des)]
+        [InlineData(Oids.TripleDesCbc)]
+        // RC4 is not supported for CNG keys (the key provider for this cert)
+        [OuterLoop("Leaks key on disk if interrupted")]
+        public static void Decrypt_256_Perphemeral(string algOid)
+        {
+            byte[] content = { 1, 1, 2, 3, 5, 8, 13, 21 };
+            ContentInfo contentInfo = new ContentInfo(content);
+            TestSimpleDecrypt_RoundTrip(
+                Certificates.RSASha256KeyTransfer1.CloneAsPerphemeralLoader(),
+                contentInfo,
+                algOid,
+                SubjectIdentifierType.IssuerAndSerialNumber);
+        }
+
+        [Theory]
+        [InlineData(Oids.Aes128)]
+        [InlineData(Oids.Aes192)]
+        [InlineData(Oids.Aes256)]
+        [InlineData(Oids.Rc2)]
+        [InlineData(Oids.Des)]
+        [InlineData(Oids.TripleDesCbc)]
+        // RC4 is not supported by the CNG version of the key, so it is not supported ephemeral.
+        public static void Decrypt_Capi_Ephemeral(string algOid)
+        {
+            byte[] content = { 1, 1, 2, 3, 5, 8, 13, 21 };
+            ContentInfo contentInfo = new ContentInfo(content);
+            TestSimpleDecrypt_RoundTrip(
+                Certificates.RSAKeyTransferCapi1.CloneAsEphemeralLoader(),
+                contentInfo,
+                algOid,
+                SubjectIdentifierType.IssuerAndSerialNumber);
+        }
+
+        [Theory]
+        [InlineData(Oids.Aes128)]
+        [InlineData(Oids.Aes192)]
+        [InlineData(Oids.Aes256)]
+        [InlineData(Oids.Rc2)]
+        [InlineData(Oids.Des)]
+        [InlineData(Oids.TripleDesCbc)]
+        // RC4 works in this context.
+        [InlineData(Oids.Rc4)]
+        [OuterLoop("Leaks key on disk if interrupted")]
+        public static void Decrypt_Capi_Perphemeral(string algOid)
+        {
+            byte[] content = { 1, 1, 2, 3, 5, 8, 13, 21 };
+            ContentInfo contentInfo = new ContentInfo(content);
+            TestSimpleDecrypt_RoundTrip(
+                Certificates.RSAKeyTransferCapi1.CloneAsPerphemeralLoader(),
+                contentInfo,
+                algOid,
+                SubjectIdentifierType.IssuerAndSerialNumber);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -148,7 +148,8 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
             ecms = new EnvelopedCms();
             ecms.Decode(encodedMessage);
 
-            using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.TryGetCertificateWithPrivateKey())
+            // In order to actually use the CAPI version of the key, perphemeral loading must be specified.
+            using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.CloneAsPerphemeralLoader().TryGetCertificateWithPrivateKey())
             {
                 if (cert == null)
                     return; // Sorry - CertLoader is not configured to load certs with private keys - we've tested as much as we can.

--- a/src/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.builds
+++ b/src/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.builds
@@ -6,6 +6,11 @@
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcore50;netcoreapp1.0;net46</TestTFMs>
     </Project>
+    <Project Include="System.Security.Cryptography.Pkcs.Tests.csproj">
+      <TargetGroup>netcoreapp1.1</TargetGroup>
+      <OSGroup>Windows_NT</OSGroup>
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
+++ b/src/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
@@ -11,7 +11,8 @@
     <AssemblyName>System.Security.Cryptography.Pkcs.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Pkcs.Tests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp1.1'">$(DefineConstants);netcoreapp11</DefineConstants>
   </PropertyGroup>
 
   <!-- Don't delete these clauses even if they look useless. They tell the VS IDE that "Windows_Debug", etc., are
@@ -54,6 +55,10 @@
     <Compile Include="Oids.cs" />
     <Compile Include="Pkcs9AttributeTests.cs" />
     <Compile Include="RecipientInfoCollectionTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp1.1'">
+      <Compile Include="EnvelopedCms\DecryptTests.KeyPersistence.cs" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
EnvelopedCms resolves the key objects from a certificate via P/Invokes instead
of calling public API (like GetRSAPrivateKey()).  The code that it has is not
capable utilizing ephemeral keys (imported with PKCS12_NO_PERSIST_KEY).

This change makes it so that ephemeral keys imported into CNG will work,
meaning that certificates opened from a PFX with
`X509KeyStorageFlags.EphemeralKeySet` will function. (Ephemeral keys imported
into CAPI are not supported with this change, as they're stored differently in the
PCERT_CONTEXT)

The tests will be as ephemeral as possible (perphemeral when running as
netstandard1.3, ephemeral when running as netcoreapp1.1). Since perphemal
is still needed for the default decryption tests they're staying marked as
OuterLoop.

Fixes #8186 (part 3/3).
cc: @steveharter @stephentoub @AtsushiKan 