### PR TITLE
Improve performance of SslStream reading and writing

### DIFF
--- a/src/Common/src/Interop/Windows/sspicli/GlobalSSPI.cs
+++ b/src/Common/src/Interop/Windows/sspicli/GlobalSSPI.cs
@@ -6,7 +6,7 @@ namespace System.Net
 {
     internal static class GlobalSSPI
     {
-        internal static SSPIInterface SSPIAuth = new SSPIAuthType();
-        internal static SSPIInterface SSPISecureChannel = new SSPISecureChannelType();
+        internal static readonly SSPIInterface SSPIAuth = new SSPIAuthType();
+        internal static readonly SSPIInterface SSPISecureChannel = new SSPISecureChannelType();
     }
 }

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -525,21 +525,8 @@ namespace System.Net.Security
         // Returns:
         // 
         //     A Task<int> representing the read.
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled<int>(cancellationToken);
-            }
-
-            return Task.Factory.FromAsync(
-                (bufferArg, offsetArg, sizeArg, callback, state) => ((SslStream)state).BeginRead(bufferArg, offsetArg, sizeArg, callback, state),
-                iar => ((SslStream)iar.AsyncState).EndRead(iar),
-                buffer,
-                offset,
-                size,
-                this);
-        }
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken) =>
+            base.ReadAsync(buffer, offset, size, cancellationToken);
 
         // WriteAsync - provide async write functionality.
         // 
@@ -556,20 +543,7 @@ namespace System.Net.Security
         // Returns:
         // 
         //     A Task representing the write.
-        public override Task WriteAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled<int>(cancellationToken);
-            }
-
-            return Task.Factory.FromAsync(
-                (bufferArg, offsetArg, sizeArg, callback, state) => ((SslStream)state).BeginWrite(bufferArg, offsetArg, sizeArg, callback, state),
-                iar => ((SslStream)iar.AsyncState).EndWrite(iar),
-                buffer,
-                offset,
-                size,
-                this);
-        }
+        public override Task WriteAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken) =>
+            base.WriteAsync(buffer, offset, size, cancellationToken);
     }
 }

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -509,41 +509,5 @@ namespace System.Net.Security
         {
             _sslState.SecureStream.EndWrite(asyncResult);
         }
-
-        // ReadAsync - provide async read functionality.
-        // 
-        // This method provides async read functionality. All we do is
-        // call through to the Begin/EndRead methods.
-        // 
-        // Input:
-        // 
-        //     buffer            - Buffer to read into.
-        //     offset            - Offset into the buffer where we're to read.
-        //     size              - Number of bytes to read.
-        //     cancellationToken - Token used to request cancellation of the operation
-        // 
-        // Returns:
-        // 
-        //     A Task<int> representing the read.
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken) =>
-            base.ReadAsync(buffer, offset, size, cancellationToken);
-
-        // WriteAsync - provide async write functionality.
-        // 
-        // This method provides async write functionality. All we do is
-        // call through to the Begin/EndWrite methods.
-        // 
-        // Input:
-        // 
-        //     buffer  - Buffer to write into.
-        //     offset  - Offset into the buffer where we're to write.
-        //     size    - Number of bytes to write.
-        //     cancellationToken - Token used to request cancellation of the operation
-        // 
-        // Returns:
-        // 
-        //     A Task representing the write.
-        public override Task WriteAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken) =>
-            base.WriteAsync(buffer, offset, size, cancellationToken);
     }
 }


### PR DESCRIPTION
This PR makes a significant dent in the allocations incurred while reading/writing an SslStream (though there is still more that can and should be done).

I wrote a simple benchmark that creates a producer and a consumer, where the producer WriteAsyncs 10K 1024 byte buffers to an SslStream, and a consumer reads with 1024 byte buffers until all data is consumed.  To try to keep things isolated from the rest of the networking stack (as some common types are shared, making analysis more difficult), the SslStreams wrap NamedPipeServer/ClientStreams.  Prior to this change, the allocations end up looking like this:
![image](https://cloud.githubusercontent.com/assets/2642209/19627173/0e937eb8-990f-11e6-8ee4-72fcc3988fed.png)

This PR does two things:

1. It removes some of the Task-related costs by switching away from using Task.Factory.FromAsync in SslStream.WriteAsync/ReadAsync.  When Stream didn't provide the Begin/EndRead/Write methods in the contract, SslStream's Begin/End methods were internal, and the implementation of Read/WriteAsync used FromAsync to delegate to them.  But the base Stream's Read/WriteAsync overloads have an optimized implementation for delegating to the Begin/End methods, taking advantage of some Task internals.  Now that Stream does expose Begin/EndRead/Write and SslStream overrides those, we can remove the FromAsync calls and just let the base stream do its thing. (In the future, we can improve on this further by avoiding going through Begin/End at all, but for now this simple change improves the allocation profile.)
2. On Windows, every call to EncryptMessage and DecryptMessage ends up going through a generic helper for dealing with SSPI.  The interface to these methods uses only safe code, so arrays of classes end up getting passed, and ends up having to do lots of expensive things in order to deal with arbitrary inputs.  But the encrypt/decrypt operations are relatively simple, and we can avoid all of those costs by just going to the SSPI calls directly.  Previously, every encrypt/decrypt call would allocate 4 SecurityBuffer instances, a SecurityBuffer[4] array, a SecBuffer[4] array, a GCHandle[4] array, a byte[4][] array, and a SecBufferDesc... after this change, all of those except for the SecBufferDesc are gone.

With these changes, a new profile of the same scenario looks like:
![image](https://cloud.githubusercontent.com/assets/2642209/19627225/0d05f6e2-9910-11e6-90e9-4e40a901f795.png)
reducing allocation numbers/size by ~70%. Throughput also increased by ~15%.

The remaining allocations after this change are:
- The SecBufferDesc allocated in EncryptMessage/DecryptMessage.  (We can get rid of that by changing the type to a struct and changing the interface to take a ```SecBufferDesc*``` (it can't be a ```ref SecBufferDesc``` as we need to be able to pass in ```null```).  That impacts a lot of code paths, though, so I haven't done it in this change.)
- The Task returned from ReadAsync/WriteAsync.  (The one from ReadAsync is mostly unavoidable, but if we rewrite the implementation with async/await, if the underlying write operation completes synchronously, we should be able to avoid the task returned from WriteAsync.)
- A BufferAsyncResult, AsyncProtocolRequest, and boxed Int32 for each read operation.  (By rewriting these methods with async/await, we should be able to eliminate the boxed Int32 entirely, and replace the other two with smaller allocations associated with the async state machine, removing them altogether if the operation completes synchronously.)
- A LazyAsyncResult and an AsyncProtocol Request for each write operation. (Same possibilities as above.)

We can then further reduce these for the CopyToAsync scenario by ammortizing most of the read-related costs.

(The ReadWriteTask allocations showing up in all of the traces are from the named pipe streams and can be ignored for the purposes of this PR.)

Contributes to https://github.com/dotnet/corefx/issues/11826
cc: @davidsh, @cipop, @ericeil, @bartonjs, @davidfowl, @benaadams 