### PR TITLE
Consistently using language keywords instead of type names

### DIFF
--- a/src/Common/src/System/NotImplemented.cs
+++ b/src/Common/src/System/NotImplemented.cs
@@ -24,7 +24,7 @@ namespace System
             }
         }
 
-        internal static Exception ByDesignWithMessage(String message)
+        internal static Exception ByDesignWithMessage(string message)
         {
             return new NotImplementedException(message);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
@@ -18,17 +18,17 @@ namespace System.Linq.Expressions
         private static ConstructorInfo s_Decimal_Ctor_Int32;
         public  static ConstructorInfo   Decimal_Ctor_Int32 =>
                                        s_Decimal_Ctor_Int32 ??
-                                      (s_Decimal_Ctor_Int32 = typeof(Decimal).GetConstructor(new[] { typeof(int) }));
+                                      (s_Decimal_Ctor_Int32 = typeof(decimal).GetConstructor(new[] { typeof(int) }));
 
         private static ConstructorInfo s_Decimal_Ctor_Int64;
         public  static ConstructorInfo   Decimal_Ctor_Int64 =>
                                        s_Decimal_Ctor_Int64 ??
-                                      (s_Decimal_Ctor_Int64 = typeof(Decimal).GetConstructor(new[] { typeof(long) }));
+                                      (s_Decimal_Ctor_Int64 = typeof(decimal).GetConstructor(new[] { typeof(long) }));
 
         private static ConstructorInfo s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte;
         public  static ConstructorInfo   Decimal_Ctor_Int32_Int32_Int32_Bool_Byte => 
                                        s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte ??
-                                      (s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte = typeof(Decimal).GetConstructor(new[] { typeof(int), typeof(int), typeof(int), typeof(bool), typeof(byte) }));
+                                      (s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte = typeof(decimal).GetConstructor(new[] { typeof(int), typeof(int), typeof(int), typeof(bool), typeof(byte) }));
 
         private static ConstructorInfo s_Closure_ObjectArray_ObjectArray;
         public  static ConstructorInfo   Closure_ObjectArray_ObjectArray =>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -49,7 +49,7 @@ namespace System.Linq.Expressions.Compiler
                     il.Emit(OpCodes.Ldarg_3);
                     break;
                 default:
-                    if (index <= Byte.MaxValue)
+                    if (index <= byte.MaxValue)
                     {
                         il.Emit(OpCodes.Ldarg_S, (byte)index);
                     }
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Compiler
         {
             Debug.Assert(index >= 0);
 
-            if (index <= Byte.MaxValue)
+            if (index <= byte.MaxValue)
             {
                 il.Emit(OpCodes.Ldarga_S, (byte)index);
             }
@@ -79,7 +79,7 @@ namespace System.Linq.Expressions.Compiler
         {
             Debug.Assert(index >= 0);
 
-            if (index <= Byte.MaxValue)
+            if (index <= byte.MaxValue)
             {
                 il.Emit(OpCodes.Starg_S, (byte)index);
             }
@@ -789,19 +789,19 @@ namespace System.Linq.Expressions.Compiler
         {
             bool isFromUnsigned = TypeUtils.IsUnsigned(typeFrom);
             bool isFromFloatingPoint = TypeUtils.IsFloatingPoint(typeFrom);
-            if (typeTo == typeof(Single))
+            if (typeTo == typeof(float))
             {
                 if (isFromUnsigned)
                     il.Emit(OpCodes.Conv_R_Un);
                 il.Emit(OpCodes.Conv_R4);
             }
-            else if (typeTo == typeof(Double))
+            else if (typeTo == typeof(double))
             {
                 if (isFromUnsigned)
                     il.Emit(OpCodes.Conv_R_Un);
                 il.Emit(OpCodes.Conv_R8);
             }
-            else if (typeTo == typeof(Decimal))
+            else if (typeTo == typeof(decimal))
             {
                 // NB: TypeUtils.IsImplicitNumericConversion makes the promise that implicit conversions
                 //     from various integral types and char to decimal are possible. Coalesce allows the
@@ -1148,17 +1148,17 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitDecimal(this ILGenerator il, decimal value)
         {
-            if (Decimal.Truncate(value) == value)
+            if (decimal.Truncate(value) == value)
             {
-                if (Int32.MinValue <= value && value <= Int32.MaxValue)
+                if (int.MinValue <= value && value <= int.MaxValue)
                 {
-                    int intValue = Decimal.ToInt32(value);
+                    int intValue = decimal.ToInt32(value);
                     il.EmitInt(intValue);
                     il.EmitNew(Decimal_Ctor_Int32);
                 }
-                else if (Int64.MinValue <= value && value <= Int64.MaxValue)
+                else if (long.MinValue <= value && value <= long.MaxValue)
                 {
-                    long longValue = Decimal.ToInt64(value);
+                    long longValue = decimal.ToInt64(value);
                     il.EmitLong(longValue);
                     il.EmitNew(Decimal_Ctor_Int64);
                 }
@@ -1175,7 +1175,7 @@ namespace System.Linq.Expressions.Compiler
 
         private static void EmitDecimalBits(this ILGenerator il, decimal value)
         {
-            int[] bits = Decimal.GetBits(value);
+            int[] bits = decimal.GetBits(value);
             il.EmitInt(bits[0]);
             il.EmitInt(bits[1]);
             il.EmitInt(bits[2]);
@@ -1237,11 +1237,11 @@ namespace System.Linq.Expressions.Compiler
                     break;
 
                 case TypeCode.Single:
-                    il.Emit(OpCodes.Ldc_R4, default(Single));
+                    il.Emit(OpCodes.Ldc_R4, default(float));
                     break;
 
                 case TypeCode.Double:
-                    il.Emit(OpCodes.Ldc_R8, default(Double));
+                    il.Emit(OpCodes.Ldc_R8, default(double));
                     break;
 
                 case TypeCode.Decimal:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
@@ -113,19 +113,19 @@ namespace System.Linq.Expressions
 
         private int GetLambdaId(LambdaExpression le)
         {
-            Debug.Assert(String.IsNullOrEmpty(le.Name));
+            Debug.Assert(string.IsNullOrEmpty(le.Name));
             return GetId(le, ref _lambdaIds);
         }
 
         private int GetParamId(ParameterExpression p)
         {
-            Debug.Assert(String.IsNullOrEmpty(p.Name));
+            Debug.Assert(string.IsNullOrEmpty(p.Name));
             return GetId(p, ref _paramIds);
         }
 
         private int GetLabelTargetId(LabelTarget target)
         {
-            Debug.Assert(String.IsNullOrEmpty(target.Name));
+            Debug.Assert(string.IsNullOrEmpty(target.Name));
             return GetId(target, ref _labelIds);
         }
 
@@ -193,7 +193,7 @@ namespace System.Linq.Expressions
                     break;
                 case Flow.NewLine:
                     WriteLine();
-                    Write(new String(' ', Depth));
+                    Write(new string(' ', Depth));
                     break;
             }
             Write(s);
@@ -401,7 +401,7 @@ namespace System.Linq.Expressions
         {
             // Have '$' for the DebugView of ParameterExpressions
             Out("$");
-            if (String.IsNullOrEmpty(node.Name))
+            if (string.IsNullOrEmpty(node.Name))
             {
                 // If no name if provided, generate a name as $var1, $var2.
                 // No guarantee for not having name conflicts with user provided variable names.
@@ -419,7 +419,7 @@ namespace System.Linq.Expressions
         protected internal override Expression VisitLambda<T>(Expression<T> node)
         {
             Out(
-                String.Format(CultureInfo.CurrentCulture,
+                string.Format(CultureInfo.CurrentCulture,
                     ".Lambda {0}<{1}>",
                     GetLambdaName(node),
                     node.Type.ToString()
@@ -488,14 +488,14 @@ namespace System.Linq.Expressions
             }
             else if ((value is string) && node.Type == typeof(string))
             {
-                Out(String.Format(
+                Out(string.Format(
                     CultureInfo.CurrentCulture,
                     "\"{0}\"",
                     value));
             }
             else if ((value is char) && node.Type == typeof(char))
             {
-                Out(String.Format(
+                Out(string.Format(
                     CultureInfo.CurrentCulture,
                     "'{0}'",
                     value));
@@ -515,7 +515,7 @@ namespace System.Linq.Expressions
                 }
                 else
                 {
-                    Out(String.Format(
+                    Out(string.Format(
                         CultureInfo.CurrentCulture,
                         ".Constant<{0}>({1})",
                         node.Type.ToString(),
@@ -527,27 +527,27 @@ namespace System.Linq.Expressions
 
         private static string GetConstantValueSuffix(Type type)
         {
-            if (type == typeof(UInt32))
+            if (type == typeof(uint))
             {
                 return "U";
             }
-            if (type == typeof(Int64))
+            if (type == typeof(long))
             {
                 return "L";
             }
-            if (type == typeof(UInt64))
+            if (type == typeof(ulong))
             {
                 return "UL";
             }
-            if (type == typeof(Double))
+            if (type == typeof(double))
             {
                 return "D";
             }
-            if (type == typeof(Single))
+            if (type == typeof(float))
             {
                 return "F";
             }
-            if (type == typeof(Decimal))
+            if (type == typeof(decimal))
             {
                 return "M";
             }
@@ -1014,7 +1014,7 @@ namespace System.Linq.Expressions
             // last expression's type in the block.
             if (node.Type != node.GetExpression(node.ExpressionCount - 1).Type)
             {
-                Out(String.Format(CultureInfo.CurrentCulture, "<{0}>", node.Type.ToString()));
+                Out(string.Format(CultureInfo.CurrentCulture, "<{0}>", node.Type.ToString()));
             }
 
             VisitDeclarations(node.Variables);
@@ -1169,7 +1169,7 @@ namespace System.Linq.Expressions
 
         protected internal override Expression VisitExtension(Expression node)
         {
-            Out(String.Format(CultureInfo.CurrentCulture, ".Extension<{0}>", node.GetType().ToString()));
+            Out(string.Format(CultureInfo.CurrentCulture, ".Extension<{0}>", node.GetType().ToString()));
 
             if (node.CanReduce)
             {
@@ -1185,7 +1185,7 @@ namespace System.Linq.Expressions
 
         protected internal override Expression VisitDebugInfo(DebugInfoExpression node)
         {
-            Out(String.Format(
+            Out(string.Format(
                 CultureInfo.CurrentCulture,
                 ".DebugInfo({0}: {1}, {2} - {3}, {4})",
                 node.Document.FileName,
@@ -1200,7 +1200,7 @@ namespace System.Linq.Expressions
 
         private void DumpLabel(LabelTarget target)
         {
-            Out(String.Format(CultureInfo.CurrentCulture, ".LabelTarget {0}:", GetLabelTargetName(target)));
+            Out(string.Format(CultureInfo.CurrentCulture, ".LabelTarget {0}:", GetLabelTargetName(target)));
         }
 
         private string GetLabelTargetName(LabelTarget target)
@@ -1219,7 +1219,7 @@ namespace System.Linq.Expressions
         private void WriteLambda(LambdaExpression lambda)
         {
             Out(
-                String.Format(
+                string.Format(
                     CultureInfo.CurrentCulture,
                     ".Lambda {0}<{1}>",
                     GetLambdaName(lambda),
@@ -1238,7 +1238,7 @@ namespace System.Linq.Expressions
 
         private string GetLambdaName(LambdaExpression lambda)
         {
-            if (String.IsNullOrEmpty(lambda.Name))
+            if (string.IsNullOrEmpty(lambda.Name))
             {
                 return "#Lambda" + GetLambdaId(lambda);
             }
@@ -1253,7 +1253,7 @@ namespace System.Linq.Expressions
         {
             foreach (char c in name)
             {
-                if (Char.IsWhiteSpace(c))
+                if (char.IsWhiteSpace(c))
                 {
                     return true;
                 }
@@ -1263,7 +1263,7 @@ namespace System.Linq.Expressions
 
         private static string QuoteName(string name)
         {
-            return String.Format(CultureInfo.CurrentCulture, "'{0}'", name);
+            return string.Format(CultureInfo.CurrentCulture, "'{0}'", name);
         }
 
         private static string GetDisplayName(string name)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
@@ -221,7 +221,7 @@ namespace System.Linq.Expressions
                 Out("ref ");
             }
             string name = node.Name;
-            if (String.IsNullOrEmpty(name))
+            if (string.IsNullOrEmpty(name))
             {
                 Out("Param_" + GetParamId(node));
             }
@@ -308,7 +308,7 @@ namespace System.Linq.Expressions
 
         protected internal override Expression VisitDebugInfo(DebugInfoExpression node)
         {
-            string s = String.Format(
+            string s = string.Format(
                 CultureInfo.CurrentCulture,
                 "<DebugInfo({0}: {1}, {2}, {3}, {4})>",
                 node.Document.FileName,
@@ -742,7 +742,7 @@ namespace System.Linq.Expressions
 
         private void DumpLabel(LabelTarget target)
         {
-            if (!String.IsNullOrEmpty(target.Name))
+            if (!string.IsNullOrEmpty(target.Name))
             {
                 Out(target.Name);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((Int32)l + (Int32)r));
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l + (int)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -48,7 +48,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((Int16)((Int16)l + (Int16)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l + (short)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -67,7 +67,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((Int64)((Int64)l + (Int64)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((long)((long)l + (long)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -86,7 +86,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((UInt16)((UInt16)l + (UInt16)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((ushort)((ushort)l + (ushort)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -105,7 +105,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((UInt32)((UInt32)l + (UInt32)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((uint)((uint)l + (uint)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((UInt64)((UInt64)l + (UInt64)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((ulong)((ulong)l + (ulong)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Single)((Single)l + (Single)r);
+                    frame.Data[frame.StackIndex - 2] = (float)((float)l + (float)r);
                 }
                 frame.StackIndex--;
                 return +1;
@@ -162,7 +162,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Double)l + (Double)r;
+                    frame.Data[frame.StackIndex - 2] = (double)l + (double)r;
                 }
                 frame.StackIndex--;
                 return +1;
@@ -210,7 +210,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((Int32)l + (Int32)r));
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l + (int)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -229,7 +229,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((Int16)((Int16)l + (Int16)r));
+                    frame.Data[frame.StackIndex - 2] = checked((short)((short)l + (short)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -248,7 +248,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((Int64)((Int64)l + (Int64)r));
+                    frame.Data[frame.StackIndex - 2] = checked((long)((long)l + (long)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -267,7 +267,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((UInt16)((UInt16)l + (UInt16)r));
+                    frame.Data[frame.StackIndex - 2] = checked((ushort)((ushort)l + (ushort)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -286,7 +286,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((UInt32)((UInt32)l + (UInt32)r));
+                    frame.Data[frame.StackIndex - 2] = checked((uint)((uint)l + (uint)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -305,7 +305,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((UInt64)((UInt64)l + (UInt64)r));
+                    frame.Data[frame.StackIndex - 2] = checked((ulong)((ulong)l + (ulong)r));
                 }
                 frame.StackIndex--;
                 return +1;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((SByte)(((SByte)left) & ((SByte)right)));
+                frame.Push((sbyte)(((sbyte)left) & ((sbyte)right)));
                 return +1;
             }
         }
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((Int16)(((Int16)left) & ((Int16)right)));
+                frame.Push((short)(((short)left) & ((short)right)));
                 return +1;
             }
         }
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((Int32)left) & ((Int32)right));
+                frame.Push(((int)left) & ((int)right));
                 return +1;
             }
         }
@@ -76,7 +76,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((Int64)left) & ((Int64)right));
+                frame.Push(((long)left) & ((long)right));
                 return +1;
             }
         }
@@ -92,7 +92,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((Byte)(((Byte)left) & ((Byte)right)));
+                frame.Push((byte)(((byte)left) & ((byte)right)));
                 return +1;
             }
         }
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((UInt16)(((UInt16)left) & ((UInt16)right)));
+                frame.Push((ushort)(((ushort)left) & ((ushort)right)));
                 return +1;
             }
         }
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((UInt32)left) & ((UInt32)right));
+                frame.Push(((uint)left) & ((uint)right));
                 return +1;
             }
         }
@@ -140,7 +140,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((UInt64)left) & ((UInt64)right));
+                frame.Push(((ulong)left) & ((ulong)right));
                 return +1;
             }
         }
@@ -159,16 +159,16 @@ namespace System.Linq.Expressions.Interpreter
                     }
                     else
                     {
-                        frame.Push((Boolean)right ? null : ScriptingRuntimeHelpers.False);
+                        frame.Push((bool)right ? null : ScriptingRuntimeHelpers.False);
                     }
                     return +1;
                 }
                 else if (right == null)
                 {
-                    frame.Push((Boolean)left ? null : ScriptingRuntimeHelpers.False);
+                    frame.Push((bool)left ? null : ScriptingRuntimeHelpers.False);
                     return +1;
                 }
-                frame.Push(((Boolean)left) & ((Boolean)right));
+                frame.Push(((bool)left) & ((bool)right));
                 return +1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/BranchLabel.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/BranchLabel.cs
@@ -23,14 +23,14 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string ToString()
         {
-            return String.Format(CultureInfo.InvariantCulture, "->{0} C({1}) S({2})", Index, ContinuationStackDepth, StackDepth);
+            return string.Format(CultureInfo.InvariantCulture, "->{0} C({1}) S({2})", Index, ContinuationStackDepth, StackDepth);
         }
     }
 
     internal sealed class BranchLabel
     {
-        internal const int UnknownIndex = Int32.MinValue;
-        internal const int UnknownDepth = Int32.MinValue;
+        internal const int UnknownIndex = int.MinValue;
+        internal const int UnknownDepth = int.MinValue;
 
         private int _targetIndex = UnknownIndex;
         private int _stackDepth = UnknownDepth;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Expressions.Interpreter
 {
     internal abstract class OffsetInstruction : Instruction
     {
-        internal const int Unknown = Int32.MinValue;
+        internal const int Unknown = int.MinValue;
         internal const int CacheSize = 32;
 
         // the offset to jump to (relative to this instruction):

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(unchecked((Int32)obj - 1)));
+                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)obj - 1)));
                 }
                 return +1;
             }
@@ -46,7 +46,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Int16)((Int16)obj - 1)));
+                    frame.Push(unchecked((short)((short)obj - 1)));
                 }
                 return +1;
             }
@@ -63,7 +63,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Int64)((Int64)obj - 1)));
+                    frame.Push(unchecked((long)((long)obj - 1)));
                 }
                 return +1;
             }
@@ -80,7 +80,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((UInt16)((UInt16)obj - 1)));
+                    frame.Push(unchecked((ushort)((ushort)obj - 1)));
                 }
                 return +1;
             }
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((UInt32)((UInt32)obj - 1)));
+                    frame.Push(unchecked((uint)((uint)obj - 1)));
                 }
                 return +1;
             }
@@ -114,7 +114,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((UInt64)((UInt64)obj - 1)));
+                    frame.Push(unchecked((ulong)((ulong)obj - 1)));
                 }
                 return +1;
             }
@@ -131,7 +131,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Single)((Single)obj - 1)));
+                    frame.Push(unchecked((float)((float)obj - 1)));
                 }
                 return +1;
             }
@@ -148,7 +148,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Double)((Double)obj - 1)));
+                    frame.Push(unchecked((double)((double)obj - 1)));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
@@ -30,7 +30,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((Int32)l / (Int32)r);
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((int)l / (int)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -49,7 +49,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Int16)((Int16)l / (Int16)r);
+                    frame.Data[frame.StackIndex - 2] = (short)((short)l / (short)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -68,7 +68,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Int64)((Int64)l / (Int64)r);
+                    frame.Data[frame.StackIndex - 2] = (long)((long)l / (long)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -87,7 +87,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (UInt16)((UInt16)l / (UInt16)r);
+                    frame.Data[frame.StackIndex - 2] = (ushort)((ushort)l / (ushort)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -106,7 +106,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (UInt32)((UInt32)l / (UInt32)r);
+                    frame.Data[frame.StackIndex - 2] = (uint)((uint)l / (uint)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -125,7 +125,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (UInt64)((UInt64)l / (UInt64)r);
+                    frame.Data[frame.StackIndex - 2] = (ulong)((ulong)l / (ulong)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Single)((Single)l / (Single)r);
+                    frame.Data[frame.StackIndex - 2] = (float)((float)l / (float)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -163,7 +163,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Double)l / (Double)r;
+                    frame.Data[frame.StackIndex - 2] = (double)l / (double)r;
                 }
                 frame.StackIndex--;
                 return 1;
@@ -212,7 +212,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((Int32)l % (Int32)r);
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((int)l % (int)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -231,7 +231,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Int16)((Int16)l % (Int16)r);
+                    frame.Data[frame.StackIndex - 2] = (short)((short)l % (short)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -250,7 +250,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Int64)((Int64)l % (Int64)r);
+                    frame.Data[frame.StackIndex - 2] = (long)((long)l % (long)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -269,7 +269,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (UInt16)((UInt16)l % (UInt16)r);
+                    frame.Data[frame.StackIndex - 2] = (ushort)((ushort)l % (ushort)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -288,7 +288,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (UInt32)((UInt32)l % (UInt32)r);
+                    frame.Data[frame.StackIndex - 2] = (uint)((uint)l % (uint)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -307,7 +307,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (UInt64)((UInt64)l % (UInt64)r);
+                    frame.Data[frame.StackIndex - 2] = (ulong)((ulong)l % (ulong)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -326,7 +326,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Single)((Single)l % (Single)r);
+                    frame.Data[frame.StackIndex - 2] = (float)((float)l % (float)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -345,7 +345,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Double)l % (Double)r;
+                    frame.Data[frame.StackIndex - 2] = (double)l % (double)r;
                 }
                 frame.StackIndex--;
                 return 1;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -35,7 +35,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Boolean)left) == ((Boolean)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((bool)left) == ((bool)right)));
                 }
                 return +1;
             }
@@ -57,7 +57,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((SByte)left) == ((SByte)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((sbyte)left) == ((sbyte)right)));
                 }
                 return +1;
             }
@@ -79,7 +79,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int16)left) == ((Int16)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((short)left) == ((short)right)));
                 }
                 return +1;
             }
