### PR TITLE
Fix for Build 20161020-31

### DIFF
--- a/src/System.IO.FileSystem/tests/FileStream/Flush.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Flush.cs
@@ -127,8 +127,10 @@ namespace System.IO.Tests
             using (StoreFlushArgFileStream fs = new StoreFlushArgFileStream(GetTestFilePath(), FileMode.Create))
             {
                 fs.Flush();
+#pragma warning disable 1690
                 Assert.True(fs.LastFlushArg.HasValue);
                 Assert.False(fs.LastFlushArg.Value);
+#pragma warning restore 1690
             }
         }
 

--- a/src/System.IO.FileSystem/tests/FileStream/Flush.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Flush.cs
@@ -165,7 +165,7 @@ namespace System.IO.Tests
             {
             }
 
-            public bool? LastFlushArg;
+            public bool? LastFlushArg { get; set; }
 
             public override void Flush(bool flushToDisk)
             {

--- a/src/System.IO.FileSystem/tests/FileStream/Flush.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Flush.cs
@@ -127,10 +127,8 @@ namespace System.IO.Tests
             using (StoreFlushArgFileStream fs = new StoreFlushArgFileStream(GetTestFilePath(), FileMode.Create))
             {
                 fs.Flush();
-#pragma warning disable 1690
                 Assert.True(fs.LastFlushArg.HasValue);
                 Assert.False(fs.LastFlushArg.Value);
-#pragma warning restore 1690
             }
         }
 


### PR DESCRIPTION
[My recent changes](https://github.com/dotnet/corefx/pull/12773) of adding MarshalByRef base class broke the official build with error:

```
error CS1690: Accessing a member on 'FileStream_Flush.StoreFlushArgFileStream.LastFlushArg' may cause a runtime exception because it is a field of a marshal-by-reference class.
```

cc: @weshaggard @joperezr 