### PR TITLE
Tighten some Globalization.Extensions tests.

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -16,6 +16,8 @@ namespace System
         public static bool IsWindows7 { get; } = IsWindows && GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;
         public static bool IsOSX { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         public static bool IsNetBSD { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
+        public static bool IsOpenSUSE { get; } = IsDistroAndVersion("opensuse");
+        public static bool IsUbuntu { get; } = IsDistroAndVersion("ubuntu");
         public static bool IsNotWindowsNanoServer { get; } = (IsWindows &&
             File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "regedit.exe")));
         public static bool IsWindows10Version1607OrGreater { get; } = IsWindows &&
@@ -50,17 +52,24 @@ namespace System
         }
 
         public static bool IsDebian8 { get; } = IsDistroAndVersion("debian", "8");
+        public static bool IsUbuntu1404 { get; } = IsDistroAndVersion("ubuntu", "14.04");
         public static bool IsUbuntu1510 { get; } = IsDistroAndVersion("ubuntu", "15.10");
         public static bool IsUbuntu1604 { get; } = IsDistroAndVersion("ubuntu", "16.04");
         public static bool IsUbuntu1610 { get; } = IsDistroAndVersion("ubuntu", "16.10");
         public static bool IsFedora23 { get; } = IsDistroAndVersion("fedora", "23");
 
-        private static bool IsDistroAndVersion(string distroId, string versionId)
+        /// <summary>
+        /// Get whether the OS platform matches the given Linux distro and optional version.
+        /// </summary>
+        /// <param name="distroId">The distribution id.</param>
+        /// <param name="versionId">The distro version.  If omitted, compares the distro only.</param>
+        /// <returns>Whether the OS platform matches the given Linux distro and optional version.</returns>
+        private static bool IsDistroAndVersion(string distroId, string versionId = null)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 IdVersionPair v = ParseOsReleaseFile();
-                if (v.Id == distroId && v.VersionId == versionId)
+                if (v.Id == distroId && (versionId == null || v.VersionId == versionId))
                 {
                     return true;
                 }

--- a/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_Win7/Unicode_Win7_IdnaTest.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_Win7/Unicode_Win7_IdnaTest.cs
@@ -2,15 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Xunit;
-using System;
 using System.Text;
