### PR TITLE
port SetIPProtectionLevel and AllowNatTraversal

### DIFF
--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -320,6 +320,7 @@ namespace System.Net.Sockets
         public int SendTo(byte[] buffer, System.Net.EndPoint remoteEP) { throw null; }
         public int SendTo(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
         public bool SendToAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
+        public void SetIPProtectionLevel(System.Net.Sockets.IPProtectionLevel level) { throw null; }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, bool optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, byte[] optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, int optionValue) { }
@@ -569,6 +570,7 @@ namespace System.Net.Sockets
         public void Start() { }
         public void Start(int backlog) { }
         public void Stop() { }
+        public void AllowNatTraversal(bool allow) { throw null; }
         public static TcpListener Create(int port) { throw null; }
     }
 
@@ -624,6 +626,7 @@ namespace System.Net.Sockets
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes) { throw null; }
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes, System.Net.IPEndPoint endPoint) { throw null; }
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes, string hostname, int port) { throw null; }
+        public void AllowNatTraversal(bool allow) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct UdpReceiveResult : System.IEquatable<System.Net.Sockets.UdpReceiveResult>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2280,7 +2280,7 @@ namespace System.Net.Sockets
         {
             if (level == IPProtectionLevel.Unspecified)
             {
-                throw new ArgumentException(SR.Format(SR.net_sockets_invalid_optionValue_all), "level");
+                throw new ArgumentException(SR.Format(SR.net_sockets_invalid_optionValue_all), nameof(level));
             }
 
             if (_addressFamily == AddressFamily.InterNetworkV6)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2276,6 +2276,27 @@ namespace System.Net.Sockets
             return optionValue;
         }
 
+        public void SetIPProtectionLevel(IPProtectionLevel level)
+        {
+            if (level == IPProtectionLevel.Unspecified)
+            {
+                throw new ArgumentException(SR.Format(SR.net_sockets_invalid_optionValue_all), "level");
+            }
+
+            if (_addressFamily == AddressFamily.InterNetworkV6)
+            {
+                SocketPal.SetIPProtectionLevel(this, SocketOptionLevel.IPv6, (int)level);
+            }
+            else if (_addressFamily == AddressFamily.InterNetwork)
+            {
+                SocketPal.SetIPProtectionLevel(this, SocketOptionLevel.IP, (int)level);
+            }
+            else
+            {
+                throw new NotSupportedException(SR.net_invalidversion);
+            }
+        }
+
         // Determines the status of the socket.
         public bool Poll(int microSeconds, SelectMode mode)
         {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -943,6 +943,11 @@ namespace System.Net.Sockets
             }
         }
 
+        public static void SetIPProtectionLevel(Socket socket, SocketOptionLevel optionLevel, int protectionLevel)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public static unsafe SocketError GetSockOpt(SafeCloseSocket handle, SocketOptionLevel optionLevel, SocketOptionName optionName, out int optionValue)
         {
             if (optionLevel == SocketOptionLevel.Socket)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -492,6 +492,11 @@ namespace System.Net.Sockets
             return errorCode == SocketError.SocketError ? GetLastSocketError() : SocketError.Success;
         }
 
+        public static void SetIPProtectionLevel(Socket socket, SocketOptionLevel optionLevel, int protectionLevel)
+        {
+            socket.SetSocketOption(optionLevel, SocketOptionName.IPProtectionLevel, protectionLevel);
+        }
+
         public static SocketError GetSockOpt(SafeCloseSocket handle, SocketOptionLevel optionLevel, SocketOptionName optionName, out int optionValue)
         {
             int optionLength = 4; // sizeof(int)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -130,14 +130,7 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.net_tcplistener_mustbestopped);
             }
 
