### PR TITLE
Modify OOM exeception check in 'System.System.Security.Cryptography.Encryption.Aes.Tests.AesContractTests'

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
@@ -77,6 +77,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 try
                 {
                     key = new byte[invalidKeySize];
+                    byte[] cloneIV = (byte[])iv.Clone();  // Check memory for Cloning in CreateEncrpyor and CreateDecryptor
                 }
                 catch (OutOfMemoryException) // in case there isn't enough memory at test-time to allocate the large array
                 {
@@ -101,6 +102,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 try
                 {
                     iv = new byte[invalidIvSize];
+                    byte[] cloneIV = (byte[])iv.Clone();  // Check memory for Cloning in CreateEncrpyor and CreateDecryptor
                 }
                 catch (OutOfMemoryException) // in case there isn't enough memory at test-time to allocate the large array
                 {

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
@@ -77,14 +77,16 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 try
                 {
                     key = new byte[invalidKeySize];
-                    byte[] cloneIV = (byte[])iv.Clone();  // Check memory for Cloning in CreateEncrpyor and CreateDecryptor
                 }
                 catch (OutOfMemoryException) // in case there isn't enough memory at test-time to allocate the large array
                 {
                     return;
                 }
-                Assert.Throws<ArgumentException>("rgbKey", () => aes.CreateEncryptor(key, iv));
-                Assert.Throws<ArgumentException>("rgbKey", () => aes.CreateDecryptor(key, iv));
+                Exception e = Record.Exception(() => aes.CreateEncryptor(key, iv));
+                Assert.True(e is ArgumentException || e is OutOfMemoryException, $"Got {e}");
+                
+                e = Record.Exception(() => aes.CreateDecryptor(key, iv));
+                Assert.True(e is ArgumentException || e is OutOfMemoryException, $"Got {e}");
             }
         }
 
@@ -102,14 +104,16 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 try
                 {
                     iv = new byte[invalidIvSize];
-                    byte[] cloneIV = (byte[])iv.Clone();  // Check memory for Cloning in CreateEncrpyor and CreateDecryptor
                 }
                 catch (OutOfMemoryException) // in case there isn't enough memory at test-time to allocate the large array
                 {
                     return;
                 }
-                Assert.Throws<ArgumentException>("rgbIV", () => aes.CreateEncryptor(key, iv));
-                Assert.Throws<ArgumentException>("rgbIV", () => aes.CreateDecryptor(key, iv));
+                Exception e = Record.Exception(() => aes.CreateEncryptor(key, iv));
+                Assert.True(e is ArgumentException || e is OutOfMemoryException, $"Got {e}");
+                
+                e = Record.Exception(() => aes.CreateDecryptor(key, iv));
+                Assert.True(e is ArgumentException || e is OutOfMemoryException, $"Got {e}");
             }
         }
 


### PR DESCRIPTION
Related issue: #12441
Additional out-of-memory exception in `System.Security.Cryptography.Encryption.Aes.Tests.AesContractTests.InvalidKeySizes`
and `System.Security.Cryptography.Encryption.Aes.Tests.AesContractTests.InvalidIVSizes`.

Because CreateEncryptor(key, iv) and CreateDecryptor(key, iv) uses Array.Clone() to array argument `iv`, we need to check OOM exception for cloned object.