### PR TITLE
Updating System.Console's project files

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -687,7 +687,6 @@
       ],
       "BaselineVersion": "4.4.0",
       "AssemblyVersionInPackageVersion": {
-        "4.0.1.0": "4.4.0",
         "4.1.0.0": "4.4.0"
       }
     },
@@ -770,7 +769,6 @@
       ],
       "BaselineVersion": "4.4.0",
       "AssemblyVersionInPackageVersion": {
-        "4.0.1.0": "4.4.0",
         "4.1.0.0": "4.4.0"
       }
     },
@@ -1042,9 +1040,8 @@
       ],
       "BaselineVersion": "4.4.0",
       "AssemblyVersionInPackageVersion": {
-        "4.0.0.0": "4.0.0",
-        "4.0.1.0": "4.4.0",
-        "4.1.0.0": "4.4.0"
+        "4.1.0.0": "4.4.0",
+        "4.0.0.0": "4.4.0"
       }
     },
     "System.Data.Common": {

--- a/src/System.Console/pkg/System.Console.pkgproj
+++ b/src/System.Console/pkg/System.Console.pkgproj
@@ -6,9 +6,6 @@
       <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Console.csproj">
-      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
-    </ProjectReference>
-    <ProjectReference Include="..\src\System.Console.csproj">
       <AdditionalProperties>TargetGroup=net463</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="win\System.Console.pkgproj" />

--- a/src/System.Console/pkg/unix/System.Console.pkgproj
+++ b/src/System.Console/pkg/unix/System.Console.pkgproj
@@ -10,10 +10,6 @@
     <ProjectReference Include="..\..\src\System.Console.csproj" >
       <OSGroup>Unix</OSGroup>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\System.Console.csproj" >
-      <OSGroup>Unix</OSGroup>
-      <TargetGroup>netstandard1.3</TargetGroup>
-    </ProjectReference>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Console/pkg/win/System.Console.pkgproj
+++ b/src/System.Console/pkg/win/System.Console.pkgproj
@@ -11,14 +11,6 @@
     <ProjectReference Include="..\..\src\System.Console.csproj" >
       <OSGroup>Windows_NT</OSGroup>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\System.Console.csproj" >
-      <OSGroup>Windows_NT</OSGroup>
-      <TargetGroup>netstandard1.3</TargetGroup>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\System.Console.csproj" >
-      <OSGroup>Windows_NT</OSGroup>
-      <TargetGroup>netcore50</TargetGroup>
-    </ProjectReference>
     <ExternalOnTargetFramework Include="net" />
   </ItemGroup>
 

--- a/src/System.Console/src/System.Console.builds
+++ b/src/System.Console/src/System.Console.builds
@@ -9,22 +9,7 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.Console.csproj">
-      <OSGroup>Unix</OSGroup>
-      <TargetGroup>netstandard1.3</TargetGroup>
-    </Project>
-    <Project Include="System.Console.csproj">
-      <OSGroup>Windows_NT</OSGroup>
-      <TargetGroup>netstandard1.3</TargetGroup>
-    </Project>
-    <Project Include="System.Console.csproj">
-      <TargetGroup>net46</TargetGroup>
-    </Project>
-    <Project Include="System.Console.csproj">
       <TargetGroup>net463</TargetGroup>
-    </Project>
-    <Project Include="System.Console.csproj">
-      <OSGroup>Windows_NT</OSGroup>
-      <TargetGroup>netcore50</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -8,13 +8,11 @@
     <ProjectGuid>{F9DF2357-81B4-4317-908E-512DA9395583}</ProjectGuid>
     <RootNamespace>System.Console</RootNamespace>
     <AssemblyName>System.Console</AssemblyName>
-    <AssemblyVersion Condition="'$(TargetGroup)'=='netstandard1.3' OR '$(TargetGroup)'=='net46' OR '$(TargetGroup)'=='netcore50'">4.0.1.0</AssemblyVersion>
-    <ContractProject Condition="'$(AssemblyVersion)'=='4.0.1.0'">../ref/4.0.0/System.Console.depproj</ContractProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.3'">
+  <ItemGroup Condition="'$(TargetGroup)'!='net463'">
     <AdditionalFiles Include="$(ToolsDir)PinvokeAnalyzer_OneCoreApis.txt" />
   </ItemGroup>
   <!-- Help VS understand available configurations -->
@@ -22,17 +20,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard1.3_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_netstandard1.3_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard1.3_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netstandard1.3_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetGroup)' != 'net463'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
     <Compile Include="System\Console.cs" />
     <Compile Include="System\ConsoleCancelEventArgs.cs" />
     <Compile Include="System\ConsoleColor.cs" />
@@ -51,12 +41,13 @@
       <Link>Common\System\IO\EncodingHelper.cs</Link>
     </Compile>
   </ItemGroup>
-  <!-- Windows : UAP -->
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'netcore50' ">
+  <!-- Windows : UAP 
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'uap101aot' ">
     <Compile Include="System\ConsolePal.Uap.cs" />
-  </ItemGroup>
+  </ItemGroup> 
+  -->
   <!-- Windows : Win32 -->
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And ('$(TargetGroup)' == '' OR '$(TargetGroup)'=='netstandard1.3')">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' And '$(TargetGroup)' == ''">
     <Compile Include="System\ConsolePal.Windows.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
@@ -168,7 +159,7 @@
     </Compile>
   </ItemGroup>
   <!-- Unix -->
-  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And ('$(TargetGroup)' == '' OR '$(TargetGroup)'=='netstandard1.3')">
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And '$(TargetGroup)' == ''"> 
     <Compile Include="System\ConsolePal.Unix.cs" />
     <Compile Include="System\TermInfo.cs" />
     <Compile Include="System\IO\StdInReader.cs" />
@@ -264,12 +255,7 @@
       <Link>Common\Interop\Unix\Interop.StdinReady.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.3' Or '$(TargetGroup)' == 'netcore50'">
-    <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
-      <Link>Common\System\SerializableAttribute.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net463'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Console/src/project.json
+++ b/src/System.Console/src/project.json
@@ -1,24 +1,5 @@
 {
   "frameworks": {
-    "netstandard1.3": {
-      "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1",
-        "System.Collections": "4.0.11",
-        "System.Diagnostics.Contracts": "4.0.1",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.Diagnostics.Tools": "4.0.1",
-        "System.IO": "4.1.0",
-        "System.IO.FileSystem.Primitives": "4.0.1",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime": "4.1.0",
-        "System.Runtime.Extensions": "4.1.0",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Text.Encoding": "4.0.11",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading": "4.0.11",
-        "System.Threading.Tasks": "4.0.11"
-      }
-    },
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
@@ -38,27 +19,9 @@
         "System.Threading.Tasks": "4.4.0-beta-24625-01"
       }
     },
-    "net46": {
-      "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
-      }
-    },
     "net463": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
-      }
-    },
-    "netcore50": {
-      "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1",
-        "System.Diagnostics.Contracts": "4.0.1",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.IO.FileSystem.Primitives": "4.0.1",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading": "4.0.11",
-        "System.Threading.Tasks": "4.0.11"
       }
     }
   }


### PR DESCRIPTION
We have added new APIs to Console and marked it as NS1.7. However we're still compiling it for NS1.3. Indeed, we're compiling System.Console for NS1.3 and NS1.7 the same way. That sounds fishy. I'm guessing that project files were not updated accordingly. I think the right thing to do is to harvest those assets from stable versions. 

@stephentoub, @weshaggard, PTAL 
/cc @dotnet/corert-contrib 