### PR TITLE
Support "offline" initializtion of Tools

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -88,53 +88,81 @@ OSName=$(uname -s)
             ;;
   esac
 fi
+
 if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
+    __PATCH_CLI_NUGET_FRAMEWORKS=0
+
     if [ -e $__TOOLRUNTIME_DIR ]; then rm -rf -- $__TOOLRUNTIME_DIR; fi
     echo "Running: $__scriptpath/init-tools.sh" > $__init_tools_log
+
     if [ ! -e $__DOTNET_PATH ]; then
-        echo "Installing dotnet cli..."
-        __DOTNET_LOCATION="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/${__DOTNET_TOOLS_VERSION}/${__DOTNET_PKG}.${__DOTNET_TOOLS_VERSION}.tar.gz"
-        # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
-        echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> $__init_tools_log
-        which curl > /dev/null 2> /dev/null
-        if [ $? -ne 0 ]; then
-            mkdir -p "$__DOTNET_PATH"
-            wget -q -O $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
+
+        mkdir -p "$__DOTNET_PATH"
+
+        if [ -n "$DOTNET_TOOLSET_DIR" ] && [ -d "$DOTNET_TOOLSET_DIR/$__DOTNET_TOOLS_VERSION" ]; then
+            echo "Copying $DOTNET_TOOLSET_DIR/$__DOTNET_TOOLS_VERSION to $__DOTNET_PATH" >> $__init_tools_log
+            cp -r $DOTNET_TOOLSET_DIR/$__DOTNET_TOOLS_VERSION/* $__DOTNET_PATH
+        elif [ -n "$DOTNET_TOOL_DIR" ] && [ -d "$DOTNET_TOOL_DIR" ]; then
+            echo "Copying $DOTNET_TOOL_DIR to $__DOTNET_PATH" >> $__init_tools_log
+            cp -r $DOTNET_TOOL_DIR/* $__DOTNET_PATH
         else
-            curl --retry 10 -sSL --create-dirs -o $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
+            echo "Installing dotnet cli..."
+            __DOTNET_LOCATION="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/${__DOTNET_TOOLS_VERSION}/${__DOTNET_PKG}.${__DOTNET_TOOLS_VERSION}.tar.gz"
+            # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
+            echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> $__init_tools_log
+            which curl > /dev/null 2> /dev/null
+            if [ $? -ne 0 ]; then
+                wget -q -O $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
+            else
+                curl --retry 10 -sSL --create-dirs -o $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
+            fi
+            cd $__DOTNET_PATH
+            tar -xf $__DOTNET_PATH/dotnet.tar
+
+            cd $__scriptpath
+
+            __PATCH_CLI_NUGET_FRAMEWORKS=1
         fi
-        cd $__DOTNET_PATH
-        tar -xf $__DOTNET_PATH/dotnet.tar
-
-        cd $__scriptpath
     fi
 
-    if [ ! -d "$__PROJECT_JSON_PATH" ]; then mkdir "$__PROJECT_JSON_PATH"; fi
-    echo $__PROJECT_JSON_CONTENTS > "$__PROJECT_JSON_FILE"
 
-    if [ ! -e $__BUILD_TOOLS_PATH ]; then
-        echo "Restoring BuildTools version $__BUILD_TOOLS_PACKAGE_VERSION..."
-        echo "Running: $__DOTNET_CMD restore \"$__PROJECT_JSON_FILE\" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE" >> $__init_tools_log
-        $__DOTNET_CMD restore "$__PROJECT_JSON_FILE" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE >> $__init_tools_log
-        if [ ! -e "$__BUILD_TOOLS_PATH/init-tools.sh" ]; then echo "ERROR: Could not restore build tools correctly. See '$__init_tools_log' for more details."1>&2; fi
+    if [ -n "$BUILD_TOOLS_TOOLSET_DIR" ] && [ -d "$BUILD_TOOLS_TOOLSET_DIR/$__BUILD_TOOLS_PACKAGE_VERSION" ]; then
+        echo "Copying $BUILD_TOOLS_TOOLSET_DIR/$__BUILD_TOOLS_PACKAGE_VERSION to $__TOOLRUNTIME_DIR" >> $__init_tools_log
+        cp -r $BUILD_TOOLS_TOOLSET_DIR/$__BUILD_TOOLS_PACKAGE_VERSION/* $__TOOLRUNTIME_DIR
+    elif [ -n "$BUILD_TOOLS_TOOL_DIR" ] && [ -d "$BUILD_TOOLS_TOOL_DIR" ]; then
+        echo "Copying $BUILD_TOOLS_TOOL_DIR to $__TOOLRUNTIME_DIR" >> $__init_tools_log
+        cp -r $BUILD_TOOLS_TOOL_DIR/* $__TOOLRUNTIME_DIR
+    else
+        if [ ! -d "$__PROJECT_JSON_PATH" ]; then mkdir "$__PROJECT_JSON_PATH"; fi
+        echo $__PROJECT_JSON_CONTENTS > "$__PROJECT_JSON_FILE"
+
+        if [ ! -e $__BUILD_TOOLS_PATH ]; then
+            echo "Restoring BuildTools version $__BUILD_TOOLS_PACKAGE_VERSION..."
+            echo "Running: $__DOTNET_CMD restore \"$__PROJECT_JSON_FILE\" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE" >> $__init_tools_log
+            $__DOTNET_CMD restore "$__PROJECT_JSON_FILE" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE >> $__init_tools_log
+            if [ ! -e "$__BUILD_TOOLS_PATH/init-tools.sh" ]; then echo "ERROR: Could not restore build tools correctly. See '$__init_tools_log' for more details."1>&2; fi
+        fi
+
+        echo "Initializing BuildTools..."
+        echo "Running: $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR" >> $__init_tools_log
+        $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR >> $__init_tools_log
+        if [ "$?" != "0" ]; then
+            echo "ERROR: An error occured when trying to initialize the tools. Please check '$__init_tools_log' for more details."1>&2
+            exit 1
+        fi
     fi
 
-    echo "Initializing BuildTools..."
-    echo "Running: $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR" >> $__init_tools_log
-    $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR >> $__init_tools_log
-    if [ "$?" != "0" ]; then
-        echo "ERROR: An error occured when trying to initialize the tools. Please check '$__init_tools_log' for more details."1>&2
-        exit 1
-    fi
-
-    echo "Updating CLI NuGet Frameworks map..."
-    cp $__TOOLRUNTIME_DIR/NuGet.Frameworks.dll $__TOOLRUNTIME_DIR/dotnetcli/sdk/$__DOTNET_TOOLS_VERSION >> $__init_tools_log
-    if [ "$?" != "0" ]; then
-        echo "ERROR: An error occured when updating Nuget for CLI . Please check '$__init_tools_log' for more details."1>&2
-        exit 1
+    if [ $__PATCH_CLI_NUGET_FRAMEWORKS -eq 1 ]; then
+        echo "Updating CLI NuGet Frameworks map..."
+        cp $__TOOLRUNTIME_DIR/NuGet.Frameworks.dll $__TOOLRUNTIME_DIR/dotnetcli/sdk/$__DOTNET_TOOLS_VERSION >> $__init_tools_log
+        if [ "$?" != "0" ]; then
+            echo "ERROR: An error occured when updating Nuget for CLI . Please check '$__init_tools_log' for more details."1>&2
+            exit 1
+        fi
     fi
 
     touch $__INIT_TOOLS_DONE_MARKER
+
     echo "Done initializing tools."
 else
     echo "Tools are already initialized"


### PR DESCRIPTION
This change allows init-tools to function in an "offline" mode where
tools are picked up from standalone folders. Specifically, it introduces
support for two new environment variables:

- DOTNET_TOOLSET_DIR
- BUILD_TOOLS_TOOLSET_DIR

If either is set, instead of downloading toolsets, we copy an already
existing one from the folder.  The TOOLSET_DIR is a folder with sub
directories for every version of the tool in question.

For buildtools, we expect a published toolset (sans the "dotnetcli"
folder) not just a set of nuget packages (i.e. the layout of Tools/
after running ./init-tools.sh in "online" mode).

The above varibles are useful for situations where we want to carry
multiple toolsets with us, but are less helpful for places where a
developer has produced their own toolset by hand (since the resulting
folder structure contains extra version information). For these cases,
I've added

- DOTNET_TOOL_DIR
- BUILD_TOOLS_TOOL_DIR

Which work like the above but don't require the nested folder structure.