### PR TITLE
Fix TcpClient.Begin/EndConnect on Unix with Socket workaround

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
@@ -192,11 +192,40 @@ namespace System.Net.Sockets
             }
         }
 
+        private Task ConnectAsyncCore(IPAddress address, int port)
+        {
+            return Client.ConnectAsync(address, port).ContinueWith((t, s) =>
+            {
+                var thisRef = (TcpClient)s;
+                if (thisRef.Client == null)
+                {
+                    throw new ObjectDisposedException(thisRef.GetType().Name); // Dispose nulls out the client socket field.
+                }
+                t.GetAwaiter().GetResult(); // propagate any exception
+                thisRef._active = true;
+            }, this, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+
         private Task ConnectAsyncCore(string host, int port)
         {
             StartConnectCore(host, port);
             return ConnectAsyncCorePrivate(host, port, (s, a, p) => s.ConnectAsync(a, p));
         }
+
+        private Task ConnectAsyncCore(IPAddress[] addresses, int port)
+        {
+            StartConnectCore(addresses, port);
+            return ConnectCorePrivate(addresses, port, (s, a, p) => s.ConnectAsync(a, p));
+        }
+
+        private IAsyncResult BeginConnectCore(string host, int port, AsyncCallback requestCallback, object state) =>
+            TaskToApm.Begin(ConnectAsyncCore(host, port), requestCallback, state);
+
+        private IAsyncResult BeginConnectCore(IPAddress[] addresses, int port, AsyncCallback requestCallback, object state) =>
+            TaskToApm.Begin(ConnectAsyncCore(addresses, port), requestCallback, state);
+
+        private void EndConnectCore(Socket socket, IAsyncResult asyncResult) =>
+            TaskToApm.End(asyncResult);
 
         private void StartConnectCore(string host, int port)
         {
@@ -232,12 +261,6 @@ namespace System.Net.Sockets
             {
                 ExitClientLock();
             }
-        }
-
-        private Task ConnectAsyncCore(IPAddress[] addresses, int port)
-        {
-            StartConnectCore(addresses, port);
-            return ConnectCorePrivate(addresses, port, (s, a, p) => s.ConnectAsync(a, p));
         }
 
         private void StartConnectCore(IPAddress[] addresses, int port)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Windows.cs
@@ -60,6 +60,16 @@ namespace System.Net.Sockets
             }
         }
 
+        private Task ConnectAsyncCore(IPAddress address, int port)
+        {
+            return Task.Factory.FromAsync(
+                (targetAddess, targetPort, callback, state) => ((TcpClient)state).BeginConnect(targetAddess, targetPort, callback, state),
+                asyncResult => ((TcpClient)asyncResult.AsyncState).EndConnect(asyncResult),
+                address,
+                port,
+                state: this);
+        }
+
         private Task ConnectAsyncCore(string host, int port)
         {
             return Task.Factory.FromAsync(
@@ -79,6 +89,15 @@ namespace System.Net.Sockets
                 port,
                 state: this);
         }
+
+        private IAsyncResult BeginConnectCore(string host, int port, AsyncCallback requestCallback, object state) =>
+            Client.BeginConnect(host, port, requestCallback, state);
+
+        private IAsyncResult BeginConnectCore(IPAddress[] addresses, int port, AsyncCallback requestCallback, object state) =>
+            Client.BeginConnect(addresses, port, requestCallback, state);
+
+        private void EndConnectCore(Socket socket, IAsyncResult asyncResult) =>
+            socket.EndConnect(asyncResult);
 
         // Gets or sets the size of the receive buffer in bytes.
         private int ReceiveBufferSizeCore

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -88,25 +88,11 @@ namespace System.Net.Sockets
             set { ExclusiveAddressUseCore = value; }
         }
 
-        public Task ConnectAsync(IPAddress address, int port)
-        {
-            return Task.Factory.FromAsync(
-                (targetAddess, targetPort, callback, state) => ((TcpClient)state).BeginConnect(targetAddess, targetPort, callback, state),
-                asyncResult => ((TcpClient)asyncResult.AsyncState).EndConnect(asyncResult),
-                address,
-                port,
-                state: this);
-        }
+        public Task ConnectAsync(IPAddress address, int port) => ConnectAsyncCore(address, port);
 
