### PR TITLE
Marking a few internal types as sealed

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/CacheDict.cs
+++ b/src/Common/src/System/Dynamic/Utils/CacheDict.cs
@@ -14,7 +14,7 @@ namespace System.Dynamic.Utils
     /// Provides a dictionary-like object used for caches which holds onto a maximum
     /// number of elements specified at construction time.
     /// </summary>
-    internal class CacheDict<TKey, TValue>
+    internal sealed class CacheDict<TKey, TValue>
     {
 
         // cache size is always ^2. 

--- a/src/Common/src/System/Dynamic/Utils/ListArgumentProvider.cs
+++ b/src/Common/src/System/Dynamic/Utils/ListArgumentProvider.cs
@@ -19,7 +19,7 @@ namespace System.Dynamic.Utils
     /// optimization.  See IArgumentProvider for more general information on the Expression
     /// tree optimizations being used here.
     /// </summary>
-    internal class ListArgumentProvider : IList<Expression>
+    internal sealed class ListArgumentProvider : IList<Expression>
     {
         private readonly IArgumentProvider _provider;
         private readonly Expression _arg0;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -539,7 +539,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class ScopeWithType : ScopeN
+    internal sealed class ScopeWithType : ScopeN
     {
         private readonly Type _type;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
@@ -13,7 +13,7 @@ namespace System.Linq.Expressions.Compiler
 {
     internal partial class StackSpiller
     {
-        private class TempMaker
+        private sealed class TempMaker
         {
             /// <summary>
             /// Current temporary variable
@@ -128,7 +128,7 @@ namespace System.Linq.Expressions.Compiler
         /// the original expression or the rewritten expression. Finish will call
         /// Expression.Comma if necessary and return a new Result.
         /// </summary>
-        private class ChildRewriter
+        private sealed class ChildRewriter
         {
             private readonly StackSpiller _self;
             private readonly Expression[] _expressions;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
@@ -15,7 +15,7 @@ namespace System.Linq.Expressions.Compiler
     /// in order to guarantee some properties of code generation, for
     /// example that we always enter try block on empty stack.
     /// </summary>
-    internal partial class StackSpiller
+    internal sealed partial class StackSpiller
     {
         // Is the evaluation stack empty?
         private enum Stack

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
@@ -131,7 +131,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class FullConditionalExpressionWithType : FullConditionalExpression
+    internal sealed class FullConditionalExpressionWithType : FullConditionalExpression
     {
         private readonly Type _type;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -128,7 +128,7 @@ namespace System.Linq.Expressions
 
     #region Specialized Subclasses
 
-    internal class InvocationExpressionN : InvocationExpression
+    internal sealed class InvocationExpressionN : InvocationExpression
     {
         private IList<Expression> _arguments;
 
@@ -165,7 +165,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InvocationExpression0 : InvocationExpression
+    internal sealed class InvocationExpression0 : InvocationExpression
     {
         public InvocationExpression0(Expression lambda, Type returnType)
             : base(lambda, returnType)
@@ -199,7 +199,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InvocationExpression1 : InvocationExpression
+    internal sealed class InvocationExpression1 : InvocationExpression
     {
         private object _arg0;       // storage for the 1st argument or a readonly collection.  See IArgumentProvider
 
@@ -244,7 +244,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InvocationExpression2 : InvocationExpression
+    internal sealed class InvocationExpression2 : InvocationExpression
     {
         private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1;  // storage for the 2nd arg
@@ -292,7 +292,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InvocationExpression3 : InvocationExpression
+    internal sealed class InvocationExpression3 : InvocationExpression
     {
         private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1;  // storage for the 2nd arg
@@ -343,7 +343,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InvocationExpression4 : InvocationExpression
+    internal sealed class InvocationExpression4 : InvocationExpression
     {
         private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1;  // storage for the 2nd arg
@@ -397,7 +397,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class InvocationExpression5 : InvocationExpression
+    internal sealed class InvocationExpression5 : InvocationExpression
     {
         private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
         private readonly Expression _arg1;  // storage for the 2nd arg

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -98,7 +98,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class FieldExpression : MemberExpression
+    internal sealed class FieldExpression : MemberExpression
     {
         private readonly FieldInfo _field;
 
@@ -119,7 +119,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class PropertyExpression : MemberExpression
+    internal sealed class PropertyExpression : MemberExpression
     {
         private readonly PropertyInfo _property;
         public PropertyExpression(Expression expression, PropertyInfo member)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -113,7 +113,7 @@ namespace System.Linq.Expressions
         }
     }
 
-    internal class NewValueTypeExpression : NewExpression
+    internal sealed class NewValueTypeExpression : NewExpression
     {
         private readonly Type _valueType;
 


### PR DESCRIPTION
We generally mark `internal` types as `sealed` when applicable, but there were a few omissions. Addressing these.