@@ -101,7 +101,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Char)left) == ((Char)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((char)left) == ((char)right)));
                 }
                 return +1;
             }
@@ -123,7 +123,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int32)left) == ((Int32)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((int)left) == ((int)right)));
                 }
                 return +1;
             }
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int64)left) == ((Int64)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((long)left) == ((long)right)));
                 }
                 return +1;
             }
@@ -167,7 +167,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Byte)left) == ((Byte)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((byte)left) == ((byte)right)));
                 }
                 return +1;
             }
@@ -189,7 +189,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt16)left) == ((UInt16)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ushort)left) == ((ushort)right)));
                 }
                 return +1;
             }
@@ -211,7 +211,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt32)left) == ((UInt32)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((uint)left) == ((uint)right)));
                 }
                 return +1;
             }
@@ -233,7 +233,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt64)left) == ((UInt64)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ulong)left) == ((ulong)right)));
                 }
                 return +1;
             }
@@ -255,7 +255,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Single)left) == ((Single)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((float)left) == ((float)right)));
                 }
                 return +1;
             }
@@ -277,7 +277,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Double)left) == ((Double)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((double)left) == ((double)right)));
                 }
                 return +1;
             }
@@ -304,7 +304,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Boolean)left) == ((Boolean)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((bool)left) == ((bool)right)));
                 }
                 return +1;
             }
