### PR TITLE
Stop crashing in NegotiateStream tests on Unix when KDCSetup fails

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
@@ -30,6 +30,7 @@ namespace System.Net.Security.Tests
         private readonly bool _isKrbPreInstalled ;
         public readonly string password;
         private const string NtlmUserFile = "NTLM_USER_FILE";
+        private readonly bool _successfulSetup = true;
 
         public KDCSetup()
         {
@@ -45,8 +46,7 @@ namespace System.Net.Security.Tests
                     {
                         Dispose();
                     }
-
-                    throw new InvalidOperationException("KDC setup failure");
+                    _successfulSetup = false; // TODO: https://github.com/dotnet/corefx/issues/12107
                 }
             }
             else
@@ -67,6 +67,11 @@ namespace System.Net.Security.Tests
         // on the host. Returns true available, false otherwise
         public bool CheckAndClearCredentials(ITestOutputHelper output)
         {
+            if (!_successfulSetup)
+            {
+                return false;
+            }
+
             // Clear the credentials
             var startInfo = new ProcessStartInfo(KDestroyCmd);
             startInfo.UseShellExecute = true;
@@ -82,7 +87,7 @@ namespace System.Net.Security.Tests
 
         public bool CheckAndInitializeNtlm(bool isKrbAvailable)
         {
-            if (!isKrbAvailable)
+            if (!_successfulSetup || !isKrbAvailable)
             {
                 return false;
             }


### PR DESCRIPTION
The NegotiateStream tests on Unix try to set up kerberos infrastructure.  The tests then check whether infrastructure is available, and gracefully don't run if it's not.  But the KDCSetup fixture is throwing an exception if the infrastructure can't be configured, which is causing a fair number of our outerloop CI runs to fail on various OSes.  Until we have a better solution in place, I'm making the failure graceful rather than crashing.

https://github.com/dotnet/corefx/issues/12107
cc: @mellinoe, @ericeil, @karelz 