### PR TITLE
Porting #12407 to 1.1.0 - Fixed Reflection on XmlConvert Not Working in Net Native.

### DIFF
--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -672,13 +672,70 @@ namespace System.Xml.Serialization
                 string methodName = $"To{mapping.TypeDesc.FormatterName}";
                 if (!mapping.TypeDesc.HasCustomFormatter)
                 {
-                    MethodInfo method = typeof(XmlConvert).GetMethod(methodName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, new Type[] { typeof(string) });
-                    return method.Invoke(null, new object[] { readFunc() });
+                    string value = readFunc();
+                    object retObj;
+                    switch (mapping.TypeDesc.FormatterName)
+                    {
+                        case "Boolean":
+                            retObj = XmlConvert.ToBoolean(value);
+                            break;
+                        case "Int32":
+                            retObj = XmlConvert.ToInt32(value);
+                            break;
+                        case "Int16":
+                            retObj = XmlConvert.ToInt16(value);
+                            break;
+                        case "Int64":
+                            retObj = XmlConvert.ToInt64(value);
+                            break;
+                        case "Single":
+                            retObj = XmlConvert.ToSingle(value);
+                            break;
+                        case "Double":
+                            retObj = XmlConvert.ToDouble(value);
+                            break;
+                        case "Decimal":
+                            retObj = XmlConvert.ToDecimal(value);
+                            break;
+                        case "Byte":
+                            retObj = XmlConvert.ToByte(value);
+                            break;
+                        case "SByte":
+                            retObj = XmlConvert.ToSByte(value);
+                            break;
+                        case "UInt16":
+                            retObj = XmlConvert.ToUInt16(value);
+                            break;
+                        case "UInt32":
+                            retObj = XmlConvert.ToUInt32(value);
+                            break;
+                        case "UInt64":
+                            retObj = XmlConvert.ToUInt64(value);
+                            break;
+                        case "Guid":
+                            retObj = XmlConvert.ToGuid(value);
+                            break;
+                        case "Char":
+                            retObj = XmlConvert.ToChar(value);
+                            break;
+                        case "TimeSpan":
+                            retObj = XmlConvert.ToTimeSpan(value);
+                            break;
+                        default:
+                            throw new InvalidOperationException(SR.Format(SR.XmlInternalErrorDetails, $"unknown FormatterName: {mapping.TypeDesc.FormatterName}"));
+                    }
+
+                    return retObj;
                 }
                 else
                 {
-                        MethodInfo method = typeof(XmlSerializationReader).GetMethod(methodName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, new Type[] { typeof(string) });
-                        return method.Invoke(this, new object[] { readFunc() });
+                    MethodInfo method = typeof(XmlSerializationReader).GetMethod(methodName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, new Type[] { typeof(string) });
+                    if (method == null)
+                    {
+                        throw new InvalidOperationException(SR.Format(SR.XmlInternalErrorDetails, $"unknown FormatterName: {mapping.TypeDesc.FormatterName}"));
+                    }
+
+                    return method.Invoke(this, new object[] { readFunc() });
                 }
             }
         }


### PR DESCRIPTION
The issue happens in Net Native only. The issue is that XmlConvert's metadata info by default is not kept by Net Native toolchain. This caused reflection on XmlConvert's methods not working.

The fix is to call XmlConvert's methods directly instead of using reflection.

Fix #12903

/cc: @mconnew @zhenlan @huanwu 