### PR TITLE
Fix DataViewTest.ColumnChangeName test

### DIFF
--- a/src/System.Data.Common/tests/System/Data/DataViewTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataViewTest.cs
@@ -742,6 +742,7 @@ namespace System.Data.Tests
             DataRowView a3 = dv.AddNew();
 
             Assert.Equal(reference, _eventWriter.ToString());
+            GC.KeepAlive(dv);
         }
 
         [Fact]
@@ -762,6 +763,7 @@ table was set.
             _dc2.ColumnName = "new_column_name";
 
             Assert.Equal(result.Replace("\r\n", "\n"), _eventWriter.ToString().Replace("\r\n", "\n"));
+            GC.KeepAlive(dv);
         }
 
         private void ListChanged(object o, ListChangedEventArgs e)


### PR DESCRIPTION
If the GC runs at just the wrong time, some callbacks kept alive only via weak references end up getting collected, don't fire, and cause the test to fail.  The fix is just to keep the relevant objects alive. (This is one of the tests ported from mono.)

Fixes https://github.com/dotnet/corefx/issues/12764
cc: @saurabh500