+using Xunit;
 
 namespace System.Globalization.Tests
 {
     /// <summary>
     /// contained in Data\Unicode_Win7\IdnaTest_Win7.txt
-    /// 
+    ///
     /// The structure of the data set is a semicolon deliminated list with the following columns:
     ///
     /// Column 1: type - T for transitional, N for nontransitional, B for both
@@ -45,10 +44,13 @@ namespace System.Globalization.Tests
             {
                 case "T":
                     return IdnType.Transitional;
+
                 case "N":
                     return IdnType.Nontransitional;
+
                 case "B":
                     return IdnType.Both;
+
                 default:
                     throw new ArgumentOutOfRangeException("idnType", "Unknown idnType");
             }
@@ -57,7 +59,7 @@ namespace System.Globalization.Tests
         /// <summary>
         /// This will convert strings with escaped sequences to literal characters.  The input string is
         /// expected to have escaped sequences in the form of '\uXXXX'.
-        /// 
+        ///
         /// Example: "a\u0020b" will be converted to 'a b'.
         /// </summary>
         private static string EscapedToLiteralString(string escaped, int lineNumber)
@@ -69,8 +71,7 @@ namespace System.Globalization.Tests
                 if (i + 1 < escaped.Length && escaped[i] == '\\' && escaped[i + 1] == 'u')
                 {
                     // Verify that the escaped sequence is not malformed
-                    if (i + 5 >= escaped.Length)
-                        Assert.False(true, "There was a problem converting to literal string on Line " + lineNumber);
+                    Assert.True(i + 5 < escaped.Length, $"There was a problem converting to literal string on Line {lineNumber}");
 
                     var codepoint = Convert.ToInt32(escaped.Substring(i + 2, 4), 16);
                     sb.Append((char)codepoint);

--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetAsciiTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetAsciiTests.cs
@@ -15,11 +15,11 @@ namespace System.Globalization.Tests
             for (int i = 0x20; i < 0x7F; i++)
             {
                 char c = (char)i;
-                
+
                 // We test '.' separately
-                if (c == '.') 
+                if (c == '.')
                 {
-                    continue; 
+                    continue;
                 }
                 string ascii = c.ToString();
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // expected platform differences, see https://github.com/dotnet/corefx/issues/8242
@@ -54,10 +54,10 @@ namespace System.Globalization.Tests
             yield return new object[] { "\u0061\u0062\u0063.\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067.\u30D1\u30D5\u30A3\u30FC\u0064\u0065\u30EB\u30F3\u30D0", 0, 21, "abc.xn--d9juau41awczczp.xn--de-jg4avhby1noc0d" }; // Fully qualified domain name
 
             // Embedded domain name conversion (NLS + only)(Priority 1)
-            // Per the spec [7], "The index and count parameters (when provided) allow the 
-            // conversion to be done on a larger string where the domain name is embedded 
-            // (such as a URI or IRI). The output string is only the converted FQDN or 
-            // label, not the whole input string (if the input string contains more 
+            // Per the spec [7], "The index and count parameters (when provided) allow the
+            // conversion to be done on a larger string where the domain name is embedded
+            // (such as a URI or IRI). The output string is only the converted FQDN or
+            // label, not the whole input string (if the input string contains more
             // character than the substring to convert)."
             // Fully Qualified Domain Name (Label1.Label2.Label3)
             yield return new object[] { "\u0061\u0062\u0063.\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067.\u30D1\u30D5\u30A3\u30FC\u0064\u0065\u30EB\u30F3\u30D0", 0, 21, "abc.xn--d9juau41awczczp.xn--de-jg4avhby1noc0d" };
@@ -83,23 +83,23 @@ namespace System.Globalization.Tests
             }
             Assert.Equal(expected, new IdnMapping().GetAscii(unicode, index, count));
         }
-        
+
         [Fact]
         public void TestGetAsciiWithDot()
         {
-            string result = "";
-            Exception ex = Record.Exception(()=> result = new IdnMapping().GetAscii("."));
-            
-            if (ex == null)
+            string dot = ".";
+            IdnMapping mapping = new IdnMapping();
+            if (PlatformDetection.IsWindows ||
+                PlatformDetection.IsOSX ||
+                PlatformDetection.IsOpenSUSE ||
+                (PlatformDetection.IsUbuntu && !PlatformDetection.IsUbuntu1404))
             {
-                // Windows and OSX always throw exception. some versions of Linux succeed and others throw exception   
-                Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
-                Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
-                Assert.Equal(result, ".");
+                Assert.Throws<ArgumentException>("unicode", () => mapping.GetAscii(dot));
             }
             else
             {
-                Assert.True(ex is ArgumentException);
+                string result = mapping.GetAscii(dot);
+                Assert.Equal(dot, result);
             }
         }
 
@@ -122,7 +122,7 @@ namespace System.Globalization.Tests
             yield return new object[] { "\u0061\u0062\u0063.\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067.\u30D1\u30D5\u30A3\u30FC\u0064\u0065\u30EB\u30F3\u30D0", 3, 8, typeof(ArgumentException) };
             yield return new object[] { "\u0061\u0062\u0063.\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067.\u30D1\u30D5\u30A3\u30FC\u0064\u0065\u30EB\u30F3\u30D0", 3, 9, typeof(ArgumentException) };
             yield return new object[] { "\u0061\u0062\u0063.\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067.\u30D1\u30D5\u30A3\u30FC\u0064\u0065\u30EB\u30F3\u30D0", 11, 10, typeof(ArgumentException) };
-            
+
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))  // expected platform differences, see https://github.com/dotnet/corefx/issues/8242
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -132,7 +132,7 @@ namespace System.Globalization.Tests
                 yield return new object[] { "-", 0, 1, typeof(ArgumentException) };
             }
             else