@@ -322,7 +322,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((SByte)left) == ((SByte)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((sbyte)left) == ((sbyte)right)));
                 }
                 return +1;
             }
@@ -340,7 +340,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int16)left) == ((Int16)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((short)left) == ((short)right)));
                 }
                 return +1;
             }
@@ -358,7 +358,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Char)left) == ((Char)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((char)left) == ((char)right)));
                 }
                 return +1;
             }
@@ -376,7 +376,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int32)left) == ((Int32)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((int)left) == ((int)right)));
                 }
                 return +1;
             }
@@ -394,7 +394,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int64)left) == ((Int64)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((long)left) == ((long)right)));
                 }
                 return +1;
             }
@@ -412,7 +412,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Byte)left) == ((Byte)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((byte)left) == ((byte)right)));
                 }
                 return +1;
             }
@@ -430,7 +430,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt16)left) == ((UInt16)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ushort)left) == ((ushort)right)));
                 }
                 return +1;
             }
@@ -448,7 +448,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt32)left) == ((UInt32)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((uint)left) == ((uint)right)));
                 }
                 return +1;
             }
@@ -466,7 +466,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt64)left) == ((UInt64)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ulong)left) == ((ulong)right)));
                 }
                 return +1;
             }
@@ -484,7 +484,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Single)left) == ((Single)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((float)left) == ((float)right)));
                 }
                 return +1;
             }
@@ -502,7 +502,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Double)left) == ((Double)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((double)left) == ((double)right)));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((SByte)(((SByte)left) ^ ((SByte)right)));
+                frame.Push((sbyte)(((sbyte)left) ^ ((sbyte)right)));
                 return +1;
             }
         }
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((Int16)(((Int16)left) ^ ((Int16)right)));
+                frame.Push((short)(((short)left) ^ ((short)right)));
                 return +1;
             }
         }
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((Int32)left) ^ ((Int32)right));
+                frame.Push(((int)left) ^ ((int)right));
                 return +1;
             }
         }
@@ -76,7 +76,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((Int64)left) ^ ((Int64)right));
+                frame.Push(((long)left) ^ ((long)right));
                 return +1;
             }
         }
@@ -92,7 +92,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((Byte)(((Byte)left) ^ ((Byte)right)));
+                frame.Push((byte)(((byte)left) ^ ((byte)right)));
                 return +1;
             }
         }
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((UInt16)(((UInt16)left) ^ ((UInt16)right)));
+                frame.Push((ushort)(((ushort)left) ^ ((ushort)right)));
                 return +1;
             }
         }
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((UInt32)left) ^ ((UInt32)right));
+                frame.Push(((uint)left) ^ ((uint)right));
                 return +1;
             }
         }
@@ -140,7 +140,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((UInt64)left) ^ ((UInt64)right));
+                frame.Push(((ulong)left) ^ ((ulong)right));
                 return +1;
             }
         }
@@ -156,7 +156,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((Boolean)left) ^ ((Boolean)right));
+                frame.Push(((bool)left) ^ ((bool)right));
                 return +1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -40,7 +40,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((SByte)left) > (SByte)right);
+                    frame.Push(((sbyte)left) > (sbyte)right);
                 }
                 return +1;
             }
@@ -63,7 +63,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int16)left) > (Int16)right);
+                    frame.Push(((short)left) > (short)right);
                 }
                 return +1;
             }
@@ -86,7 +86,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Char)left) > (Char)right);
+                    frame.Push(((char)left) > (char)right);
                 }
                 return +1;
             }
@@ -109,7 +109,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int32)left) > (Int32)right);
+                    frame.Push(((int)left) > (int)right);
                 }
                 return +1;
             }
@@ -132,7 +132,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int64)left) > (Int64)right);
+                    frame.Push(((long)left) > (long)right);
                 }
                 return +1;
             }
@@ -155,7 +155,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Byte)left) > (Byte)right);
+                    frame.Push(((byte)left) > (byte)right);
                 }
                 return +1;
             }
@@ -178,7 +178,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt16)left) > (UInt16)right);
+                    frame.Push(((ushort)left) > (ushort)right);
                 }
                 return +1;
             }
@@ -201,7 +201,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt32)left) > (UInt32)right);
+                    frame.Push(((uint)left) > (uint)right);
                 }
                 return +1;
             }
@@ -224,7 +224,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt64)left) > (UInt64)right);
+                    frame.Push(((ulong)left) > (ulong)right);
                 }
                 return +1;
             }
@@ -247,7 +247,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Single)left) > (Single)right);
+                    frame.Push(((float)left) > (float)right);
                 }
                 return +1;
             }
@@ -270,7 +270,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Double)left) > (Double)right);
+                    frame.Push(((double)left) > (double)right);
                 }
                 return +1;
             }
@@ -356,7 +356,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((SByte)left) >= (SByte)right);
+                    frame.Push(((sbyte)left) >= (sbyte)right);
                 }
                 return +1;
             }
@@ -379,7 +379,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int16)left) >= (Int16)right);
+                    frame.Push(((short)left) >= (short)right);
                 }
                 return +1;
             }
@@ -402,7 +402,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Char)left) >= (Char)right);
+                    frame.Push(((char)left) >= (char)right);
                 }
                 return +1;
             }
@@ -425,7 +425,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int32)left) >= (Int32)right);
+                    frame.Push(((int)left) >= (int)right);
                 }
                 return +1;
             }
@@ -448,7 +448,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int64)left) >= (Int64)right);
+                    frame.Push(((long)left) >= (long)right);
                 }
                 return +1;
             }
@@ -471,7 +471,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Byte)left) >= (Byte)right);
+                    frame.Push(((byte)left) >= (byte)right);
                 }
                 return +1;
             }
@@ -494,7 +494,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt16)left) >= (UInt16)right);
+                    frame.Push(((ushort)left) >= (ushort)right);
                 }
                 return +1;
             }
@@ -517,7 +517,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt32)left) >= (UInt32)right);
+                    frame.Push(((uint)left) >= (uint)right);
                 }
                 return +1;
             }
@@ -540,7 +540,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt64)left) >= (UInt64)right);
+                    frame.Push(((ulong)left) >= (ulong)right);
                 }
                 return +1;
             }
@@ -563,7 +563,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Single)left) >= (Single)right);
+                    frame.Push(((float)left) >= (float)right);
                 }
                 return +1;
             }
@@ -586,7 +586,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Double)left) >= (Double)right);
+                    frame.Push(((double)left) >= (double)right);
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(unchecked(1 + (Int32)obj)));
+                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(unchecked(1 + (int)obj)));
                 }
                 return +1;
             }
@@ -46,7 +46,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Int16)(1 + (Int16)obj)));
+                    frame.Push(unchecked((short)(1 + (short)obj)));
                 }
                 return +1;
             }
@@ -63,7 +63,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Int64)(1 + (Int64)obj)));
+                    frame.Push(unchecked((long)(1 + (long)obj)));
                 }
                 return +1;
             }
@@ -80,7 +80,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((UInt16)(1 + (UInt16)obj)));
+                    frame.Push(unchecked((ushort)(1 + (ushort)obj)));
                 }
                 return +1;
             }
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((UInt32)(1 + (UInt32)obj)));
+                    frame.Push(unchecked((uint)(1 + (uint)obj)));
                 }
                 return +1;
             }
@@ -114,7 +114,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((UInt64)(1 + (UInt64)obj)));
+                    frame.Push(unchecked((ulong)(1 + (ulong)obj)));
                 }
                 return +1;
             }
@@ -131,7 +131,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Single)(1 + (Single)obj)));
+                    frame.Push(unchecked((float)(1 + (float)obj)));
                 }
                 return +1;
             }
@@ -148,7 +148,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Double)(1 + (Double)obj)));
+                    frame.Push(unchecked((double)(1 + (double)obj)));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
@@ -98,7 +98,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((Int64)~(Int64)value);
+                    frame.Push((long)~(long)value);
                 }
                 return +1;
             }
@@ -115,7 +115,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((Int32)(~(Int32)value));
+                    frame.Push((int)(~(int)value));
                 }
                 return +1;
             }
