### PR TITLE
Enable DTFI & NFI netstandard 1.7 tests

### DIFF
--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoTests.netstandard1.7.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoTests.netstandard1.7.cs
@@ -34,7 +34,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(11611, TestPlatforms.AnyUnix)]
         public void SeparatorsTest()
         {
             DateTimeFormatInfo dtfi = (DateTimeFormatInfo) CultureInfo.InvariantCulture.DateTimeFormat.Clone();
@@ -60,9 +59,8 @@ namespace System.Globalization.Tests
             expectedFormattedString = formattedTime.Replace(timeSep, dtfi.TimeSeparator);
             Assert.Equal(expectedFormattedString, d.ToString("HH:mm:ss", dtfi));
         }
-
+        
         [Theory]
-        [ActiveIssue(11611, TestPlatforms.AnyUnix)]
         [MemberData(nameof(DateTimeFormatInfo_TestData))]
         public void NativeCalendarNameTest(DateTimeFormatInfo dtfi, Calendar calendar, string nativeCalendarName)
         {
@@ -71,15 +69,22 @@ namespace System.Globalization.Tests
                 dtfi.Calendar = calendar;
                 Assert.Equal(nativeCalendarName, dtfi.NativeCalendarName);
             }
-            catch 
+            catch
             {
-                // Persian calendar is recently supported as one of the optional calendars for fa-IR
-                Assert.True(calendar is PersianCalendar, "Exception can occur only with PersianCalendar");
+                if (PlatformDetection.IsWindows)
+                {
+                    // Persian calendar is recently supported as one of the optional calendars for fa-IR
+                    Assert.True(calendar is PersianCalendar, "Exception can occur only with PersianCalendar");
+                }
+                else // !PlatformDetection.IsWindows
+                {                 
+                    Assert.True(calendar is HijriCalendar || calendar is UmAlQuraCalendar || calendar is ThaiBuddhistCalendar || 
+                                calendar is HebrewCalendar || calendar is KoreanCalendar, "failed to set the calendar on DTFI");
+                }
             }
         }
 
         [Theory]
-        [ActiveIssue(11611, TestPlatforms.AnyUnix)]
         [MemberData(nameof(CultureNames_TestData))]
         public void AllDateTimePatternsTest(string cultureName)
         {
@@ -117,7 +122,6 @@ namespace System.Globalization.Tests
         }
 
         [Theory]
