### PR TITLE
Another fix for the TickCount test.

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
@@ -16,14 +16,14 @@ namespace System.Tests
         {
             int start = Environment.TickCount;
             HashSet<int> times = new HashSet<int>();
+            Func<bool> test = () =>
+            {
+                int time = Environment.TickCount;
+                times.Add(time);
+                return time - start > 0;
+            };
             Assert.True(
-                SpinWait.SpinUntil(() =>
-                {
-                    int time = Environment.TickCount;
-                    times.Add(time);
-                    return time - start > 0;
-                },
-                TimeSpan.FromSeconds(1)),
+                SpinWait.SpinUntil(test, TimeSpan.FromSeconds(1)) || test(),
                 $"TickCount did not increase after one second. start: {start}, values tested: {string.Join(", ", times.ToArray())}.");
         }
     }


### PR DESCRIPTION
From test failure logs, it appears that this test tends to fail when the "Spin block" test is only performed once. This seems to indicate that the TickCount is only read once upon entering the spin. The SpinUntil call terminates (after one second) before the TickCount is ever read again. If we encounter a scenario like that, we now attempt to read the TickCount once more after the SpinUntil call, to ensure we have read the TickCount after the second delay.

@stephentoub