### PR TITLE
Change '--testTFM' option to '--testRelPath' and default value in run-test.sh

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -48,8 +48,8 @@ usage()
     echo "                                      specified by --corefx-tests"
     echo "    --test-dir-file <path>            Run tests only in the directories specified by the file at <path>. Paths are"
     echo "                                      listed one line, relative to the directory specified by --corefx-tests"
-    echo "    --testTFM <project>               Set TestTFM to run"
-    echo "                                      default: netcoreapp1.1"
+    echo "    --testRelPath <project>           Set tests relative path from project name"
+    echo "                                      default: default.netcoreapp1.1/netcoreapp1.1"
     echo
     echo "Runtime Code Coverage options:"
     echo "    --coreclr-coverage                Optional argument to get coreclr code coverage reports"
@@ -106,7 +106,7 @@ TestSelection=".*"
 TestsFailed=0
 
 # TestTFM default
-TestTFM="netcoreapp1.1"
+TestRelPath="default.netcoreapp1.1/netcoreapp1.1"
 
 ensure_binaries_are_present()
 {
@@ -219,7 +219,7 @@ run_test()
     exit 0
   fi
 
-  dirName="$1/$TestTFM"
+  dirName="$1/$TestRelPath"
   copy_test_overlay $dirName
 
   pushd $dirName > /dev/null
@@ -351,8 +351,8 @@ do
         --test-dir-file)
         TestDirFile=$2
         ;;
-        --testTFM)
-        TestTFM=$2
+        --testRelPath)
+        TestRelPath=$2
         ;;
         --outerloop)
         OuterLoop=""


### PR DESCRIPTION
Similar issue with #12440 
Test path changed by #12634 (dotnet/buildtools#1121)

- Change option name of `--testTFM` to `--testRelPath` to set relative path from project directory to test script.

- Set default value to `default.netcoreapp1.1/netcoreapp1.1`

cc/ @weshaggard @stephentoub