-        public Task ConnectAsync(string host, int port)
-        {
-            return ConnectAsyncCore(host, port);
-        }
+        public Task ConnectAsync(string host, int port) => ConnectAsyncCore(host, port);
 
-        public Task ConnectAsync(IPAddress[] addresses, int port)
-        {
-            return ConnectAsyncCore(addresses, port);
-        }
+        public Task ConnectAsync(IPAddress[] addresses, int port) => ConnectAsyncCore(addresses, port);
 
         public IAsyncResult BeginConnect(IPAddress address, int port, AsyncCallback requestCallback, object state)
         {
@@ -116,6 +102,7 @@ namespace System.Net.Sockets
             }
 
             IAsyncResult result = Client.BeginConnect(address, port, requestCallback, state);
+
             if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, nameof(BeginConnect), null);
@@ -131,7 +118,8 @@ namespace System.Net.Sockets
                 NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, nameof(BeginConnect), host);
             }
 
-            IAsyncResult result = Client.BeginConnect(host, port, requestCallback, state);
+            IAsyncResult result = BeginConnectCore(host, port, requestCallback, state);
+
             if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, nameof(BeginConnect), null);
@@ -147,7 +135,8 @@ namespace System.Net.Sockets
                 NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, nameof(BeginConnect), addresses);
             }
 
-            IAsyncResult result = Client.BeginConnect(addresses, port, requestCallback, state);
+            IAsyncResult result = BeginConnectCore(addresses, port, requestCallback, state);
+
             if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, nameof(BeginConnect), null);
@@ -169,9 +158,11 @@ namespace System.Net.Sockets
                 // Dispose nulls out the client socket field.
                 throw new ObjectDisposedException(GetType().Name);
             }
-            s.EndConnect(asyncResult);
+
+            EndConnectCore(s, asyncResult);
 
             _active = true;
+
             if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, nameof(EndConnect), null);

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -27,6 +27,9 @@ namespace System.Net.Sockets.Tests
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
         public async Task ConnectAsync_DnsEndPoint_Success(int mode)
         {
             using (TcpClient client = new TcpClient())
@@ -36,16 +39,32 @@ namespace System.Net.Sockets.Tests
                 string host = System.Net.Test.Common.Configuration.Sockets.SocketServer.IdnHost;
                 int port = System.Net.Test.Common.Configuration.Sockets.SocketServer.Port;
 
-                if (mode == 0)
+                IPAddress[] addresses;
+                switch (mode)
                 {
-                    await client.ConnectAsync(host, port);
-                }
-                else
-                {
-                    IPAddress[] addresses = await Dns.GetHostAddressesAsync(host);
-                    await (mode == 1 ?
-                        client.ConnectAsync(addresses[0], port) :
-                        client.ConnectAsync(addresses, port));
+                    case 0:
+                        await client.ConnectAsync(host, port);
+                        break;
+                    case 1:
+                        addresses = await Dns.GetHostAddressesAsync(host);
+                        await client.ConnectAsync(addresses[0], port);
+                        break;
+                    case 2:
+                        addresses = await Dns.GetHostAddressesAsync(host);
+                        await client.ConnectAsync(addresses, port);
+                        break;
+
+                    case 3:
+                        await Task.Factory.FromAsync(client.BeginConnect, client.EndConnect, host, port, null);
+                        break;
+                    case 4:
+                        addresses = await Dns.GetHostAddressesAsync(host);
+                        await Task.Factory.FromAsync(client.BeginConnect, client.EndConnect, addresses[0], port, null);
+                        break;
+                    case 5:
+                        addresses = await Dns.GetHostAddressesAsync(host);
+                        await Task.Factory.FromAsync(client.BeginConnect, client.EndConnect, addresses, port, null);
+                        break;
                 }
 
                 Assert.True(client.Connected);


### PR DESCRIPTION
TcpClient.Connect{Async} have a workaround on Unix for Socket's lack of ability to target DNS endpoints.  When TcpClient.Begin/EndConnect were recently added back, they were added without that workaround.  This commit fixes those members such that, on Unix, they're implemented in terms of ConnectAsync, getting the workaround implicitly.

Fixes https://github.com/dotnet/corefx/issues/12740
cc: @priya91, @ericeil, @davidsh, @cipop