### PR TITLE
Make derived types of SymmetricAlgorithm use field assignment in ctors.

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Aes.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Aes.cs
@@ -10,8 +10,8 @@ namespace System.Security.Cryptography
     {
         protected Aes()
         {
-            LegalBlockSizesValue = s_legalBlockSizes;
-            LegalKeySizesValue = s_legalKeySizes;
+            LegalBlockSizesValue = s_legalBlockSizes.CloneKeySizesArray();
+            LegalKeySizesValue = s_legalKeySizes.CloneKeySizesArray();
 
             BlockSizeValue = 128;
             // TODO(12368): FeedbackSizeValue = 8;, but the field is not yet available.

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Aes.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Aes.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -12,33 +10,19 @@ namespace System.Security.Cryptography
     {
         protected Aes()
         {
-            this.BlockSize = 128;
-            this.KeySize = 256;
-            this.Mode = CipherMode.CBC;
-        }
+            LegalBlockSizesValue = s_legalBlockSizes;
+            LegalKeySizesValue = s_legalKeySizes;
 
-        public override KeySizes[] LegalBlockSizes
-        {
-            get
-            {
-                return s_legalBlockSizes.CloneKeySizesArray();
-            }
-        }
-
-        public override KeySizes[] LegalKeySizes
-        {
-            get
-            {
-                return s_legalKeySizes.CloneKeySizesArray();
-            }
+            BlockSizeValue = 128;
+            // TODO(12368): FeedbackSizeValue = 8;, but the field is not yet available.
+            KeySizeValue = 256;
+            ModeValue = CipherMode.CBC;
         }
 
         public static Aes Create()
         {
             return new AesImplementation();
         }
-
-
 
         private static readonly KeySizes[] s_legalBlockSizes = { new KeySizes(128, 128, 0) };
         private static readonly KeySizes[] s_legalKeySizes = { new KeySizes(128, 256, 64) };

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
@@ -16,8 +16,8 @@ namespace System.Security.Cryptography
             KeySizeValue = 3*64;
             BlockSizeValue = 64;
             // TODO(12368): FeedbackSizeValue = BlockSizeValue; but the field is not yet available.
-            LegalBlockSizesValue = s_legalBlockSizes;
-            LegalKeySizesValue = s_legalKeySizes;
+            LegalBlockSizesValue = s_legalBlockSizes.CloneKeySizesArray();
+            LegalKeySizesValue = s_legalKeySizes.CloneKeySizesArray();
         }
 
         public static TripleDES Create()

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
@@ -13,29 +13,16 @@ namespace System.Security.Cryptography
     {
         protected TripleDES()
         {
-            KeySize = 3*64;
-            BlockSize = 64;
+            KeySizeValue = 3*64;
+            BlockSizeValue = 64;
+            // TODO(12368): FeedbackSizeValue = BlockSizeValue; but the field is not yet available.
+            LegalBlockSizesValue = s_legalBlockSizes;
+            LegalKeySizesValue = s_legalKeySizes;
         }
 
         public static TripleDES Create()
         {
             return new TripleDesImplementation();
-        }
-
-        public override KeySizes[] LegalKeySizes
-        {
-            get
-            {
-                return s_legalKeySizes.CloneKeySizesArray();
-            }
-        }
-
-        public override KeySizes[] LegalBlockSizes
-        {
-            get
-            {
-                return s_legalBlockSizes.CloneKeySizesArray();
-            }
         }
 
         public override byte[] Key

--- a/src/System.Security.Cryptography.Algorithms/tests/AesTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/AesTests.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Algorithms.Tests
+{
+    public partial class AesTests
+    {
+        [Fact]
+        public static void AesDefaultCtor()
+        {
+            using (Aes aes = new AesMinimal())
+            {
+                Assert.Equal(256, aes.KeySize);
+                Assert.Equal(128, aes.BlockSize);
+                Assert.Equal(CipherMode.CBC, aes.Mode);
+                Assert.Equal(PaddingMode.PKCS7, aes.Padding);
+            }
+        }
+
+        private class AesMinimal : Aes
+        {
+            // If the constructor uses a virtual call to any of the property setters
+            // they will fail.
+            private readonly bool _ready;
+
+            public AesMinimal()
+            {
+                // Don't set this as a field initializer, otherwise it runs before the base ctor.
+                _ready = true;
+            }
+
+            public override int KeySize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.KeySize = value;
+                }
+            }
+
+            public override int BlockSize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.BlockSize = value;
+                }
+            }
+
+            public override byte[] IV
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.IV = value;
+                }
+            }
+
+            public override byte[] Key
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Key = value;
+                }
+            }
+
+            public override CipherMode Mode
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Mode = value;
+                }
+            }
+
+            public override PaddingMode Padding
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Padding = value;
+                }
+            }
+
+            public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateIV()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateKey()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/AesTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/AesTests.cs
@@ -20,6 +20,29 @@ namespace System.Security.Cryptography.Algorithms.Tests
             }
         }
 