@@ -132,7 +132,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((Int16)(~(Int16)value));
+                    frame.Push((short)(~(short)value));
                 }
                 return +1;
             }
@@ -149,7 +149,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((UInt64)(~(UInt64)value));
+                    frame.Push((ulong)(~(ulong)value));
                 }
                 return +1;
             }
@@ -166,7 +166,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((UInt32)(~(UInt32)value));
+                    frame.Push((uint)(~(uint)value));
                 }
                 return +1;
             }
@@ -183,7 +183,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((UInt16)(~(UInt16)value));
+                    frame.Push((ushort)(~(ushort)value));
                 }
                 return +1;
             }
@@ -200,7 +200,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((object)(Byte)(~(Byte)value));
+                    frame.Push((object)(byte)(~(byte)value));
                 }
                 return +1;
             }
@@ -217,7 +217,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((object)(SByte)(~(SByte)value));
+                    frame.Push((object)(sbyte)(~(sbyte)value));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -93,12 +93,12 @@ namespace System.Linq.Expressions.Interpreter
             Data[StackIndex++] = value;
         }
 
-        public void Push(Int16 value)
+        public void Push(short value)
         {
             Data[StackIndex++] = value;
         }
 
-        public void Push(UInt16 value)
+        public void Push(ushort value)
         {
             Data[StackIndex++] = value;
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Interpreter.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Interpreter.cs
@@ -20,7 +20,7 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class Interpreter
     {
         internal static readonly object NoValue = new object();
-        internal const int RethrowOnReturn = Int32.MaxValue;
+        internal const int RethrowOnReturn = int.MaxValue;
 
         private readonly InstructionArray _instructions;
         internal readonly object[] _objects;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((SByte)(((SByte)value) << ((int)shift)));
+                    frame.Push((sbyte)(((sbyte)value) << ((int)shift)));
                 }
                 return +1;
             }
@@ -47,7 +47,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((Int16)(((Int16)value) << ((int)shift)));
+                    frame.Push((short)(((short)value) << ((int)shift)));
                 }
                 return +1;
             }
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int32)value) << ((int)shift));
+                    frame.Push(((int)value) << ((int)shift));
                 }
                 return +1;
             }
@@ -83,7 +83,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int64)value) << ((int)shift));
+                    frame.Push(((long)value) << ((int)shift));
                 }
                 return +1;
             }
@@ -101,7 +101,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((Byte)(((Byte)value) << ((int)shift)));
+                    frame.Push((byte)(((byte)value) << ((int)shift)));
                 }
                 return +1;
             }
@@ -119,7 +119,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((UInt16)(((UInt16)value) << ((int)shift)));
+                    frame.Push((ushort)(((ushort)value) << ((int)shift)));
                 }
                 return +1;
             }
@@ -137,7 +137,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt32)value) << ((int)shift));
+                    frame.Push(((uint)value) << ((int)shift));
                 }
                 return +1;
             }
@@ -155,7 +155,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt64)value) << ((int)shift));
+                    frame.Push(((ulong)value) << ((int)shift));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -41,7 +41,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((SByte)left) < (SByte)right);
+                    frame.Push(((sbyte)left) < (sbyte)right);
                 }
                 return +1;
             }
@@ -64,7 +64,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int16)left) < (Int16)right);
+                    frame.Push(((short)left) < (short)right);
                 }
                 return +1;
             }
@@ -87,7 +87,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Char)left) < (Char)right);
+                    frame.Push(((char)left) < (char)right);
                 }
                 return +1;
             }
@@ -110,7 +110,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int32)left) < (Int32)right);
+                    frame.Push(((int)left) < (int)right);
                 }
                 return +1;
             }
@@ -133,7 +133,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int64)left) < (Int64)right);
+                    frame.Push(((long)left) < (long)right);
                 }
                 return +1;
             }
@@ -156,7 +156,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Byte)left) < (Byte)right);
+                    frame.Push(((byte)left) < (byte)right);
                 }
                 return +1;
             }
@@ -179,7 +179,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt16)left) < (UInt16)right);
+                    frame.Push(((ushort)left) < (ushort)right);
                 }
                 return +1;
             }
@@ -202,7 +202,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt32)left) < (UInt32)right);
+                    frame.Push(((uint)left) < (uint)right);
                 }
                 return +1;
             }
@@ -225,7 +225,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt64)left) < (UInt64)right);
+                    frame.Push(((ulong)left) < (ulong)right);
                 }
                 return +1;
             }
@@ -248,7 +248,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Single)left) < (Single)right);
+                    frame.Push(((float)left) < (float)right);
                 }
                 return +1;
             }
@@ -271,7 +271,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Double)left) < (Double)right);
+                    frame.Push(((double)left) < (double)right);
                 }
                 return +1;
             }
@@ -354,7 +354,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((SByte)left) <= (SByte)right);
+                    frame.Push(((sbyte)left) <= (sbyte)right);
                 }
                 return +1;
             }
@@ -377,7 +377,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int16)left) <= (Int16)right);
+                    frame.Push(((short)left) <= (short)right);
                 }
                 return +1;
             }
@@ -400,7 +400,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Char)left) <= (Char)right);
+                    frame.Push(((char)left) <= (char)right);
                 }
                 return +1;
             }
@@ -423,7 +423,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int32)left) <= (Int32)right);
+                    frame.Push(((int)left) <= (int)right);
                 }
                 return +1;
             }
@@ -446,7 +446,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int64)left) <= (Int64)right);
+                    frame.Push(((long)left) <= (long)right);
                 }
                 return +1;
             }
@@ -469,7 +469,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Byte)left) <= (Byte)right);
+                    frame.Push(((byte)left) <= (byte)right);
                 }
                 return +1;
             }
@@ -492,7 +492,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt16)left) <= (UInt16)right);
+                    frame.Push(((ushort)left) <= (ushort)right);
                 }
                 return +1;
             }
@@ -515,7 +515,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt32)left) <= (UInt32)right);
+                    frame.Push(((uint)left) <= (uint)right);
                 }
                 return +1;
             }
@@ -538,7 +538,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt64)left) <= (UInt64)right);
+                    frame.Push(((ulong)left) <= (ulong)right);
                 }
                 return +1;
             }
@@ -561,7 +561,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Single)left) <= (Single)right);
+                    frame.Push(((float)left) <= (float)right);
                 }
                 return +1;
             }
@@ -584,7 +584,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Double)left) <= (Double)right);
+                    frame.Push(((double)left) <= (double)right);
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -250,11 +250,11 @@ namespace System.Linq.Expressions.Interpreter
         {
             if (IsClear)
             {
-                return String.Format(CultureInfo.InvariantCulture, "{0}: clear", Index);
+                return string.Format(CultureInfo.InvariantCulture, "{0}: clear", Index);
             }
             else
             {
-                return String.Format(CultureInfo.InvariantCulture, "{0}: [{1}-{2}] '{3}'", Index, StartLine, EndLine, FileName);
+                return string.Format(CultureInfo.InvariantCulture, "{0}: [{1}-{2}] '{3}'", Index, StartLine, EndLine, FileName);
             }
         }
     }
@@ -3050,7 +3050,7 @@ namespace System.Linq.Expressions.Interpreter
                     break;
             }
             Debug.Assert(_instructions.CurrentStackDepth == startingStackDepth + (expr.Type == typeof(void) ? 0 : 1),
-                String.Format("{0} vs {1} for {2}", _instructions.CurrentStackDepth, startingStackDepth + (expr.Type == typeof(void) ? 0 : 1), expr.NodeType));
+                string.Format("{0} vs {1} for {2}", _instructions.CurrentStackDepth, startingStackDepth + (expr.Type == typeof(void) ? 0 : 1), expr.NodeType));
         }
 
         public void Compile(Expression expr)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
@@ -49,7 +49,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string ToString()
         {
-            return String.Format(CultureInfo.InvariantCulture, "{0}: {1} {2}", Index, IsBoxed ? "boxed" : null, InClosure ? "in closure" : null);
+            return string.Format(CultureInfo.InvariantCulture, "{0}: {1} {2}", Index, IsBoxed ? "boxed" : null, InClosure ? "in closure" : null);
         }
     }
 
@@ -250,7 +250,7 @@ namespace System.Linq.Expressions.Interpreter
         private sealed class VariableScope
         {
             public readonly int Start;
-            public int Stop = Int32.MaxValue;
+            public int Stop = int.MaxValue;
             public readonly LocalVariable Variable;
             public readonly VariableScope Parent;
             public List<VariableScope> ChildScopes;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((Int32)l * (Int32)r));
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l * (int)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -48,7 +48,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((Int16)((Int16)l * (Int16)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l * (short)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -67,7 +67,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((Int64)((Int64)l * (Int64)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((long)((long)l * (long)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -86,7 +86,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((UInt16)((UInt16)l * (UInt16)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((ushort)((ushort)l * (ushort)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -105,7 +105,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((UInt32)((UInt32)l * (UInt32)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((uint)((uint)l * (uint)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((UInt64)((UInt64)l * (UInt64)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((ulong)((ulong)l * (ulong)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Single)((Single)l * (Single)r);
+                    frame.Data[frame.StackIndex - 2] = (float)((float)l * (float)r);
                 }
                 frame.StackIndex--;
                 return +1;
@@ -162,7 +162,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Double)l * (Double)r;
+                    frame.Data[frame.StackIndex - 2] = (double)l * (double)r;
                 }
                 frame.StackIndex--;
                 return +1;
@@ -211,7 +211,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((Int32)l * (Int32)r));
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l * (int)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -230,7 +230,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((Int16)((Int16)l * (Int16)r));
+                    frame.Data[frame.StackIndex - 2] = checked((short)((short)l * (short)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -249,7 +249,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((Int64)((Int64)l * (Int64)r));
+                    frame.Data[frame.StackIndex - 2] = checked((long)((long)l * (long)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -268,7 +268,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((UInt16)((UInt16)l * (UInt16)r));
+                    frame.Data[frame.StackIndex - 2] = checked((ushort)((ushort)l * (ushort)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -287,7 +287,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((UInt32)((UInt32)l * (UInt32)r));
+                    frame.Data[frame.StackIndex - 2] = checked((uint)((uint)l * (uint)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -306,7 +306,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((UInt64)((UInt64)l * (UInt64)r));
+                    frame.Data[frame.StackIndex - 2] = checked((ulong)((ulong)l * (ulong)r));
                 }
                 frame.StackIndex--;
                 return +1;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(unchecked(-(Int32)obj)));
+                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(unchecked(-(int)obj)));
                 }
                 return +1;
             }
@@ -46,7 +46,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Int16)(-(Int16)obj)));
+                    frame.Push(unchecked((short)(-(short)obj)));
                 }
                 return +1;
             }
@@ -63,7 +63,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Int64)(-(Int64)obj)));
+                    frame.Push(unchecked((long)(-(long)obj)));
                 }
                 return +1;
             }
@@ -80,7 +80,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Single)(-(Single)obj)));
+                    frame.Push(unchecked((float)(-(float)obj)));
                 }
                 return +1;
             }
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked((Double)(-(Double)obj)));
+                    frame.Push(unchecked((double)(-(double)obj)));
                 }
                 return +1;
             }