-            if (allowed)
-            {
-                _serverSocket.SetIPProtectionLevel(IPProtectionLevel.Unrestricted);
-            }
-            else
-            {
-                _serverSocket.SetIPProtectionLevel(IPProtectionLevel.EdgeRestricted);
-            }
+            _serverSocket.SetIPProtectionLevel(allowed ? IPProtectionLevel.Unrestricted : IPProtectionLevel.EdgeRestricted);
         }
 
         // Starts listening to network requests.

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -123,6 +123,23 @@ namespace System.Net.Sockets
             }
         }
 
+        public void AllowNatTraversal(bool allowed)
+        {
+            if (_active)
+            {
+                throw new InvalidOperationException(SR.net_tcplistener_mustbestopped);
+            }
+
+            if (allowed)
+            {
+                _serverSocket.SetIPProtectionLevel(IPProtectionLevel.Unrestricted);
+            }
+            else
+            {
+                _serverSocket.SetIPProtectionLevel(IPProtectionLevel.EdgeRestricted);
+            }
+        }
+
         // Starts listening to network requests.
         public void Start()
         {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -196,14 +196,7 @@ namespace System.Net.Sockets
 
         public void AllowNatTraversal(bool allowed)
         {
-            if (allowed)
-            {
-                _clientSocket.SetIPProtectionLevel(IPProtectionLevel.Unrestricted);
-            }
-            else
-            {
-                _clientSocket.SetIPProtectionLevel(IPProtectionLevel.EdgeRestricted);
-            }
+            _clientSocket.SetIPProtectionLevel(allowed ? IPProtectionLevel.Unrestricted : IPProtectionLevel.EdgeRestricted);
         }
 
         private bool _cleanedUp = false;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -194,6 +194,18 @@ namespace System.Net.Sockets
             }
         }
 
+        public void AllowNatTraversal(bool allowed)
+        {
+            if (allowed)
+            {
+                _clientSocket.SetIPProtectionLevel(IPProtectionLevel.Unrestricted);
+            }
+            else
+            {
+                _clientSocket.SetIPProtectionLevel(IPProtectionLevel.EdgeRestricted);
+            }
+        }
+
         private bool _cleanedUp = false;
         private void FreeResources()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/AgnosticListenerTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/AgnosticListenerTest.cs
@@ -112,6 +112,33 @@ namespace System.Net.Sockets.Tests
             listener.Stop();
         }
 
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void AllowNatTraversal_Windows()
+        {
+            var l = new TcpListener(IPAddress.Any, 0);
+            l.AllowNatTraversal(true);
+            Assert.Equal((int)IPProtectionLevel.Unrestricted, (int)l.Server.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPProtectionLevel));
+
+            l = new TcpListener(IPAddress.Any, 0);
+            l.AllowNatTraversal(false);
+            Assert.Equal((int)IPProtectionLevel.EdgeRestricted, (int)l.Server.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPProtectionLevel));
+        }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void AllowNatTraversal_AnyUnix()
+        {
+            var l = new TcpListener(IPAddress.Any, 0);
+            Assert.Throws<PlatformNotSupportedException>(() => l.AllowNatTraversal(true));
+
+            l = new TcpListener(IPAddress.Any, 0);
+            Assert.Throws<PlatformNotSupportedException>(() => l.AllowNatTraversal(false));
+        }
+
+
         #region GC Finalizer test
         // This test assumes sequential execution of tests and that it is going to be executed after other tests
         // that used Sockets.