-        [ActiveIssue(11611, TestPlatforms.AnyUnix)]
         [MemberData(nameof(CultureNames_TestData))]
         public void ShortestDayNamesTest(string cultureName)
         {

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoTests.netstandard1.7.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoTests.netstandard1.7.cs
@@ -10,8 +10,64 @@ namespace System.Globalization.Tests
 {
     public class NumberFormatInfoMiscTests
     {
+        public static IEnumerable<object[]> DigitSubstitution_TestData()
+        {
+            yield return new object[] { "ar"        , DigitShapes.Context };
+            yield return new object[] { "ar-001"    , DigitShapes.Context };
+            yield return new object[] { "ar-AE"     , DigitShapes.Context };
+            yield return new object[] { "ar-BH"     , DigitShapes.Context };
+            yield return new object[] { "ar-DJ"     , DigitShapes.Context };
+            yield return new object[] { "ar-EG"     , DigitShapes.Context };
+            yield return new object[] { "ar-ER"     , DigitShapes.Context };
+            yield return new object[] { "ar-IL"     , DigitShapes.Context };
+            yield return new object[] { "ar-IQ"     , DigitShapes.Context };
+            yield return new object[] { "ar-JO"     , DigitShapes.Context };
+            yield return new object[] { "ar-KM"     , DigitShapes.Context };
+            yield return new object[] { "ar-KW"     , DigitShapes.Context };
+            yield return new object[] { "ar-LB"     , DigitShapes.Context };
+            yield return new object[] { "ar-MR"     , DigitShapes.Context };
+            yield return new object[] { "ar-OM"     , DigitShapes.Context };
+            yield return new object[] { "ar-PS"     , DigitShapes.Context };
+            yield return new object[] { "ar-QA"     , DigitShapes.Context };
+            yield return new object[] { "ar-SA"     , DigitShapes.Context };
+            yield return new object[] { "ar-SD"     , DigitShapes.Context };
+            yield return new object[] { "ar-SO"     , DigitShapes.Context };
+            yield return new object[] { "ar-SS"     , DigitShapes.Context };
+            yield return new object[] { "ar-SY"     , DigitShapes.Context };
+            yield return new object[] { "ar-TD"     , DigitShapes.Context };
+            yield return new object[] { "ar-YE"     , DigitShapes.Context };
+            yield return new object[] { "dz"        , DigitShapes.NativeNational };
+            yield return new object[] { "dz-BT"     , DigitShapes.NativeNational };
+            yield return new object[] { "fa"        , DigitShapes.Context };
+            yield return new object[] { "fa-IR"     , DigitShapes.Context };
+            yield return new object[] { "km"        , DigitShapes.NativeNational };
+            yield return new object[] { "km-KH"     , DigitShapes.NativeNational };
+            yield return new object[] { "ks"        , DigitShapes.NativeNational };
+            yield return new object[] { "ks-Arab"   , DigitShapes.NativeNational };
+            yield return new object[] { "ks-Arab-IN", DigitShapes.NativeNational };
+            yield return new object[] { "ku"        , DigitShapes.Context };
+            yield return new object[] { "ku-Arab"   , DigitShapes.Context };
+            yield return new object[] { "ku-Arab-IQ", DigitShapes.Context };
+            yield return new object[] { "my"        , DigitShapes.NativeNational };
+            yield return new object[] { "my-MM"     , DigitShapes.NativeNational };
+            yield return new object[] { "ne-IN"     , DigitShapes.NativeNational };
+            yield return new object[] { "nqo"       , DigitShapes.NativeNational };
+            yield return new object[] { "nqo-GN"    , DigitShapes.NativeNational };
+            yield return new object[] { "pa-Arab"   , DigitShapes.NativeNational };
+            yield return new object[] { "pa-Arab-PK", DigitShapes.NativeNational };
+            yield return new object[] { "prs"       , DigitShapes.NativeNational };
+            yield return new object[] { "prs-AF"    , DigitShapes.NativeNational };
+            yield return new object[] { "ps"        , DigitShapes.NativeNational };
+            yield return new object[] { "ps-AF"     , DigitShapes.NativeNational };
+            yield return new object[] { "sd"        , DigitShapes.NativeNational };
+            yield return new object[] { "sd-Arab"   , DigitShapes.NativeNational };
+            yield return new object[] { "sd-Arab-PK", DigitShapes.NativeNational };
+            yield return new object[] { "ur-IN"     , DigitShapes.NativeNational };
+            yield return new object[] { "uz-Arab"   , DigitShapes.NativeNational };
+            yield return new object[] { "uz-Arab-AF", DigitShapes.NativeNational };
+        }
+        
         [Fact]
-        [ActiveIssue(11612, TestPlatforms.AnyUnix)]
         public void DigitSubstitutionTest()
         {
             // DigitSubstitution is not used in number formatting.
@@ -19,7 +75,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(11612, TestPlatforms.AnyUnix)]
         public void NativeDigitsTest()
         {
             string [] nativeDigits = CultureInfo.InvariantCulture.NumberFormat.NativeDigits;
@@ -31,5 +86,21 @@ namespace System.Globalization.Tests
 
             Assert.Equal(newDigits, nfi.NativeDigits);
         }
+        
+        [Theory]
+        [MemberData(nameof(DigitSubstitution_TestData))]
+        public void DigitSubstitutionListTest(string cultureName, DigitShapes shape)
+        {
+            try
+            {
+                CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
+                Assert.Equal(ci.NumberFormat.DigitSubstitution, shape);
+            }
+            catch (CultureNotFoundException)
+            {
+                // ignore the cultures that we cannot create as it is not supported on the platforms
+            }
+        }
+        
     }
 }

--- a/src/System.Text.Encoding.Extensions/ref/System.Text.Encoding.Extensions.cs
+++ b/src/System.Text.Encoding.Extensions/ref/System.Text.Encoding.Extensions.cs
@@ -44,10 +44,22 @@ namespace System.Text
         public UnicodeEncoding(bool bigEndian, bool byteOrderMark, bool throwOnInvalidBytes) { }
         public override bool Equals(object value) { throw null; }
         public override int GetByteCount(char[] chars, int index, int count) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        [System.Security.SecurityCriticalAttribute]
+        public unsafe override int GetByteCount(char* chars, int count) { throw null; }
         public override int GetByteCount(string s) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        [System.Security.SecurityCriticalAttribute]
+        public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         public override int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        [System.Security.SecurityCriticalAttribute]
+        public unsafe override int GetCharCount(byte* bytes, int count) { throw null; }
         public override int GetCharCount(byte[] bytes, int index, int count) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        [System.Security.SecurityCriticalAttribute]
+        public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) { throw null; }
         public override System.Text.Decoder GetDecoder() { throw null; }
         public override System.Text.Encoder GetEncoder() { throw null; }


### PR DESCRIPTION
This change also include adding the missing APIs in the System.Text.Encoding.Extensions contract