@@ -141,7 +141,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(checked(-(Int32)obj)));
+                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(checked(-(int)obj)));
                 }
                 return +1;
             }
@@ -158,7 +158,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(checked((Int16)(-(Int16)obj)));
+                    frame.Push(checked((short)(-(short)obj)));
                 }
                 return +1;
             }
@@ -175,7 +175,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(checked((Int64)(-(Int64)obj)));
+                    frame.Push(checked((long)(-(long)obj)));
                 }
                 return +1;
             }
@@ -191,7 +191,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(checked((Single)(-(Single)obj)));
+                    frame.Push(checked((float)(-(float)obj)));
                 }
                 return +1;
             }
@@ -208,7 +208,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(checked((Double)(-(Double)obj)));
+                    frame.Push(checked((double)(-(double)obj)));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -35,7 +35,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Boolean)left) != ((Boolean)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((bool)left) != ((bool)right)));
                 }
                 return +1;
             }
@@ -57,7 +57,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((SByte)left) != ((SByte)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((sbyte)left) != ((sbyte)right)));
                 }
                 return +1;
             }
@@ -79,7 +79,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int16)left) != ((Int16)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((short)left) != ((short)right)));
                 }
                 return +1;
             }
@@ -101,7 +101,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Char)left) != ((Char)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((char)left) != ((char)right)));
                 }
                 return +1;
             }
@@ -123,7 +123,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int32)left) != ((Int32)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((int)left) != ((int)right)));
                 }
                 return +1;
             }
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int64)left) != ((Int64)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((long)left) != ((long)right)));
                 }
                 return +1;
             }
@@ -167,7 +167,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Byte)left) != ((Byte)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((byte)left) != ((byte)right)));
                 }
                 return +1;
             }
@@ -189,7 +189,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt16)left) != ((UInt16)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ushort)left) != ((ushort)right)));
                 }
                 return +1;
             }
@@ -211,7 +211,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt32)left) != ((UInt32)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((uint)left) != ((uint)right)));
                 }
                 return +1;
             }
@@ -233,7 +233,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt64)left) != ((UInt64)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ulong)left) != ((ulong)right)));
                 }
                 return +1;
             }
@@ -255,7 +255,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Single)left) != ((Single)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((float)left) != ((float)right)));
                 }
                 return +1;
             }
@@ -277,7 +277,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Double)left) != ((Double)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((double)left) != ((double)right)));
                 }
                 return +1;
             }
@@ -305,7 +305,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Boolean)left) != ((Boolean)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((bool)left) != ((bool)right)));
                 }
                 return +1;
             }
@@ -323,7 +323,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((SByte)left) != ((SByte)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((sbyte)left) != ((sbyte)right)));
                 }
                 return +1;
             }
@@ -341,7 +341,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int16)left) != ((Int16)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((short)left) != ((short)right)));
                 }
                 return +1;
             }
@@ -359,7 +359,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Char)left) != ((Char)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((char)left) != ((char)right)));
                 }
                 return +1;
             }
@@ -377,7 +377,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int32)left) != ((Int32)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((int)left) != ((int)right)));
                 }
                 return +1;
             }
@@ -395,7 +395,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Int64)left) != ((Int64)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((long)left) != ((long)right)));
                 }
                 return +1;
             }
@@ -413,7 +413,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Byte)left) != ((Byte)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((byte)left) != ((byte)right)));
                 }
                 return +1;
             }
@@ -431,7 +431,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt16)left) != ((UInt16)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ushort)left) != ((ushort)right)));
                 }
                 return +1;
             }
@@ -449,7 +449,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt32)left) != ((UInt32)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((uint)left) != ((uint)right)));
                 }
                 return +1;
             }
@@ -467,7 +467,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((UInt64)left) != ((UInt64)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ulong)left) != ((ulong)right)));
                 }
                 return +1;
             }
@@ -485,7 +485,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Single)left) != ((Single)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((float)left) != ((float)right)));
                 }
                 return +1;
             }
@@ -503,7 +503,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((Double)left) != ((Double)right)));
+                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((double)left) != ((double)right)));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
@@ -66,18 +66,18 @@ namespace System.Linq.Expressions.Interpreter
             {
                 switch (_from)
                 {
-                    case TypeCode.Boolean: return ConvertInt32((Boolean)obj ? 1 : 0);
-                    case TypeCode.Byte: return ConvertInt32((Byte)obj);
-                    case TypeCode.SByte: return ConvertInt32((SByte)obj);
-                    case TypeCode.Int16: return ConvertInt32((Int16)obj);
-                    case TypeCode.Char: return ConvertInt32((Char)obj);
-                    case TypeCode.Int32: return ConvertInt32((Int32)obj);
-                    case TypeCode.Int64: return ConvertInt64((Int64)obj);
-                    case TypeCode.UInt16: return ConvertInt32((UInt16)obj);
-                    case TypeCode.UInt32: return ConvertInt64((UInt32)obj);
-                    case TypeCode.UInt64: return ConvertUInt64((UInt64)obj);
-                    case TypeCode.Single: return ConvertDouble((Single)obj);
-                    case TypeCode.Double: return ConvertDouble((Double)obj);
+                    case TypeCode.Boolean: return ConvertInt32((bool)obj ? 1 : 0);
+                    case TypeCode.Byte: return ConvertInt32((byte)obj);
+                    case TypeCode.SByte: return ConvertInt32((sbyte)obj);
+                    case TypeCode.Int16: return ConvertInt32((short)obj);
+                    case TypeCode.Char: return ConvertInt32((char)obj);
+                    case TypeCode.Int32: return ConvertInt32((int)obj);
+                    case TypeCode.Int64: return ConvertInt64((long)obj);
+                    case TypeCode.UInt16: return ConvertInt32((ushort)obj);
+                    case TypeCode.UInt32: return ConvertInt64((uint)obj);
+                    case TypeCode.UInt64: return ConvertUInt64((ulong)obj);
+                    case TypeCode.Single: return ConvertDouble((float)obj);
+                    case TypeCode.Double: return ConvertDouble((double)obj);
                     default: throw ContractUtils.Unreachable;
                 }
             }
