### PR TITLE
Fix TFS build of System.Net.WebClient.Tests

### DIFF
--- a/src/System.Net.WebClient/ref/System.Net.WebClient.csproj
+++ b/src/System.Net.WebClient/ref/System.Net.WebClient.csproj
@@ -13,5 +13,10 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- TODO: Remove these reference once packages are updated -->
+    <ProjectReference Include="..\..\System.Net.Primitives\ref\System.Net.Primitives.csproj" />
+    <ProjectReference Include="..\..\System.Net.Requests\ref\System.Net.Requests.csproj" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.WebClient/src/System.Net.WebClient.csproj
+++ b/src/System.Net.WebClient/src/System.Net.WebClient.csproj
@@ -33,5 +33,14 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- TODO: Remove these reference once packages are updated -->
+    <ProjectReference Include="..\..\System.Net.Primitives\ref\System.Net.Primitives.csproj">
+      <UndefineProperties>TargetGroup;OSGroup</UndefineProperties>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Net.Requests\ref\System.Net.Requests.csproj">
+      <UndefineProperties>TargetGroup;OSGroup</UndefineProperties>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
+++ b/src/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
@@ -30,6 +30,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <!-- TODO: Remove these reference once packages are updated -->
+    <ProjectReference Include="..\..\System.Net.Primitives\pkg\System.Net.Primitives.pkgproj" />
+    <ProjectReference Include="..\..\System.Net.Requests\pkg\System.Net.Requests.pkgproj" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
Internal builds are failing with:
```
2016-10-21T13:55:07.0700647Z WebClientTest.cs(25,28): error CS7069: Reference to type 'RequestCachePolicy' claims it is defined in 'System.Net.Requests', but it could not be found [D:\A\_work\55\s\corefx\src\System.Net.WebClient\tests\System.Net.WebClient.Tests.csproj]
2016-10-21T13:55:07.0700647Z WebClientTest.cs(269,16): error CS7069: Reference to type 'RequestCachePolicy' claims it is defined in 'System.Net.Requests', but it could not be found [D:\A\_work\55\s\corefx\src\System.Net.WebClient\tests\System.Net.WebClient.Tests.csproj]
2016-10-21T13:55:07.0700647Z WebClientTest.cs(270,31): error CS7069: Reference to type 'RequestCachePolicy' claims it is defined in 'System.Net.Requests', but it could not be found [D:\A\_work\55\s\corefx\src\System.Net.WebClient\tests\System.Net.WebClient.Tests.csproj]
2016-10-21T13:55:08.3669554Z WebClientTest.cs(25,28): error CS7069: Reference to type 'RequestCachePolicy' claims it is defined in 'System.Net.Requests', but it could not be found [D:\A\_work\55\s\corefx\src\System.Net.WebClient\tests\System.Net.WebClient.Tests.csproj]
2016-10-21T13:55:08.3669554Z WebClientTest.cs(269,16): error CS7069: Reference to type 'RequestCachePolicy' claims it is defined in 'System.Net.Requests', but it could not be found [D:\A\_work\55\s\corefx\src\System.Net.WebClient\tests\System.Net.WebClient.Tests.csproj]
2016-10-21T13:55:08.3669554Z WebClientTest.cs(270,31): error CS7069: Reference to type 'RequestCachePolicy' claims it is defined in 'System.Net.Requests', but it could not be found [D:\A\_work\55\s\corefx\src\System.Net.WebClient\tests\System.Net.WebClient.Tests.csproj]
```
Trying to fix it with temporary P2P references.
cc: @weshaggard 