### PR TITLE
Workaround compiler warning in test UnixGssFakeNegotiateStream class

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/UnixGssFakeNegotiateStream.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/UnixGssFakeNegotiateStream.cs
@@ -54,7 +54,10 @@ namespace System.Net.Security.Tests
                 byte[] outBuf = null;
                 try
                 {
-                    handshakeDone = EstablishSecurityContext(ref thisRef._context, inBuf, out outBuf);
+                    SafeGssContextHandle context = thisRef._context; // workaround warning about a ref to a field on a MarshalByRefObject
+                    handshakeDone = EstablishSecurityContext(ref context, inBuf, out outBuf);
+                    thisRef._context = context;
+
                     thisRef._framer.WriteHandshakeFrame(outBuf, 0, outBuf.Length);
                 }
                 catch (Interop.NetSecurityNative.GssApiException e)


### PR DESCRIPTION
Simple change to avoid passing this _context field by ref to suppress the warning:
```
2016-10-22T01:52:17.1092891Z UnixGssFakeNegotiateStream.cs(57,66): error CS0197: Using 'UnixGssFakeNegotiateStream._context' as a ref or out value or taking its address may cause a runtime exception because it is a field of a marshal-by-reference class [D:\A\_work\32\s\corefx\src\System.Net.Security\tests\FunctionalTests\System.Net.Security.Tests.csproj]
```
cc: @weshaggard, @safern 