### PR TITLE
Uses s_localTimeOffset to adjust time offset

### DIFF
--- a/src/System.Net.Mail/tests/Functional/ContentDispositionTest.cs
+++ b/src/System.Net.Mail/tests/Functional/ContentDispositionTest.cs
@@ -227,7 +227,7 @@ namespace System.Net.Mime.Tests
             var cd = new ContentDisposition(disposition);
 
             Assert.Equal(ValidDateGmtOffset, cd.Parameters["creation-date"]);
-            Assert.Equal(new DateTime(2009, 5, 17, 15 + s_localTimeOffset.Hours, 34, 07, DateTimeKind.Local), cd.CreationDate);
+            Assert.Equal(new DateTime(2009, 5, 17, 15, 34, 07, DateTimeKind.Local) + s_localTimeOffset, cd.CreationDate);
 
             Assert.Equal("inline", cd.DispositionType);
             Assert.Equal(dispositionValue, cd.ToString());
@@ -252,7 +252,7 @@ namespace System.Net.Mime.Tests
             cd.Parameters["creation-date"] = ValidDateGmt;
 
             Assert.Equal(DateTimeKind.Local, cd.CreationDate.Kind);
-            Assert.Equal(new DateTime(2009, 5, 17, 15 + s_localTimeOffset.Hours, 34, 07, DateTimeKind.Local), cd.CreationDate);
+            Assert.Equal(new DateTime(2009, 5, 17, 15, 34, 07, DateTimeKind.Local) + s_localTimeOffset, cd.CreationDate);
         }
 
         [Fact]
@@ -320,7 +320,7 @@ namespace System.Net.Mime.Tests
 
             Assert.Equal("inline", cd.DispositionType);
             Assert.Equal(ValidDateGmtOffset, cd.Parameters["creation-date"]);
-            Assert.Equal(new DateTime(2009, 5, 17, 15 + s_localTimeOffset.Hours, 34, 07, DateTimeKind.Local), cd.CreationDate);
+            Assert.Equal(new DateTime(2009, 5, 17, 15, 34, 07, DateTimeKind.Local) + s_localTimeOffset, cd.CreationDate);
         }
 
         [Fact]


### PR DESCRIPTION
The use of ``s_localTimeOffset.Hours`` can cause unexpected behavior if
the time offset is above 9:00 (which is discussed in #12944).

This commit revises the check to use ``s_localTimeOffset`` instead of
``s_localTimeOffset.Hours`` in order to avoid the issue discussed in #12944.

This commit also attempts to prevent potential danger from  unusual time offset such as -9:30.