--- a/src/System.Net.Sockets/tests/FunctionalTests/AgnosticListenerTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/AgnosticListenerTest.cs
@@ -113,29 +113,26 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
+        [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void AllowNatTraversal_Windows()
+        [InlineData(true, IPProtectionLevel.Unrestricted)]
+        [InlineData(false, IPProtectionLevel.EdgeRestricted)]
+        public void AllowNatTraversal_Windows(bool allow, IPProtectionLevel resultLevel)
         {
             var l = new TcpListener(IPAddress.Any, 0);
-            l.AllowNatTraversal(true);
-            Assert.Equal((int)IPProtectionLevel.Unrestricted, (int)l.Server.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPProtectionLevel));
-
-            l = new TcpListener(IPAddress.Any, 0);
-            l.AllowNatTraversal(false);
-            Assert.Equal((int)IPProtectionLevel.EdgeRestricted, (int)l.Server.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPProtectionLevel));
+            l.AllowNatTraversal(allow);
+            Assert.Equal((int)resultLevel, (int)l.Server.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPProtectionLevel));
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
+        [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public void AllowNatTraversal_AnyUnix()
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AllowNatTraversal_AnyUnix(bool allow)
         {
             var l = new TcpListener(IPAddress.Any, 0);
-            Assert.Throws<PlatformNotSupportedException>(() => l.AllowNatTraversal(true));
-
-            l = new TcpListener(IPAddress.Any, 0);
-            Assert.Throws<PlatformNotSupportedException>(() => l.AllowNatTraversal(false));
+            Assert.Throws<PlatformNotSupportedException>(() => l.AllowNatTraversal(allow));
         }
 
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -297,24 +297,19 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData(IPProtectionLevel.EdgeRestricted)]
-        [InlineData(IPProtectionLevel.Restricted)]
-        [InlineData(IPProtectionLevel.Unrestricted)]
-        public void SetIPProtectionLevel_Windows(IPProtectionLevel level)
+        [InlineData(IPProtectionLevel.EdgeRestricted, AddressFamily.InterNetwork, SocketOptionLevel.IP)]
+        [InlineData(IPProtectionLevel.Restricted, AddressFamily.InterNetwork, SocketOptionLevel.IP)]
+        [InlineData(IPProtectionLevel.Unrestricted, AddressFamily.InterNetwork, SocketOptionLevel.IP)]
+        [InlineData(IPProtectionLevel.EdgeRestricted, AddressFamily.InterNetworkV6, SocketOptionLevel.IPv6)]
+        [InlineData(IPProtectionLevel.Restricted, AddressFamily.InterNetworkV6, SocketOptionLevel.IPv6)]
+        [InlineData(IPProtectionLevel.Unrestricted, AddressFamily.InterNetworkV6, SocketOptionLevel.IPv6)]
+        public void SetIPProtectionLevel_Windows(IPProtectionLevel level, AddressFamily family, SocketOptionLevel optionLevel)
         {
-            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            using (var socket = new Socket(family, SocketType.Stream, ProtocolType.Tcp))
             {
                 socket.SetIPProtectionLevel(level);
 
-                int result = (int)socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPProtectionLevel);
-                Assert.Equal(result, (int)level);
-            }
-
-            using (var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
-            {
-                socket.SetIPProtectionLevel(level);
-
-                int result = (int)socket.GetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPProtectionLevel);
+                int result = (int)socket.GetSocketOption(optionLevel, SocketOptionName.IPProtectionLevel);
                 Assert.Equal(result, (int)level);
             }
         }