@@ -88,87 +88,87 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     switch (_to)
                     {
-                        case TypeCode.Byte: return (Byte)obj;
-                        case TypeCode.SByte: return (SByte)obj;
-                        case TypeCode.Int16: return (Int16)obj;
-                        case TypeCode.Char: return (Char)obj;
-                        case TypeCode.Int32: return (Int32)obj;
-                        case TypeCode.Int64: return (Int64)obj;
-                        case TypeCode.UInt16: return (UInt16)obj;
-                        case TypeCode.UInt32: return (UInt32)obj;
-                        case TypeCode.UInt64: return (UInt64)obj;
-                        case TypeCode.Single: return (Single)obj;
-                        case TypeCode.Double: return (Double)obj;
-                        case TypeCode.Decimal: return (Decimal)obj;
+                        case TypeCode.Byte: return (byte)obj;
+                        case TypeCode.SByte: return (sbyte)obj;
+                        case TypeCode.Int16: return (short)obj;
+                        case TypeCode.Char: return (char)obj;
+                        case TypeCode.Int32: return (int)obj;
+                        case TypeCode.Int64: return (long)obj;
+                        case TypeCode.UInt16: return (ushort)obj;
+                        case TypeCode.UInt32: return (uint)obj;
+                        case TypeCode.UInt64: return (ulong)obj;
+                        case TypeCode.Single: return (float)obj;
+                        case TypeCode.Double: return (double)obj;
+                        case TypeCode.Decimal: return (decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
             }
 
-            private object ConvertInt64(Int64 obj)
+            private object ConvertInt64(long obj)
             {
                 unchecked
                 {
                     switch (_to)
                     {
-                        case TypeCode.Byte: return (Byte)obj;
-                        case TypeCode.SByte: return (SByte)obj;
-                        case TypeCode.Int16: return (Int16)obj;
-                        case TypeCode.Char: return (Char)obj;
-                        case TypeCode.Int32: return (Int32)obj;
-                        case TypeCode.Int64: return (Int64)obj;
-                        case TypeCode.UInt16: return (UInt16)obj;
-                        case TypeCode.UInt32: return (UInt32)obj;
-                        case TypeCode.UInt64: return (UInt64)obj;
-                        case TypeCode.Single: return (Single)obj;
-                        case TypeCode.Double: return (Double)obj;
-                        case TypeCode.Decimal: return (Decimal)obj;
+                        case TypeCode.Byte: return (byte)obj;
+                        case TypeCode.SByte: return (sbyte)obj;
+                        case TypeCode.Int16: return (short)obj;
+                        case TypeCode.Char: return (char)obj;
+                        case TypeCode.Int32: return (int)obj;
+                        case TypeCode.Int64: return (long)obj;
+                        case TypeCode.UInt16: return (ushort)obj;
+                        case TypeCode.UInt32: return (uint)obj;
+                        case TypeCode.UInt64: return (ulong)obj;
+                        case TypeCode.Single: return (float)obj;
+                        case TypeCode.Double: return (double)obj;
+                        case TypeCode.Decimal: return (decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
             }
 
-            private object ConvertUInt64(UInt64 obj)
+            private object ConvertUInt64(ulong obj)
             {
                 unchecked
                 {
                     switch (_to)
                     {
-                        case TypeCode.Byte: return (Byte)obj;
-                        case TypeCode.SByte: return (SByte)obj;
-                        case TypeCode.Int16: return (Int16)obj;
-                        case TypeCode.Char: return (Char)obj;
-                        case TypeCode.Int32: return (Int32)obj;
-                        case TypeCode.Int64: return (Int64)obj;
-                        case TypeCode.UInt16: return (UInt16)obj;
-                        case TypeCode.UInt32: return (UInt32)obj;
-                        case TypeCode.UInt64: return (UInt64)obj;
-                        case TypeCode.Single: return (Single)obj;
-                        case TypeCode.Double: return (Double)obj;
-                        case TypeCode.Decimal: return (Decimal)obj;
+                        case TypeCode.Byte: return (byte)obj;
+                        case TypeCode.SByte: return (sbyte)obj;
+                        case TypeCode.Int16: return (short)obj;
+                        case TypeCode.Char: return (char)obj;
+                        case TypeCode.Int32: return (int)obj;
+                        case TypeCode.Int64: return (long)obj;
+                        case TypeCode.UInt16: return (ushort)obj;
+                        case TypeCode.UInt32: return (uint)obj;
+                        case TypeCode.UInt64: return (ulong)obj;
+                        case TypeCode.Single: return (float)obj;
+                        case TypeCode.Double: return (double)obj;
+                        case TypeCode.Decimal: return (decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
             }
 
-            private object ConvertDouble(Double obj)
+            private object ConvertDouble(double obj)
             {
                 unchecked
                 {
                     switch (_to)
                     {
-                        case TypeCode.Byte: return (Byte)obj;
-                        case TypeCode.SByte: return (SByte)obj;
-                        case TypeCode.Int16: return (Int16)obj;
-                        case TypeCode.Char: return (Char)obj;
-                        case TypeCode.Int32: return (Int32)obj;
-                        case TypeCode.Int64: return (Int64)obj;
-                        case TypeCode.UInt16: return (UInt16)obj;
-                        case TypeCode.UInt32: return (UInt32)obj;
-                        case TypeCode.UInt64: return (UInt64)obj;
-                        case TypeCode.Single: return (Single)obj;
-                        case TypeCode.Double: return (Double)obj;
-                        case TypeCode.Decimal: return (Decimal)obj;
+                        case TypeCode.Byte: return (byte)obj;
+                        case TypeCode.SByte: return (sbyte)obj;
+                        case TypeCode.Int16: return (short)obj;
+                        case TypeCode.Char: return (char)obj;
+                        case TypeCode.Int32: return (int)obj;
+                        case TypeCode.Int64: return (long)obj;
+                        case TypeCode.UInt16: return (ushort)obj;
+                        case TypeCode.UInt32: return (uint)obj;
+                        case TypeCode.UInt64: return (ulong)obj;
+                        case TypeCode.Single: return (float)obj;
+                        case TypeCode.Double: return (double)obj;
+                        case TypeCode.Decimal: return (decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
@@ -189,18 +189,18 @@ namespace System.Linq.Expressions.Interpreter
             {
                 switch (_from)
                 {
-                    case TypeCode.Boolean: return ConvertInt32((Boolean)obj ? 1 : 0);
-                    case TypeCode.Byte: return ConvertInt32((Byte)obj);
-                    case TypeCode.SByte: return ConvertInt32((SByte)obj);
-                    case TypeCode.Int16: return ConvertInt32((Int16)obj);
-                    case TypeCode.Char: return ConvertInt32((Char)obj);
-                    case TypeCode.Int32: return ConvertInt32((Int32)obj);
-                    case TypeCode.Int64: return ConvertInt64((Int64)obj);
-                    case TypeCode.UInt16: return ConvertInt32((UInt16)obj);
-                    case TypeCode.UInt32: return ConvertInt64((UInt32)obj);
-                    case TypeCode.UInt64: return ConvertUInt64((UInt64)obj);
-                    case TypeCode.Single: return ConvertDouble((Single)obj);
-                    case TypeCode.Double: return ConvertDouble((Double)obj);
+                    case TypeCode.Boolean: return ConvertInt32((bool)obj ? 1 : 0);
+                    case TypeCode.Byte: return ConvertInt32((byte)obj);
+                    case TypeCode.SByte: return ConvertInt32((sbyte)obj);
+                    case TypeCode.Int16: return ConvertInt32((short)obj);
+                    case TypeCode.Char: return ConvertInt32((char)obj);
+                    case TypeCode.Int32: return ConvertInt32((int)obj);
+                    case TypeCode.Int64: return ConvertInt64((long)obj);
+                    case TypeCode.UInt16: return ConvertInt32((ushort)obj);
+                    case TypeCode.UInt32: return ConvertInt64((uint)obj);
+                    case TypeCode.UInt64: return ConvertUInt64((ulong)obj);
+                    case TypeCode.Single: return ConvertDouble((float)obj);
+                    case TypeCode.Double: return ConvertDouble((double)obj);
                     default: throw ContractUtils.Unreachable;
                 }
             }
@@ -211,87 +211,87 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     switch (_to)
                     {
-                        case TypeCode.Byte: return (Byte)obj;
-                        case TypeCode.SByte: return (SByte)obj;
-                        case TypeCode.Int16: return (Int16)obj;
-                        case TypeCode.Char: return (Char)obj;
-                        case TypeCode.Int32: return (Int32)obj;
-                        case TypeCode.Int64: return (Int64)obj;
-                        case TypeCode.UInt16: return (UInt16)obj;
-                        case TypeCode.UInt32: return (UInt32)obj;
-                        case TypeCode.UInt64: return (UInt64)obj;
-                        case TypeCode.Single: return (Single)obj;
-                        case TypeCode.Double: return (Double)obj;
-                        case TypeCode.Decimal: return (Decimal)obj;
+                        case TypeCode.Byte: return (byte)obj;
+                        case TypeCode.SByte: return (sbyte)obj;
+                        case TypeCode.Int16: return (short)obj;
+                        case TypeCode.Char: return (char)obj;
+                        case TypeCode.Int32: return (int)obj;
+                        case TypeCode.Int64: return (long)obj;
+                        case TypeCode.UInt16: return (ushort)obj;
+                        case TypeCode.UInt32: return (uint)obj;
+                        case TypeCode.UInt64: return (ulong)obj;
+                        case TypeCode.Single: return (float)obj;
+                        case TypeCode.Double: return (double)obj;
+                        case TypeCode.Decimal: return (decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
             }
 
-            private object ConvertInt64(Int64 obj)
+            private object ConvertInt64(long obj)
             {
                 checked
                 {
                     switch (_to)
                     {
-                        case TypeCode.Byte: return (Byte)obj;
-                        case TypeCode.SByte: return (SByte)obj;
-                        case TypeCode.Int16: return (Int16)obj;
-                        case TypeCode.Char: return (Char)obj;
-                        case TypeCode.Int32: return (Int32)obj;
-                        case TypeCode.Int64: return (Int64)obj;
-                        case TypeCode.UInt16: return (UInt16)obj;
-                        case TypeCode.UInt32: return (UInt32)obj;
-                        case TypeCode.UInt64: return (UInt64)obj;
-                        case TypeCode.Single: return (Single)obj;
-                        case TypeCode.Double: return (Double)obj;
-                        case TypeCode.Decimal: return (Decimal)obj;
+                        case TypeCode.Byte: return (byte)obj;
+                        case TypeCode.SByte: return (sbyte)obj;
+                        case TypeCode.Int16: return (short)obj;
+                        case TypeCode.Char: return (char)obj;
+                        case TypeCode.Int32: return (int)obj;
+                        case TypeCode.Int64: return (long)obj;
+                        case TypeCode.UInt16: return (ushort)obj;
+                        case TypeCode.UInt32: return (uint)obj;
+                        case TypeCode.UInt64: return (ulong)obj;
+                        case TypeCode.Single: return (float)obj;
+                        case TypeCode.Double: return (double)obj;
+                        case TypeCode.Decimal: return (decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
             }
 
-            private object ConvertUInt64(UInt64 obj)
+            private object ConvertUInt64(ulong obj)
             {
                 checked
                 {
                     switch (_to)
                     {
-                        case TypeCode.Byte: return (Byte)obj;
-                        case TypeCode.SByte: return (SByte)obj;
-                        case TypeCode.Int16: return (Int16)obj;
-                        case TypeCode.Char: return (Char)obj;
-                        case TypeCode.Int32: return (Int32)obj;
-                        case TypeCode.Int64: return (Int64)obj;
-                        case TypeCode.UInt16: return (UInt16)obj;
-                        case TypeCode.UInt32: return (UInt32)obj;
-                        case TypeCode.UInt64: return (UInt64)obj;
-                        case TypeCode.Single: return (Single)obj;
-                        case TypeCode.Double: return (Double)obj;
-                        case TypeCode.Decimal: return (Decimal)obj;
+                        case TypeCode.Byte: return (byte)obj;
+                        case TypeCode.SByte: return (sbyte)obj;
+                        case TypeCode.Int16: return (short)obj;
+                        case TypeCode.Char: return (char)obj;
+                        case TypeCode.Int32: return (int)obj;
+                        case TypeCode.Int64: return (long)obj;
+                        case TypeCode.UInt16: return (ushort)obj;
+                        case TypeCode.UInt32: return (uint)obj;
+                        case TypeCode.UInt64: return (ulong)obj;
+                        case TypeCode.Single: return (float)obj;
+                        case TypeCode.Double: return (double)obj;
+                        case TypeCode.Decimal: return (decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }
             }
 
-            private object ConvertDouble(Double obj)
+            private object ConvertDouble(double obj)
             {
                 checked
                 {
                     switch (_to)
                     {
-                        case TypeCode.Byte: return (Byte)obj;
-                        case TypeCode.SByte: return (SByte)obj;
-                        case TypeCode.Int16: return (Int16)obj;
-                        case TypeCode.Char: return (Char)obj;
-                        case TypeCode.Int32: return (Int32)obj;
-                        case TypeCode.Int64: return (Int64)obj;
-                        case TypeCode.UInt16: return (UInt16)obj;
-                        case TypeCode.UInt32: return (UInt32)obj;
-                        case TypeCode.UInt64: return (UInt64)obj;
-                        case TypeCode.Single: return (Single)obj;
-                        case TypeCode.Double: return (Double)obj;
-                        case TypeCode.Decimal: return (Decimal)obj;
+                        case TypeCode.Byte: return (byte)obj;
+                        case TypeCode.SByte: return (sbyte)obj;
+                        case TypeCode.Int16: return (short)obj;
+                        case TypeCode.Char: return (char)obj;
+                        case TypeCode.Int32: return (int)obj;
+                        case TypeCode.Int64: return (long)obj;
+                        case TypeCode.UInt16: return (ushort)obj;
+                        case TypeCode.UInt32: return (uint)obj;
+                        case TypeCode.UInt64: return (ulong)obj;
+                        case TypeCode.Single: return (float)obj;
+                        case TypeCode.Double: return (double)obj;
+                        case TypeCode.Decimal: return (decimal)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OnesComplementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OnesComplementInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(~(Int32)obj));
+                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(~(int)obj));
                 }
                 return +1;
             }
@@ -46,7 +46,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((Int16)(~(Int16)obj));
+                    frame.Push((short)(~(short)obj));
                 }
                 return +1;
             }
@@ -63,7 +63,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((Int64)(~(Int64)obj));
+                    frame.Push((long)(~(long)obj));
                 }
                 return +1;
             }
@@ -80,7 +80,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((UInt16)(~(UInt16)obj));
+                    frame.Push((ushort)(~(ushort)obj));
                 }
                 return +1;
             }
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((UInt32)(~(UInt32)obj));
+                    frame.Push((uint)(~(uint)obj));
                 }
                 return +1;
             }
@@ -114,7 +114,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((UInt64)(~(UInt64)obj));
+                    frame.Push((ulong)(~(ulong)obj));
                 }
                 return +1;
             }
@@ -131,7 +131,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((Byte)(~(Byte)obj));
+                    frame.Push((byte)(~(byte)obj));
                 }
                 return +1;
             }
@@ -148,7 +148,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((SByte)(~(SByte)obj));
+                    frame.Push((sbyte)(~(sbyte)obj));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((SByte)(((SByte)left) | ((SByte)right)));
+                frame.Push((sbyte)(((sbyte)left) | ((sbyte)right)));
                 return +1;
             }
         }
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((Int16)(((Int16)left) | ((Int16)right)));
+                frame.Push((short)(((short)left) | ((short)right)));
                 return +1;
             }
         }
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((Int32)left) | ((Int32)right));
+                frame.Push(((int)left) | ((int)right));
                 return +1;
             }
         }
