### PR TITLE
Applying consistent rules around usage of var

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/CacheDict.cs
+++ b/src/Common/src/System/Dynamic/Utils/CacheDict.cs
@@ -44,7 +44,7 @@ namespace System.Dynamic.Utils
         /// <param name="size">The maximum number of elements to store will be this number aligned to next ^2.</param>
         internal CacheDict(int size)
         {
-            var alignedSize = AlignSize(size);
+            int alignedSize = AlignSize(size);
             this.mask = alignedSize - 1;
             this.entries = new Entry[alignedSize];
         }
@@ -74,7 +74,7 @@ namespace System.Dynamic.Utils
             int hash = key.GetHashCode();
             int idx = hash & mask;
 
-            var entry = Volatile.Read(ref this.entries[idx]);
+            Entry entry = Volatile.Read(ref this.entries[idx]);
             if (entry != null && entry.hash == hash && entry.key.Equals(key))
             {
                 value = entry.value;
@@ -91,10 +91,10 @@ namespace System.Dynamic.Utils
         /// </summary>
         internal void Add(TKey key, TValue value)
         {
-            var hash = key.GetHashCode();
-            var idx = hash & mask;
+            int hash = key.GetHashCode();
+            int idx = hash & mask;
 
-            var entry = Volatile.Read(ref this.entries[idx]);
+            Entry entry = Volatile.Read(ref this.entries[idx]);
             if (entry == null || entry.hash != hash || !entry.key.Equals(key))
             {
                 Volatile.Write(ref entries[idx], new Entry(hash, key, value));

--- a/src/Common/src/System/Dynamic/Utils/CollectionExtensions.cs
+++ b/src/Common/src/System/Dynamic/Utils/CollectionExtensions.cs
@@ -47,7 +47,7 @@ namespace System.Dynamic.Utils
         // We could probably improve the hashing here
         public static int ListHashCode<T>(this IEnumerable<T> list)
         {
-            var cmp = EqualityComparer<T>.Default;
+            EqualityComparer<T> cmp = EqualityComparer<T>.Default;
             int h = 6551;
             foreach (T t in list)
             {
@@ -71,7 +71,7 @@ namespace System.Dynamic.Utils
                 return false;
             }
 
-            var cmp = EqualityComparer<T>.Default;
+            EqualityComparer<T> cmp = EqualityComparer<T>.Default;
             for(int i = 0; i != count; ++i)
             {
                 if (!cmp.Equals(first[i], second[i]))

--- a/src/Common/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -14,7 +14,7 @@ namespace System.Dynamic.Utils
         internal static ParameterInfo[] GetParametersCached(this MethodBase method)
         {
             ParameterInfo[] pis;
-            var pic = s_paramInfoCache;
+            CacheDict<MethodBase, ParameterInfo[]> pic = s_paramInfoCache;
             if (!pic.TryGetValue(method, out pis))
             {
                 pis = method.GetParameters();

--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -84,7 +84,7 @@ namespace System.Dynamic.Utils
             // that allows mscorlib types to be specialized by types in other
             // assemblies.
 
-            var asm = t.GetTypeInfo().Assembly;
+            Assembly asm = t.GetTypeInfo().Assembly;
             if (asm != _mscorlib)
             {
                 // Not in mscorlib or our assembly

--- a/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
+++ b/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
@@ -36,7 +36,7 @@ namespace System.Linq.Expressions.Compiler
             var name = new AssemblyName("Snippets");
 
             // mark the assembly transparent so that it works in partial trust:
-            var attributes = new[] {
+            CustomAttributeBuilder[] attributes = new[] {
                 new CustomAttributeBuilder(typeof(SecurityTransparentAttribute).GetConstructor(Type.EmptyTypes), Array.Empty<object>())
             };
 

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/Helpers.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/Helpers.cs
@@ -12,7 +12,7 @@ namespace System.Dynamic.Utils
     {
         internal static T CommonNode<T>(T first, T second, Func<T, T> parent) where T : class
         {
-            var cmp = EqualityComparer<T>.Default;
+            EqualityComparer<T> cmp = EqualityComparer<T>.Default;
             if (cmp.Equals(first, second))
             {
                 return first;

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -43,7 +43,7 @@ namespace System.Dynamic.Utils
             {
                 return false;
             }
-            var ps = mi.GetParameters();
+            ParameterInfo[] ps = mi.GetParameters();
 
             if (ps.Length != argTypes.Length)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -269,22 +269,22 @@ namespace System.Linq.Expressions
             var vars = new ArrayBuilder<ParameterExpression>(index.ArgumentCount + 2);
             var exprs = new ArrayBuilder<Expression>(index.ArgumentCount + 3);
 
-            var tempObj = Expression.Variable(index.Object.Type, "tempObj");
+            ParameterExpression tempObj = Expression.Variable(index.Object.Type, "tempObj");
             vars.UncheckedAdd(tempObj);
             exprs.UncheckedAdd(Expression.Assign(tempObj, index.Object));
 
-            var n = index.ArgumentCount;
+            int n = index.ArgumentCount;
             var tempArgs = new ArrayBuilder<Expression>(n);
             for (var i = 0; i < n; i++)
             {
-                var arg = index.GetArgument(i);
-                var tempArg = Expression.Variable(arg.Type, "tempArg" + i);
+                Expression arg = index.GetArgument(i);
+                ParameterExpression tempArg = Expression.Variable(arg.Type, "tempArg" + i);
                 vars.UncheckedAdd(tempArg);
                 tempArgs.UncheckedAdd(tempArg);
                 exprs.UncheckedAdd(Expression.Assign(tempArg, arg));
             }
 
-            var tempIndex = Expression.MakeIndex(tempObj, index.Indexer, tempArgs.ToReadOnly());
+            IndexExpression tempIndex = Expression.MakeIndex(tempObj, index.Indexer, tempArgs.ToReadOnly());
 
             // tempValue = tempObj[tempArg0, ... tempArgN] (op) r
             ExpressionType binaryOp = GetBinaryOpFromAssignmentOp(NodeType);
@@ -294,7 +294,7 @@ namespace System.Linq.Expressions
             {
                 op = Expression.Invoke(conversion, op);
             }
-            var tempValue = Expression.Variable(op.Type, "tempValue");
+            ParameterExpression tempValue = Expression.Variable(op.Type, "tempValue");
             vars.UncheckedAdd(tempValue);
             exprs.UncheckedAdd(Expression.Assign(tempValue, op));
 
@@ -440,8 +440,8 @@ namespace System.Linq.Expressions
         {
             Debug.Assert(IsLiftedLogical);
 
-            var left = Parameter(_left.Type, "left");
-            var right = Parameter(Right.Type, "right");
+            ParameterExpression left = Parameter(_left.Type, "left");
+            ParameterExpression right = Parameter(Right.Type, "right");
             string opName = NodeType == ExpressionType.AndAlso ? "op_False" : "op_True";
             MethodInfo opTrueFalse = TypeUtils.GetBooleanOperator(Method.DeclaringType, opName);
             Debug.Assert(opTrueFalse != null);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -866,18 +866,18 @@ namespace System.Linq.Expressions
         public static BlockExpression Block(IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions)
         {
             ContractUtils.RequiresNotNull(expressions, nameof(expressions));
-            var variableList = variables.ToReadOnly();
+            ReadOnlyCollection<ParameterExpression> variableList = variables.ToReadOnly();
 
             if (variableList.Count == 0)
             {
-                var expressionList = expressions as IReadOnlyList<Expression> ?? expressions.ToReadOnly();
+                IReadOnlyList<Expression> expressionList = expressions as IReadOnlyList<Expression> ?? expressions.ToReadOnly();
                 RequiresCanRead(expressionList, nameof(expressions));
 
                 return GetOptimizedBlockExpression(expressionList);
             }
             else
             {
-                var expressionList = expressions.ToReadOnly();
+                ReadOnlyCollection<Expression> expressionList = expressions.ToReadOnly();
                 RequiresCanRead(expressionList, nameof(expressions));
 
                 return BlockCore(null, variableList, expressionList);
@@ -896,18 +896,18 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(type, nameof(type));
             ContractUtils.RequiresNotNull(expressions, nameof(expressions));
 
-            var expressionList = expressions.ToReadOnly();
+            ReadOnlyCollection<Expression> expressionList = expressions.ToReadOnly();
             RequiresCanRead(expressionList, nameof(expressions));
 
-            var variableList = variables.ToReadOnly();
+            ReadOnlyCollection<ParameterExpression> variableList = variables.ToReadOnly();
 
             if (variableList.Count == 0 && expressionList.Count != 0)
             {
-                var expressionCount = expressionList.Count;
+                int expressionCount = expressionList.Count;
 
                 if (expressionCount != 0)
                 {
-                    var lastExpression = expressionList[expressionCount - 1];
+                    Expression lastExpression = expressionList[expressionCount - 1];
 
                     if (lastExpression.Type == type)
                     {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
@@ -96,7 +96,7 @@ namespace System.Linq.Expressions.Compiler
         {
             Node = node;
             IsMethod = isMethod;
-            var variables = GetVariables(node);
+            IList<ParameterExpression> variables = GetVariables(node);
 
             Definitions = new Dictionary<ParameterExpression, VariableStorageKind>(variables.Count);
             foreach (var v in variables)
@@ -293,7 +293,7 @@ namespace System.Linq.Expressions.Compiler
                 _closureHoistedLocals = _parent.NearestHoistedLocals;
             }
 
-            var hoistedVars = GetVariables().Where(p => Definitions[p] == VariableStorageKind.Hoisted).ToReadOnly();
+            ReadOnlyCollection<ParameterExpression> hoistedVars = GetVariables().Where(p => Definitions[p] == VariableStorageKind.Hoisted).ToReadOnly();
 
             if (hoistedVars.Count > 0)
             {
@@ -417,7 +417,7 @@ namespace System.Linq.Expressions.Compiler
 
             while ((locals = locals.Parent) != null)
             {
-                var v = locals.SelfVariable;
+                ParameterExpression v = locals.SelfVariable;
                 var local = new LocalStorage(lc, v);
                 local.EmitStore(ResolveVariable(v));
                 _locals.Add(v, local);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
@@ -206,7 +206,7 @@ namespace System.Linq.Expressions.Compiler
             }
             else
             {
-                var address = node.Object.Type.GetMethod("Address", BindingFlags.Public | BindingFlags.Instance);
+                MethodInfo address = node.Object.Type.GetMethod("Address", BindingFlags.Public | BindingFlags.Instance);
                 EmitMethodCall(node.Object, address, node);
             }
         }
@@ -294,7 +294,7 @@ namespace System.Linq.Expressions.Compiler
             EmitCall(instanceType, pi.GetGetMethod(true));
 
             // emit the address of the value
-            var valueLocal = GetLocal(node.Type);
+            LocalBuilder valueLocal = GetLocal(node.Type);
             _ilg.Emit(OpCodes.Stloc, valueLocal);
             _ilg.Emit(OpCodes.Ldloca, valueLocal);
 
@@ -339,14 +339,14 @@ namespace System.Linq.Expressions.Compiler
 
             // Emit indexes. We don't allow byref args, so no need to worry
             // about write-backs or EmitAddress
-            var n = node.ArgumentCount;
+            int n = node.ArgumentCount;
             var args = new LocalBuilder[n];
             for (var i = 0; i < n; i++)
             {
-                var arg = node.GetArgument(i);
+                Expression arg = node.GetArgument(i);
                 EmitExpression(arg);
 
-                var argLocal = GetLocal(arg.Type);
+                LocalBuilder argLocal = GetLocal(arg.Type);
                 _ilg.Emit(OpCodes.Dup);
                 _ilg.Emit(OpCodes.Stloc, argLocal);
                 args[i] = argLocal;
@@ -356,7 +356,7 @@ namespace System.Linq.Expressions.Compiler
             EmitGetIndexCall(node, instanceType);
 
             // emit the address of the value
-            var valueLocal = GetLocal(node.Type);
+            LocalBuilder valueLocal = GetLocal(node.Type);
             _ilg.Emit(OpCodes.Stloc, valueLocal);
             _ilg.Emit(OpCodes.Ldloca, valueLocal);
 
@@ -383,7 +383,7 @@ namespace System.Linq.Expressions.Compiler
 
         private LocalBuilder GetInstanceLocal(Type type)
         {
-            var instanceLocalType = type.GetTypeInfo().IsValueType ? type.MakeByRefType() : type;
+            Type instanceLocalType = type.GetTypeInfo().IsValueType ? type.MakeByRefType() : type;
             return GetLocal(instanceLocalType);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.ControlFlow.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.ControlFlow.cs
@@ -99,9 +99,9 @@ namespace System.Linq.Expressions.Compiler
         private void EmitGotoExpression(Expression expr, CompilationFlags flags)
         {
             var node = (GotoExpression)expr;
-            var labelInfo = ReferenceLabel(node.Target);
+            LabelInfo labelInfo = ReferenceLabel(node.Target);
 
-            var tailCall = flags & CompilationFlags.EmitAsTailCallMask;
+            CompilationFlags tailCall = flags & CompilationFlags.EmitAsTailCallMask;
             if (tailCall != CompilationFlags.EmitAsNoTail)
             {
                 // Since tail call flags are not passed into EmitTryExpression, CanReturn 
@@ -165,7 +165,7 @@ namespace System.Linq.Expressions.Compiler
                     // thing if it's in a switch case body.
                     if (_labelBlock.Kind == LabelScopeKind.Block)
                     {
-                        var label = ((LabelExpression)node).Target;
+                        LabelTarget label = ((LabelExpression)node).Target;
                         if (_labelBlock.ContainsTarget(label))
                         {
                             return false;
@@ -248,7 +248,7 @@ namespace System.Linq.Expressions.Compiler
         // This allows us to generate better IL
         private void AddReturnLabel(LambdaExpression lambda)
         {
-            var expression = lambda.Body;
+            Expression expression = lambda.Body;
 
             while (true)
             {
@@ -260,7 +260,7 @@ namespace System.Linq.Expressions.Compiler
                     case ExpressionType.Label:
                         // Found the label. We can directly return from this place
                         // only if the label type is reference assignable to the lambda return type.
-                        var label = ((LabelExpression)expression).Target;
+                        LabelTarget label = ((LabelExpression)expression).Target;
                         _labelInfo.Add(label, new LabelInfo(_ilg, label, TypeUtils.AreReferenceAssignable(lambda.ReturnType, label.Type)));
                         return;
                     case ExpressionType.Block:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -35,7 +35,7 @@ namespace System.Linq.Expressions.Compiler
         private static CompilationFlags UpdateEmitAsTailCallFlag(CompilationFlags flags, CompilationFlags newValue)
         {
             Debug.Assert(newValue == CompilationFlags.EmitAsTail || newValue == CompilationFlags.EmitAsMiddle || newValue == CompilationFlags.EmitAsNoTail);
-            var oldValue = flags & CompilationFlags.EmitAsTailCallMask;
+            CompilationFlags oldValue = flags & CompilationFlags.EmitAsTailCallMask;
             return flags ^ oldValue | newValue;
         }
 
@@ -45,7 +45,7 @@ namespace System.Linq.Expressions.Compiler
         private static CompilationFlags UpdateEmitExpressionStartFlag(CompilationFlags flags, CompilationFlags newValue)
         {
             Debug.Assert(newValue == CompilationFlags.EmitExpressionStart || newValue == CompilationFlags.EmitNoExpressionStart);
-            var oldValue = flags & CompilationFlags.EmitExpressionStartMask;
+            CompilationFlags oldValue = flags & CompilationFlags.EmitExpressionStartMask;
             return flags ^ oldValue | newValue;
         }
 
@@ -55,7 +55,7 @@ namespace System.Linq.Expressions.Compiler
         private static CompilationFlags UpdateEmitAsTypeFlag(CompilationFlags flags, CompilationFlags newValue)
         {
             Debug.Assert(newValue == CompilationFlags.EmitAsDefaultType || newValue == CompilationFlags.EmitAsVoidType);
-            var oldValue = flags & CompilationFlags.EmitAsTypeMask;
+            CompilationFlags oldValue = flags & CompilationFlags.EmitAsTypeMask;
             return flags ^ oldValue | newValue;
         }
 
@@ -192,7 +192,7 @@ namespace System.Linq.Expressions.Compiler
 
         private void EmitInlinedInvoke(InvocationExpression invoke, CompilationFlags flags)
         {
-            var lambda = invoke.LambdaOperand;
+            LambdaExpression lambda = invoke.LambdaOperand;
 
             // This is tricky: we need to emit the arguments outside of the
             // scope, but set them inside the scope. Fortunately, using the IL
@@ -237,7 +237,7 @@ namespace System.Linq.Expressions.Compiler
             // about write-backs or EmitAddress
             for (int i = 0, n = node.ArgumentCount; i < n; i++)
             {
-                var arg = node.GetArgument(i);
+                Expression arg = node.GetArgument(i);
                 EmitExpression(arg);
             }
 
@@ -248,7 +248,7 @@ namespace System.Linq.Expressions.Compiler
         {
             var index = (IndexExpression)node.Left;
 
-            var emitAs = flags & CompilationFlags.EmitAsTypeMask;
+            CompilationFlags emitAs = flags & CompilationFlags.EmitAsTypeMask;
 
             // Emit instance, if calling an instance method
             Type objectType = null;
@@ -261,7 +261,7 @@ namespace System.Linq.Expressions.Compiler
             // about write-backs or EmitAddress
             for (int i = 0, n = index.ArgumentCount; i < n; i++)
             {
-                var arg = index.GetArgument(i);
+                Expression arg = index.GetArgument(i);
                 EmitExpression(arg);
             }
 
@@ -291,7 +291,7 @@ namespace System.Linq.Expressions.Compiler
             if (node.Indexer != null)
             {
                 // For indexed properties, just call the getter
-                var method = node.Indexer.GetGetMethod(true);
+                MethodInfo method = node.Indexer.GetGetMethod(true);
                 EmitCall(objectType, method);
             }
             else
@@ -319,7 +319,7 @@ namespace System.Linq.Expressions.Compiler
             if (node.Indexer != null)
             {
                 // For indexed properties, just call the setter
-                var method = node.Indexer.GetSetMethod(true);
+                MethodInfo method = node.Indexer.GetSetMethod(true);
                 EmitCall(objectType, method);
             }
             else
@@ -586,17 +586,17 @@ namespace System.Linq.Expressions.Compiler
 
             var node = (IDynamicExpression)expr;
 
-            var site = node.CreateCallSite();
+            object site = node.CreateCallSite();
             Type siteType = site.GetType();
 
-            var invoke = node.DelegateType.GetMethod("Invoke");
+            MethodInfo invoke = node.DelegateType.GetMethod("Invoke");
 
             // site.Target.Invoke(site, args)
             EmitConstant(site, siteType);
 
             // Emit the temp as type CallSite so we get more reuse
             _ilg.Emit(OpCodes.Dup);
-            var siteTemp = GetLocal(siteType);
+            LocalBuilder siteTemp = GetLocal(siteType);
             _ilg.Emit(OpCodes.Stloc, siteTemp);
             _ilg.Emit(OpCodes.Ldfld, siteType.GetField("Target"));
             _ilg.Emit(OpCodes.Ldloc, siteTemp);
@@ -693,7 +693,7 @@ namespace System.Linq.Expressions.Compiler
         private void EmitVariableAssignment(BinaryExpression node, CompilationFlags flags)
         {
             var variable = (ParameterExpression)node.Left;
-            var emitAs = flags & CompilationFlags.EmitAsTypeMask;
+            CompilationFlags emitAs = flags & CompilationFlags.EmitAsTypeMask;
 
             EmitExpression(node.Right);
             if (emitAs != CompilationFlags.EmitAsVoidType)
@@ -782,7 +782,7 @@ namespace System.Linq.Expressions.Compiler
             EmitExpression(node.Right);
 
             LocalBuilder temp = null;
-            var emitAs = flags & CompilationFlags.EmitAsTypeMask;
+            CompilationFlags emitAs = flags & CompilationFlags.EmitAsTypeMask;
             if (emitAs != CompilationFlags.EmitAsVoidType)
             {
                 // save the value so we can return it

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Lambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Lambda.cs
@@ -158,8 +158,8 @@ namespace System.Linq.Expressions.Compiler
 
         private static Type[] GetParameterTypes(LambdaExpression lambda, Type firstType)
         {
-            var parameters = lambda.Parameters;
-            var count = parameters.Count;
+            Collections.ObjectModel.ReadOnlyCollection<ParameterExpression> parameters = lambda.Parameters;
+            int count = parameters.Count;
 
             Type[] result;
             int i;
@@ -178,7 +178,7 @@ namespace System.Linq.Expressions.Compiler
 
             for (var j = 0; j < count; j++, i++)
             {
-                var p = parameters[j];
+                ParameterExpression p = parameters[j];
                 result[i] = p.IsByRef ? p.Type.MakeByRefType() : p.Type;
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -36,8 +36,8 @@ namespace System.Linq.Expressions.Compiler
             CompilationFlags tailCall = flags & CompilationFlags.EmitAsTailCallMask;
             for (int index = 0; index < count - 1; index++)
             {
-                var e = node.GetExpression(index);
-                var next = node.GetExpression(index + 1);
+                Expression e = node.GetExpression(index);
+                Expression next = node.GetExpression(index + 1);
 
                 CompilationFlags tailCallFlag;
                 if (tailCall != CompilationFlags.EmitAsNoTail)
@@ -199,8 +199,8 @@ namespace System.Linq.Expressions.Compiler
             // transform the tree to avoid stack overflow on a big switch.
             //
 
-            var switchValue = Expression.Parameter(node.SwitchValue.Type, "switchValue");
-            var testValue = Expression.Parameter(GetTestValueType(node), "testValue");
+            ParameterExpression switchValue = Expression.Parameter(node.SwitchValue.Type, "switchValue");
+            ParameterExpression testValue = Expression.Parameter(GetTestValueType(node), "testValue");
             _scope.AddLocal(this, switchValue);
             _scope.AddLocal(this, testValue);
 
@@ -285,7 +285,7 @@ namespace System.Linq.Expressions.Compiler
                 Default = @default;
                 Type = Node.SwitchValue.Type;
                 IsUnsigned = TypeUtils.IsUnsigned(Type);
-                var code = Type.GetTypeCode();
+                TypeCode code = Type.GetTypeCode();
                 Is64BitSwitch = code == TypeCode.UInt64 || code == TypeCode.Int64;
             }
         }
@@ -729,9 +729,9 @@ namespace System.Linq.Expressions.Compiler
             //     default:
             // }
             //
-            var switchValue = Expression.Variable(typeof(string), "switchValue");
-            var switchIndex = Expression.Variable(typeof(int), "switchIndex");
-            var reduced = Expression.Block(
+            ParameterExpression switchValue = Expression.Variable(typeof(string), "switchValue");
+            ParameterExpression switchIndex = Expression.Variable(typeof(int), "switchIndex");
+            BlockExpression reduced = Expression.Block(
                 new[] { switchIndex, switchValue },
                 Expression.Assign(switchValue, node.SwitchValue),
                 Expression.IfThenElse(

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
@@ -156,7 +156,7 @@ namespace System.Linq.Expressions.Compiler
                 body = ((BlockExpression)node).Expressions;
             }
 
-            var currentScope = _scopes.Peek();
+            CompilerScope currentScope = _scopes.Peek();
 
             // A block body is mergeable if the body only contains one single block node containing variables,
             // and the child block has the same type as the parent block.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
@@ -104,7 +104,7 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(addMethod, nameof(addMethod));
             ContractUtils.RequiresNotNull(arguments, nameof(arguments));
 
-            var argumentsRO = arguments.ToReadOnly();
+            ReadOnlyCollection<Expression> argumentsRO = arguments.ToReadOnly();
 
             RequiresCanRead(argumentsRO, nameof(arguments));
             ValidateElementInitAddMethodInfo(addMethod, nameof(addMethod));

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
@@ -183,7 +183,7 @@ namespace System.Linq.Expressions
         {
             if (!CanReduce) throw Error.MustBeReducible();
 
-            var newNode = Reduce();
+            Expression newNode = Reduce();
 
             // 1. Reduction must return a new, non-null node
             // 2. Reduction must return a new node whose result type can be assigned to the type of the original node
@@ -199,7 +199,7 @@ namespace System.Linq.Expressions
         /// <returns>The reduced expression.</returns>
         public Expression ReduceExtensions()
         {
-            var node = this;
+            Expression node = this;
             while (node.NodeType == ExpressionType.Extension)
             {
                 node = node.ReduceAndCheck();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
@@ -499,7 +499,7 @@ namespace System.Linq.Expressions
             Out("new ");
             Out(node.Type.Name);
             Out('(');
-            var members = node.Members;
+            Collections.ObjectModel.ReadOnlyCollection<MemberInfo> members = node.Members;
             for (int i = 0; i < node.ArgumentCount; i++)
             {
                 if (i > 0)
@@ -718,7 +718,7 @@ namespace System.Linq.Expressions
         protected internal override Expression VisitExtension(Expression node)
         {
             // Prefer an overridden ToString, if available.
-            var toString = node.GetType().GetMethod("ToString", Type.EmptyTypes);
+            MethodInfo toString = node.GetType().GetMethod("ToString", Type.EmptyTypes);
             if (toString.DeclaringType != typeof(Expression) && !toString.IsStatic)
             {
                 Out(node.ToString());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
@@ -214,7 +214,7 @@ namespace System.Linq.Expressions
         protected internal virtual Expression VisitBlock(BlockExpression node)
         {
             Expression[] nodes = ExpressionVisitorUtils.VisitBlockExpressions(this, node);
-            var v = VisitAndConvert(node.Variables, "VisitBlock");
+            ReadOnlyCollection<ParameterExpression> v = VisitAndConvert(node.Variables, "VisitBlock");
 
             if (v == node.Variables && nodes == null)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -189,7 +189,7 @@ namespace System.Linq.Expressions
                 throw Error.ArgumentMustBeArray(nameof(array));
             }
 
-            var indexList = indexes.ToReadOnly();
+            ReadOnlyCollection<Expression> indexList = indexes.ToReadOnly();
             if (arrayType.GetArrayRank() != indexList.Count)
             {
                 throw Error.IncorrectNumberOfIndexes();
@@ -354,7 +354,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="IndexExpression"/>.</returns>
         public static IndexExpression Property(Expression instance, PropertyInfo indexer, IEnumerable<Expression> arguments)
         {
-            var argList = arguments.ToReadOnly();
+            ReadOnlyCollection<Expression> argList = arguments.ToReadOnly();
             ValidateIndexedProperty(instance, indexer, ref argList);
             return new IndexExpression(instance, indexer, argList);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
@@ -21,8 +21,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -37,8 +37,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -53,8 +53,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -69,8 +69,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -85,8 +85,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -101,8 +101,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -117,8 +117,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -133,8 +133,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -149,8 +149,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     if (right == null)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
@@ -77,7 +77,7 @@ namespace System.Linq.Expressions.Interpreter
             var lengths = new int[_rank];
             for (int i = _rank - 1; i >= 0; i--)
             {
-                var length = ConvertHelper.ToInt32NoNull(frame.Pop());
+                int length = ConvertHelper.ToInt32NoNull(frame.Pop());
 
                 if (length < 0)
                 {
@@ -87,7 +87,7 @@ namespace System.Linq.Expressions.Interpreter
 
                 lengths[i] = length;
             }
-            var array = Array.CreateInstance(_elementType, lengths);
+            Array array = Array.CreateInstance(_elementType, lengths);
             frame.Push(array);
             return +1;
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -326,7 +326,7 @@ namespace System.Linq.Expressions.Interpreter
             object ret;
             if (_target.IsStatic)
             {
-                var args = GetArgs(frame, first, 0);
+                object[] args = GetArgs(frame, first, 0);
                 try
                 {
                     ret = _target.Invoke(null, args);
@@ -338,10 +338,10 @@ namespace System.Linq.Expressions.Interpreter
             }
             else
             {
-                var instance = frame.Data[first];
+                object instance = frame.Data[first];
                 NullCheck(instance);
 
-                var args = GetArgs(frame, first, 1);
+                object[] args = GetArgs(frame, first, 1);
 
                 LightLambda targetLambda;
                 if (TryGetLightLambdaTarget(instance, out targetLambda))
@@ -377,7 +377,7 @@ namespace System.Linq.Expressions.Interpreter
 
         protected object[] GetArgs(InterpretedFrame frame, int first, int skip)
         {
-            var count = _argumentCount - skip;
+            int count = _argumentCount - skip;
 
             if (count > 0)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -24,7 +24,7 @@ namespace System.Linq.Expressions.Interpreter
             Debug.Assert(_offset == Unknown && offset != Unknown);
             _offset = offset;
 
-            var cache = Cache;
+            Instruction[] cache = Cache;
             if (cache != null && offset >= 0 && offset < cache.Length)
             {
                 return cache[offset] ?? (cache[offset] = this);
@@ -282,7 +282,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             if (labelIndex < CacheSize)
             {
-                var index = Variants * labelIndex | (labelTargetGetsValue ? 4 : 0) | (hasResult ? 2 : 0) | (hasValue ? 1 : 0);
+                int index = Variants * labelIndex | (labelTargetGetsValue ? 4 : 0) | (hasResult ? 2 : 0) | (hasValue ? 1 : 0);
                 return s_cache[index] ?? (s_cache[index] = new GotoInstruction(labelIndex, hasResult, hasValue, labelTargetGetsValue));
             }
             return new GotoInstruction(labelIndex, hasResult, hasValue, labelTargetGetsValue);
@@ -344,7 +344,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.InstructionIndex++;
 
             // Start to run the try/catch/finally blocks
-            var instructions = frame.Interpreter.Instructions.Instructions;
+            Instruction[] instructions = frame.Interpreter.Instructions.Instructions;
             ExceptionHandler exHandler;
             try
             {
@@ -471,7 +471,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.InstructionIndex++;
 
             // Start to run the try/fault blocks
-            var instructions = frame.Interpreter.Instructions.Instructions;
+            Instruction[] instructions = frame.Interpreter.Instructions.Instructions;
 
             // C# 6 has no direct support for fault blocks, but they can be faked or coerced out of the compiler
             // in several ways. Catch-and-rethrow can work in specific cases, but not generally as the double-pass

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -23,8 +23,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -45,8 +45,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -67,8 +67,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -89,8 +89,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -111,8 +111,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -133,8 +133,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -155,8 +155,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -177,8 +177,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -199,8 +199,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -221,8 +221,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -243,8 +243,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -265,8 +265,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
@@ -296,8 +296,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -314,8 +314,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -332,8 +332,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -350,8 +350,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -368,8 +368,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -386,8 +386,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -404,8 +404,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -422,8 +422,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -440,8 +440,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -458,8 +458,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -476,8 +476,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -494,8 +494,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -513,8 +513,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
@@ -21,8 +21,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -37,8 +37,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -53,8 +53,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -69,8 +69,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -85,8 +85,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -101,8 +101,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -117,8 +117,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -133,8 +133,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -149,8 +149,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -32,8 +32,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -55,8 +55,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -78,8 +78,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -101,8 +101,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -124,8 +124,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -147,8 +147,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -170,8 +170,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -193,8 +193,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -216,8 +216,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -239,8 +239,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -262,8 +262,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -348,8 +348,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -371,8 +371,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -394,8 +394,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -417,8 +417,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -440,8 +440,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -463,8 +463,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -486,8 +486,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -509,8 +509,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -532,8 +532,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -555,8 +555,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -578,8 +578,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
@@ -74,7 +74,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var value = frame.Pop();
+                object value = frame.Pop();
                 if (value == null)
                 {
                     frame.Push(null);
@@ -91,7 +91,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var value = frame.Pop();
+                object value = frame.Pop();
                 if (value == null)
                 {
                     frame.Push(null);
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var value = frame.Pop();
+                object value = frame.Pop();
                 if (value == null)
                 {
                     frame.Push(null);
@@ -125,7 +125,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var value = frame.Pop();
+                object value = frame.Pop();
                 if (value == null)
                 {
                     frame.Push(null);
@@ -142,7 +142,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var value = frame.Pop();
+                object value = frame.Pop();
                 if (value == null)
                 {
                     frame.Push(null);
@@ -159,7 +159,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var value = frame.Pop();
+                object value = frame.Pop();
                 if (value == null)
                 {
                     frame.Push(null);
@@ -176,7 +176,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var value = frame.Pop();
+                object value = frame.Pop();
                 if (value == null)
                 {
                     frame.Push(null);
@@ -193,7 +193,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var value = frame.Pop();
+                object value = frame.Pop();
                 if (value == null)
                 {
                     frame.Push(null);
@@ -210,7 +210,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var value = frame.Pop();
+                object value = frame.Pop();
                 if (value == null)
                 {
                     frame.Push(null);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -114,8 +114,8 @@ namespace System.Linq.Expressions.Interpreter
                 int stackDepth = 0;
                 int continuationsDepth = 0;
 
-                var cookieEnumerator = (debugCookies ?? Array.Empty<KeyValuePair<int, object>>()).GetEnumerator();
-                var hasCookie = cookieEnumerator.MoveNext();
+                IEnumerator<KeyValuePair<int, object>> cookieEnumerator = (debugCookies ?? Array.Empty<KeyValuePair<int, object>>()).GetEnumerator();
+                bool hasCookie = cookieEnumerator.MoveNext();
 
                 for (int i = 0, n = instructions.Count; i < n; i++)
                 {
@@ -409,7 +409,7 @@ namespace System.Linq.Expressions.Interpreter
 
             if (instruction != null)
             {
-                var newInstruction = instruction.BoxIfIndexMatches(index);
+                Instruction newInstruction = instruction.BoxIfIndexMatches(index);
                 if (newInstruction != null)
                 {
                     _instructions[instructionIndex] = newInstruction;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -142,7 +142,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public IEnumerable<InterpretedFrameInfo> GetStackTraceDebugInfo()
         {
-            var frame = this;
+            InterpretedFrame frame = this;
             do
             {
                 yield return new InterpretedFrameInfo(frame.Name, frame.GetDebugInfo(frame.InstructionIndex));
@@ -169,7 +169,7 @@ namespace System.Linq.Expressions.Interpreter
             get
             {
                 var trace = new List<string>();
-                var frame = this;
+                InterpretedFrame frame = this;
                 do
                 {
                     trace.Add(frame.Name);
@@ -182,7 +182,7 @@ namespace System.Linq.Expressions.Interpreter
 
         internal InterpretedFrame Enter()
         {
-            var currentFrame = CurrentFrame;
+            InterpretedFrame currentFrame = CurrentFrame;
             CurrentFrame = this;
             return _parent = currentFrame;
         }
@@ -213,7 +213,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public int YieldToCurrentContinuation()
         {
-            var target = Interpreter._labels[_continuations[_continuationIndex - 1]];
+            RuntimeLabel target = Interpreter._labels[_continuations[_continuationIndex - 1]];
             SetStackDepth(target.StackDepth);
             return target.Index - InstructionIndex;
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Interpreter.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Interpreter.cs
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Interpreter
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Run(InterpretedFrame frame)
         {
-            var instructions = _instructions.Instructions;
+            Instruction[] instructions = _instructions.Instructions;
             int index = frame.InstructionIndex;
             while (index < instructions.Length)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LabelInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LabelInfo.cs
@@ -219,7 +219,7 @@ namespace System.Linq.Expressions.Interpreter
 
         internal static T CommonNode<T>(T first, T second, Func<T, T> parent) where T : class
         {
-            var cmp = EqualityComparer<T>.Default;
+            EqualityComparer<T> cmp = EqualityComparer<T>.Default;
             if (cmp.Equals(first, second))
             {
                 return first;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
@@ -21,8 +21,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -39,8 +39,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -57,8 +57,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -75,8 +75,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -93,8 +93,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -111,8 +111,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -129,8 +129,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -147,8 +147,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -33,8 +33,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -56,8 +56,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -79,8 +79,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -102,8 +102,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -125,8 +125,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -148,8 +148,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -171,8 +171,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -194,8 +194,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -217,8 +217,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -240,8 +240,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -263,8 +263,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -346,8 +346,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -369,8 +369,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -392,8 +392,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -415,8 +415,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -438,8 +438,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -461,8 +461,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -484,8 +484,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -507,8 +507,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -530,8 +530,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -553,8 +553,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);
@@ -576,8 +576,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(_nullValue);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -316,7 +316,7 @@ namespace System.Linq.Expressions.Interpreter
             //Console.WriteLine(node.DebugView);
             foreach (var p in node.Parameters)
             {
-                var local = _locals.DefineLocal(p, 0);
+                LocalDefinition local = _locals.DefineLocal(p, 0);
                 _instructions.EmitInitializeParameter(local.Index);
             }
 
@@ -335,7 +335,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private Interpreter MakeInterpreter(string lambdaName)
         {
-            var debugInfos = _debugInfos.ToArray();
+            DebugInfo[] debugInfos = _debugInfos.ToArray();
             return new Interpreter(lambdaName, _locals, GetBranchMapping(), _instructions.ToArray(), debugInfos);
         }
 
@@ -519,9 +519,9 @@ namespace System.Linq.Expressions.Interpreter
 
             if (node.ExpressionCount != 0)
             {
-                var end = CompileBlockStart(node);
+                LocalDefinition[] end = CompileBlockStart(node);
 
-                var lastExpression = node.Expressions[node.Expressions.Count - 1];
+                Expression lastExpression = node.Expressions[node.Expressions.Count - 1];
                 Compile(lastExpression, asVoid);
                 CompileBlockEnd(end);
             }
@@ -529,10 +529,10 @@ namespace System.Linq.Expressions.Interpreter
 
         private LocalDefinition[] CompileBlockStart(BlockExpression node)
         {
-            var start = _instructions.Count;
+            int start = _instructions.Count;
 
             LocalDefinition[] locals;
-            var variables = node.Variables;
+            ReadOnlyCollection<ParameterExpression> variables = node.Variables;
             if (variables.Count != 0)
             {
                 // TODO: basic flow analysis so we don't have to initialize all
@@ -541,7 +541,7 @@ namespace System.Linq.Expressions.Interpreter
                 int localCnt = 0;
                 foreach (var variable in variables)
                 {
-                    var local = _locals.DefineLocal(variable, start);
+                    LocalDefinition local = _locals.DefineLocal(variable, start);
                     locals[localCnt++] = local;
 
                     _instructions.EmitInitializeLocal(local.Index, variable.Type);
@@ -651,7 +651,7 @@ namespace System.Linq.Expressions.Interpreter
         private void CompileMemberAssignment(BinaryExpression node, bool asVoid)
         {
             var member = (MemberExpression)node.Left;
-            var expr = member.Expression;
+            Expression expr = member.Expression;
             if (expr != null)
             {
                 EmitThisForMethodCall(expr);
@@ -665,7 +665,7 @@ namespace System.Linq.Expressions.Interpreter
             var pi = refMember as PropertyInfo;
             if (pi != null)
             {
-                var method = pi.GetSetMethod(true);
+                MethodInfo method = pi.GetSetMethod(true);
                 if (forBinding && method.IsStatic)
                 {
                     throw Error.InvalidProgram();
@@ -984,8 +984,8 @@ namespace System.Linq.Expressions.Interpreter
 
         private void CompileComparison(BinaryExpression node)
         {
-            var left = node.Left;
-            var right = node.Right;
+            Expression left = node.Left;
+            Expression right = node.Right;
             Debug.Assert(left.Type == right.Type && TypeUtils.IsNumeric(left.Type));
 
             Compile(left);
@@ -1142,7 +1142,7 @@ namespace System.Linq.Expressions.Interpreter
                     _instructions.EmitBranchTrue(whenNull);
 
                     // get constructor for nullable type
-                    var constructor = typeTo.GetConstructor(new[] { typeTo.GetNonNullableType() });
+                    ConstructorInfo constructor = typeTo.GetConstructor(new[] { typeTo.GetNonNullableType() });
                     _instructions.EmitNew(constructor);
 
                     _instructions.MarkLabel(whenNull);
@@ -1234,8 +1234,8 @@ namespace System.Linq.Expressions.Interpreter
             Compile(node.Operand);
             if (node.IsLifted)
             {
-                var notNull = _instructions.MakeLabel();
-                var computed = _instructions.MakeLabel();
+                BranchLabel notNull = _instructions.MakeLabel();
+                BranchLabel computed = _instructions.MakeLabel();
 
                 _instructions.EmitCoalescingBranch(notNull);
                 _instructions.EmitBranch(computed);
@@ -1256,8 +1256,8 @@ namespace System.Linq.Expressions.Interpreter
             Compile(node.Operand);
             if (node.IsLifted)
             {
-                var notNull = _instructions.MakeLabel();
-                var computed = _instructions.MakeLabel();
+                BranchLabel notNull = _instructions.MakeLabel();
+                BranchLabel computed = _instructions.MakeLabel();
 
                 _instructions.EmitCoalescingBranch(notNull);
                 _instructions.EmitBranch(computed);
@@ -1307,7 +1307,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private void CompileMethodLogicalBinaryExpression(BinaryExpression expr, bool andAlso)
         {
-            var labEnd = _instructions.MakeLabel();
+            BranchLabel labEnd = _instructions.MakeLabel();
             Compile(expr.Left);
             _instructions.EmitDup();
 
@@ -1326,10 +1326,10 @@ namespace System.Linq.Expressions.Interpreter
 
         private void CompileLiftedLogicalBinaryExpression(BinaryExpression node, bool andAlso)
         {
-            var computeRight = _instructions.MakeLabel();
-            var returnFalse = _instructions.MakeLabel();
-            var returnNull = _instructions.MakeLabel();
-            var returnValue = _instructions.MakeLabel();
+            BranchLabel computeRight = _instructions.MakeLabel();
+            BranchLabel returnFalse = _instructions.MakeLabel();
+            BranchLabel returnNull = _instructions.MakeLabel();
+            BranchLabel returnValue = _instructions.MakeLabel();
             LocalDefinition result = _locals.DefineLocal(Expression.Parameter(node.Left.Type), _instructions.Count);
             LocalDefinition leftTemp = _locals.DefineLocal(Expression.Parameter(node.Left.Type), _instructions.Count);
 
@@ -1406,8 +1406,8 @@ namespace System.Linq.Expressions.Interpreter
 
         private void CompileUnliftedLogicalBinaryExpression(BinaryExpression expr, bool andAlso)
         {
-            var elseLabel = _instructions.MakeLabel();
-            var endLabel = _instructions.MakeLabel();
+            BranchLabel elseLabel = _instructions.MakeLabel();
+            BranchLabel endLabel = _instructions.MakeLabel();
             Compile(expr.Left);
 
             if (andAlso)
@@ -1432,20 +1432,20 @@ namespace System.Linq.Expressions.Interpreter
 
             if (node.IfTrue == AstUtils.Empty())
             {
-                var endOfFalse = _instructions.MakeLabel();
+                BranchLabel endOfFalse = _instructions.MakeLabel();
                 _instructions.EmitBranchTrue(endOfFalse);
                 Compile(node.IfFalse, asVoid);
                 _instructions.MarkLabel(endOfFalse);
             }
             else
             {
-                var endOfTrue = _instructions.MakeLabel();
+                BranchLabel endOfTrue = _instructions.MakeLabel();
                 _instructions.EmitBranchFalse(endOfTrue);
                 Compile(node.IfTrue, asVoid);
 
                 if (node.IfFalse != AstUtils.Empty())
                 {
-                    var endOfFalse = _instructions.MakeLabel();
+                    BranchLabel endOfFalse = _instructions.MakeLabel();
                     _instructions.EmitBranch(endOfFalse, false, !asVoid);
                     _instructions.MarkLabel(endOfTrue);
                     Compile(node.IfFalse, asVoid);
@@ -1509,7 +1509,7 @@ namespace System.Linq.Expressions.Interpreter
                     return;
                 }
 
-                var switchType = System.Dynamic.Utils.TypeExtensions.GetTypeCode(node.SwitchValue.Type);
+                TypeCode switchType = System.Dynamic.Utils.TypeExtensions.GetTypeCode(node.SwitchValue.Type);
 
                 if (node.Comparison == null)
                 {
@@ -1559,7 +1559,7 @@ namespace System.Linq.Expressions.Interpreter
             Compile(node.SwitchValue);
             _instructions.EmitStoreLocal(temp.Index);
 
-            var doneLabel = Expression.Label(node.Type, "done");
+            LabelTarget doneLabel = Expression.Label(node.Type, "done");
 
             foreach (var @case in node.Cases)
             {
@@ -1606,7 +1606,7 @@ namespace System.Linq.Expressions.Interpreter
 
             for (int i = 0; i < node.Cases.Count; i++)
             {
-                var switchCase = node.Cases[i];
+                SwitchCase switchCase = node.Cases[i];
 
                 int caseOffset = _instructions.Count - switchIndex;
                 foreach (ConstantExpression testValue in switchCase.TestValues)
@@ -1653,7 +1653,7 @@ namespace System.Linq.Expressions.Interpreter
 
             for (int i = 0; i < node.Cases.Count; i++)
             {
-                var switchCase = node.Cases[i];
+                SwitchCase switchCase = node.Cases[i];
 
                 int caseOffset = _instructions.Count - switchIndex;
                 foreach (ConstantExpression testValue in switchCase.TestValues)
@@ -1729,7 +1729,7 @@ namespace System.Linq.Expressions.Interpreter
         private void CompileGotoExpression(Expression expr)
         {
             var node = (GotoExpression)expr;
-            var labelInfo = ReferenceLabel(node.Target);
+            LabelInfo labelInfo = ReferenceLabel(node.Target);
 
             if (node.Value != null)
             {
@@ -1805,7 +1805,7 @@ namespace System.Linq.Expressions.Interpreter
                     // thing if it's in a switch case body.
                     if (_labelBlock.Kind == LabelScopeKind.Block)
                     {
-                        var label = ((LabelExpression)node).Target;
+                        LabelTarget label = ((LabelExpression)node).Target;
                         if (_labelBlock.ContainsTarget(label))
                         {
                             return false;
@@ -1986,9 +1986,9 @@ namespace System.Linq.Expressions.Interpreter
                     exHandlers = new List<ExceptionHandler>();
                     foreach (var handler in node.Handlers)
                     {
-                        var parameter = handler.Variable ?? Expression.Parameter(handler.Test);
+                        ParameterExpression parameter = handler.Variable ?? Expression.Parameter(handler.Test);
 
-                        var local = _locals.DefineLocal(parameter, _instructions.Count);
+                        LocalDefinition local = _locals.DefineLocal(parameter, _instructions.Count);
                         _exceptionForRethrowStack.Push(parameter);
 
                         ExceptionFilter filter = null;
@@ -2082,7 +2082,7 @@ namespace System.Linq.Expressions.Interpreter
             // Mark where we begin.
             int tryStart = _instructions.Count;
             BranchLabel end = _instructions.MakeLabel();
-            var enterTryInstr = _instructions.EmitEnterTryFault(end);
+            EnterTryFaultInstruction enterTryInstr = _instructions.EmitEnterTryFault(end);
             Debug.Assert(enterTryInstr == _instructions.GetInstruction(tryStart));
             
             // Emit the try block.
@@ -2117,13 +2117,13 @@ namespace System.Linq.Expressions.Interpreter
 
         private void CompileMethodCallExpression(Expression @object, MethodInfo method, IArgumentProvider arguments)
         {
-            var parameters = method.GetParameters();
+            ParameterInfo[] parameters = method.GetParameters();
 
             // TODO: Support pass by reference.
             List<ByRefUpdater> updaters = null;
             if (!method.IsStatic)
             {
-                var updater = CompileAddress(@object, -1);
+                ByRefUpdater updater = CompileAddress(@object, -1);
                 if (updater != null)
                 {
                     updaters = new List<ByRefUpdater>() { updater };
@@ -2134,13 +2134,13 @@ namespace System.Linq.Expressions.Interpreter
 
             for (int i = 0, n = arguments.ArgumentCount; i < n; i++)
             {
-                var arg = arguments.GetArgument(i);
+                Expression arg = arguments.GetArgument(i);
 
                 // byref calls leave out values on the stack, we use a callback
                 // to emit the code which processes each value left on the stack.
                 if (parameters[i].ParameterType.IsByRef)
                 {
-                    var updater = CompileAddress(arg, i);
+                    ByRefUpdater updater = CompileAddress(arg, i);
                     if (updater != null)
                     {
                         if (updaters == null)
@@ -2184,8 +2184,8 @@ namespace System.Linq.Expressions.Interpreter
 
         private ByRefUpdater CompileArrayIndexAddress(Expression array, Expression index, int argumentIndex)
         {
-            var left = _locals.DefineLocal(Expression.Parameter(array.Type, "array"), _instructions.Count);
-            var right = _locals.DefineLocal(Expression.Parameter(index.Type, "index"), _instructions.Count);
+            LocalDefinition left = _locals.DefineLocal(Expression.Parameter(array.Type, "array"), _instructions.Count);
+            LocalDefinition right = _locals.DefineLocal(Expression.Parameter(index.Type, "index"), _instructions.Count);
             Compile(array);
             _instructions.EmitStoreLocal(left.Index);
             Compile(index);
@@ -2262,10 +2262,10 @@ namespace System.Linq.Expressions.Interpreter
                             var indexLocals = new LocalDefinition[count];
                             for (int i = 0; i < count; i++)
                             {
-                                var arg = indexNode.GetArgument(i);
+                                Expression arg = indexNode.GetArgument(i);
                                 Compile(arg);
 
-                                var argTmp = _locals.DefineLocal(Expression.Parameter(arg.Type), _instructions.Count);
+                                LocalDefinition argTmp = _locals.DefineLocal(Expression.Parameter(arg.Type), _instructions.Count);
                                 _instructions.EmitDup();
                                 _instructions.EmitStoreLocal(argTmp.Index);
 
@@ -2350,10 +2350,10 @@ namespace System.Linq.Expressions.Interpreter
             var indexLocals = new LocalDefinition[count];
             for (int i = 0; i < count; i++)
             {
-                var arg = arguments.GetArgument(i);
+                Expression arg = arguments.GetArgument(i);
                 Compile(arg);
 
-                var argTmp = _locals.DefineLocal(Expression.Parameter(arg.Type), _instructions.Count);
+                LocalDefinition argTmp = _locals.DefineLocal(Expression.Parameter(arg.Type), _instructions.Count);
                 _instructions.EmitDup();
                 _instructions.EmitStoreLocal(argTmp.Index);
 
@@ -2374,16 +2374,16 @@ namespace System.Linq.Expressions.Interpreter
                 if (node.Constructor.DeclaringType.GetTypeInfo().IsAbstract)
                     throw Error.NonAbstractConstructorRequired();
 
-                var parameters = node.Constructor.GetParameters();
+                ParameterInfo[] parameters = node.Constructor.GetParameters();
                 List<ByRefUpdater> updaters = null;
 
                 for (int i = 0; i < parameters.Length; i++)
                 {
-                    var arg = node.GetArgument(i);
+                    Expression arg = node.GetArgument(i);
 
                     if (parameters[i].ParameterType.IsByRef)
                     {
-                        var updater = CompileAddress(arg, i);
+                        ByRefUpdater updater = CompileAddress(arg, i);
                         if (updater != null)
                         {
                             if (updaters == null)
@@ -2464,7 +2464,7 @@ namespace System.Linq.Expressions.Interpreter
                 var pi = (PropertyInfo)member;
                 if (pi != null)
                 {
-                    var method = pi.GetGetMethod(true);
+                    MethodInfo method = pi.GetGetMethod(true);
                     if (forBinding && method.IsStatic)
                     {
                         throw Error.InvalidProgram();
@@ -2553,7 +2553,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             var node = (LambdaExpression)expr;
             var compiler = new LightCompiler(this);
-            var creator = compiler.CompileTop(node);
+            LightDelegateCreator creator = compiler.CompileTop(node);
 
             if (compiler._locals.ClosureVariables != null)
             {
@@ -2570,8 +2570,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             var node = (BinaryExpression)expr;
 
-            var hasConversion = node.Conversion != null;
-            var hasImplicitConversion = false;
+            bool hasConversion = node.Conversion != null;
+            bool hasImplicitConversion = false;
             if (!hasConversion && TypeUtils.IsNullableType(node.Left.Type))
             {
                 // reference types don't need additional conversions (the interpreter operates on Object
@@ -2587,7 +2587,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
             }
 
-            var leftNotNull = _instructions.MakeLabel();
+            BranchLabel leftNotNull = _instructions.MakeLabel();
             BranchLabel end = null;
 
             Compile(node.Left);
@@ -2606,8 +2606,8 @@ namespace System.Linq.Expressions.Interpreter
 
             if (node.Conversion != null)
             {
-                var temp = Expression.Parameter(node.Left.Type, "temp");
-                var local = _locals.DefineLocal(temp, _instructions.Count);
+                ParameterExpression temp = Expression.Parameter(node.Left.Type, "temp");
+                LocalDefinition local = _locals.DefineLocal(temp, _instructions.Count);
                 _instructions.EmitStoreLocal(local.Index);
 
                 CompileMethodCallExpression(
@@ -2634,7 +2634,7 @@ namespace System.Linq.Expressions.Interpreter
 
             if (typeof(LambdaExpression).IsAssignableFrom(node.Expression.Type))
             {
-                var compMethod = node.Expression.Type.GetMethod("Compile", Array.Empty<Type>());
+                MethodInfo compMethod = node.Expression.Type.GetMethod("Compile", Array.Empty<Type>());
                 CompileMethodCallExpression(
                     Expression.Call(
                         node.Expression,
@@ -2657,7 +2657,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             var node = (ListInitExpression)expr;
             EmitThisForMethodCall(node.NewExpression);
-            var initializers = node.Initializers;
+            ReadOnlyCollection<ElementInit> initializers = node.Initializers;
             CompileListInit(initializers);
         }
 
@@ -2671,7 +2671,7 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     Compile(arg);
                 }
-                var add = initializer.AddMethod;
+                MethodInfo add = initializer.AddMethod;
                 _instructions.EmitCall(add);
                 if (add.ReturnType != typeof(void))
                     _instructions.EmitPop();
@@ -3094,7 +3094,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             if (_parameter.InClosure)
             {
-                var box = frame.Closure[_parameter.Index];
+                IStrongBox box = frame.Closure[_parameter.Index];
                 box.Value = value;
             }
             else if (_parameter.IsBoxed)
@@ -3122,7 +3122,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override void Update(InterpretedFrame frame, object value)
         {
-            var index = frame.Data[_index.Index];
+            object index = frame.Data[_index.Index];
             ((Array)frame.Data[_array.Index]).SetValue(value, (int)index);
         }
 
@@ -3147,7 +3147,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override void Update(InterpretedFrame frame, object value)
         {
-            var obj = _object == null ? null : frame.Data[_object.Value.Index];
+            object obj = _object == null ? null : frame.Data[_object.Value.Index];
             _field.SetValue(obj, value);
         }
 
@@ -3174,7 +3174,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override void Update(InterpretedFrame frame, object value)
         {
-            var obj = _object == null ? null : frame.Data[_object.Value.Index];
+            object obj = _object == null ? null : frame.Data[_object.Value.Index];
 
             try
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -364,7 +364,7 @@ namespace System.Linq.Expressions.Interpreter
         internal Delegate MakeDelegate(Type delegateType)
         {
 #if !NO_FEATURE_STATIC_DELEGATE
-            var method = delegateType.GetMethod("Invoke");
+            MethodInfo method = delegateType.GetMethod("Invoke");
             if (method.ReturnType == typeof(void))
             {
                 return System.Dynamic.Utils.DelegateHelpers.CreateObjectArrayDelegate(delegateType, RunVoid);
@@ -416,12 +416,12 @@ namespace System.Linq.Expressions.Interpreter
 
         public object Run(params object[] arguments)
         {
-            var frame = MakeFrame();
+            InterpretedFrame frame = MakeFrame();
             for (int i = 0; i < arguments.Length; i++)
             {
                 frame.Data[i] = arguments[i];
             }
-            var currentFrame = frame.Enter();
+            InterpretedFrame currentFrame = frame.Enter();
             try
             {
                 _interpreter.Run(frame);
@@ -440,12 +440,12 @@ namespace System.Linq.Expressions.Interpreter
 
         public object RunVoid(params object[] arguments)
         {
-            var frame = MakeFrame();
+            InterpretedFrame frame = MakeFrame();
             for (int i = 0; i < arguments.Length; i++)
             {
                 frame.Data[i] = arguments[i];
             }
-            var currentFrame = frame.Enter();
+            InterpretedFrame currentFrame = frame.Enter();
             try
             {
                 _interpreter.Run(frame);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -85,7 +85,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            var box = frame.Closure[_index];
+            IStrongBox box = frame.Closure[_index];
             frame.Data[frame.StackIndex++] = box.Value;
             return +1;
         }
@@ -103,7 +103,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            var box = frame.Closure[_index];
+            IStrongBox box = frame.Closure[_index];
             frame.Data[frame.StackIndex++] = box;
             return +1;
         }
@@ -209,7 +209,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            var box = frame.Closure[_index];
+            IStrongBox box = frame.Closure[_index];
             box.Value = frame.Peek();
             return +1;
         }
@@ -415,7 +415,7 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var value = default(object);
+                object value = default(object);
 
                 try
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
@@ -132,7 +132,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public void UndefineLocal(LocalDefinition definition, int end)
         {
-            var scope = _variables[definition.Parameter];
+            VariableScope scope = _variables[definition.Parameter];
             scope.Stop = end;
             if (scope.Parent != null)
             {
@@ -148,7 +148,7 @@ namespace System.Linq.Expressions.Interpreter
 
         internal void Box(ParameterExpression variable, InstructionList instructions)
         {
-            var scope = _variables[variable];
+            VariableScope scope = _variables[variable];
 
             LocalVariable local = scope.Variable;
             Debug.Assert(!local.IsBoxed && !local.InClosure);
@@ -160,7 +160,7 @@ namespace System.Linq.Expressions.Interpreter
                 if (scope.ChildScopes != null && scope.ChildScopes[curChild].Start == i)
                 {
                     // skip boxing in the child scope
-                    var child = scope.ChildScopes[curChild];
+                    VariableScope child = scope.ChildScopes[curChild];
                     i = child.Stop;
 
                     curChild++;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NewInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NewInstruction.cs
@@ -25,7 +25,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             int first = frame.StackIndex - _argumentCount;
 
-            var args = GetArgs(frame, first);
+            object[] args = GetArgs(frame, first);
 
             object ret;
             try
@@ -82,7 +82,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             int first = frame.StackIndex - _argumentCount;
 
-            var args = GetArgs(frame, first);
+            object[] args = GetArgs(frame, first);
 
             try
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -23,8 +23,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -45,8 +45,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -67,8 +67,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -89,8 +89,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -111,8 +111,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -133,8 +133,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -155,8 +155,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -177,8 +177,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -199,8 +199,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -221,8 +221,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -243,8 +243,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -265,8 +265,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
@@ -297,8 +297,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -315,8 +315,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -333,8 +333,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -351,8 +351,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -369,8 +369,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -387,8 +387,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -405,8 +405,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -423,8 +423,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -441,8 +441,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -459,8 +459,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -477,8 +477,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -495,8 +495,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
@@ -21,8 +21,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -37,8 +37,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -53,8 +53,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -69,8 +69,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -85,8 +85,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -101,8 +101,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -117,8 +117,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -133,8 +133,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var left = frame.Pop();
-                var right = frame.Pop();
+                object left = frame.Pop();
+                object right = frame.Pop();
                 if (left == null || right == null)
                 {
                     frame.Push(null);
@@ -149,8 +149,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var right = frame.Pop();
-                var left = frame.Pop();
+                object right = frame.Pop();
+                object left = frame.Pop();
                 if (left == null)
                 {
                     if (right == null)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
@@ -21,8 +21,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -39,8 +39,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -57,8 +57,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -75,8 +75,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -93,8 +93,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -111,8 +111,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -129,8 +129,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);
@@ -147,8 +147,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var shift = frame.Pop();
-                var value = frame.Pop();
+                object shift = frame.Pop();
+                object value = frame.Pop();
                 if (value == null || shift == null)
                 {
                     frame.Push(null);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
@@ -84,7 +84,7 @@ namespace System.Linq.Expressions.Interpreter
         
         public override int Run(InterpretedFrame frame)
         {
-            var value = frame.Peek();
+            object value = frame.Peek();
             frame.Data[frame.StackIndex++] = value;
             return +1;
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -150,7 +150,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var obj = frame.Pop();
+                object obj = frame.Pop();
                 frame.Push(ScriptingRuntimeHelpers.BooleanToObject(obj != null));
                 return +1;
             }
@@ -195,8 +195,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var dflt = frame.Pop();
-                var obj = frame.Pop();
+                object dflt = frame.Pop();
+                object obj = frame.Pop();
                 if (obj == null)
                 {
                     frame.Push(dflt);
@@ -215,8 +215,8 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var other = frame.Pop();
-                var obj = frame.Pop();
+                object other = frame.Pop();
+                object obj = frame.Pop();
                 if (obj == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.BooleanToObject(other == null));
@@ -237,7 +237,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var obj = frame.Pop();
+                object obj = frame.Pop();
                 if (obj == null)
                 {
                     frame.Push("");
@@ -254,7 +254,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var obj = frame.Pop();
+                object obj = frame.Pop();
                 if (obj == null)
                 {
                     frame.Push(ScriptingRuntimeHelpers.Int32ToObject(0));
@@ -309,7 +309,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                var value = frame.Pop();
+                object value = frame.Pop();
                 frame.Push((T)value);
                 return +1;
             }
@@ -337,10 +337,10 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                var value = frame.Pop();
+                object value = frame.Pop();
                 if (value != null)
                 {
-                    var valueType = value.GetType();
+                    Type valueType = value.GetType();
 
                     if (!TypeUtils.HasReferenceConversion(valueType, _t) &&
                         !TypeUtils.HasIdentityPrimitiveOrNullableConversion(valueType, _t))
@@ -431,7 +431,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            var from = frame.Pop();
+            object from = frame.Pop();
             switch (Convert.GetTypeCode(from))
             {
                 case TypeCode.Empty:
@@ -469,7 +469,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            var from = frame.Pop();
+            object from = frame.Pop();
             if (from == null)
             {
                 frame.Push(null);
@@ -607,7 +607,7 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     _shadowedVars.Push(new HashSet<ParameterExpression>(node.Variables));
                 }
-                var b = ExpressionVisitorUtils.VisitBlockExpressions(this, node);
+                Expression[] b = ExpressionVisitorUtils.VisitBlockExpressions(this, node);
                 if (node.Variables.Count > 0)
                 {
                     _shadowedVars.Pop();
@@ -665,7 +665,7 @@ namespace System.Linq.Expressions.Interpreter
                     return node;
                 }
 
-                var boxesConst = Expression.Constant(new RuntimeOps.RuntimeVariables(boxes.ToArray()), typeof(IRuntimeVariables));
+                ConstantExpression boxesConst = Expression.Constant(new RuntimeOps.RuntimeVariables(boxes.ToArray()), typeof(IRuntimeVariables));
                 // All of them were rewritten. Just return the array as a constant
                 if (vars.Count == 0)
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -482,9 +482,9 @@ namespace System.Linq.Expressions
 
             RequiresCanRead(expression, nameof(expression));
 
-            var method = GetInvokeMethod(expression);
+            MethodInfo method = GetInvokeMethod(expression);
 
-            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+            ParameterInfo[] pis = GetParametersForValidation(method, ExpressionType.Invoke);
 
             ValidateArgumentCount(method, ExpressionType.Invoke, 0, pis);
 
@@ -518,9 +518,9 @@ namespace System.Linq.Expressions
 
             RequiresCanRead(expression, nameof(expression));
 
-            var method = GetInvokeMethod(expression);
+            MethodInfo method = GetInvokeMethod(expression);
 
-            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+            ParameterInfo[] pis = GetParametersForValidation(method, ExpressionType.Invoke);
 
             ValidateArgumentCount(method, ExpressionType.Invoke, 1, pis);
 
@@ -558,9 +558,9 @@ namespace System.Linq.Expressions
             // NB: This method is marked as non-public to avoid public API additions at this point.
             RequiresCanRead(expression, nameof(expression));
 
-            var method = GetInvokeMethod(expression);
+            MethodInfo method = GetInvokeMethod(expression);
 
-            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+            ParameterInfo[] pis = GetParametersForValidation(method, ExpressionType.Invoke);
 
             ValidateArgumentCount(method, ExpressionType.Invoke, 2, pis);
 
@@ -603,9 +603,9 @@ namespace System.Linq.Expressions
 
             RequiresCanRead(expression, nameof(expression));
 
-            var method = GetInvokeMethod(expression);
+            MethodInfo method = GetInvokeMethod(expression);
 
-            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+            ParameterInfo[] pis = GetParametersForValidation(method, ExpressionType.Invoke);
 
             ValidateArgumentCount(method, ExpressionType.Invoke, 3, pis);
 
@@ -652,9 +652,9 @@ namespace System.Linq.Expressions
 
             RequiresCanRead(expression, nameof(expression));
 
-            var method = GetInvokeMethod(expression);
+            MethodInfo method = GetInvokeMethod(expression);
 
-            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+            ParameterInfo[] pis = GetParametersForValidation(method, ExpressionType.Invoke);
 
             ValidateArgumentCount(method, ExpressionType.Invoke, 4, pis);
 
@@ -705,9 +705,9 @@ namespace System.Linq.Expressions
 
             RequiresCanRead(expression, nameof(expression));
 
-            var method = GetInvokeMethod(expression);
+            MethodInfo method = GetInvokeMethod(expression);
 
-            var pis = GetParametersForValidation(method, ExpressionType.Invoke);
+            ParameterInfo[] pis = GetParametersForValidation(method, ExpressionType.Invoke);
 
             ValidateArgumentCount(method, ExpressionType.Invoke, 5, pis);
 
@@ -771,7 +771,7 @@ namespace System.Linq.Expressions
         ///<paramref name="arguments" /> does not contain the same number of elements as the list of parameters for the delegate represented by <paramref name="expression" />.</exception>
         public static InvocationExpression Invoke(Expression expression, IEnumerable<Expression> arguments)
         {
-            var argumentList = arguments as IReadOnlyList<Expression> ?? arguments.ToReadOnly();
+            IReadOnlyList<Expression> argumentList = arguments as IReadOnlyList<Expression> ?? arguments.ToReadOnly();
 
             switch (argumentList.Count)
             {
@@ -791,8 +791,8 @@ namespace System.Linq.Expressions
 
             RequiresCanRead(expression, nameof(expression));
 
-            var args = argumentList.ToReadOnly(); // Ensure is TrueReadOnlyCollection when count > 5. Returns fast if it already is.
-            var mi = GetInvokeMethod(expression);
+            ReadOnlyCollection<Expression> args = argumentList.ToReadOnly(); // Ensure is TrueReadOnlyCollection when count > 5. Returns fast if it already is.
+            MethodInfo mi = GetInvokeMethod(expression);
             ValidateArgumentTypes(mi, ExpressionType.Invoke, ref args, nameof(expression));
             return new InvocationExpressionN(expression, args, mi.ReturnType);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -259,7 +259,7 @@ namespace System.Linq.Expressions
             // method and call that will be used for creating instances of this
             // delegate type
             Func<Expression, string, bool, ReadOnlyCollection<ParameterExpression>, LambdaExpression> fastPath;
-            var factories = s_lambdaFactories;
+            CacheDict<Type, Func<Expression, string, bool, ReadOnlyCollection<ParameterExpression>, LambdaExpression>> factories = s_lambdaFactories;
             if (factories == null)
             {
                 s_lambdaFactories = factories = new CacheDict<Type, Func<Expression, string, bool, ReadOnlyCollection<ParameterExpression>, LambdaExpression>>(50);
@@ -362,7 +362,7 @@ namespace System.Linq.Expressions
         /// <returns>An <see cref="Expression{TDelegate}"/> that has the <see cref="P:NodeType"/> property equal to <see cref="P:Lambda"/> and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
         public static Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, bool tailCall, IEnumerable<ParameterExpression> parameters)
         {
-            var parameterList = parameters.ToReadOnly();
+            ReadOnlyCollection<ParameterExpression> parameterList = parameters.ToReadOnly();
             ValidateLambdaArgs(typeof(TDelegate), ref body, parameterList, nameof(TDelegate));
             return new Expression<TDelegate>(body, name, tailCall, parameterList);
         }
@@ -488,7 +488,7 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(body, nameof(body));
 
-            var parameterList = parameters.ToReadOnly();
+            ReadOnlyCollection<ParameterExpression> parameterList = parameters.ToReadOnly();
 
             int paramCount = parameterList.Count;
             Type[] typeArgs = new Type[paramCount + 1];
@@ -497,7 +497,7 @@ namespace System.Linq.Expressions
                 var set = new HashSet<ParameterExpression>();
                 for (int i = 0; i < paramCount; i++)
                 {
-                    var param = parameterList[i];
+                    ParameterExpression param = parameterList[i];
                     ContractUtils.RequiresNotNull(param, "parameter");
                     typeArgs[i] = param.IsByRef ? param.Type.MakeByRefType() : param.Type;
                     if (!set.Add(param))
@@ -523,7 +523,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="P:NodeType"/> property equal to Lambda and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Type delegateType, Expression body, string name, IEnumerable<ParameterExpression> parameters)
         {
-            var paramList = parameters.ToReadOnly();
+            ReadOnlyCollection<ParameterExpression> paramList = parameters.ToReadOnly();
             ValidateLambdaArgs(delegateType, ref body, paramList, nameof(delegateType));
 
             return CreateLambda(delegateType, body, name, false, paramList);
@@ -540,7 +540,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="P:NodeType"/> property equal to Lambda and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Type delegateType, Expression body, string name, bool tailCall, IEnumerable<ParameterExpression> parameters)
         {
-            var paramList = parameters.ToReadOnly();
+            ReadOnlyCollection<ParameterExpression> paramList = parameters.ToReadOnly();
             ValidateLambdaArgs(delegateType, ref body, paramList, nameof(delegateType));
 
             return CreateLambda(delegateType, body, name, tailCall, paramList);
@@ -557,7 +557,7 @@ namespace System.Linq.Expressions
             }
 
             MethodInfo mi;
-            var ldc = s_lambdaDelegateCache;
+            CacheDict<Type, MethodInfo> ldc = s_lambdaDelegateCache;
             if (!ldc.TryGetValue(delegateType, out mi))
             {
                 mi = delegateType.GetMethod("Invoke");
@@ -631,7 +631,7 @@ namespace System.Linq.Expressions
 
             for (int i = 0; i < typeArgs.Length; i++)
             {
-                var a = typeArgs[i];
+                Type a = typeArgs[i];
                 if (a == null)
                 {
                     return TryGetFuncActionArgsResult.ArgumentNull;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -139,7 +139,7 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(newExpression, nameof(newExpression));
             ContractUtils.RequiresNotNull(initializers, nameof(initializers));
 
-            var initializerlist = initializers.ToReadOnly();
+            ReadOnlyCollection<Expression> initializerlist = initializers.ToReadOnly();
             if (initializerlist.Count == 0)
             {
                 return new ListInitExpression(newExpression, EmptyReadOnlyCollection<ElementInit>.Instance);
@@ -177,7 +177,7 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(newExpression, nameof(newExpression));
             ContractUtils.RequiresNotNull(initializers, nameof(initializers));
 
-            var initializerlist = initializers.ToReadOnly();
+            ReadOnlyCollection<Expression> initializerlist = initializers.ToReadOnly();
             ElementInit[] initList = new ElementInit[initializerlist.Count];
             for (int i = 0; i < initializerlist.Count; i++)
             {
@@ -218,7 +218,7 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(newExpression, nameof(newExpression));
             ContractUtils.RequiresNotNull(initializers, nameof(initializers));
-            var initializerlist = initializers.ToReadOnly();
+            ReadOnlyCollection<ElementInit> initializerlist = initializers.ToReadOnly();
             ValidateListInitArgs(newExpression.Type, initializerlist, nameof(newExpression));
             return new ListInitExpression(newExpression, initializerlist);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -337,7 +337,7 @@ namespace System.Linq.Expressions
             Type type = mi.DeclaringType;
             BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic;
             flags |= (mi.IsStatic) ? BindingFlags.Static : BindingFlags.Instance;
-            var props = type.GetProperties(flags);
+            PropertyInfo[] props = type.GetProperties(flags);
             foreach (PropertyInfo pi in props)
             {
                 if (pi.CanRead && CheckMethod(mi, pi.GetGetMethod(true)))

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
@@ -92,7 +92,7 @@ namespace System.Linq.Expressions
 
         internal static Expression ReduceMemberInit(Expression objExpression, ReadOnlyCollection<MemberBinding> bindings, bool keepOnStack)
         {
-            var objVar = Expression.Variable(objExpression.Type, null);
+            ParameterExpression objVar = Expression.Variable(objExpression.Type, null);
             int count = bindings.Count;
             var block = new Expression[count + 2];
             block[0] = Expression.Assign(objVar, objExpression);
@@ -106,7 +106,7 @@ namespace System.Linq.Expressions
 
         internal static Expression ReduceListInit(Expression listExpression, ReadOnlyCollection<ElementInit> initializers, bool keepOnStack)
         {
-            var listVar = Expression.Variable(listExpression.Type, null);
+            ParameterExpression listVar = Expression.Variable(listExpression.Type, null);
             int count = initializers.Count;
             var block = new Expression[count + 2];
             block[0] = Expression.Assign(listVar, listExpression);
@@ -177,7 +177,7 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(newExpression, nameof(newExpression));
             ContractUtils.RequiresNotNull(bindings, nameof(bindings));
-            var roBindings = bindings.ToReadOnly();
+            ReadOnlyCollection<MemberBinding> roBindings = bindings.ToReadOnly();
             ValidateMemberInitArgs(newExpression.Type, roBindings);
             return new MemberInitExpression(newExpression, roBindings);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
@@ -80,7 +80,7 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(initializers, nameof(initializers));
             Type memberType;
             ValidateGettableFieldOrPropertyMember(member, out memberType);
-            var initList = initializers.ToReadOnly();
+            ReadOnlyCollection<ElementInit> initList = initializers.ToReadOnly();
             ValidateListInitArgs(memberType, initList, nameof(member));
             return new MemberListBinding(member, initList);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -166,7 +166,7 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(constructor.DeclaringType, nameof(constructor) + "." + nameof(constructor.DeclaringType));
             TypeUtils.ValidateType(constructor.DeclaringType, nameof(constructor));
             ValidateConstructor(constructor, nameof(constructor));
-            var argList = arguments.ToReadOnly();
+            ReadOnlyCollection<Expression> argList = arguments.ToReadOnly();
             ValidateArgumentTypes(constructor, ExpressionType.New, ref argList, nameof(constructor));
 
             return new NewExpression(constructor, argList, null);
@@ -186,8 +186,8 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(constructor.DeclaringType, nameof(constructor) + "." + nameof(constructor.DeclaringType));
             TypeUtils.ValidateType(constructor.DeclaringType, nameof(constructor));
             ValidateConstructor(constructor, nameof(constructor));
-            var memberList = members.ToReadOnly();
-            var argList = arguments.ToReadOnly();
+            ReadOnlyCollection<MemberInfo> memberList = members.ToReadOnly();
+            ReadOnlyCollection<Expression> argList = arguments.ToReadOnly();
             ValidateNewArgs(constructor, ref argList, ref memberList);
             return new NewExpression(constructor, argList, memberList);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/RuntimeVariablesExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/RuntimeVariablesExpression.cs
@@ -99,7 +99,7 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(variables, nameof(variables));
 
-            var vars = variables.ToReadOnly();
+            ReadOnlyCollection<ParameterExpression> vars = variables.ToReadOnly();
             for (int i = 0; i < vars.Count; i++)
             {
                 ContractUtils.RequiresNotNull(vars[i], nameof(variables), i);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/StackGuard.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/StackGuard.cs
@@ -73,9 +73,9 @@ namespace System.Linq.Expressions
             try
             {
                 // Using default scheduler rather than picking up the current scheduler.
-                var task = Task.Factory.StartNew(action, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                Task<R> task = Task.Factory.StartNew(action, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 
-                var awaiter = task.GetAwaiter();
+                TaskAwaiter<R> awaiter = task.GetAwaiter();
 
                 // Avoid AsyncWaitHandle lazy allocation of ManualResetEvent in the rare case we finish quickly.
                 if (!awaiter.IsCompleted)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
@@ -91,7 +91,7 @@ namespace System.Linq.Expressions
         {
             RequiresCanRead(body, nameof(body));
 
-            var values = testValues.ToReadOnly();
+            ReadOnlyCollection<Expression> values = testValues.ToReadOnly();
             ContractUtils.RequiresNotEmpty(values, nameof(testValues));
             RequiresCanRead(values, nameof(testValues));
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
@@ -202,7 +202,7 @@ namespace System.Linq.Expressions
             RequiresCanRead(switchValue, nameof(switchValue));
             if (switchValue.Type == typeof(void)) throw Error.ArgumentCannotBeOfTypeVoid(nameof(switchValue));
 
-            var caseList = cases.ToReadOnly();
+            ReadOnlyCollection<SwitchCase> caseList = cases.ToReadOnly();
             ContractUtils.RequiresNotNullItems(caseList, nameof(cases));
 
             // Type of the result. Either provided, or it is type of the branches.
@@ -219,14 +219,14 @@ namespace System.Linq.Expressions
 
             if (comparison != null)
             {
-                var pms = comparison.GetParametersCached();
+                ParameterInfo[] pms = comparison.GetParametersCached();
                 if (pms.Length != 2)
                 {
                     throw Error.IncorrectNumberOfMethodCallArguments(comparison, nameof(comparison));
                 }
                 // Validate that the switch value's type matches the comparison method's 
                 // left hand side parameter type.
-                var leftParam = pms[0];
+                ParameterInfo leftParam = pms[0];
                 bool liftedCall = false;
                 if (!ParameterIsAssignable(leftParam, switchValue.Type))
                 {
@@ -237,7 +237,7 @@ namespace System.Linq.Expressions
                     }
                 }
 
-                var rightParam = pms[1];
+                ParameterInfo rightParam = pms[1];
                 foreach (var c in caseList)
                 {
                     ContractUtils.RequiresNotNull(c, nameof(cases));
@@ -272,7 +272,7 @@ namespace System.Linq.Expressions
             {
                 // When comparison method is not present, all the test values must have
                 // the same type. Use the first test value's type as the baseline.
-                var firstTestValue = caseList[0].TestValues[0];
+                Expression firstTestValue = caseList[0].TestValues[0];
                 foreach (var c in caseList)
                 {
                     ContractUtils.RequiresNotNull(c, nameof(cases));
@@ -290,7 +290,7 @@ namespace System.Linq.Expressions
                 // Now we need to validate that switchValue.Type and testValueType
                 // make sense in an Equal node. Fortunately, Equal throws a
                 // reasonable error, so just call it.
-                var equal = Equal(switchValue, firstTestValue, false, comparison);
+                BinaryExpression equal = Equal(switchValue, firstTestValue, false, comparison);
 
                 // Get the comparison function from equals node.
                 comparison = equal.Method;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
@@ -176,7 +176,7 @@ namespace System.Linq.Expressions
         {
             RequiresCanRead(body, nameof(body));
 
-            var @catch = handlers.ToReadOnly();
+            ReadOnlyCollection<CatchBlock> @catch = handlers.ToReadOnly();
             ContractUtils.RequiresNotNullItems(@catch, nameof(handlers));
             ValidateTryAndCatchHaveSameType(type, body, @catch);
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -129,7 +129,7 @@ namespace System.Linq.Expressions
             // if TypeOperand is an interface.
             if (_typeOperand.GetTypeInfo().IsInterface)
             {
-                var temp = Expression.Parameter(typeof(Type));
+                ParameterExpression temp = Expression.Parameter(typeof(Type));
                 getType = Expression.Block(new[] { temp }, Expression.Assign(temp, getType), temp);
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -186,7 +186,7 @@ namespace System.Linq.Expressions
             // temp = var
             // var = op(var)
             // temp
-            var temp = Parameter(_operand.Type, null);
+            ParameterExpression temp = Parameter(_operand.Type, null);
             return Block(
                 new[] { temp },
                 Assign(temp, _operand),
@@ -205,8 +205,8 @@ namespace System.Linq.Expressions
             }
             else
             {
-                var temp1 = Parameter(member.Expression.Type, null);
-                var initTemp1 = Assign(temp1, member.Expression);
+                ParameterExpression temp1 = Parameter(member.Expression.Type, null);
+                BinaryExpression initTemp1 = Assign(temp1, member.Expression);
                 member = MakeMemberAccess(temp1, member.Member);
 
                 if (IsPrefix)
@@ -228,7 +228,7 @@ namespace System.Linq.Expressions
                 // temp2 = temp1.member
                 // temp1.member = op(temp2)
                 // temp2
-                var temp2 = Parameter(member.Type, null);
+                ParameterExpression temp2 = Parameter(member.Type, null);
                 return Block(
                     new[] { temp1, temp2 },
                     initTemp1,
@@ -266,7 +266,7 @@ namespace System.Linq.Expressions
             i++;
             while (i <= count)
             {
-                var arg = index.GetArgument(i - 1);
+                Expression arg = index.GetArgument(i - 1);
                 args[i - 1] = temps[i] = Parameter(arg.Type, null);
                 block[i] = Assign(temps[i], arg);
                 i++;
@@ -274,7 +274,7 @@ namespace System.Linq.Expressions
             index = MakeIndex(temps[0], index.Indexer, new TrueReadOnlyCollection<Expression>(args));
             if (!prefix)
             {
-                var lastTemp = temps[i] = Parameter(index.Type, null);
+                ParameterExpression lastTemp = temps[i] = Parameter(index.Type, null);
                 block[i] = Assign(temps[i], index);
                 i++;
                 Debug.Assert(i == temps.Length);

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
@@ -89,7 +89,7 @@ namespace System.Runtime.CompilerServices
                 {
                     _shadowedVars.Push(new HashSet<ParameterExpression>(node.Variables));
                 }
-                var b = ExpressionVisitorUtils.VisitBlockExpressions(this, node);
+                Expression[] b = ExpressionVisitorUtils.VisitBlockExpressions(this, node);
                 if (node.Variables.Count > 0)
                 {
                     _shadowedVars.Pop();
@@ -147,7 +147,7 @@ namespace System.Runtime.CompilerServices
                     return node;
                 }
 
-                var boxesConst = Expression.Constant(new RuntimeVariables(boxes.ToArray()), typeof(IRuntimeVariables));
+                ConstantExpression boxesConst = Expression.Constant(new RuntimeVariables(boxes.ToArray()), typeof(IRuntimeVariables));
                 // All of them were rewritten. Just return the array as a constant
                 if (vars.Count == 0)
                 {


### PR DESCRIPTION
This is a PR suggestion to address inconsistencies in the usage of `var` as brought up in many code reviews. It's carried out by a Roslyn analyzer that allows `var` when the type is obvious from the expression on the right. Determining whether the type is "obvious" is based on simple Roslyn node kind checks for:

* object creation, e.g. `new T(...)`
* array creation, e.g. `new T[...]`
* conversions, e.g. `(T)o`
* use of 'as', e.g. `o as T`

More kinds could be added, e.g. `default(T)`, or more involved checks could be used (e.g. `ToString` could be deemed "obvious", and getting an enum value could be too).

In this PR, I've applied my Roslyn analyzer and code fix provider to `System.Linq.Expressions` to see the result and gather feedback. I can share the Roslyn code somewhere as well.

CC @stephentoub, what do you think?