### PR TITLE
Add updated desktop runner dependencies

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -318,6 +318,10 @@
                     "include": "compile"
                 }
             }
+        },
+        "net46":{
+            "xunit.runner.utility": "2.2.0-beta2-build3300",
+            "xunit.runner.console": "2.2.0-beta2-build3300",
         }
     },
     "supports": {


### PR DESCRIPTION
The older version of xunit.console.exe was incompatible with 2.2.0 xunit dependencies, hence the version update added to the net46 framework. 

/cc @MattGal 