@@ -76,7 +76,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((Int64)left) | ((Int64)right));
+                frame.Push(((long)left) | ((long)right));
                 return +1;
             }
         }
@@ -92,7 +92,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((Byte)(((Byte)left) | ((Byte)right)));
+                frame.Push((byte)(((byte)left) | ((byte)right)));
                 return +1;
             }
         }
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((UInt16)(((UInt16)left) | ((UInt16)right)));
+                frame.Push((ushort)(((ushort)left) | ((ushort)right)));
                 return +1;
             }
         }
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((UInt32)left) | ((UInt32)right));
+                frame.Push(((uint)left) | ((uint)right));
                 return +1;
             }
         }
@@ -140,7 +140,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((UInt64)left) | ((UInt64)right));
+                frame.Push(((ulong)left) | ((ulong)right));
                 return +1;
             }
         }
@@ -159,16 +159,16 @@ namespace System.Linq.Expressions.Interpreter
                     }
                     else
                     {
-                        frame.Push((Boolean)right ? ScriptingRuntimeHelpers.True : null);
+                        frame.Push((bool)right ? ScriptingRuntimeHelpers.True : null);
                     }
                     return +1;
                 }
                 else if (right == null)
                 {
-                    frame.Push((Boolean)left ? ScriptingRuntimeHelpers.True : null);
+                    frame.Push((bool)left ? ScriptingRuntimeHelpers.True : null);
                     return +1;
                 }
-                frame.Push(((Boolean)left) | ((Boolean)right));
+                frame.Push(((bool)left) | ((bool)right));
                 return +1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((SByte)(((SByte)value) >> ((int)shift)));
+                    frame.Push((sbyte)(((sbyte)value) >> ((int)shift)));
                 }
                 return +1;
             }
@@ -47,7 +47,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((Int16)(((Int16)value) >> ((int)shift)));
+                    frame.Push((short)(((short)value) >> ((int)shift)));
                 }
                 return +1;
             }
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int32)value) >> ((int)shift));
+                    frame.Push(((int)value) >> ((int)shift));
                 }
                 return +1;
             }
@@ -83,7 +83,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((Int64)value) >> ((int)shift));
+                    frame.Push(((long)value) >> ((int)shift));
                 }
                 return +1;
             }
@@ -101,7 +101,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((Byte)(((Byte)value) >> ((int)shift)));
+                    frame.Push((byte)(((byte)value) >> ((int)shift)));
                 }
                 return +1;
             }
@@ -119,7 +119,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((UInt16)(((UInt16)value) >> ((int)shift)));
+                    frame.Push((ushort)(((ushort)value) >> ((int)shift)));
                 }
                 return +1;
             }
@@ -137,7 +137,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt32)value) >> ((int)shift));
+                    frame.Push(((uint)value) >> ((int)shift));
                 }
                 return +1;
             }