@@ -322,34 +317,29 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [InlineData(IPProtectionLevel.EdgeRestricted)]
-        [InlineData(IPProtectionLevel.Restricted)]
-        [InlineData(IPProtectionLevel.Unrestricted)]
-        public void SetIPProtectionLevel_Unix(IPProtectionLevel level)
+        [InlineData(IPProtectionLevel.EdgeRestricted, AddressFamily.InterNetwork)]
+        [InlineData(IPProtectionLevel.Restricted, AddressFamily.InterNetwork)]
+        [InlineData(IPProtectionLevel.Unrestricted, AddressFamily.InterNetwork)]
+        [InlineData(IPProtectionLevel.EdgeRestricted, AddressFamily.InterNetworkV6)]
+        [InlineData(IPProtectionLevel.Restricted, AddressFamily.InterNetworkV6)]
+        [InlineData(IPProtectionLevel.Unrestricted, AddressFamily.InterNetworkV6)]
+        public void SetIPProtectionLevel_Unix(IPProtectionLevel level, AddressFamily family)
         {
-            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            {
-                Assert.Throws<PlatformNotSupportedException>(() => socket.SetIPProtectionLevel(level));
-            }
-
-            using (var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
+            using (var socket = new Socket(family, SocketType.Stream, ProtocolType.Tcp))
             {
                 Assert.Throws<PlatformNotSupportedException>(() => socket.SetIPProtectionLevel(level));
             }
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SetIPProtectionLevel_ArgumentException()
+        [Theory]
+        [InlineData(AddressFamily.InterNetwork)]
+        [InlineData(AddressFamily.InterNetworkV6)]
+        public void SetIPProtectionLevel_ArgumentException(AddressFamily family)
         {
-            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            using (var socket = new Socket(family, SocketType.Stream, ProtocolType.Tcp))
             {
-                Assert.Throws<ArgumentException>(() => socket.SetIPProtectionLevel(IPProtectionLevel.Unspecified));
-            }
-
-            using (var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
-            {
-                Assert.Throws<ArgumentException>(() => socket.SetIPProtectionLevel(IPProtectionLevel.Unspecified));
+                Assert.Throws<ArgumentException>("level", () => socket.SetIPProtectionLevel(IPProtectionLevel.Unspecified));
             }
         }
     }

--- a/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -117,5 +117,39 @@ namespace System.Net.Sockets.Tests
             udpService.EndSend(ar);
             _waitHandle.Set();
         }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void AllowNatTraversal_Windows()
+        {
+            using (var c = new UdpClient())
+            {
+                c.AllowNatTraversal(true);
+                Assert.Equal((int)IPProtectionLevel.Unrestricted, (int)c.Client.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPProtectionLevel));
+            }
+
+            using (var c = new UdpClient())
+            {
+                c.AllowNatTraversal(false);
+                Assert.Equal((int)IPProtectionLevel.EdgeRestricted, (int)c.Client.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPProtectionLevel));
+            }
+        }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void AllowNatTraversal_AnyUnix()
+        {
+            using (var c = new UdpClient())
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => c.AllowNatTraversal(true));
+            }
+
+            using (var c = new UdpClient())
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => c.AllowNatTraversal(false));
+            }
+        }
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -119,36 +119,29 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
+        [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void AllowNatTraversal_Windows()
+        [InlineData(true, IPProtectionLevel.Unrestricted)]
+        [InlineData(false, IPProtectionLevel.EdgeRestricted)]
+        public void AllowNatTraversal_Windows(bool allow, IPProtectionLevel resultLevel)
         {
             using (var c = new UdpClient())
             {
-                c.AllowNatTraversal(true);
-                Assert.Equal((int)IPProtectionLevel.Unrestricted, (int)c.Client.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPProtectionLevel));
-            }
-
-            using (var c = new UdpClient())
-            {
-                c.AllowNatTraversal(false);
-                Assert.Equal((int)IPProtectionLevel.EdgeRestricted, (int)c.Client.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPProtectionLevel));
+                c.AllowNatTraversal(allow);
+                Assert.Equal((int)resultLevel, (int)c.Client.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPProtectionLevel));
             }
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
+        [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public void AllowNatTraversal_AnyUnix()
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AllowNatTraversal_AnyUnix(bool allow)
         {
             using (var c = new UdpClient())
             {
-                Assert.Throws<PlatformNotSupportedException>(() => c.AllowNatTraversal(true));
-            }
-
-            using (var c = new UdpClient())
-            {
-                Assert.Throws<PlatformNotSupportedException>(() => c.AllowNatTraversal(false));
+                Assert.Throws<PlatformNotSupportedException>(() => c.AllowNatTraversal(allow));
             }
         }
     }


### PR DESCRIPTION
Fixes #12462 

Add Socket.SetIPProtectionLevel.  Not supported on Unix (throws PlatformNotSupportedException)
Add UdpClient.AllowNatTraversal and TcpListener.AllowNatTraversal which use this.