-            {                
+            {
                 yield return new object[] { ".", 0, 1, typeof(ArgumentException) };
             }
 

--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingUseStd3AsciiRulesTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingUseStd3AsciiRulesTests.cs
@@ -8,13 +8,13 @@ using Xunit;
 namespace System.Globalization.Tests
 {
     /// <summary>
-    /// According to the ToASCII algorithm, if the UseSTD3ASCIIRules flag is set, 
-    /// then perform these checks: 
+    /// According to the ToASCII algorithm, if the UseSTD3ASCIIRules flag is set,
+    /// then perform these checks:
     ///
-    ///	(a) Verify the absence of non-LDH ASCII code points; that is, the absence 
+    ///	(a) Verify the absence of non-LDH ASCII code points; that is, the absence
     ///      of 0..2C, 2E..2F, 3A..40, 5B..60, and 7B..7F.
     ///
-    /// (b) Verify the absence of leading and trailing hyphen-minus; that is, the 
+    /// (b) Verify the absence of leading and trailing hyphen-minus; that is, the
     ///      absence of U+002D at the beginning and end of the sequence.
     ///
     /// By default this flag should not be set.
@@ -61,10 +61,9 @@ namespace System.Globalization.Tests
                 Assert.Equal(unicode, idnStd3False.GetAscii(unicode));
             }
 
-            Exception exception = Record.Exception(() => idnStd3True.GetAscii(unicode));
-            Assert.True(exception is ArgumentException);
+            ArgumentException ae = Assert.Throws<ArgumentException>(() => idnStd3True.GetAscii(unicode));
             // sometimes the desktop returns "Unicode" instead of "unicode" for the parameter name.
-            Assert.True(((ArgumentException) exception).ParamName.Equals("unicode", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal("unicode", ae.ParamName, ignoreCase: true);
         }
 
         [Fact]

--- a/src/System.Globalization.Extensions/tests/Normalization/NormalizationAll.cs
+++ b/src/System.Globalization.Extensions/tests/Normalization/NormalizationAll.cs
@@ -23,7 +23,6 @@ namespace System.Globalization.Tests
         }
         
         [Fact]
-        [ActiveIssue(11803, TestPlatforms.AnyUnix)]
         public void Normalize()
         {
             // Windows 8 test data came from http://www.unicode.org/Public/UCD/latest/ucd/NormalizationTest.txt 
@@ -31,7 +30,6 @@ namespace System.Globalization.Tests
 
             using (Stream stream = typeof(StringNormalizationAllTests).GetTypeInfo().Assembly.GetManifestResourceStream(PlatformDetection.IsWindows7 ? "NormalizationDataWin7" : "NormalizationDataWin8"))
             {
-                Assert.True(stream != null, "Couldn't get the stream for the normalization embedded file");
                 using (StreamReader sr = new StreamReader(stream))
                 {
                     int index = 0;

--- a/src/System.Globalization.Extensions/tests/Normalization/StringNormalizationTests.cs
+++ b/src/System.Globalization.Extensions/tests/Normalization/StringNormalizationTests.cs
@@ -32,13 +32,6 @@ namespace System.Globalization.Tests
             Assert.Throws<ArgumentException>("strInput", () => "\uD800\uD800".IsNormalized()); // Invalid surrogate pair
 
             Assert.Throws<ArgumentNullException>("strInput", () => StringNormalizationExtensions.IsNormalized(null));
-            
-            Exception exception = Record.Exception(() => ((string)null).IsNormalized());
-            
-            // On desktop IsNormalized is not extension method, trying to do ((string)null).IsNormalized()
-            // will get NullReferenceException, in .Net Core we use extension method which will throw
-            // ArgumentNullException
-            Assert.True((exception is ArgumentNullException) || (exception is NullReferenceException));
         }
 
         [Theory]
@@ -71,13 +64,6 @@ namespace System.Globalization.Tests
             Assert.Throws<ArgumentException>("strInput", () => "\uD800\uD800".Normalize()); // Invalid surrogate pair
 
             Assert.Throws<ArgumentNullException>("strInput", () => StringNormalizationExtensions.Normalize(null));
-            
-            Exception exception = Record.Exception(() => ((string)null).Normalize());
-            
-            // On desktop Normalize is not extension method, trying to do ((string)null).Normalize()
-            // will get NullReferenceException, in .Net Core we use extension method which will throw
-            // ArgumentNullException
-            Assert.True((exception is ArgumentNullException) || (exception is NullReferenceException));
         }
     }
 }


### PR DESCRIPTION
Re-issue of #12783, which was reverted in #12865 .

Note that history has been squashed down, to make it easier to read.  The tests using `PlatformDetection` now do so inside a single test, as  `ConditionalFact` reports as being skipped (whereas what we're doing here is closer to an expanded `PlatformSpecific`).

cc @stephentoub , @tarekgh 