### PR TITLE
Fix null reference exception in NetworkAvailabilityChanged on Linux

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Linux.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Linux.cs
@@ -99,8 +99,12 @@ namespace System.Net.NetworkInformation
                     s_availabilityChangedSubscribers -= value;
                     if (s_availabilityChangedSubscribers == null)
                     {
-                        s_availabilityTimer.Dispose();
-                        s_availabilityTimer = null;
+                        if (s_availabilityTimer != null)
+                        {
+                            s_availabilityTimer.Dispose();
+                            s_availabilityTimer = null;
+                        }
+
                         if (s_addressChangedSubscribers == null)
                         {
                             CloseSocket();

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
@@ -6,26 +6,23 @@ using Xunit;
 
 namespace System.Net.NetworkInformation.Tests
 {
-    public class NetworkAddressChangedTests
+    // Partial class used for both NetworkAddressChanged and NetworkAvailabilityChanged
+    // so that the tests for each don't run concurrently
+    public partial class NetworkChangedTests
     {
+        private readonly NetworkAddressChangedEventHandler _addressHandler = delegate { };
+
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/308
         public void NetworkAddressChanged_AddRemove_Success()
         {
-            NetworkAddressChangedEventHandler handler = NetworkChange_NetworkAddressChanged;
-            NetworkChange.NetworkAddressChanged += handler;
-            NetworkChange.NetworkAddressChanged -= handler;
+            NetworkChange.NetworkAddressChanged += _addressHandler;
+            NetworkChange.NetworkAddressChanged -= _addressHandler;
         }
 
         [Fact]
         public void NetworkAddressChanged_JustRemove_Success()
         {
-            NetworkAddressChangedEventHandler handler = NetworkChange_NetworkAddressChanged;
-            NetworkChange.NetworkAddressChanged -= handler;
+            NetworkChange.NetworkAddressChanged -= _addressHandler;
         }
-
-        private void NetworkChange_NetworkAddressChanged(object sender, EventArgs e)
-        {
-        }
-
     }
 }


### PR DESCRIPTION
If NetworkAddressChanged has a subscriber and NetworkAvailabilityChanged doesn't, attempting to remove a delegate from NetworkAvailabilityChanged results in a NullReferenceException as a null timer static field is dereferenced.

This was failing intermittently in tests because the NetworkAddressChanged and NetworkAvailabilityChanged tests were in different classes and thus could potentially run in parallel.  If the NetworkAvailabilityChanged_JustRemove_Success test ran while one of the NetworkAddressChanged tests was in flight, it would fail with a null ref.

I've fixed the product bug by adding a null check.  I've also updated the tests so that all of these event handler tests are in the same class, and added explicit tests for this case that will deterministically fail if the product regresses.

Fixes https://github.com/dotnet/corefx/issues/12886
cc: @mellinoe, @davidsh, @cipop