### PR TITLE
Make Microsoft.CSharp target netstandard1.7

### DIFF
--- a/src/Microsoft.CSharp/pkg/Microsoft.CSharp.pkgproj
+++ b/src/Microsoft.CSharp/pkg/Microsoft.CSharp.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\Microsoft.CSharp.csproj">
-      <SupportedFramework>net45;netcore45;netcoreapp1.0;wp8;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.CSharp.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10">

--- a/src/Microsoft.CSharp/ref/Microsoft.CSharp.csproj
+++ b/src/Microsoft.CSharp/ref/Microsoft.CSharp.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Microsoft.CSharp.cs" />

--- a/src/Microsoft.CSharp/ref/project.json
+++ b/src/Microsoft.CSharp/ref/project.json
@@ -1,14 +1,10 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.0",
-    "System.Dynamic.Runtime": "4.0.0",
-    "System.Linq.Expressions": "4.0.0"
+    "System.Runtime": "4.4.0-beta-24617-03",
+    "System.Dynamic.Runtime": "4.4.0-beta-24617-03",
+    "System.Linq.Expressions": "4.4.0-beta-24617-03"
   },
   "frameworks": {
-    "netstandard1.0": {
-      "imports": [
-        "dotnet5.1"
-      ]
-    }
+    "netstandard1.7": {}
   }
 }

--- a/src/Microsoft.CSharp/src/Microsoft.CSharp.csproj
+++ b/src/Microsoft.CSharp/src/Microsoft.CSharp.csproj
@@ -7,8 +7,7 @@
     <RootNamespace>Microsoft.CSharp</RootNamespace>
     <!-- dotnet/corefx#3128 tracks removing this exclusion -->
     <ExcludeLocalizationImport Condition="'$(TargetsWindows)' != 'true'">true</ExcludeLocalizationImport>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
-    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.3;netcore50</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Microsoft.CSharp/src/project.json
+++ b/src/Microsoft.CSharp/src/project.json
@@ -1,30 +1,25 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1",
-    "System.Collections": "4.0.10",
-    "System.Diagnostics.Debug": "4.0.10",
-    "System.Diagnostics.Tools": "4.0.0",
-    "System.Dynamic.Runtime": "4.0.0",
-    "System.Globalization": "4.0.10",
-    "System.Linq": "4.0.0",
-    "System.Linq.Expressions": "4.0.0",
-    "System.ObjectModel": "4.0.10",
-    "System.Reflection": "4.0.10",
-    "System.Reflection.Extensions": "4.0.0",
-    "System.Reflection.Primitives": "4.0.0",
-    "System.Reflection.TypeExtensions": "4.0.0",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Runtime": "4.0.20",
-    "System.Runtime.Extensions": "4.0.10",
-    "System.Runtime.InteropServices": "4.0.20",
-    "System.Threading": "4.0.10",
-    "System.Threading.Tasks": "4.0.10"
+    "System.Collections": "4.4.0-beta-24617-03",
+    "System.Diagnostics.Debug": "4.4.0-beta-24617-03",
+    "System.Diagnostics.Tools": "4.4.0-beta-24617-03",
+    "System.Dynamic.Runtime": "4.4.0-beta-24617-03",
+    "System.Globalization": "4.4.0-beta-24617-03",
+    "System.Linq": "4.4.0-beta-24617-03",
+    "System.Linq.Expressions": "4.4.0-beta-24617-03",
+    "System.ObjectModel": "4.4.0-beta-24617-03",
+    "System.Reflection": "4.4.0-beta-24617-03",
+    "System.Reflection.Extensions": "4.4.0-beta-24617-03",
+    "System.Reflection.Primitives": "4.4.0-beta-24617-03",
+    "System.Reflection.TypeExtensions": "4.4.0-beta-24617-03",
+    "System.Resources.ResourceManager": "4.4.0-beta-24617-03",
+    "System.Runtime": "4.4.0-beta-24617-03",
+    "System.Runtime.Extensions": "4.4.0-beta-24617-03",
+    "System.Runtime.InteropServices": "4.4.0-beta-24617-03",
+    "System.Threading": "4.4.0-beta-24617-03",
+    "System.Threading.Tasks": "4.4.0-beta-24617-03"
   },
   "frameworks": {
-    "netstandard1.3": {
-      "imports": [
-        "dotnet5.4"
-      ]
-    }
+    "netstandard1.7": {}
   }
 }

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.builds
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.builds
@@ -5,6 +5,11 @@
     <Project Include="Microsoft.CSharp.Tests.csproj" />
     <Project Include="Microsoft.CSharp.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
+      <TestTFMs>net463</TestTFMs>
+    </Project>
+    <Project Include="Microsoft.CSharp.Tests.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
       <TestTFMs>netcore50;net46</TestTFMs>
     </Project>
   </ItemGroup>

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
     <AssemblyName>Microsoft.CSharp.Tests</AssemblyName>
     <RootNamespace>Microsoft.CSharp.Tests</RootNamespace>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />


### PR DESCRIPTION
Makes the ref, src, & tests target netstandard1.7.
The tests cross-compile to preserve the test build for older fxs.

I intentionally *did not* bump the version of this assembly.  The reason
being that a bump would require an update to desktop to ship this
assembly out of band, however that isn't needed.  Since all the new API
is already part of desktop we can make this work while still treating it
as inbox.

/cc @danmosemsft @stephentoub @weshaggard 