+        [Fact]
+        public static void EnsureLegalSizesValuesIsolated()
+        {
+            new AesLegalSizesBreaker().Dispose();
+
+            using (Aes aes = Aes.Create())
+            {
+                Assert.Equal(128, aes.LegalKeySizes[0].MinSize);
+                Assert.Equal(128, aes.LegalBlockSizes[0].MinSize);
+
+                aes.Key = new byte[16];
+            }
+        }
+
+        private class AesLegalSizesBreaker : AesMinimal
+        {
+            public AesLegalSizesBreaker()
+            {
+                LegalKeySizesValue[0] = new KeySizes(1, 1, 0);
+                LegalBlockSizesValue[0] = new KeySizes(1, 1, 0);
+            }
+        }
+
         private class AesMinimal : Aes
         {
             // If the constructor uses a virtual call to any of the property setters

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -108,6 +108,7 @@
       <Link>CommonTest\System\RandomDataGenerator.cs</Link>
     </Compile>
     <Compile Include="AesProvider.cs" />
+    <Compile Include="AesTests.cs" />
     <Compile Include="DefaultECDsaProvider.cs" />
     <Compile Include="DefaultRSAProvider.cs" />
     <Compile Include="HashAlgorithmTest.cs" />

--- a/src/System.Security.Cryptography.Algorithms/tests/TripleDesTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/TripleDesTests.cs
@@ -4,8 +4,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using Test.Cryptography;
 using Xunit;
@@ -16,7 +14,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
     public static partial class TripleDesTests
     {
         [Fact]
-        public static void DesDefaultCtor()
+        public static void TripleDesDefaultCtor()
         {
             using (TripleDES tdes = new TripleDESMinimal())
             {
@@ -106,8 +104,92 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
 
         private sealed class TripleDESMinimal : TripleDES
         {
+            // If the constructor uses a virtual call to any of the property setters
+            // they will fail.
+            private readonly bool _ready;
+
             public TripleDESMinimal()
             {
+                // Don't set this as a field initializer, otherwise it runs before the base ctor.
+                _ready = true;
+            }
+
+            public override int KeySize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.KeySize = value;
+                }
+            }
+
+            public override int BlockSize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.BlockSize = value;
+                }
+            }
+
+            public override byte[] IV
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.IV = value;
+                }
+            }
+
+            public override byte[] Key
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Key = value;
+                }
+            }
+
+            public override CipherMode Mode
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Mode = value;
+                }
+            }
+
+            public override PaddingMode Padding
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Padding = value;
+                }
             }
 
             public sealed override void GenerateIV()

--- a/src/System.Security.Cryptography.Algorithms/tests/TripleDesTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/TripleDesTests.cs
@@ -76,6 +76,25 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             Assert.Equal(inputBytes, decryptedBytes);
         }
 
+        [Fact]
+        public static void EnsureLegalSizesValuesIsolated()
+        {
+            new TripleDESLegalSizesBreaker().Dispose();
+
+            using (TripleDES tripleDes = TripleDES.Create())
+            {
+                Assert.Equal(3 * 64, tripleDes.LegalKeySizes[0].MaxSize);
+                Assert.Equal(64, tripleDes.LegalBlockSizes[0].MaxSize);
+
+                tripleDes.Key = new byte[]
+                {
+                    /* k1 */ 0, 1, 2, 3, 4, 5, 6, 7,
+                    /* k2 */ 0, 0, 0, 2, 4, 6, 0, 1,
+                    /* k3 */ 0, 1, 2, 3, 4, 5, 6, 7,
+                };
+            }
+        }
+
         private static IEnumerable<byte[]> BadKeys()
         {
             foreach (byte[] key in _weakKeys)
@@ -102,7 +121,16 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0000000000000000".HexToByteArray(),
         };
 
-        private sealed class TripleDESMinimal : TripleDES
+        private class TripleDESLegalSizesBreaker : TripleDESMinimal
+        {
+            public TripleDESLegalSizesBreaker()
+            {
+                LegalKeySizesValue[0] = new KeySizes(1, 1, 0);
+                LegalBlockSizesValue[0] = new KeySizes(1, 1, 0);
+            }
+        }
+
+        private class TripleDESMinimal : TripleDES
         {
             // If the constructor uses a virtual call to any of the property setters
             // they will fail.


### PR DESCRIPTION
Aes and TripleDES both did assignments via virtual property setters in their ctor,
which were field assignments in .NET Framework.  3rd party implementations
may have written properties which assumed that the ctor had run to completion,
and they are broken by that behavioral change.

This change makes the ctors look like they do in net462, aside from when
net462 sets fields which don't exist.

It also makes the tests fail if virtual setter dispatch was utilized (for any currently
defined property, at least).

This addresses  #12079 in master, a porting change may follow for release/1.1.0.
cc: @steveharter