### PR TITLE
Port remaining methods in CookieCollection and CookieContainer

### DIFF
--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -48,12 +48,15 @@ namespace System.Net
         public CookieCollection() { }
         public int Count { get { throw null; } }
         public System.Net.Cookie this[string name] { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public System.Net.Cookie this[int index] { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
         public void Add(System.Net.Cookie cookie) { }
         public void Add(System.Net.CookieCollection cookies) { }
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(Cookie[] array, int index) { }
+        public bool IsReadOnly { get { throw null; } }
     }
     public partial class CookieContainer
     {
@@ -70,6 +73,10 @@ namespace System.Net
         public string GetCookieHeader(System.Uri uri) { throw null; }
         public System.Net.CookieCollection GetCookies(System.Uri uri) { throw null; }
         public void SetCookies(System.Uri uri, string cookieHeader) { }
+        public CookieContainer(int capacity) { }
+        public CookieContainer(int capacity, int perDomainCapacity, int maxCookieSize) { }
+        public void Add(CookieCollection cookies) { }
+        public void Add(Cookie cookie) { }
     }
     public partial class CookieException : System.FormatException, System.Runtime.Serialization.ISerializable
     {

--- a/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -86,6 +86,14 @@ namespace System.Net
             }
         }
 
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public int Count
         {
             get
@@ -94,7 +102,7 @@ namespace System.Net
             }
         }
 
-        bool ICollection.IsSynchronized
+        public bool IsSynchronized
         {
             get
             {
@@ -102,7 +110,7 @@ namespace System.Net
             }
         }
 
-        object ICollection.SyncRoot
+        public object SyncRoot
         {
             get
             {
@@ -110,9 +118,14 @@ namespace System.Net
             }
         }
 
-        void ICollection.CopyTo(Array array, int index)
+        public void CopyTo(Array array, int index)
         {
             ((ICollection)_list).CopyTo(array, index);
+        }
+
+        public void CopyTo(Cookie[] array, int index)
+        {
+            _list.CopyTo(array, index);
         }
 
         internal DateTime TimeStamp(Stamp how)

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -117,7 +117,7 @@ namespace System.Net
             // Otherwise it will remain string.Empty.
         }
 
-        internal CookieContainer(int capacity) : this()
+        public CookieContainer(int capacity) : this()
         {
             if (capacity <= 0)
             {
@@ -126,7 +126,7 @@ namespace System.Net
             _maxCookies = capacity;
         }
 
-        internal CookieContainer(int capacity, int perDomainCapacity, int maxCookieSize) : this(capacity)
+        public CookieContainer(int capacity, int perDomainCapacity, int maxCookieSize) : this(capacity)
         {
             if (perDomainCapacity != Int32.MaxValue && (perDomainCapacity <= 0 || perDomainCapacity > capacity))
             {
@@ -214,7 +214,7 @@ namespace System.Net
         }
 
         // This method will construct a faked URI: the Domain property is required for param.
-        internal void Add(Cookie cookie)
+        public void Add(Cookie cookie)
         {
             if (cookie == null)
             {
@@ -520,7 +520,7 @@ namespace System.Net
             }
         }
 
-        internal void Add(CookieCollection cookies)
+        public void Add(CookieCollection cookies)
         {
             if (cookies == null)
             {

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieContainerAddTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieContainerAddTest.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Primitives.Functional.Tests
+{
+    public partial class CookieContainerTest
+    {
+        [Fact]
+        public static void AddCookieCollection_Null_Throws()
+        {
+            CookieContainer cc = new CookieContainer();
+            CookieCollection cookieCollection = null;
+            Assert.Throws<ArgumentNullException>(() => cc.Add(cookieCollection));
+        }
+
+        [Fact]
+        public static void AddCookieCollection_Success()
+        {
+            CookieContainer cc = new CookieContainer();
+            CookieCollection cookieCollection = new CookieCollection();
+            cookieCollection.Add(new Cookie("name3", "value","/",".contoso.com"));
+            cc.Add(cookieCollection);
+            Assert.Equal(1, cc.Count);
+        }
+    }
+}

--- a/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
+++ b/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="SerializationTest.cs" />
+    <Compile Include="CookieContainerAddTest.cs" />
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/12125
The required methods already exists , but were internal.
This change just expose them from the public contracts.