### PR TITLE
Add Microsoft.Win32.Primitives package dependency for S.Net.Requests

### DIFF
--- a/src/System.Net.Requests/src/project.json
+++ b/src/System.Net.Requests/src/project.json
@@ -3,6 +3,7 @@
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
+        "Microsoft.Win32.Primitives": "4.4.0-beta-24619-02",
         "System.Collections": "4.4.0-beta-24619-02",
         "System.Collections.Concurrent": "4.4.0-beta-24619-02",
         "System.Collections.NonGeneric": "4.4.0-beta-24619-02",


### PR DESCRIPTION
@geoffkizer looks like your PR https://github.com/dotnet/corefx/pull/12594 was missing this dependency.

I'm not sure how CI ever passed without it. Perhaps there it was coming in transitively and isn't now at any rate the direct dependency should be included so here it is. 
