### PR TITLE
Added PrePrepareMethodAttribute to System.Runtime.ConstrainedExcecution

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -3102,6 +3102,10 @@ namespace System.Runtime.ConstrainedExecution
         public System.Runtime.ConstrainedExecution.Cer Cer { get { throw null; } }
         public System.Runtime.ConstrainedExecution.Consistency ConsistencyGuarantee { get { throw null; } }
     }
+    public sealed partial class PrePrepareMethodAttribute : System.Attribute
+    {
+        public PrePrepareMethodAttribute() { }
+    }
 }
 
 namespace System.Runtime.InteropServices

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == '' OR '$(TargetGroup)' == 'netstandard1.7' OR '$(TargetGroup)' == 'uap101aot'">
     <Compile Include="System\IO\HandleInheritability.cs" />
+    <Compile Include="System\Runtime\ConstrainedExecution\PrePrepareMethodAttribute.cs" />
     <Compile Include="System\Threading\WaitHandleExtensions.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'!='netcore50aot' And '$(TargetGroup)'!='uap101aot' And '$(TargetGroup)'!='net462' AND '$(TargetGroup)'!='net463'">

--- a/src/System.Runtime/src/System/Runtime/ConstrainedExecution/PrePrepareMethodAttribute.cs
+++ b/src/System.Runtime/src/System/Runtime/ConstrainedExecution/PrePrepareMethodAttribute.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 namespace System.Runtime.ConstrainedExecution
 {
     public sealed class PrePrepareMethodAttribute : Attribute

--- a/src/System.Runtime/src/System/Runtime/ConstrainedExecution/PrePrepareMethodAttribute.cs
+++ b/src/System.Runtime/src/System/Runtime/ConstrainedExecution/PrePrepareMethodAttribute.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Runtime.InteropServices;
 
 namespace System.Runtime.ConstrainedExecution
-{ 
+{
     public sealed class PrePrepareMethodAttribute : Attribute
     {
         public PrePrepareMethodAttribute()

--- a/src/System.Runtime/src/System/Runtime/ConstrainedExecution/PrePrepareMethodAttribute.cs
+++ b/src/System.Runtime/src/System/Runtime/ConstrainedExecution/PrePrepareMethodAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace System.Runtime.ConstrainedExecution
+{ 
+    public sealed class PrePrepareMethodAttribute : Attribute
+    {
+        public PrePrepareMethodAttribute()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #12255
I Just added PreprepareMethodAttribute because ReliabilityContractAttribute was already there.

cc @danmosemsft @joperezr @AlexGhiondea