### PR TITLE
Fix CS0197 error that was produced on FileStreamCompletionSource.Win32

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
@@ -567,6 +567,8 @@ namespace System.IO
             }
         }
 
+        private FileStreamCompletionSource CompareExchangeCurrentOverlappedOwner(FileStreamCompletionSource newSource, FileStreamCompletionSource existingSource) => Interlocked.CompareExchange(ref _currentOverlappedOwner, newSource, existingSource);
+
         public override int Read(byte[] array, int offset, int count)
         {
             if (array == null)

--- a/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
@@ -567,6 +567,8 @@ namespace System.IO
             }
         }
 
+        // Instance method to help code external to this MarshalByRefObject avoid
+        // accessing its fields by ref.  This avoids a compiler warning.
         private FileStreamCompletionSource CompareExchangeCurrentOverlappedOwner(FileStreamCompletionSource newSource, FileStreamCompletionSource existingSource) => Interlocked.CompareExchange(ref _currentOverlappedOwner, newSource, existingSource);
 
         public override int Read(byte[] array, int offset, int count)


### PR DESCRIPTION
This is a fix to a CS0197 that was produced on FileStreamCompletionSource.Win32 after adding base class MarshalByRefObject to Stream:

```
error CS0197: Using 'FileStream._currentOverlappedOwner' as a ref or out value or taking its address may cause a runtime exception because it is a field of a marshal-by-reference class
```

cc: @weshaggard @joperezr 