### PR TITLE
Don't allow Expression.Parameter and Expression.Variable to have open generic types

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
@@ -209,6 +209,7 @@ namespace System.Linq.Expressions
         public static ParameterExpression Parameter(Type type, string name)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
+            TypeUtils.ValidateType(type, nameof(type));
 
             if (type == typeof(void))
             {
@@ -238,6 +239,7 @@ namespace System.Linq.Expressions
         public static ParameterExpression Variable(Type type, string name)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
+            TypeUtils.ValidateType(type, nameof(type));
             if (type == typeof(void)) throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
             if (type.IsByRef) throw Error.TypeMustNotBeByRef(nameof(type));
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -267,7 +267,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory]
-        [ClassData(typeof(InvalidTypes))]
+        [ClassData(typeof(InvalidTypesData))]
         public static void Left_InvalidType_ThrowsArgumentException(Type type)
         {
             Expression left = new FakeExpression(ExpressionType.Parameter, type);
@@ -275,7 +275,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory]
-        [ClassData(typeof(InvalidTypes))]
+        [ClassData(typeof(InvalidTypesData))]
         public static void Right_InvalidType_ThrowsArgumentException(Type type)
         {
             Expression right = new FakeExpression(ExpressionType.Parameter, type);

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -289,7 +289,7 @@ namespace System.Linq.Expressions.Tests
         public static void StaticMethod() { }
     }
     
-    public class InvalidTypes : IEnumerable<object[]>
+    public class InvalidTypesData : IEnumerable<object[]>
     {
         private static readonly object[] GenericTypeDefinition = new object[] { typeof(GenericClass<>) };
         private static readonly object[] ContainsGenericParameters = new object[] { typeof(GenericClass<>).MakeGenericType(typeof(GenericClass<>)) };

--- a/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
@@ -45,6 +45,14 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("type", () => Expression.Parameter(typeof(void), "var"));
         }
 
+        [Theory]
+        [ClassData(typeof(InvalidTypesData))]
+        public void OpenGenericType_ThrowsArgumentException(Type type)
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Parameter(type));
+            Assert.Throws<ArgumentException>("type", () => Expression.Parameter(type, "name"));
+        }
+
         [Fact]
         public void NullType()
         {

--- a/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
@@ -101,6 +101,14 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>(null, () => variable.ReduceAndCheck());
         }
 
+        [Theory]
+        [ClassData(typeof(InvalidTypesData))]
+        public void OpenGenericType_ThrowsArgumentException(Type type)
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Variable(type));
+            Assert.Throws<ArgumentException>("type", () => Expression.Variable(type, "name"));
+        }
+
         [Fact]
         public void CannotBePointerType()
         {


### PR DESCRIPTION
Fixes #8081

/cc @stephentoub @bartdesmet @svick @vsadov