### PR TITLE
Port System.Security.Cryptography.Algorithms.Rijndael and RijndaelMan…

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -293,6 +293,31 @@ namespace System.Security.Cryptography
         public override int KeySize { get { return default(int); } set { } }
         public static System.Security.Cryptography.RC2 Create() { return default(System.Security.Cryptography.RC2); }
     }
+    [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+    public abstract partial class Rijndael : System.Security.Cryptography.SymmetricAlgorithm
+    {
+        protected Rijndael() { }
+        public static System.Security.Cryptography.Rijndael Create() { return default(System.Security.Cryptography.Rijndael); }
+    }
+    [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+    public sealed partial class RijndaelManaged : System.Security.Cryptography.Rijndael
+    {
+        public RijndaelManaged() { }
+        public override int BlockSize { get { return default(int); } set { } }
+        public override byte[] IV { get { return default(byte[]); } set { } }
+        public override byte[] Key { get { return default(byte[]); } set { } }
+        public override int KeySize { get { return default(int); } set { } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
+        public override System.Security.Cryptography.CipherMode Mode { get { return default(System.Security.Cryptography.CipherMode); } set { } }
+        public override System.Security.Cryptography.PaddingMode Padding { get { return default(System.Security.Cryptography.PaddingMode); } set { } }
+        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor() { return default(System.Security.Cryptography.ICryptoTransform); }
+        public override System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) { return default(System.Security.Cryptography.ICryptoTransform); }
+        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor() { return default(System.Security.Cryptography.ICryptoTransform); }
+        public override System.Security.Cryptography.ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) { return default(System.Security.Cryptography.ICryptoTransform); }
+        protected override void Dispose(bool disposing) { }
+        public override void GenerateIV() { }
+        public override void GenerateKey() { }
+    }
     public partial class Rfc2898DeriveBytes : System.Security.Cryptography.DeriveBytes
     {
         public Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations) { }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RijndaelImplementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RijndaelImplementation.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    /// <summary>
+    /// Internal implementation of Rijndael.
+    /// This class is returned from Rijndael.Create() instead of the public RijndaelManaged to 
+    /// be consistent with the rest of the static Create() methods which return opaque types.
+    /// They both have have the same implementation.
+    /// </summary>
+    internal sealed class RijndaelImplementation : Rijndael
+    {
+        private readonly Aes _impl;
+
+        internal RijndaelImplementation()
+        {
+            LegalBlockSizesValue = new KeySizes[] { new KeySizes(minSize: 128, maxSize: 128, skipSize: 0) };
+
+            // This class wraps Aes
+            _impl = Aes.Create();
+        }
+
+        public override int BlockSize
+        {
+            get { return _impl.BlockSize; }
+            set
+            {
+                // Values which were legal in desktop RijndaelManaged but not here in this wrapper type
+                if (value == 192 || value == 256)
+                    throw new PlatformNotSupportedException(SR.Cryptography_Rijndael_BlockSize);
+
+                // Any other invalid block size will get the normal “invalid block size” exception.
+                _impl.BlockSize = value;
+            }
+        }
+
+        public override byte[] IV
+        {
+            get { return _impl.IV; }
+            set { _impl.IV = value; }
+        }
+
+        public override byte[] Key
+        {
+            get { return _impl.Key; }
+            set { _impl.Key = value; }
+        }
+
+        public override int KeySize
+        {
+            get { return _impl.KeySize; }
+            set { _impl.KeySize = value; }
+        }
+        public override CipherMode Mode
+        {
+            get { return _impl.Mode; }
+            set { _impl.Mode = value; }
+        }
+
+        public override PaddingMode Padding
+        {
+            get { return _impl.Padding; }
+            set { _impl.Padding = value; }
+        }
+
+        public override KeySizes[] LegalKeySizes => _impl.LegalKeySizes;
+        public override ICryptoTransform CreateEncryptor() => _impl.CreateEncryptor();
+        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) => _impl.CreateEncryptor(rgbKey, rgbIV);
+        public override ICryptoTransform CreateDecryptor() => _impl.CreateDecryptor();
+        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) => _impl.CreateDecryptor(rgbKey, rgbIV);
+        public override void GenerateIV() => _impl.GenerateIV();
+        public override void GenerateKey() => _impl.GenerateKey();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _impl.Dispose();
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -252,6 +252,9 @@
   <data name="Cryptography_RC2_EKSKS2" xml:space="preserve">
     <value>EffectiveKeySize must be the same as KeySize in this implementation.</value>
   </data>
