### PR TITLE
Fix CredentialCache arg names in implementation

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -21,24 +21,24 @@ namespace System.Net
         {
         }
 
-        public void Add(Uri uriPrefix, string authenticationType, NetworkCredential credential)
+        public void Add(Uri uriPrefix, string authType, NetworkCredential cred)
         {
             if (uriPrefix == null)
             {
                 throw new ArgumentNullException(nameof(uriPrefix));
             }
-            if (authenticationType == null)
+            if (authType == null)
             {
-                throw new ArgumentNullException(nameof(authenticationType));
+                throw new ArgumentNullException(nameof(authType));
             }
 
             ++_version;
 
-            var key = new CredentialKey(uriPrefix, authenticationType);
+            var key = new CredentialKey(uriPrefix, authType);
 
             if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Print("CredentialCache::Add() Adding key:[" + key.ToString() + "], cred:[" + credential.Domain + "],[" + credential.UserName + "]");
+                GlobalLog.Print("CredentialCache::Add() Adding key:[" + key.ToString() + "], cred:[" + cred.Domain + "],[" + cred.UserName + "]");
             }
 
             if (_cache == null)
@@ -46,7 +46,7 @@ namespace System.Net
                 _cache = new Dictionary<CredentialKey, NetworkCredential>();
             }
 
-            _cache.Add(key, credential);
+            _cache.Add(key, cred);
         }
 
         public void Add(string host, int port, string authenticationType, NetworkCredential credential)
@@ -88,9 +88,9 @@ namespace System.Net
             _cacheForHosts.Add(key, credential);
         }
 
-        public void Remove(Uri uriPrefix, string authenticationType)
+        public void Remove(Uri uriPrefix, string authType)
         {
-            if (uriPrefix == null || authenticationType == null)
+            if (uriPrefix == null || authType == null)
             {
                 // These couldn't possibly have been inserted into
                 // the cache because of the test in Add().
@@ -109,7 +109,7 @@ namespace System.Net
 
             ++_version;
 
-            var key = new CredentialKey(uriPrefix, authenticationType);
+            var key = new CredentialKey(uriPrefix, authType);
 
             if (GlobalLog.IsEnabled)
             {
@@ -155,20 +155,20 @@ namespace System.Net
             _cacheForHosts.Remove(key);
         }
 
-        public NetworkCredential GetCredential(Uri uriPrefix, string authenticationType)
+        public NetworkCredential GetCredential(Uri uriPrefix, string authType)
         {
             if (uriPrefix == null)
             {
                 throw new ArgumentNullException(nameof(uriPrefix));
             }
-            if (authenticationType == null)
+            if (authType == null)
             {
-                throw new ArgumentNullException(nameof(authenticationType));
+                throw new ArgumentNullException(nameof(authType));
             }
 
             if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Print("CredentialCache::GetCredential(uriPrefix=\"" + uriPrefix + "\", authType=\"" + authenticationType + "\")");
+                GlobalLog.Print("CredentialCache::GetCredential(uriPrefix=\"" + uriPrefix + "\", authType=\"" + authType + "\")");
             }
 
             if (_cache == null)
@@ -190,7 +190,7 @@ namespace System.Net
                 CredentialKey key = pair.Key;
 
                 // Determine if this credential is applicable to the current Uri/AuthType
-                if (key.Match(uriPrefix, authenticationType))
+                if (key.Match(uriPrefix, authType))
                 {
                     int prefixLen = key.UriPrefixLength;
 

--- a/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -122,7 +122,7 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Null(cc.GetCredential(uriPrefix1, "invalid-authentication-type")); //No such authenticationType
 
             Assert.Throws<ArgumentNullException>("uriPrefix", () => cc.Add(null, "some", new NetworkCredential())); //Null uriPrefix
-            Assert.Throws<ArgumentNullException>("authenticationType", () => cc.Add(new Uri("http://microsoft:80"), null, new NetworkCredential())); //Null authenticationType
+            Assert.Throws<ArgumentNullException>("authType", () => cc.Add(new Uri("http://microsoft:80"), null, new NetworkCredential())); //Null authenticationType
         }
 
         [Fact]
@@ -233,7 +233,7 @@ namespace System.Net.Primitives.Functional.Tests
             CredentialCache cc = new CredentialCache();
 
             Assert.Throws<ArgumentNullException>("uriPrefix", () => cc.GetCredential(null, "authenticationType")); //Null uriPrefix
-            Assert.Throws<ArgumentNullException>("authenticationType", () => cc.GetCredential(new Uri("http://microsoft:80"), null)); //Null authenticationType
+            Assert.Throws<ArgumentNullException>("authType", () => cc.GetCredential(new Uri("http://microsoft:80"), null)); //Null authenticationType
         }
 
         [Fact]


### PR DESCRIPTION
The names of arguments to several CredentialCache members are different between the CredentialCache implementation and the CredentialCache in the ref contract (the one in the ref contract is "correct" in that it matches both what's in desktop and what's in netstandard).  Since the contract is correct, this isn't actually visible for a dev using the contract, but it is for a few exception types that end up including the name of the argument.  To match desktop (and to make sense to the dev), the exceptions should contain the name used in the ref contract.

Fixes https://github.com/dotnet/corefx/issues/12126
cc: @weshaggard, @davidsh, @cipop