### PR TITLE
Fixing more XML doc comments in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
@@ -110,7 +110,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Break, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, and a null value to be passed to the target label upon jumping.
         /// </returns>
         public static GotoExpression Break(LabelTarget target)
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Break, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
         /// </returns>
@@ -137,9 +137,9 @@ namespace System.Linq.Expressions
         /// Creates a <see cref="GotoExpression"/> representing a break statement with the specified type.
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
-        /// <param name="type">An <see cref="Type"/> to set the <see cref="Type"/> property equal to.</param>
+        /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Break, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
         /// and the <see cref="Type"/> property set to <paramref name="type"/>.
         /// </returns>
@@ -154,9 +154,9 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
-        /// <param name="type">An <see cref="Type"/> to set the <see cref="Type"/> property equal to.</param>
+        /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Break, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
@@ -171,7 +171,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Continue, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Continue"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
         /// and a null value to be passed to the target label upon jumping.
         /// </returns>
@@ -184,9 +184,9 @@ namespace System.Linq.Expressions
         /// Creates a <see cref="GotoExpression"/> representing a continue statement with the specified type.
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
-        /// <param name="type">An <see cref="Type"/> to set the <see cref="Type"/> property equal to.</param>
+        /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Continue, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Continue"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and a null value to be passed to the target label upon jumping.
@@ -201,7 +201,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Return, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
         /// and a null value to be passed to the target label upon jumping.
         /// </returns>
@@ -214,9 +214,9 @@ namespace System.Linq.Expressions
         /// Creates a <see cref="GotoExpression"/> representing a return statement with the specified type.
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
-        /// <param name="type">An <see cref="Type"/> to set the <see cref="Type"/> property equal to.</param>
+        /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Return, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and a null value to be passed to the target label upon jumping.
@@ -232,7 +232,7 @@ namespace System.Linq.Expressions
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Continue, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
         /// </returns>
@@ -247,9 +247,9 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
-        /// <param name="type">An <see cref="Type"/> to set the <see cref="Type"/> property equal to.</param>
+        /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Continue, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
@@ -264,7 +264,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Goto, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to the specified value, 
         /// and a null value to be passed to the target label upon jumping.
         /// </returns>
@@ -277,9 +277,9 @@ namespace System.Linq.Expressions
         /// Creates a <see cref="GotoExpression"/> representing a goto with the specified type.
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
-        /// <param name="type">An <see cref="Type"/> to set the <see cref="Type"/> property equal to.</param>
+        /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Goto, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to the specified value, 
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and a null value to be passed to the target label upon jumping.
@@ -295,7 +295,7 @@ namespace System.Linq.Expressions
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Goto, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
         /// </returns>
@@ -310,9 +310,9 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
-        /// <param name="type">An <see cref="Type"/> to set the <see cref="Type"/> property equal to.</param>
+        /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to Goto, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
@@ -329,7 +329,7 @@ namespace System.Linq.Expressions
         /// <param name="kind">The <see cref="GotoExpressionKind"/> of the <see cref="GotoExpression"/>.</param>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
