### PR TITLE
Disable RC2 tests due to win7

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
@@ -140,6 +140,7 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
             }
         }
 
+        [ActiveIssue(12926)]
         [Theory, MemberData(nameof(RC2TestData))]
         public static void RC2RoundTrip(CipherMode cipherMode, PaddingMode paddingMode, string key, string iv, string textHex, string expectedDecrypted, string expectedEncrypted)
         {
@@ -163,6 +164,7 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
             }
         }
 
+        [ActiveIssue(12926)]
         [Fact]
         public static void RC2ReuseEncryptorDecryptor()
         {
@@ -204,6 +206,7 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
             }
         }
 
+        [ActiveIssue(12926)]
         [Fact]
         public static void RC2ExplicitEncryptorDecryptor_WithIV()
         {
@@ -223,6 +226,7 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
             }
         }
 
+        [ActiveIssue(12926)]
         [Fact]
         public static void RC2ExplicitEncryptorDecryptor_NoIV()
         {


### PR DESCRIPTION
Disabling for now; need to get environment setup to repro.

Issue https://github.com/dotnet/corefx/issues/12926