@@ -155,7 +155,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((UInt64)value) >> ((int)shift));
+                    frame.Push(((ulong)value) >> ((int)shift));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
@@ -48,7 +48,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IList<object> objects)
         {
-            return String.Format(CultureInfo.InvariantCulture, "LoadCached({0}: {1})", _index, objects[(int)_index]);
+            return string.Format(CultureInfo.InvariantCulture, "LoadCached({0}: {1})", _index, objects[(int)_index]);
         }
 
         public override string ToString() => "LoadCached(" + _index + ")";

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((Int32)l - (Int32)r));
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l - (int)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -48,7 +48,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((Int16)((Int16)l - (Int16)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l - (short)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -67,7 +67,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((Int64)((Int64)l - (Int64)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((long)((long)l - (long)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -86,7 +86,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((UInt16)((UInt16)l - (UInt16)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((ushort)((ushort)l - (ushort)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -105,7 +105,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((UInt32)((UInt32)l - (UInt32)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((uint)((uint)l - (uint)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = unchecked((UInt64)((UInt64)l - (UInt64)r));
+                    frame.Data[frame.StackIndex - 2] = unchecked((ulong)((ulong)l - (ulong)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Single)((Single)l - (Single)r);
+                    frame.Data[frame.StackIndex - 2] = (float)((float)l - (float)r);
                 }
                 frame.StackIndex--;
                 return +1;
@@ -162,7 +162,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = (Double)l - (Double)r;
+                    frame.Data[frame.StackIndex - 2] = (double)l - (double)r;
                 }
                 frame.StackIndex--;
                 return +1;
@@ -210,7 +210,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((Int32)l - (Int32)r));
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l - (int)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -229,7 +229,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((Int16)((Int16)l - (Int16)r));
+                    frame.Data[frame.StackIndex - 2] = checked((short)((short)l - (short)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -248,7 +248,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((Int64)((Int64)l - (Int64)r));
+                    frame.Data[frame.StackIndex - 2] = checked((long)((long)l - (long)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -267,7 +267,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((UInt16)((UInt16)l - (UInt16)r));
+                    frame.Data[frame.StackIndex - 2] = checked((ushort)((ushort)l - (ushort)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -286,7 +286,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((UInt32)((UInt32)l - (UInt32)r));
+                    frame.Data[frame.StackIndex - 2] = checked((uint)((uint)l - (uint)r));
                 }
                 frame.StackIndex--;
                 return +1;
@@ -305,7 +305,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Data[frame.StackIndex - 2] = checked((UInt64)((UInt64)l - (UInt64)r));
+                    frame.Data[frame.StackIndex - 2] = checked((ulong)((ulong)l - (ulong)r));
                 }
                 frame.StackIndex--;
                 return +1;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -397,21 +397,21 @@ namespace System.Linq.Expressions.Interpreter
             {
                 switch (System.Dynamic.Utils.TypeExtensions.GetTypeCode(t))
                 {
-                    case TypeCode.Boolean: return s_boolean ?? (s_boolean = new CastInstructionT<Boolean>());
-                    case TypeCode.Byte: return s_byte ?? (s_byte = new CastInstructionT<Byte>());
-                    case TypeCode.Char: return s_char ?? (s_char = new CastInstructionT<Char>());
+                    case TypeCode.Boolean: return s_boolean ?? (s_boolean = new CastInstructionT<bool>());
+                    case TypeCode.Byte: return s_byte ?? (s_byte = new CastInstructionT<byte>());
+                    case TypeCode.Char: return s_char ?? (s_char = new CastInstructionT<char>());
                     case TypeCode.DateTime: return s_dateTime ?? (s_dateTime = new CastInstructionT<DateTime>());
-                    case TypeCode.Decimal: return s_decimal ?? (s_decimal = new CastInstructionT<Decimal>());
-                    case TypeCode.Double: return s_double ?? (s_double = new CastInstructionT<Double>());
-                    case TypeCode.Int16: return s_int16 ?? (s_int16 = new CastInstructionT<Int16>());
-                    case TypeCode.Int32: return s_int32 ?? (s_int32 = new CastInstructionT<Int32>());
-                    case TypeCode.Int64: return s_int64 ?? (s_int64 = new CastInstructionT<Int64>());
-                    case TypeCode.SByte: return s_SByte ?? (s_SByte = new CastInstructionT<SByte>());
-                    case TypeCode.Single: return s_single ?? (s_single = new CastInstructionT<Single>());
-                    case TypeCode.String: return s_string ?? (s_string = new CastInstructionT<String>());
-                    case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new CastInstructionT<UInt16>());
-                    case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new CastInstructionT<UInt32>());
-                    case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new CastInstructionT<UInt64>());
+                    case TypeCode.Decimal: return s_decimal ?? (s_decimal = new CastInstructionT<decimal>());
+                    case TypeCode.Double: return s_double ?? (s_double = new CastInstructionT<double>());
+                    case TypeCode.Int16: return s_int16 ?? (s_int16 = new CastInstructionT<short>());
+                    case TypeCode.Int32: return s_int32 ?? (s_int32 = new CastInstructionT<int>());
+                    case TypeCode.Int64: return s_int64 ?? (s_int64 = new CastInstructionT<long>());
+                    case TypeCode.SByte: return s_SByte ?? (s_SByte = new CastInstructionT<sbyte>());
+                    case TypeCode.Single: return s_single ?? (s_single = new CastInstructionT<float>());
+                    case TypeCode.String: return s_string ?? (s_string = new CastInstructionT<string>());
+                    case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new CastInstructionT<ushort>());
+                    case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new CastInstructionT<uint>());
+                    case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new CastInstructionT<ulong>());
                 }
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -127,43 +127,43 @@ namespace System.Linq.Expressions.Interpreter
                     result = ScriptingRuntimeHelpers.False;
                     break;
                 case TypeCode.SByte:
-                    result = default(SByte);
+                    result = default(sbyte);
                     break;
                 case TypeCode.Byte:
-                    result = default(Byte);
+                    result = default(byte);
                     break;
                 case TypeCode.Char:
-                    result = default(Char);
+                    result = default(char);
                     break;
                 case TypeCode.Int16:
-                    result = default(Int16);
+                    result = default(short);
                     break;
                 case TypeCode.Int32:
                     result = ScriptingRuntimeHelpers.Int32_0;
                     break;
                 case TypeCode.Int64:
-                    result = default(Int64);
+                    result = default(long);
                     break;
                 case TypeCode.UInt16:
-                    result = default(UInt16);
+                    result = default(ushort);
                     break;
                 case TypeCode.UInt32:
-                    result = default(UInt32);
+                    result = default(uint);
                     break;
                 case TypeCode.UInt64:
-                    result = default(UInt64);
+                    result = default(ulong);
                     break;
 
                 case TypeCode.Single:
-                    return default(Single);
+                    return default(float);
                 case TypeCode.Double:
-                    return default(Double);
+                    return default(double);
                 //            case TypeCode.DBNull: 
                 //                  return default(DBNull); 
                 case TypeCode.DateTime:
                     return default(DateTime);
                 case TypeCode.Decimal:
-                    return default(Decimal);
+                    return default(decimal);
                 default:
                     return null;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
@@ -46,7 +46,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="String"/> that represents the current <see cref="Object"/>. </returns>
         public override string ToString()
         {
-            return String.IsNullOrEmpty(this.Name) ? "UnamedLabel" : this.Name;
+            return string.IsNullOrEmpty(this.Name) ? "UnamedLabel" : this.Name;
         }
     }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -115,7 +115,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Produces a delegate that represents the lambda expression.
         /// </summary>
-        /// <param name="preferInterpretation">A <see cref="Boolean"/> that indicates if the expression should be compiled to an interpreted form, if available. </param>
+        /// <param name="preferInterpretation">A <see cref="bool"/> that indicates if the expression should be compiled to an interpreted form, if available. </param>
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
         public Delegate Compile(bool preferInterpretation)
         {
@@ -181,7 +181,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Produces a delegate that represents the lambda expression.
         /// </summary>
-        /// <param name="preferInterpretation">A <see cref="Boolean"/> that indicates if the expression should be compiled to an interpreted form, if available. </param>
+        /// <param name="preferInterpretation">A <see cref="bool"/> that indicates if the expression should be compiled to an interpreted form, if available. </param>
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
         public new TDelegate Compile(bool preferInterpretation)
         {
@@ -305,7 +305,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <typeparam name="TDelegate">The delegate type. </typeparam>
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="P:Body"/> property equal to. </param>
-        /// <param name="tailCall">A <see cref="Boolean"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
+        /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
         /// <param name="parameters">An array that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="P:Parameters"/> collection. </param>
         /// <returns>An <see cref="Expression{TDelegate}"/> that has the <see cref="P:NodeType"/> property equal to <see cref="P:Lambda"/> and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
         public static Expression<TDelegate> Lambda<TDelegate>(Expression body, bool tailCall, params ParameterExpression[] parameters)
@@ -330,7 +330,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <typeparam name="TDelegate">The delegate type. </typeparam>
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="P:Body"/> property equal to. </param>
-        /// <param name="tailCall">A <see cref="Boolean"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
+        /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="P:Parameters"/> collection. </param>
         /// <returns>An <see cref="Expression{TDelegate}"/> that has the <see cref="P:NodeType"/> property equal to <see cref="P:Lambda"/> and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
         public static Expression<TDelegate> Lambda<TDelegate>(Expression body, bool tailCall, IEnumerable<ParameterExpression> parameters)
@@ -346,7 +346,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="P:Parameters"/> collection. </param>
         /// <param name="name">The name of the lambda. Used for generating debugging info.</param>
         /// <returns>An <see cref="Expression{TDelegate}"/> that has the <see cref="P:NodeType"/> property equal to <see cref="P:Lambda"/> and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
-        public static Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, IEnumerable<ParameterExpression> parameters)
+        public static Expression<TDelegate> Lambda<TDelegate>(Expression body, string name, IEnumerable<ParameterExpression> parameters)
         {
             return Lambda<TDelegate>(body, name, false, parameters);
         }
@@ -358,9 +358,9 @@ namespace System.Linq.Expressions
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="P:Body"/> property equal to. </param>
         /// <param name="name">The name of the lambda. Used for generating debugging info.</param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="P:Parameters"/> collection. </param>
-        /// <param name="tailCall">A <see cref="Boolean"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
+        /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
         /// <returns>An <see cref="Expression{TDelegate}"/> that has the <see cref="P:NodeType"/> property equal to <see cref="P:Lambda"/> and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
-        public static Expression<TDelegate> Lambda<TDelegate>(Expression body, String name, bool tailCall, IEnumerable<ParameterExpression> parameters)
+        public static Expression<TDelegate> Lambda<TDelegate>(Expression body, string name, bool tailCall, IEnumerable<ParameterExpression> parameters)
         {
             ReadOnlyCollection<ParameterExpression> parameterList = parameters.ToReadOnly();
             ValidateLambdaArgs(typeof(TDelegate), ref body, parameterList, nameof(TDelegate));
@@ -383,7 +383,7 @@ namespace System.Linq.Expressions
         /// Creates a LambdaExpression by first constructing a delegate type. 
         /// </summary>
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="P:Body"/> property equal to. </param>
-        /// <param name="tailCall">A <see cref="Boolean"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
+        /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
         /// <param name="parameters">An array that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="P:Parameters"/> collection. </param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="P:NodeType"/> property equal to Lambda and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Expression body, bool tailCall, params ParameterExpression[] parameters)
@@ -406,7 +406,7 @@ namespace System.Linq.Expressions
         /// Creates a LambdaExpression by first constructing a delegate type. 
         /// </summary>
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="P:Body"/> property equal to. </param>
-        /// <param name="tailCall">A <see cref="Boolean"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
+        /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="P:Parameters"/> collection. </param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="P:NodeType"/> property equal to Lambda and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Expression body, bool tailCall, IEnumerable<ParameterExpression> parameters)
@@ -430,7 +430,7 @@ namespace System.Linq.Expressions
         /// Creates a LambdaExpression by first constructing a delegate type. 
         /// </summary>
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="P:Body"/> property equal to. </param>
-        /// <param name="tailCall">A <see cref="Boolean"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
+        /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
         /// <param name="parameters">An array that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="P:Parameters"/> collection. </param>
         /// <param name="delegateType">A <see cref="Type"/> representing the delegate signature for the lambda.</param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="P:NodeType"/> property equal to Lambda and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
@@ -455,7 +455,7 @@ namespace System.Linq.Expressions
         /// Creates a LambdaExpression by first constructing a delegate type. 
         /// </summary>
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="P:Body"/> property equal to. </param>
-        /// <param name="tailCall">A <see cref="Boolean"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
+        /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="P:Parameters"/> collection. </param>
         /// <param name="delegateType">A <see cref="Type"/> representing the delegate signature for the lambda.</param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="P:NodeType"/> property equal to Lambda and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
@@ -481,7 +481,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="P:Body"/> property equal to. </param>
         /// <param name="name">The name for the lambda. Used for emitting debug information.</param>
-        /// <param name="tailCall">A <see cref="Boolean"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
+        /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="P:Parameters"/> collection. </param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="P:NodeType"/> property equal to Lambda and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Expression body, string name, bool tailCall, IEnumerable<ParameterExpression> parameters)
@@ -535,7 +535,7 @@ namespace System.Linq.Expressions
         /// <param name="delegateType">A <see cref="Type"/> representing the delegate signature for the lambda.</param>
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="P:Body"/> property equal to. </param>
         /// <param name="name">The name for the lambda. Used for emitting debug information.</param>
-        /// <param name="tailCall">A <see cref="Boolean"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
+        /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression. </param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="P:Parameters"/> collection. </param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="P:NodeType"/> property equal to Lambda and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Type delegateType, Expression body, string name, bool tailCall, IEnumerable<ParameterExpression> parameters)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
@@ -34,15 +34,15 @@ namespace System.Linq.Expressions
                 {
                     switch (type.GetTypeCode())
                     {
-                        case TypeCode.Boolean: return new PrimitiveParameterExpression<Boolean>(name);
-                        case TypeCode.Byte: return new PrimitiveParameterExpression<Byte>(name);
-                        case TypeCode.Char: return new PrimitiveParameterExpression<Char>(name);
+                        case TypeCode.Boolean: return new PrimitiveParameterExpression<bool>(name);
+                        case TypeCode.Byte: return new PrimitiveParameterExpression<byte>(name);
+                        case TypeCode.Char: return new PrimitiveParameterExpression<char>(name);
                         case TypeCode.DateTime: return new PrimitiveParameterExpression<DateTime>(name);
-                        case TypeCode.Decimal: return new PrimitiveParameterExpression<Decimal>(name);
-                        case TypeCode.Double: return new PrimitiveParameterExpression<Double>(name);
-                        case TypeCode.Int16: return new PrimitiveParameterExpression<Int16>(name);
-                        case TypeCode.Int32: return new PrimitiveParameterExpression<Int32>(name);
-                        case TypeCode.Int64: return new PrimitiveParameterExpression<Int64>(name);
+                        case TypeCode.Decimal: return new PrimitiveParameterExpression<decimal>(name);
+                        case TypeCode.Double: return new PrimitiveParameterExpression<double>(name);
+                        case TypeCode.Int16: return new PrimitiveParameterExpression<short>(name);
+                        case TypeCode.Int32: return new PrimitiveParameterExpression<int>(name);
+                        case TypeCode.Int64: return new PrimitiveParameterExpression<long>(name);
                         case TypeCode.Object:
                             // common reference types which we optimize go here.  Of course object is in
                             // the list, the others are driven by profiling of various workloads.  This list
@@ -60,12 +60,12 @@ namespace System.Linq.Expressions
                                 return new PrimitiveParameterExpression<object[]>(name);
                             }
                             break;
-                        case TypeCode.SByte: return new PrimitiveParameterExpression<SByte>(name);
-                        case TypeCode.Single: return new PrimitiveParameterExpression<Single>(name);
-                        case TypeCode.String: return new PrimitiveParameterExpression<String>(name);
-                        case TypeCode.UInt16: return new PrimitiveParameterExpression<UInt16>(name);
-                        case TypeCode.UInt32: return new PrimitiveParameterExpression<UInt32>(name);
-                        case TypeCode.UInt64: return new PrimitiveParameterExpression<UInt64>(name);
+                        case TypeCode.SByte: return new PrimitiveParameterExpression<sbyte>(name);
+                        case TypeCode.Single: return new PrimitiveParameterExpression<float>(name);
+                        case TypeCode.String: return new PrimitiveParameterExpression<string>(name);
+                        case TypeCode.UInt16: return new PrimitiveParameterExpression<ushort>(name);
+                        case TypeCode.UInt32: return new PrimitiveParameterExpression<uint>(name);
+                        case TypeCode.UInt64: return new PrimitiveParameterExpression<ulong>(name);
                     }
                 }
             }


### PR DESCRIPTION
Applying the rules described @ https://github.com/dotnet/corefx/issues/391.