### PR TITLE
[release/1.1.0] Make derived types of SymmetricAlgorithm use field assignment in ctors.

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Aes.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Aes.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -12,33 +10,18 @@ namespace System.Security.Cryptography
     {
         protected Aes()
         {
-            this.BlockSize = 128;
-            this.KeySize = 256;
-            this.Mode = CipherMode.CBC;
-        }
+            LegalBlockSizesValue = s_legalBlockSizes.CloneKeySizesArray();
+            LegalKeySizesValue = s_legalKeySizes.CloneKeySizesArray();
 
-        public override KeySizes[] LegalBlockSizes
-        {
-            get
-            {
-                return s_legalBlockSizes.CloneKeySizesArray();
-            }
-        }
-
-        public override KeySizes[] LegalKeySizes
-        {
-            get
-            {
-                return s_legalKeySizes.CloneKeySizesArray();
-            }
+            BlockSizeValue = 128;
+            KeySizeValue = 256;
+            ModeValue = CipherMode.CBC;
         }
 
         public static Aes Create()
         {
             return new AesImplementation();
         }
-
-
 
         private static readonly KeySizes[] s_legalBlockSizes = { new KeySizes(128, 128, 0) };
         private static readonly KeySizes[] s_legalKeySizes = { new KeySizes(128, 256, 64) };

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
@@ -13,29 +13,15 @@ namespace System.Security.Cryptography
     {
         protected TripleDES()
         {
-            KeySize = 3*64;
-            BlockSize = 64;
+            KeySizeValue = 3*64;
+            BlockSizeValue = 64;
+            LegalBlockSizesValue = s_legalBlockSizes.CloneKeySizesArray();
+            LegalKeySizesValue = s_legalKeySizes.CloneKeySizesArray();
         }
 
         public static TripleDES Create()
         {
             return new TripleDesImplementation();
-        }
-
-        public override KeySizes[] LegalKeySizes
-        {
-            get
-            {
-                return s_legalKeySizes.CloneKeySizesArray();
-            }
-        }
-
-        public override KeySizes[] LegalBlockSizes
-        {
-            get
-            {
-                return s_legalBlockSizes.CloneKeySizesArray();
-            }
         }
 
         public override byte[] Key

--- a/src/System.Security.Cryptography.Algorithms/tests/AesTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/AesTests.cs
@@ -1,0 +1,157 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Algorithms.Tests
+{
+    public partial class AesTests
+    {
+        [Fact]
+        public static void AesDefaultCtor()
+        {
+            using (Aes aes = new AesMinimal())
+            {
+                Assert.Equal(256, aes.KeySize);
+                Assert.Equal(128, aes.BlockSize);
+                Assert.Equal(CipherMode.CBC, aes.Mode);
+                Assert.Equal(PaddingMode.PKCS7, aes.Padding);
+            }
+        }
+
+        [Fact]
+        public static void EnsureLegalSizesValuesIsolated()
+        {
+            new AesLegalSizesBreaker().Dispose();
+
+            using (Aes aes = Aes.Create())
+            {
+                Assert.Equal(128, aes.LegalKeySizes[0].MinSize);
+                Assert.Equal(128, aes.LegalBlockSizes[0].MinSize);
+
+                aes.Key = new byte[16];
+            }
+        }
+
+        private class AesLegalSizesBreaker : AesMinimal
+        {
+            public AesLegalSizesBreaker()
+            {
+                LegalKeySizesValue[0] = new KeySizes(1, 1, 0);
+                LegalBlockSizesValue[0] = new KeySizes(1, 1, 0);
+            }
+        }
+
+        private class AesMinimal : Aes
+        {
+            // If the constructor uses a virtual call to any of the property setters
+            // they will fail.
+            private readonly bool _ready;
+
+            public AesMinimal()
+            {
+                // Don't set this as a field initializer, otherwise it runs before the base ctor.
+                _ready = true;
+            }
+
+            public override int KeySize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.KeySize = value;
+                }
+            }
+
+            public override int BlockSize
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.BlockSize = value;
+                }
+            }
+
+            public override byte[] IV
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.IV = value;
+                }
+            }
+
+            public override byte[] Key
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Key = value;
+                }
+            }
+
+            public override CipherMode Mode
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Mode = value;
+                }
+            }
+
+            public override PaddingMode Padding
+            {
+                set
+                {
+                    if (!_ready)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    base.Padding = value;
+                }
+            }
+
+            public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateIV()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateKey()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -99,6 +99,7 @@
       <Link>CommonTest\System\RandomDataGenerator.cs</Link>
     </Compile>
     <Compile Include="AesProvider.cs" />
+    <Compile Include="AesTests.cs" />
     <Compile Include="DefaultECDsaProvider.cs" />
     <Compile Include="DefaultRSAProvider.cs" />
     <Compile Include="HashAlgorithmTest.cs" />


### PR DESCRIPTION
Aes and TripleDES both did assignments via virtual property setters in their ctor,
which were field assignments in .NET Framework.  3rd party implementations
may have written properties which assumed that the ctor had run to completion,
and they are broken by that behavioral change.

This change makes the ctors look like they do in net462, aside from when
net462 sets fields which don't exist.

It also makes the tests fail if virtual setter dispatch was utilized (for any currently
defined property, at least).

cherry-pick of 53455257f1dd9a55623798f00b8dbeafbf5b7118 and
207e52e8b851c621e1a8f2cea5002f42192ea1b4 to the release/1.1.0 branch,
with master-only TODO comments removed.

Port of #12800.
Fixes #12079.
cc: @steveharter @stephentoub 