### PR TITLE
Transactions were timing out early due to truncation of timeout ticks…

### DIFF
--- a/src/System.Transactions/src/System/Transactions/TransactionTable.cs
+++ b/src/System.Transactions/src/System/Transactions/TransactionTable.cs
@@ -178,7 +178,16 @@ namespace System.Transactions
                 //       (nearly 300 billion) years.
                 long timeoutTicks = ((timeout.Ticks / TimeSpan.TicksPerMillisecond) >>
                         TransactionTable.timerInternalExponent) + _ticks;
-                return timeoutTicks;
+                // The increment of 2 is necessary to account for the half-second that is
+                // lost due to the right-shift truncation and also for the half-second
+                // that might be lost because the transaction's AbsoluteTimeout is
+                // calculated just before this._ticks is incremented.
+                // This increment by 2 could cause a transaction to last up to 1 second longer than the
+                // specified timeout, but there are no guarantees that the transaction
+                // will timeout exactly at the time specified. But we shouldn't timeout
+                // the transaction earlier than the specified time, which is possible without
+                // this adjustment.
+                return timeoutTicks + 2;
             }
             else
             {

--- a/src/System.Transactions/tests/NonMsdtcPromoterTests.cs
+++ b/src/System.Transactions/tests/NonMsdtcPromoterTests.cs
@@ -1434,9 +1434,9 @@ namespace System.Transactions.Tests
             AutoResetEvent pspeCompleted = new AutoResetEvent(false);
             NonMSDTCPromoterEnlistment pspe = null;
 
-            try
+            Assert.Throws<TransactionAbortedException>(() =>
             {
-                CommittableTransaction tx = new CommittableTransaction(TimeSpan.FromSeconds(3));
+                CommittableTransaction tx = new CommittableTransaction(TimeSpan.FromSeconds(1));
 
                 pspe = (NonMSDTCPromoterEnlistment)CreatePSPEEnlistment(NonMsdtcPromoterTests.PromoterType1,
                     NonMsdtcPromoterTests.PromotedToken1,
@@ -1452,18 +1452,14 @@ namespace System.Transactions.Tests
                     Promote(testCaseDescription, NonMsdtcPromoterTests.PromotedToken1, tx);
                 }
 
-                NoStressTrace(string.Format("There will be a 7 second delay here - {0}", DateTime.Now.ToString()));
+                NoStressTrace(string.Format("There will be a 3 second delay here - {0}", DateTime.Now.ToString()));
 
-                Task.Delay(TimeSpan.FromSeconds(7)).Wait();
+                Task.Delay(TimeSpan.FromSeconds(3)).Wait();
 
                 NoStressTrace(string.Format("Woke up from sleep. Attempting Commit - {0}", DateTime.Now.ToString()));
 
                 tx.Commit();
-            }
-            catch (Exception ex)
-            {
-                Assert.IsType<TransactionAbortedException>(ex);
-            }
+            });
 
             Assert.True(pspeCompleted.WaitOne(TimeSpan.FromSeconds(5)));
 

--- a/src/System.Transactions/tests/TransactionScopeTest.cs
+++ b/src/System.Transactions/tests/TransactionScopeTest.cs
@@ -505,7 +505,7 @@ namespace System.Transactions.Tests
             Assert.Null(Transaction.Current);
             TransactionAbortedException e = Assert.Throws<TransactionAbortedException>(() =>
             {
-                using (TransactionScope scope = new TransactionScope(TransactionScopeOption.Required, new TimeSpan(0, 0, 30)))
+                using (TransactionScope scope = new TransactionScope(TransactionScopeOption.Required, new TimeSpan(0, 0, 10)))
                 {
                     irm.Value = 2;
                     irm2.Value = 20;


### PR DESCRIPTION
… and the algorithm

that utilizes a single timer object.

Modified NonMsdtcPromoterTests to fail if a transaction commits when expected to abort.

Shortened some timeouts to reduce overall time requied to execute some outerloop tests.