+  <data name="Cryptography_Rijndael_BlockSize" xml:space="preserve">
+    <value>BlockSize must be 128 in this implementation.</value>
+  </data>
   <data name="Cryptography_TransformBeyondEndOfBuffer" xml:space="preserve">
     <value>Attempt to transform beyond end of buffer.</value>
   </data>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -30,6 +30,7 @@
     <Compile Include="Internal\Cryptography\HMACCommon.cs" />
     <Compile Include="Internal\Cryptography\HashAlgorithmNames.cs" />
     <Compile Include="Internal\Cryptography\RC2Implementation.cs" />
+    <Compile Include="Internal\Cryptography\RijndaelImplementation.cs" />
     <Compile Include="Internal\Cryptography\TripleDesImplementation.cs" />
     <Compile Include="System\Security\Cryptography\Aes.cs" />
     <Compile Include="System\Security\Cryptography\AsymmetricKeyExchangeDeformatter.cs" />
@@ -62,6 +63,8 @@
     <Compile Include="System\Security\Cryptography\IncrementalHash.cs" />
     <Compile Include="System\Security\Cryptography\RandomNumberGenerator.cs" />
     <Compile Include="System\Security\Cryptography\RC2.cs" />
+    <Compile Include="System\Security\Cryptography\Rijndael.cs" />
+    <Compile Include="System\Security\Cryptography\RijndaelManaged.cs" />
     <Compile Include="System\Security\Cryptography\Rfc2898DeriveBytes.cs" />
     <Compile Include="System\Security\Cryptography\RSA.cs" />
     <Compile Include="System\Security\Cryptography\RSAEncryptionPadding.cs" />

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rijndael.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rijndael.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Cryptography;
+using System.ComponentModel;
+
+namespace System.Security.Cryptography
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class Rijndael : SymmetricAlgorithm
+    {
+        public static Rijndael Create()
+        {
+            return new RijndaelImplementation();
+        }
+
+        protected Rijndael()
+        {
+            LegalBlockSizesValue = s_legalBlockSizes.CloneKeySizesArray();
+            LegalKeySizesValue = s_legalKeySizes.CloneKeySizesArray();
+            KeySizeValue = 256;
+            BlockSizeValue = 128;
+        }
+
+        private static readonly KeySizes[] s_legalBlockSizes =
+        {
+            new KeySizes(minSize: 128, maxSize: 256, skipSize: 64)
+        };
+
+        private static readonly KeySizes[] s_legalKeySizes =
+        {
+            new KeySizes(minSize: 128, maxSize: 256, skipSize: 64)
+        };
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RijndaelManaged.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RijndaelManaged.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+
+namespace System.Security.Cryptography
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class RijndaelManaged : Rijndael
+    {
+        private readonly Aes _impl;
+
+        public RijndaelManaged()
+        {
+            LegalBlockSizesValue = new KeySizes[] { new KeySizes(minSize: 128, maxSize: 128, skipSize: 0) };
+
+            // This class wraps Aes
+            _impl = Aes.Create();
+        }
+
+        public override int BlockSize
+        {
+            get { return _impl.BlockSize; }
+            set
+            {
+                // Values which were legal in desktop RijndaelManaged but not here in this wrapper type
+                if (value == 192 || value == 256)
+                    throw new PlatformNotSupportedException(SR.Cryptography_Rijndael_BlockSize);
+
+                // Any other invalid block size will get the normal “invalid block size” exception.
+                _impl.BlockSize = value;
+            }
+        }
+
+        public override byte[] IV
+        {
+            get { return _impl.IV; }
+            set { _impl.IV = value; }
+        }
+
+        public override byte[] Key
+        {
+            get { return _impl.Key; }
+            set { _impl.Key = value; }
+        }
+
+        public override int KeySize
+        {
+            get { return _impl.KeySize; }
+            set { _impl.KeySize = value; }
+        }
+        public override CipherMode Mode
+        {
+            get { return _impl.Mode; }
+            set { _impl.Mode = value; }
+        }
+
+        public override PaddingMode Padding
+        {
+            get { return _impl.Padding; }
+            set { _impl.Padding = value; }
+        }
+
+        public override KeySizes[] LegalKeySizes => _impl.LegalKeySizes;
+        public override ICryptoTransform CreateEncryptor() => _impl.CreateEncryptor();
+        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) => _impl.CreateEncryptor(rgbKey, rgbIV);
+        public override ICryptoTransform CreateDecryptor() => _impl.CreateDecryptor();
+        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) => _impl.CreateDecryptor(rgbKey, rgbIV);
+        public override void GenerateIV() => _impl.GenerateIV();
+        public override void GenerateKey() => _impl.GenerateKey();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _impl.Dispose();
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
@@ -1,0 +1,299 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.Rijndael.Tests
+{
+    using Rijndael = System.Security.Cryptography.Rijndael;
+
+    /// <summary>
+    /// Since the Rijndael classes wrap Aes, we only test minimally here since Aes has the full test suite.
+    /// </summary>
+    public class RijndaelTests
+    {
+        [Fact]
+        public static void VerifyDefaults()
+        {
+            using (var alg = Rijndael.Create())
+            {
+                // We use an internal class for the implementation, not the public RijndaelManaged
+                Assert.IsNotType<RijndaelManaged>(alg);
+
+                VerifyDefaults(alg);
+            }
+
+            using (var alg = new RijndaelManaged())
+            {
+                VerifyDefaults(alg);
+            }
+        }
+
+        private static void VerifyDefaults(Rijndael alg)
+        {
+            // The block size differs from the base
+            Assert.Equal(128, alg.LegalBlockSizes[0].MinSize);
+            Assert.Equal(128, alg.LegalBlockSizes[0].MaxSize);
+            Assert.Equal(128, alg.BlockSize);
+
+            // Different exception since we have different supported BlockSizes than desktop
+            Assert.Throws<PlatformNotSupportedException>(() => alg.BlockSize = 192);
+            Assert.Throws<PlatformNotSupportedException>(() => alg.BlockSize = 256);
+
+            // Normal exception for rest
+            Assert.Throws<CryptographicException>(() => alg.BlockSize = 111);
+
+            Assert.Equal(CipherMode.CBC, alg.Mode);
+            Assert.Equal(PaddingMode.PKCS7, alg.Padding);
+        }
+
+        [Fact]
+        public static void EncryptDecryptKnownECB192()
+        {
+            using (var alg = Rijndael.Create())
+            {
+                EncryptDecryptKnownECB192(alg);
+            }
+
+            using (var alg = new RijndaelManaged())
+            {
+                EncryptDecryptKnownECB192(alg);
+            }
+        }
+
+        private static void EncryptDecryptKnownECB192(Rijndael alg)
+        {
+            byte[] plainTextBytes =
+                new ASCIIEncoding().GetBytes("This is a sentence that is longer than a block, it ensures that multi-block functions work.");
+
+            byte[] encryptedBytesExpected = new byte[]
+            {
+                0xC9, 0x7F, 0xA5, 0x5B, 0xC3, 0x92, 0xDC, 0xA6,
+                0xE4, 0x9F, 0x2D, 0x1A, 0xEF, 0x7A, 0x27, 0x03,
+                0x04, 0x9C, 0xFB, 0x56, 0x63, 0x38, 0xAE, 0x4F,
+                0xDC, 0xF6, 0x36, 0x98, 0x28, 0x05, 0x32, 0xE9,
+                0xF2, 0x6E, 0xEC, 0x0C, 0x04, 0x9D, 0x12, 0x17,
+                0x18, 0x35, 0xD4, 0x29, 0xFC, 0x01, 0xB1, 0x20,
+                0xFA, 0x30, 0xAE, 0x00, 0x53, 0xD4, 0x26, 0x25,
+                0xA4, 0xFD, 0xD5, 0xE6, 0xED, 0x79, 0x35, 0x2A,
+                0xE2, 0xBB, 0x95, 0x0D, 0xEF, 0x09, 0xBB, 0x6D,
+                0xC5, 0xC4, 0xDB, 0x28, 0xC6, 0xF4, 0x31, 0x33,
+                0x9A, 0x90, 0x12, 0x36, 0x50, 0xA0, 0xB7, 0xD1,
+                0x35, 0xC4, 0xCE, 0x81, 0xE5, 0x2B, 0x85, 0x6B,
+            };
+
+            byte[] aes192Key = new byte[]
+            {
+                0xA6, 0x1E, 0xC7, 0x54, 0x37, 0x4D, 0x8C, 0xA5,
+                0xA4, 0xBB, 0x99, 0x50, 0x35, 0x4B, 0x30, 0x4D,
+                0x6C, 0xFE, 0x3B, 0x59, 0x65, 0xCB, 0x93, 0xE3,
+            };
+
+            // The CipherMode and KeySize are different than the default values; this ensures the type
+            // forwards the state properly to Aes.
+            alg.Mode = CipherMode.ECB;
+            alg.Key = aes192Key;
+
+            byte[] encryptedBytes = alg.Encrypt(plainTextBytes);
+            Assert.Equal(encryptedBytesExpected, encryptedBytes);
+
+            byte[] decryptedBytes = alg.Decrypt(encryptedBytes);
+            Assert.Equal(plainTextBytes, decryptedBytes);
+        }
+
+        [Fact]
+        public static void TestShims()
+        {
+            using (var alg = Rijndael.Create())
+            {
+                TestShims(alg);
+            }
+
+            using (var alg = new RijndaelManaged())
+            {
+                TestShims(alg);
+            }
+        }
+
+        private static void TestShims(Rijndael alg)
+        {
+            alg.BlockSize = 128;
+            Assert.Equal(128, alg.BlockSize);
+
+            var emptyIV = new byte[alg.BlockSize / 8];
+            alg.IV = emptyIV;
+            Assert.Equal(emptyIV, alg.IV);
+            alg.GenerateIV();
+            Assert.NotEqual(emptyIV, alg.IV);
+
+            var emptyKey = new byte[alg.KeySize / 8];
+            alg.Key = emptyKey;
+            Assert.Equal(emptyKey, alg.Key);
+            alg.GenerateKey();
+            Assert.NotEqual(emptyKey, alg.Key);
+
+            alg.KeySize = 128;
+            Assert.Equal(128, alg.KeySize);
+
+            alg.Mode = CipherMode.ECB;
+            Assert.Equal(CipherMode.ECB, alg.Mode);
+
+            alg.Padding = PaddingMode.PKCS7;
+            Assert.Equal(PaddingMode.PKCS7, alg.Padding);
+        }
+
+        [Fact]
+        public static void RijndaelKeySize_BaseClass()
+        {
+            using (Rijndael alg = new RijndaelMinimal())
+            {
+                Assert.Equal(128, alg.LegalKeySizes[0].MinSize);
+                Assert.Equal(256, alg.LegalKeySizes[0].MaxSize);
+                Assert.Equal(64, alg.LegalKeySizes[0].SkipSize);
+                Assert.Equal(256, alg.KeySize);
+
+                Assert.Equal(128, alg.LegalBlockSizes[0].MinSize);
+                Assert.Equal(256, alg.LegalBlockSizes[0].MaxSize);
+                Assert.Equal(64, alg.LegalBlockSizes[0].SkipSize);
+                Assert.Equal(128, alg.BlockSize);
+            }
+        }
+
+        [Fact]
+        public static void EnsureLegalSizesValuesIsolated()
+        {
+            new RijndaelLegalSizesBreaker().Dispose();
+
+            using (Rijndael alg = Rijndael.Create())
+            {
+                Assert.Equal(128, alg.LegalKeySizes[0].MinSize);
+                Assert.Equal(128, alg.LegalBlockSizes[0].MinSize);
+
+                alg.Key = new byte[16];
+            }
+        }
+
+        private class RijndaelLegalSizesBreaker : RijndaelMinimal
+        {
+            public RijndaelLegalSizesBreaker()
+            {
+                LegalKeySizesValue[0] = new KeySizes(1, 1, 0);
+                LegalBlockSizesValue[0] = new KeySizes(1, 1, 0);
+            }
+        }
+
+        private class RijndaelMinimal : Rijndael
+        {
+            // If the constructor uses a virtual call to any of the property setters
+            // they will fail.
+            private readonly bool _ready;
+
+            public RijndaelMinimal()
+            {
+                // Don't set this as a field initializer, otherwise it runs before the base ctor.
+                _ready = true;
+            }
+
+            public override int KeySize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.KeySize = value;
+                }
+            }
+
+            public override int BlockSize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.BlockSize = value;
+                }
+            }
+
+            public override byte[] IV
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.IV = value;
+                }
+            }
+
+            public override byte[] Key
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Key = value;
+                }
+            }
+
+            public override CipherMode Mode
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Mode = value;
+                }
+            }
+
+            public override PaddingMode Padding
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Padding = value;
+                }
+            }
+
+            public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateIV()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateKey()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="ECDiffieHellmanPublicKeyTests.cs" />
     <Compile Include="RC2Provider.cs" />
     <Compile Include="RC2Tests.cs" />
+    <Compile Include="RijndaelTests.cs" />
     <Compile Include="RSAKeyExchangeFormatterTests.cs" />
     <Compile Include="RSASignatureFormatterTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AsymmetricSignatureFormatter.cs">


### PR DESCRIPTION
Address issue #9984 Port System.Security.Cryptography.RijndaelManaged, limited to AES

Per the requirements, the two new types wrap\shim Aes and limit BlockSize to 128, unlike the Rijndael desktop types which also allow 192 and 256.

@bartonjs please review