-        /// <param name="type">An <see cref="Type"/> to set the <see cref="Type"/> property equal to.</param>
+        /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
         /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <paramref name="kind"/>, 
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IArgumentProvider.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IArgumentProvider.cs
@@ -5,35 +5,42 @@
 namespace System.Linq.Expressions
 {
     /// <summary>
-    /// Interface for accessing the arguments of multiple tree nodes (DynamicExpression, ElementInit,
-    /// MethodCallExpression, InvocationExpression, NewExpression, and IndexExpression).
+    /// Interface for accessing the arguments of multiple tree nodes (<see cref="IDynamicExpression"/>,
+    /// <see cref="ElementInit"/>, <see cref="MethodCallExpression"/>, <see cref="InvocationExpression"/>,
+    /// <see cref="NewExpression"/>, and <see cref="IndexExpression"/>).
     /// </summary>
     /// <remarks>
     /// This enables two optimizations which reduce the size of the trees.  The first is it enables
-    /// the nodes to hold onto an IList of T instead of a ReadOnlyCollection.  This saves the cost
-    /// of allocating the ReadOnlyCollection for each node.  The second is that it enables specialized
-    /// subclasses to be created which hold onto a specific number of arguments.  For example Block2,
-    /// Block3, Block4.  These nodes can therefore avoid allocating both a ReadOnlyCollection and an
-    /// array for storing their elements saving 32 bytes per node.
+    /// the nodes to hold onto an <see cref="Collections.Generic.IList{T}"/> instead of a
+    /// <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/>.  This saves the cost of allocating
+    /// the read-only collection for each node.  The second is that it enables specialized subclasses to be
+    /// created which hold onto a specific number of arguments.  These nodes can therefore avoid allocating
+    /// both a <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/> and an array for storing their
+    /// elements, thus saving 32 bytes per node.  This technique is used by various nodes including
+    /// <see cref="BlockExpression"/>, <see cref="InvocationExpression"/>, <see cref="MethodCallExpression"/>.
     /// 
-    /// Meanwhile the nodes can continue to expose the original LINQ properties of ReadOnlyCollections.  They
-    /// do this by re-using 1 field for storing both the array or an element that would normally be stored
-    /// in the array.  
+    /// Meanwhile the nodes can expose properties of <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/>s.
+    /// They do this by re-using one field for storing both the array or an element that would normally be stored
+    /// in the array.
     /// 
-    /// For the array case the collection is typed to IList of T instead of ReadOnlyCollection of T.
-    /// When the node is initially constructed it is an array.  When the compiler accesses the members it
-    /// uses this interface.  If a user accesses the members the array is promoted to a ReadOnlyCollection.
+    /// For the array case the collection is typed to <see cref="Collections.Generic.IList{T}"/> instead
+    /// of <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/>. When the node is initially constructed
+    /// it is an array.  When utilities in this library access the arguments it uses this interface. If a user
+    /// accesses the property the array is promoted to a <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/>.
     /// 
-    /// For the object case we store the 1st argument in a field typed to object and when the node is initially
-    /// constructed this holds directly onto the Expression.  When the compiler accesses the members
-    /// it again uses this interface and the accessor for the 1st argument uses Expression.ReturnObject to
-    /// return the object which handles the Expression or ReadOnlyCollection case.  When the user accesses
-    /// the ReadOnlyCollection then the object field is updated to hold directly onto the ReadOnlyCollection.
+    /// For the object case we store the first argument in a field typed to <see cref="object"/> and when
+    /// the node is initially constructed this holds directly onto the <see cref="Expression"/> of the
+    /// first argument.  When utilities in this library access the arguments it again uses this interface
+    /// and the accessor for the first argument uses <see cref="Expression.ReturnObject"/> to return the object
+    /// which handles the <see cref="Expression"/> or <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/> case.
+    /// When the user accesses the property the object field is updated to hold directly onto the
+    /// <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/>.
     /// 
-    /// It is important that the Expressions consistently return the same ReadOnlyCollection otherwise the
-    /// re-writer will be broken and it would be a breaking change from LINQ v1.  The problem is that currently
-    /// users can rely on object identity to tell if the node has changed.  Storing the readonly collection in 
-    /// an overloaded field enables us to both reduce memory usage as well as maintain compatibility and an 
+    /// It is important that <see cref="Expression"/> properties consistently return the same 
+    /// <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/> otherwise the rewriter used by expression
+    /// visitors will be broken and it would be a breaking change from LINQ v1.  The problem is that currently
+    /// users can rely on object identity to tell if the node has changed.  Storing the read-only collection in
+    /// an overloaded field enables us to both reduce memory usage as well as maintain compatibility and an
     /// easy to use external API.
     /// </remarks>
     public interface IArgumentProvider

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -351,7 +351,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="LambdaExpression.Body"/> property equal to.</param>
         /// <param name="parameters">An array that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Expression body, params ParameterExpression[] parameters)
         {
             return Lambda(body, false, (IEnumerable<ParameterExpression>)parameters);
@@ -363,7 +363,7 @@ namespace System.Linq.Expressions
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="LambdaExpression.Body"/> property equal to.</param>
         /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An array that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Expression body, bool tailCall, params ParameterExpression[] parameters)
         {
             return Lambda(body, tailCall, (IEnumerable<ParameterExpression>)parameters);
@@ -374,7 +374,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="LambdaExpression.Body"/> property equal to.</param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Expression body, IEnumerable<ParameterExpression> parameters)
         {
             return Lambda(body, null, false, parameters);
@@ -386,7 +386,7 @@ namespace System.Linq.Expressions
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="LambdaExpression.Body"/> property equal to.</param>
         /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Expression body, bool tailCall, IEnumerable<ParameterExpression> parameters)
         {
             return Lambda(body, null, tailCall, parameters);
@@ -398,7 +398,7 @@ namespace System.Linq.Expressions
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="LambdaExpression.Body"/> property equal to.</param>
         /// <param name="parameters">An array that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <param name="delegateType">A <see cref="Type"/> representing the delegate signature for the lambda.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Type delegateType, Expression body, params ParameterExpression[] parameters)
         {
             return Lambda(delegateType, body, null, false, parameters);
@@ -411,7 +411,7 @@ namespace System.Linq.Expressions
         /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An array that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <param name="delegateType">A <see cref="Type"/> representing the delegate signature for the lambda.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Type delegateType, Expression body, bool tailCall, params ParameterExpression[] parameters)
         {
             return Lambda(delegateType, body, null, tailCall, parameters);
@@ -423,7 +423,7 @@ namespace System.Linq.Expressions
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="LambdaExpression.Body"/> property equal to.</param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <param name="delegateType">A <see cref="Type"/> representing the delegate signature for the lambda.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Type delegateType, Expression body, IEnumerable<ParameterExpression> parameters)
         {
             return Lambda(delegateType, body, null, false, parameters);
@@ -436,7 +436,7 @@ namespace System.Linq.Expressions
         /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <param name="delegateType">A <see cref="Type"/> representing the delegate signature for the lambda.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Type delegateType, Expression body, bool tailCall, IEnumerable<ParameterExpression> parameters)
         {
             return Lambda(delegateType, body, null, tailCall, parameters);
@@ -448,7 +448,7 @@ namespace System.Linq.Expressions
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="LambdaExpression.Body"/> property equal to.</param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <param name="name">The name for the lambda. Used for emitting debug information.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Expression body, string name, IEnumerable<ParameterExpression> parameters)
         {
             return Lambda(body, name, false, parameters);
@@ -461,7 +461,7 @@ namespace System.Linq.Expressions
         /// <param name="name">The name for the lambda. Used for emitting debug information.</param>
         /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Expression body, string name, bool tailCall, IEnumerable<ParameterExpression> parameters)
         {
             ContractUtils.RequiresNotNull(body, nameof(body));
@@ -498,7 +498,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <param name="name">The name for the lambda. Used for emitting debug information.</param>
         /// <param name="delegateType">A <see cref="Type"/> representing the delegate signature for the lambda.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Type delegateType, Expression body, string name, IEnumerable<ParameterExpression> parameters)
         {
             ReadOnlyCollection<ParameterExpression> paramList = parameters.ToReadOnly();
@@ -515,7 +515,7 @@ namespace System.Linq.Expressions
         /// <param name="name">The name for the lambda. Used for emitting debug information.</param>
         /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
-        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to Lambda and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Type delegateType, Expression body, string name, bool tailCall, IEnumerable<ParameterExpression> parameters)
         {
             ReadOnlyCollection<ParameterExpression> paramList = parameters.ToReadOnly();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -177,7 +177,7 @@ namespace System.Linq.Expressions
         /// </returns>
         /// <remarks>
         /// The <see cref="Type"/> property of <paramref name="newExpression"/> must represent a type that implements <see cref="Collections.IEnumerable"/>. 
-        /// The <see cref="Type"/> property of the resulting <see cref="ListInitExpression"/> is equal to newExpression.Type. 
+        /// The <see cref="Type"/> property of the resulting <see cref="ListInitExpression"/> is equal to <paramref name="newExpression"/>.Type.
         /// </remarks>
         public static ListInitExpression ListInit(NewExpression newExpression, params ElementInit[] initializers)
         {
@@ -192,7 +192,7 @@ namespace System.Linq.Expressions
         /// <returns>An <see cref="IEnumerable{T}"/> that contains <see cref="Expressions.ElementInit"/> objects to use to populate the <see cref="ListInitExpression.Initializers"/> collection.</returns>
         /// <remarks>
         /// The <see cref="Type"/> property of <paramref name="newExpression"/> must represent a type that implements <see cref="Collections.IEnumerable"/>. 
-        /// The <see cref="Type"/> property of the resulting <see cref="ListInitExpression"/> is equal to newExpression.Type. 
+        /// The <see cref="Type"/> property of the resulting <see cref="ListInitExpression"/> is equal to <paramref name="newExpression"/>.Type.
         /// </remarks>
         public static ListInitExpression ListInit(NewExpression newExpression, IEnumerable<ElementInit> initializers)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/IQueryable.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/IQueryable.cs
@@ -14,12 +14,12 @@ namespace System.Linq
     public interface IQueryable : IEnumerable
     {
         /// <summary>
-        /// Gets the expression tree that is associated with the instance of IQueryable.
+        /// Gets the expression tree that is associated with the instance of <see cref="IQueryable"/>.
         /// </summary>
         Expression Expression { get; }
 
         /// <summary>
-        /// Gets the type of the element(s) that are returned when the expression tree associated with this instance of IQueryable is executed.
+        /// Gets the type of the element(s) that are returned when the expression tree associated with this instance of <see cref="IQueryable"/> is executed.
         /// </summary>
         Type ElementType { get; }
 
@@ -41,7 +41,7 @@ namespace System.Linq
     /// Defines methods to create and execute queries that are described by an <see cref="IQueryable"/> object.
     /// </summary>
     /// <remarks>
-    /// The IQueryProvider interface is intended for implementation by query providers.
+    /// The <see cref="IQueryProvider"/> interface is intended for implementation by query providers.
     /// </remarks>
     public interface IQueryProvider
     {
@@ -62,7 +62,7 @@ namespace System.Linq
         /// <param name="expression">An expression tree that represents a LINQ query.</param>
         /// <returns>An <see cref="IQueryable{T}"/> that can evaluate the query represented by the specified expression tree.</returns>
         /// <remarks>
-        /// The CreateQuery{TElement} method is used to create new <see cref="IQueryable{T}"/> objects, given an expression tree. The query that is represented by the returned object is associated with a specific LINQ provider.
+        /// The <see cref="CreateQuery{TElement}"/> method is used to create new <see cref="IQueryable{T}"/> objects, given an expression tree. The query that is represented by the returned object is associated with a specific LINQ provider.
         /// Most of the Queryable standard query operator methods that return enumerable results call this method.They pass it a <see cref="MethodCallExpression"/> that represents a LINQ query.
         /// </remarks>
         IQueryable<TElement> CreateQuery<TElement>(Expression expression);
@@ -73,7 +73,7 @@ namespace System.Linq
         /// <param name="expression">An expression tree that represents a LINQ query.</param>
         /// <returns>The value that results from executing the specified query.</returns>
         /// <remarks>
-        /// The Execute method executes queries that return a single value (instead of an enumerable sequence of values). Expression trees that represent queries that return enumerable results are executed when their associated <see cref="IQueryable"/> object is enumerated.
+        /// The <see cref="Execute"/> method executes queries that return a single value (instead of an enumerable sequence of values). Expression trees that represent queries that return enumerable results are executed when their associated <see cref="IQueryable"/> object is enumerated.
         /// </remarks>
         object Execute(Expression expression);
 
@@ -84,8 +84,8 @@ namespace System.Linq
         /// <param name="expression">An expression tree that represents a LINQ query.</param>
         /// <returns>The value that results from executing the specified query.</returns>
         /// <remarks>
-        /// The Execute{TResult} method executes queries that return a single value (instead of an enumerable sequence of values). Expression trees that represent queries that return enumerable results are executed when the <see cref="IQueryable{T}"/> object that contains the expression tree is enumerated.
-        /// The Queryable standard query operator methods that return singleton results call Execute{TResult}.They pass it a <see cref="MethodCallExpression"/> that represents a LINQ query.
+        /// The <see cref="Execute{TElement}"/> method executes queries that return a single value (instead of an enumerable sequence of values). Expression trees that represent queries that return enumerable results are executed when the <see cref="IQueryable{T}"/> object that contains the expression tree is enumerated.
+        /// The Queryable standard query operator methods that return singleton results call <see cref="Execute{TElement}"/>. They pass it a <see cref="MethodCallExpression"/> that represents a LINQ query.
         /// </remarks>
         TResult Execute<TResult>(Expression expression);
     }


### PR DESCRIPTION
Addressing some code review feedback from the previous PR on fixing XML doc comments. Also fixing a few other places where comments were wrong.

CC @stephentoub