### PR TITLE
Using read-only properties in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -443,7 +443,7 @@ namespace System.Linq.Expressions
             _body = body;
         }
 
-        protected IList<Expression> Body => _body;
+        protected IList<Expression> Body { get;}
 
         internal override Expression GetExpression(int index)
         {
@@ -474,15 +474,13 @@ namespace System.Linq.Expressions
 
     internal sealed class ScopeWithType : ScopeN
     {
-        private readonly Type _type;
-
         internal ScopeWithType(IList<ParameterExpression> variables, IList<Expression> expressions, Type type)
             : base(variables, expressions)
         {
-            _type = type;
+            Type = type;
         }
 
-        public sealed override Type Type => _type;
+        public sealed override Type Type { get; }
 
         internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
         {
@@ -490,12 +488,12 @@ namespace System.Linq.Expressions
             {
                 Debug.Assert(variables.Count == Variables.Count);
                 ValidateVariables(variables, nameof(variables));
-                return new ScopeWithType(variables, Body, _type);
+                return new ScopeWithType(variables, Body, Type);
             }
             Debug.Assert(args.Length == ExpressionCount);
             Debug.Assert(variables == null || variables.Count == Variables.Count);
 
-            return new ScopeWithType(ReuseOrValidateVariables(variables), args, _type);
+            return new ScopeWithType(ReuseOrValidateVariables(variables), args, Type);
         }
     }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
@@ -14,38 +14,33 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(Expression.CatchBlockProxy))]
     public sealed class CatchBlock
     {
-        private readonly Type _test;
-        private readonly ParameterExpression _var;
-        private readonly Expression _body;
-        private readonly Expression _filter;
-
         internal CatchBlock(Type test, ParameterExpression variable, Expression body, Expression filter)
         {
-            _test = test;
-            _var = variable;
-            _body = body;
-            _filter = filter;
+            Test = test;
+            Variable = variable;
+            Body = body;
+            Filter = filter;
         }
 
         /// <summary>
         /// Gets a reference to the <see cref="Exception"/> object caught by this handler.
         /// </summary>
-        public ParameterExpression Variable => _var;
+        public ParameterExpression Variable { get; }
 
         /// <summary>
         /// Gets the type of <see cref="Exception"/> this handler catches.
         /// </summary>
-        public Type Test => _test;
+        public Type Test { get; }
 
         /// <summary>
         /// Gets the body of the catch block.
         /// </summary>
-        public Expression Body => _body;
+        public Expression Body { get; }
 
         /// <summary>
         /// Gets the body of the <see cref="CatchBlock"/>'s filter.
         /// </summary>
-        public Expression Filter => _filter;
+        public Expression Filter { get; }
 
         /// <summary>
         /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>. 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
@@ -15,13 +15,10 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(ConditionalExpressionProxy))]
     public class ConditionalExpression : Expression
     {
-        private readonly Expression _test;
-        private readonly Expression _true;
-
         internal ConditionalExpression(Expression test, Expression ifTrue)
         {
-            _test = test;
-            _true = ifTrue;
+            Test = test;
+            IfTrue = ifTrue;
         }
 
         internal static ConditionalExpression Make(Expression test, Expression ifTrue, Expression ifFalse, Type type)
@@ -56,12 +53,12 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the test of the conditional operation.
         /// </summary>
-        public Expression Test => _test;
+        public Expression Test { get; }
 
         /// <summary>
         /// Gets the expression to execute if the test evaluates to true.
         /// </summary>
-        public Expression IfTrue => _true;
+        public Expression IfTrue { get; }
 
         /// <summary>
         /// Gets the expression to execute if the test evaluates to false.
@@ -116,15 +113,13 @@ namespace System.Linq.Expressions
 
     internal sealed class FullConditionalExpressionWithType : FullConditionalExpression
     {
-        private readonly Type _type;
-
         internal FullConditionalExpressionWithType(Expression test, Expression ifTrue, Expression ifFalse, Type type)
             : base(test, ifTrue, ifFalse)
         {
-            _type = type;
+            Type = type;
         }
 
-        public sealed override Type Type => _type;
+        public sealed override Type Type { get; }
     }
 
     public partial class Expression

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
@@ -14,11 +14,9 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(ConstantExpressionProxy))]
     public class ConstantExpression : Expression
     {
-        private readonly object _value;
-
         internal ConstantExpression(object value)
         {
-            _value = value;
+            Value = value;
         }
 
         /// <summary>
@@ -29,12 +27,12 @@ namespace System.Linq.Expressions
         {
             get
             {
-                if (_value == null)
+                if (Value == null)
                 {
                     return typeof(object);
                 }
 
-                return _value.GetType();
+                return Value.GetType();
             }
         }
 
@@ -48,7 +46,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the value of the constant expression.
         /// </summary>
-        public object Value => _value;
+        public object Value { get; }
 
         /// <summary>
         /// Dispatches to the specific visit method for this node type.
@@ -61,15 +59,13 @@ namespace System.Linq.Expressions
 
     internal class TypedConstantExpression : ConstantExpression
     {
-        private readonly Type _type;
-
         internal TypedConstantExpression(object value, Type type)
             : base(value)
         {
-            _type = type;
+            Type = type;
         }
 
-        public sealed override Type Type => _type;
+        public sealed override Type Type { get; }
     }
 
     public partial class Expression

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
@@ -17,11 +17,9 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(DebugInfoExpressionProxy))]
     public class DebugInfoExpression : Expression
     {
-        private readonly SymbolDocumentInfo _document;
-
         internal DebugInfoExpression(SymbolDocumentInfo document)
         {
-            _document = document;
+            Document = document;
         }
 
         /// <summary>
@@ -75,7 +73,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the <see cref="SymbolDocumentInfo"/> that represents the source file.
         /// </summary>
-        public SymbolDocumentInfo Document => _document;
+        public SymbolDocumentInfo Document { get; }
 
         /// <summary>
         /// Gets the value to indicate if the <see cref="DebugInfoExpression"/> is for clearing a sequence point.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DefaultExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DefaultExpression.cs
@@ -13,18 +13,16 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(DefaultExpressionProxy))]
     public sealed class DefaultExpression : Expression
     {
-        private readonly Type _type;
-
         internal DefaultExpression(Type type)
         {
-            _type = type;
+            Type = type;
         }
 
         /// <summary>
         /// Gets the static type of the expression that this <see cref="Expression"/> represents.
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public sealed override Type Type => _type;
+        public sealed override Type Type { get; }
 
         /// <summary>
         /// Returns the node type of this Expression. Extension nodes should return

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
@@ -14,36 +14,33 @@ namespace System.Linq.Expressions
     /// </summary>
     public sealed class ElementInit : IArgumentProvider
     {
-        private MethodInfo _addMethod;
-        private ReadOnlyCollection<Expression> _arguments;
-
         internal ElementInit(MethodInfo addMethod, ReadOnlyCollection<Expression> arguments)
         {
-            _addMethod = addMethod;
-            _arguments = arguments;
+            AddMethod = addMethod;
+            Arguments = arguments;
         }
 
         /// <summary>
         /// Gets the <see cref="MethodInfo"/> used to add elements to the object.
         /// </summary>
-        public MethodInfo AddMethod => _addMethod;
+        public MethodInfo AddMethod { get; }
 
         /// <summary>
         /// Gets the list of elements to be added to the object.
         /// </summary>
-        public ReadOnlyCollection<Expression> Arguments => _arguments;
+        public ReadOnlyCollection<Expression> Arguments { get; }
 
         /// <summary>
         /// Gets the argument expression with the specified <paramref name="index"/>.
         /// </summary>
         /// <param name="index">The index of the argument expression to get.</param>
         /// <returns>The expression representing the argument at the specified <paramref name="index"/>.</returns>
-        public Expression GetArgument(int index) => _arguments[index];
+        public Expression GetArgument(int index) => Arguments[index];
 
         /// <summary>
         /// Gets the number of argument expressions of the node.
         /// </summary>
-        public int ArgumentCount => _arguments.Count;
+        public int ArgumentCount => Arguments.Count;
 
         /// <summary>
         /// Creates a <see cref="String"/> representation of the node.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
@@ -36,24 +36,19 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(GotoExpressionProxy))]
     public sealed class GotoExpression : Expression
     {
-        private readonly GotoExpressionKind _kind;
-        private readonly Expression _value;
-        private readonly LabelTarget _target;
-        private readonly Type _type;
-
         internal GotoExpression(GotoExpressionKind kind, LabelTarget target, Expression value, Type type)
         {
-            _kind = kind;
-            _value = value;
-            _target = target;
-            _type = type;
+            Kind = kind;
+            Value = value;
+            Target = target;
+            Type = type;
         }
 
         /// <summary>
         /// Gets the static type of the expression that this <see cref="Expression"/> represents. (Inherited from <see cref="Expression"/>.)
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public sealed override Type Type => _type;
+        public sealed override Type Type { get; }
 
         /// <summary>
         /// Returns the node type of this <see cref="Expression"/>. (Inherited from <see cref="Expression"/>.)
@@ -65,17 +60,17 @@ namespace System.Linq.Expressions
         /// The value passed to the target, or null if the target is of type
         /// System.Void.
         /// </summary>
-        public Expression Value => _value;
+        public Expression Value { get; }
 
         /// <summary>
         /// The target label where this node jumps to.
         /// </summary>
-        public LabelTarget Target => _target;
+        public LabelTarget Target { get; }
 
         /// <summary>
         /// The kind of the goto. For information purposes only.
         /// </summary>
-        public GotoExpressionKind Kind => _kind;
+        public GotoExpressionKind Kind { get; }
 
         /// <summary>
         /// Dispatches to the specific visit method for this node type.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -18,8 +18,6 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(IndexExpressionProxy))]
     public sealed class IndexExpression : Expression, IArgumentProvider
     {
-        private readonly Expression _instance;
-        private readonly PropertyInfo _indexer;
         private IList<Expression> _arguments;
 
         internal IndexExpression(
@@ -33,8 +31,8 @@ namespace System.Linq.Expressions
                 Debug.Assert(instance.Type.GetArrayRank() == arguments.Count);
             }
 
-            _instance = instance;
-            _indexer = indexer;
+            Object = instance;
+            Indexer = indexer;
             _arguments = arguments;
         }
 
@@ -52,23 +50,23 @@ namespace System.Linq.Expressions
         {
             get
             {
-                if (_indexer != null)
+                if (Indexer != null)
                 {
-                    return _indexer.PropertyType;
+                    return Indexer.PropertyType;
                 }
-                return _instance.Type.GetElementType();
+                return Object.Type.GetElementType();
             }
         }
 
         /// <summary>
         /// An object to index.
         /// </summary>
-        public Expression Object => _instance;
+        public Expression Object { get; }
 
         /// <summary>
         /// Gets the <see cref="PropertyInfo"/> for the property if the expression represents an indexed property, returns null otherwise.
         /// </summary>
-        public PropertyInfo Indexer => _indexer;
+        public PropertyInfo Indexer { get; }
 
         /// <summary>
         /// Gets the arguments to be used to index the property or array.
@@ -120,7 +118,7 @@ namespace System.Linq.Expressions
             Debug.Assert(instance != null);
             Debug.Assert(arguments == null || arguments.Length == _arguments.Count);
 
-            return Expression.MakeIndex(instance, _indexer, arguments ?? _arguments);
+            return Expression.MakeIndex(instance, Indexer, arguments ?? _arguments);
         }
     }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -17,20 +17,17 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(InvocationExpressionProxy))]
     public class InvocationExpression : Expression, IArgumentProvider
     {
-        private readonly Expression _lambda;
-        private readonly Type _returnType;
-
-        internal InvocationExpression(Expression lambda, Type returnType)
+        internal InvocationExpression(Expression expression, Type returnType)
         {
-            _lambda = lambda;
-            _returnType = returnType;
+            Expression = expression;
+            Type = returnType;
         }
 
         /// <summary>
         /// Gets the static type of the expression that this <see cref="Expression"/> represents.
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public sealed override Type Type => _returnType;
+        public sealed override Type Type { get; }
 
         /// <summary>
         /// Returns the node type of this Expression. Extension nodes should return
@@ -42,7 +39,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the delegate or lambda expression to be applied.
         /// </summary>
-        public Expression Expression => _lambda;
+        public Expression Expression { get; }
 
         /// <summary>
         /// Gets the arguments that the delegate or lambda expression is applied to.
@@ -114,9 +111,9 @@ namespace System.Linq.Expressions
         {
             get
             {
-                return (_lambda.NodeType == ExpressionType.Quote)
-                    ? (LambdaExpression)((UnaryExpression)_lambda).Operand
-                    : (_lambda as LambdaExpression);
+                return (Expression.NodeType == ExpressionType.Quote)
+                    ? (LambdaExpression)((UnaryExpression)Expression).Operand
+                    : (Expression as LambdaExpression);
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelExpression.cs
@@ -15,20 +15,17 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(LabelExpressionProxy))]
     public sealed class LabelExpression : Expression
     {
-        private readonly Expression _defaultValue;
-        private readonly LabelTarget _target;
-
         internal LabelExpression(LabelTarget label, Expression defaultValue)
         {
-            _target = label;
-            _defaultValue = defaultValue;
+            Target = label;
+            DefaultValue = defaultValue;
         }
 
         /// <summary>
         /// Gets the static type of the expression that this <see cref="Expression"/> represents. (Inherited from <see cref="Expression"/>.)
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public sealed override Type Type => _target.Type;
+        public sealed override Type Type => Target.Type;
 
         /// <summary>
         /// Returns the node type of this <see cref="Expression"/>. (Inherited from <see cref="Expression"/>.)
@@ -39,13 +36,13 @@ namespace System.Linq.Expressions
         /// <summary>
         /// The <see cref="LabelTarget"/> which this label is associated with.
         /// </summary>
-        public LabelTarget Target => _target;
+        public LabelTarget Target { get; }
 
         /// <summary>
         /// The value of the <see cref="LabelExpression"/> when the label is reached through
         /// normal control flow (e.g. is not jumped to).
         /// </summary>
-        public Expression DefaultValue => _defaultValue;
+        public Expression DefaultValue { get; }
 
         /// <summary>
         /// Dispatches to the specific visit method for this node type.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
@@ -11,27 +11,24 @@ namespace System.Linq.Expressions
     /// </summary>
     public sealed class LabelTarget
     {
-        private readonly Type _type;
-        private readonly string _name;
-
         internal LabelTarget(Type type, string name)
         {
-            _type = type;
-            _name = name;
+            Type = type;
+            Name = name;
         }
 
         /// <summary>
         /// Gets the name of the label.
         /// </summary>
         /// <remarks>The label's name is provided for information purposes only.</remarks>
-        public string Name => _name;
+        public string Name { get; }
 
         /// <summary>
         /// The type of value that is passed when jumping to the label
         /// (or System.Void if no value should be passed).
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public Type Type => _type;
+        public Type Type { get; }
 
         /// <summary>
         /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>. 
@@ -39,7 +36,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="String"/> that represents the current <see cref="Object"/>.</returns>
         public override string ToString()
         {
-            return string.IsNullOrEmpty(this.Name) ? "UnamedLabel" : this.Name;
+            return string.IsNullOrEmpty(Name) ? "UnamedLabel" : Name;
         }
     }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -21,13 +21,10 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(ListInitExpressionProxy))]
     public sealed class ListInitExpression : Expression
     {
-        private readonly NewExpression _newExpression;
-        private readonly ReadOnlyCollection<ElementInit> _initializers;
-
         internal ListInitExpression(NewExpression newExpression, ReadOnlyCollection<ElementInit> initializers)
         {
-            _newExpression = newExpression;
-            _initializers = initializers;
+            NewExpression = newExpression;
+            Initializers = initializers;
         }
 
         /// <summary>
@@ -40,7 +37,7 @@ namespace System.Linq.Expressions
         /// Gets the static type of the expression that this <see cref="Expression"/> represents. (Inherited from <see cref="Expression"/>.)
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public sealed override Type Type => _newExpression.Type;
+        public sealed override Type Type => NewExpression.Type;
 
         /// <summary>
         /// Gets a value that indicates whether the expression tree node can be reduced. 
@@ -50,12 +47,12 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the expression that contains a call to the constructor of a collection type. 
         /// </summary>
-        public NewExpression NewExpression => _newExpression;
+        public NewExpression NewExpression { get; }
 
         /// <summary>
         /// Gets the element initializers that are used to initialize a collection. 
         /// </summary>
-        public ReadOnlyCollection<ElementInit> Initializers => _initializers;
+        public ReadOnlyCollection<ElementInit> Initializers { get; }
 
         /// <summary>
         /// Dispatches to the specific visit method for this node type.
@@ -74,7 +71,7 @@ namespace System.Linq.Expressions
         /// <returns>The reduced expression.</returns>
         public override Expression Reduce()
         {
-            return MemberInitExpression.ReduceListInit(_newExpression, _initializers, true);
+            return MemberInitExpression.ReduceListInit(NewExpression, Initializers, true);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LoopExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LoopExpression.cs
@@ -12,22 +12,18 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(LoopExpressionProxy))]
     public sealed class LoopExpression : Expression
     {
-        private readonly Expression _body;
-        private readonly LabelTarget _break;
-        private readonly LabelTarget _continue;
-
         internal LoopExpression(Expression body, LabelTarget @break, LabelTarget @continue)
         {
-            _body = body;
-            _break = @break;
-            _continue = @continue;
+            Body = body;
+            BreakLabel = @break;
+            ContinueLabel = @continue;
         }
 
         /// <summary>
         /// Gets the static type of the expression that this <see cref="Expression"/> represents.
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public sealed override Type Type => _break == null ? typeof(void) : _break.Type;
+        public sealed override Type Type => BreakLabel == null ? typeof(void) : BreakLabel.Type;
 
         /// <summary>
         /// Returns the node type of this Expression. Extension nodes should return
@@ -39,17 +35,17 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the <see cref="Expression"/> that is the body of the loop.
         /// </summary>
-        public Expression Body => _body;
+        public Expression Body { get; }
 
         /// <summary>
         /// Gets the <see cref="LabelTarget"/> that is used by the loop body as a break statement target.
         /// </summary>
-        public LabelTarget BreakLabel => _break;
+        public LabelTarget BreakLabel { get; }
 
         /// <summary>
         /// Gets the <see cref="LabelTarget"/> that is used by the loop body as a continue statement target.
         /// </summary>
-        public LabelTarget ContinueLabel => _continue;
+        public LabelTarget ContinueLabel { get; }
 
         /// <summary>
         /// Dispatches to the specific visit method for this node type.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberBinding.cs
@@ -30,9 +30,6 @@ namespace System.Linq.Expressions
     /// </summary>
     public abstract class MemberBinding
     {
-        private MemberBindingType _type;
-        private MemberInfo _member;
-
         /// <summary>
         /// Initializes an instance of <see cref="MemberBinding"/> class.
         /// </summary>
@@ -41,19 +38,19 @@ namespace System.Linq.Expressions
         [Obsolete("Do not use this constructor. It will be removed in future releases.")]
         protected MemberBinding(MemberBindingType type, MemberInfo member)
         {
-            _type = type;
-            _member = member;
+            BindingType = type;
+            Member = member;
         }
 
         /// <summary>
         /// Gets the type of binding that is represented.
         /// </summary>
-        public MemberBindingType BindingType => _type;
+        public MemberBindingType BindingType { get; }
 
         /// <summary>
         /// Gets the field or property to be initialized.
         /// </summary>
-        public MemberInfo Member => _member;
+        public MemberInfo Member { get; }
 
         /// <summary>
         /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>. 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -15,8 +15,6 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(MemberExpressionProxy))]
     public class MemberExpression : Expression
     {
-        private readonly Expression _expression;
-
         /// <summary>
         /// Gets the field or property to be accessed.
         /// </summary>
@@ -25,12 +23,12 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the containing object of the field or property.
         /// </summary>
-        public Expression Expression => _expression;
+        public Expression Expression { get; }
 
         // param order: factories args in order, then other args
         internal MemberExpression(Expression expression)
         {
-            _expression = expression;
+            Expression = expression;
         }
 
         internal static PropertyExpression Make(Expression expression, PropertyInfo property)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
@@ -16,20 +16,17 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(MemberInitExpressionProxy))]
     public sealed class MemberInitExpression : Expression
     {
-        private readonly NewExpression _newExpression;
-        private readonly ReadOnlyCollection<MemberBinding> _bindings;
-
         internal MemberInitExpression(NewExpression newExpression, ReadOnlyCollection<MemberBinding> bindings)
         {
-            _newExpression = newExpression;
-            _bindings = bindings;
+            NewExpression = newExpression;
+            Bindings = bindings;
         }
 
         /// <summary>
         /// Gets the static type of the expression that this <see cref="Expression"/> represents.
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public sealed override Type Type => _newExpression.Type;
+        public sealed override Type Type => NewExpression.Type;
 
         /// <summary>
         /// Gets a value that indicates whether the expression tree node can be reduced. 
@@ -45,11 +42,11 @@ namespace System.Linq.Expressions
 
         /// <summary>Gets the expression that represents the constructor call.</summary>
         /// <returns>A <see cref="Expressions.NewExpression"/> that represents the constructor call.</returns>
-        public NewExpression NewExpression => _newExpression;
+        public NewExpression NewExpression { get; }
 
         /// <summary>Gets the bindings that describe how to initialize the members of the newly created object.</summary>
         /// <returns>A <see cref="ReadOnlyCollection{T}"/> of <see cref="MemberBinding"/> objects which describe how to initialize the members.</returns>
-        public ReadOnlyCollection<MemberBinding> Bindings => _bindings;
+        public ReadOnlyCollection<MemberBinding> Bindings { get; }
 
         /// <summary>
         /// Dispatches to the specific visit method for this node type.
@@ -68,7 +65,7 @@ namespace System.Linq.Expressions
         /// <returns>The reduced expression.</returns>
         public override Expression Reduce()
         {
-            return ReduceMemberInit(_newExpression, _bindings, true);
+            return ReduceMemberInit(NewExpression, Bindings, true);
         }
 
         internal static Expression ReduceMemberInit(Expression objExpression, ReadOnlyCollection<MemberBinding> bindings, bool keepOnStack)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
@@ -15,20 +15,18 @@ namespace System.Linq.Expressions
     /// </summary>
     public sealed class MemberListBinding : MemberBinding
     {
-        private ReadOnlyCollection<ElementInit> _initializers;
-
         internal MemberListBinding(MemberInfo member, ReadOnlyCollection<ElementInit> initializers)
 #pragma warning disable 618
             : base(MemberBindingType.ListBinding, member)
         {
 #pragma warning restore 618
-            _initializers = initializers;
+            Initializers = initializers;
         }
 
         /// <summary>
         /// Gets the element initializers for initializing a collection member of a newly created object.
         /// </summary>
-        public ReadOnlyCollection<ElementInit> Initializers => _initializers;
+        public ReadOnlyCollection<ElementInit> Initializers { get; }
 
         /// <summary>
         /// Creates a new expression that is like this one, but using the

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
@@ -18,20 +18,18 @@ namespace System.Linq.Expressions
     /// </remarks>
     public sealed class MemberMemberBinding : MemberBinding
     {
-        private ReadOnlyCollection<MemberBinding> _bindings;
-
         internal MemberMemberBinding(MemberInfo member, ReadOnlyCollection<MemberBinding> bindings)
 #pragma warning disable 618
             : base(MemberBindingType.MemberBinding, member)
         {
 #pragma warning restore 618
-            _bindings = bindings;
+            Bindings = bindings;
         }
 
         /// <summary>
         /// Gets the bindings that describe how to initialize the members of a member. 
         /// </summary>
-        public ReadOnlyCollection<MemberBinding> Bindings => _bindings;
+        public ReadOnlyCollection<MemberBinding> Bindings { get; }
 
         /// <summary>
         /// Creates a new expression that is like this one, but using the

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -17,17 +17,12 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(MethodCallExpressionProxy))]
     public class MethodCallExpression : Expression, IArgumentProvider
     {
-        private readonly MethodInfo _method;
-
         internal MethodCallExpression(MethodInfo method)
         {
-            _method = method;
+            Method = method;
         }
 
-        internal virtual Expression GetInstance()
-        {
-            return null;
-        }
+        internal virtual Expression GetInstance() => null;
 
         /// <summary>
         /// Returns the node type of this <see cref="Expression"/>. (Inherited from <see cref="Expression"/>.)
@@ -39,12 +34,12 @@ namespace System.Linq.Expressions
         /// Gets the static type of the expression that this <see cref="Expression"/> represents. (Inherited from <see cref="Expression"/>.)
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public sealed override Type Type => _method.ReturnType;
+        public sealed override Type Type => Method.ReturnType;
 
         /// <summary>
         /// Gets the <see cref="MethodInfo"/> for the method to be called.
         /// </summary>
-        public MethodInfo Method => _method;
+        public MethodInfo Method { get; }
 
         /// <summary>
         /// Gets the <see cref="Expression"/> that represents the instance 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -16,13 +16,10 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(NewArrayExpressionProxy))]
     public class NewArrayExpression : Expression
     {
-        private readonly ReadOnlyCollection<Expression> _expressions;
-        private readonly Type _type;
-
         internal NewArrayExpression(Type type, ReadOnlyCollection<Expression> expressions)
         {
-            _expressions = expressions;
-            _type = type;
+            Expressions = expressions;
+            Type = type;
         }
 
         internal static NewArrayExpression Make(ExpressionType nodeType, Type type, ReadOnlyCollection<Expression> expressions)
@@ -42,12 +39,12 @@ namespace System.Linq.Expressions
         /// Gets the static type of the expression that this <see cref="Expression"/> represents. (Inherited from <see cref="Expression"/>.)
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public sealed override Type Type => _type;
+        public sealed override Type Type { get; }
 
         /// <summary>
         /// Gets the bounds of the array if the value of the <see cref="ExpressionType"/> property is NewArrayBounds, or the values to initialize the elements of the new array if the value of the <see cref="Expression.NodeType"/> property is NewArrayInit. 
         /// </summary>
-        public ReadOnlyCollection<Expression> Expressions => _expressions;
+        public ReadOnlyCollection<Expression> Expressions { get; }
 
         /// <summary>
         /// Dispatches to the specific visit method for this node type.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -17,22 +17,20 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(NewExpressionProxy))]
     public class NewExpression : Expression, IArgumentProvider
     {
-        private readonly ConstructorInfo _constructor;
         private IList<Expression> _arguments;
-        private readonly ReadOnlyCollection<MemberInfo> _members;
 
         internal NewExpression(ConstructorInfo constructor, IList<Expression> arguments, ReadOnlyCollection<MemberInfo> members)
         {
-            _constructor = constructor;
+            Constructor = constructor;
             _arguments = arguments;
-            _members = members;
+            Members = members;
         }
 
         /// <summary>
         /// Gets the static type of the expression that this <see cref="Expression"/> represents. (Inherited from <see cref="Expression"/>.)
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public override Type Type => _constructor.DeclaringType;
+        public override Type Type => Constructor.DeclaringType;
 
         /// <summary>
         /// Returns the node type of this <see cref="Expression"/>. (Inherited from <see cref="Expression"/>.)
@@ -43,7 +41,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the called constructor.
         /// </summary>
-        public ConstructorInfo Constructor => _constructor;
+        public ConstructorInfo Constructor { get; }
 
         /// <summary>
         /// Gets the arguments to the constructor.
@@ -65,7 +63,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the members that can retrieve the values of the fields that were initialized with constructor arguments.
         /// </summary>
-        public ReadOnlyCollection<MemberInfo> Members => _members;
+        public ReadOnlyCollection<MemberInfo> Members { get; }
 
         /// <summary>
         /// Dispatches to the specific visit method for this node type.
@@ -98,15 +96,13 @@ namespace System.Linq.Expressions
 
     internal sealed class NewValueTypeExpression : NewExpression
     {
-        private readonly Type _valueType;
-
         internal NewValueTypeExpression(Type type, ReadOnlyCollection<Expression> arguments, ReadOnlyCollection<MemberInfo> members)
             : base(null, arguments, members)
         {
-            _valueType = type;
+            Type = type;
         }
 
-        public sealed override Type Type => _valueType;
+        public sealed override Type Type { get; }
     }
 
     public partial class Expression

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
@@ -14,11 +14,9 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(ParameterExpressionProxy))]
     public class ParameterExpression : Expression
     {
-        private readonly string _name;
-
         internal ParameterExpression(string name)
         {
-            _name = name;
+            Name = name;
         }
 
         internal static ParameterExpression Make(Type type, string name, bool isByRef)
@@ -87,7 +85,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// The Name of the parameter or variable.
         /// </summary>
-        public string Name => _name;
+        public string Name { get; }
 
         /// <summary>
         /// Indicates that this <see cref="ParameterExpression"/> is to be treated as a ByRef parameter.
@@ -126,15 +124,13 @@ namespace System.Linq.Expressions
     /// </summary>
     internal class TypedParameterExpression : ParameterExpression
     {
-        private readonly Type _paramType;
-
         internal TypedParameterExpression(Type type, string name)
             : base(name)
         {
-            _paramType = type;
+            Type = type;
         }
 
-        public sealed override Type Type => _paramType;
+        public sealed override Type Type { get; }
     }
 
     /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/RuntimeVariablesExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/RuntimeVariablesExpression.cs
@@ -18,11 +18,9 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(RuntimeVariablesExpressionProxy))]
     public sealed class RuntimeVariablesExpression : Expression
     {
-        private readonly ReadOnlyCollection<ParameterExpression> _variables;
-
         internal RuntimeVariablesExpression(ReadOnlyCollection<ParameterExpression> variables)
         {
-            _variables = variables;
+            Variables = variables;
         }
 
         /// <summary>
@@ -41,7 +39,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// The variables or parameters to which to provide runtime access.
         /// </summary>
-        public ReadOnlyCollection<ParameterExpression> Variables => _variables;
+        public ReadOnlyCollection<ParameterExpression> Variables { get; }
 
         /// <summary>
         /// Dispatches to the specific visit method for this node type.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
@@ -15,24 +15,21 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(Expression.SwitchCaseProxy))]
     public sealed class SwitchCase
     {
-        private readonly ReadOnlyCollection<Expression> _testValues;
-        private readonly Expression _body;
-
         internal SwitchCase(Expression body, ReadOnlyCollection<Expression> testValues)
         {
-            _body = body;
-            _testValues = testValues;
+            Body = body;
+            TestValues = testValues;
         }
 
         /// <summary>
         /// Gets the values of this case. This case is selected for execution when the <see cref="SwitchExpression.SwitchValue"/> matches any of these values.
         /// </summary>
-        public ReadOnlyCollection<Expression> TestValues => _testValues;
+        public ReadOnlyCollection<Expression> TestValues { get; }
 
         /// <summary>
         /// Gets the body of this case.
         /// </summary>
-        public Expression Body => _body;
+        public Expression Body { get; }
 
         /// <summary>
         /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>. 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
@@ -16,26 +16,20 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(SwitchExpressionProxy))]
     public sealed class SwitchExpression : Expression
     {
-        private readonly Type _type;
-        private readonly Expression _switchValue;
-        private readonly ReadOnlyCollection<SwitchCase> _cases;
-        private readonly Expression _defaultBody;
-        private readonly MethodInfo _comparison;
-
         internal SwitchExpression(Type type, Expression switchValue, Expression defaultBody, MethodInfo comparison, ReadOnlyCollection<SwitchCase> cases)
         {
-            _type = type;
-            _switchValue = switchValue;
-            _defaultBody = defaultBody;
-            _comparison = comparison;
-            _cases = cases;
+            Type = type;
+            SwitchValue = switchValue;
+            DefaultBody = defaultBody;
+            Comparison = comparison;
+            Cases = cases;
         }
 
         /// <summary>
         /// Gets the static type of the expression that this <see cref="Expression"/> represents.
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public sealed override Type Type => _type;
+        public sealed override Type Type { get; }
 
         /// <summary>
         /// Returns the node type of this Expression. Extension nodes should return
@@ -47,22 +41,22 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the test for the switch.
         /// </summary>
-        public Expression SwitchValue => _switchValue;
+        public Expression SwitchValue { get; }
 
         /// <summary>
         /// Gets the collection of <see cref="SwitchCase"/> objects for the switch.
         /// </summary>
-        public ReadOnlyCollection<SwitchCase> Cases => _cases;
+        public ReadOnlyCollection<SwitchCase> Cases { get; }
 
         /// <summary>
         /// Gets the test for the switch.
         /// </summary>
-        public Expression DefaultBody => _defaultBody;
+        public Expression DefaultBody { get; }
 
         /// <summary>
         /// Gets the equality comparison method, if any.
         /// </summary>
-        public MethodInfo Comparison => _comparison;
+        public MethodInfo Comparison { get; }
 
         /// <summary>
         /// Dispatches to the specific visit method for this node type.
@@ -76,10 +70,10 @@ namespace System.Linq.Expressions
         {
             get
             {
-                if (_switchValue.Type.IsNullableType())
+                if (SwitchValue.Type.IsNullableType())
                 {
-                    return (_comparison == null) ||
-                        !TypeUtils.AreEquivalent(_switchValue.Type, _comparison.GetParametersCached()[0].ParameterType.GetNonRefType());
+                    return (Comparison == null) ||
+                        !TypeUtils.AreEquivalent(SwitchValue.Type, Comparison.GetParametersCached()[0].ParameterType.GetNonRefType());
                 }
                 return false;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SymbolDocumentInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SymbolDocumentInfo.cs
@@ -12,18 +12,16 @@ namespace System.Linq.Expressions
     /// </summary>
     public class SymbolDocumentInfo
     {
-        private readonly string _fileName;
-
         internal SymbolDocumentInfo(string fileName)
         {
             ContractUtils.RequiresNotNull(fileName, nameof(fileName));
-            _fileName = fileName;
+            FileName = fileName;
         }
 
         /// <summary>
         /// The source file name.
         /// </summary>
-        public string FileName => _fileName;
+        public string FileName { get; }
 
         /// <summary>
         /// Returns the language's unique identifier, if any.
@@ -46,38 +44,34 @@ namespace System.Linq.Expressions
 
     internal sealed class SymbolDocumentWithGuids : SymbolDocumentInfo
     {
-        private readonly Guid _language;
-        private readonly Guid _vendor;
-        private readonly Guid _documentType;
-
         internal SymbolDocumentWithGuids(string fileName, ref Guid language)
             : base(fileName)
         {
-            _language = language;
-            _documentType = SymbolDocumentInfo.DocumentType_Text;
+            Language = language;
+            DocumentType = DocumentType_Text;
         }
 
         internal SymbolDocumentWithGuids(string fileName, ref Guid language, ref Guid vendor)
             : base(fileName)
         {
-            _language = language;
-            _vendor = vendor;
-            _documentType = SymbolDocumentInfo.DocumentType_Text;
+            Language = language;
+            LanguageVendor = vendor;
+            DocumentType = DocumentType_Text;
         }
 
         internal SymbolDocumentWithGuids(string fileName, ref Guid language, ref Guid vendor, ref Guid documentType)
             : base(fileName)
         {
-            _language = language;
-            _vendor = vendor;
-            _documentType = documentType;
+            Language = language;
+            LanguageVendor = vendor;
+            DocumentType = documentType;
         }
 
-        public override Guid Language => _language;
+        public override Guid Language { get; }
 
-        public override Guid LanguageVendor => _vendor;
+        public override Guid LanguageVendor { get; }
 
-        public override Guid DocumentType => _documentType;
+        public override Guid DocumentType { get; }
     }
 
     public partial class Expression

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
@@ -22,26 +22,20 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(TryExpressionProxy))]
     public sealed class TryExpression : Expression
     {
-        private readonly Type _type;
-        private readonly Expression _body;
-        private readonly ReadOnlyCollection<CatchBlock> _handlers;
-        private readonly Expression _finally;
-        private readonly Expression _fault;
-
         internal TryExpression(Type type, Expression body, Expression @finally, Expression fault, ReadOnlyCollection<CatchBlock> handlers)
         {
-            _type = type;
-            _body = body;
-            _handlers = handlers;
-            _finally = @finally;
-            _fault = fault;
+            Type = type;
+            Body = body;
+            Handlers = handlers;
+            Finally = @finally;
+            Fault = fault;
         }
 
         /// <summary>
         /// Gets the static type of the expression that this <see cref="Expression"/> represents. (Inherited from <see cref="Expression"/>.)
         /// </summary>
         /// <returns>The <see cref="System.Type"/> that represents the static type of the expression.</returns>
-        public sealed override Type Type => _type;
+        public sealed override Type Type { get; }
 
         /// <summary>
         /// Returns the node type of this <see cref="Expression"/>. (Inherited from <see cref="Expression"/>.)
@@ -52,22 +46,22 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the <see cref="Expression"/> representing the body of the try block.
         /// </summary>
-        public Expression Body => _body;
+        public Expression Body { get; }
 
         /// <summary>
         /// Gets the collection of <see cref="CatchBlock"/>s associated with the try block.
         /// </summary>
-        public ReadOnlyCollection<CatchBlock> Handlers => _handlers;
+        public ReadOnlyCollection<CatchBlock> Handlers { get; }
 
         /// <summary>
         /// Gets the <see cref="Expression"/> representing the finally block.
         /// </summary>
-        public Expression Finally => _finally;
+        public Expression Finally { get; }
 
         /// <summary>
         /// Gets the <see cref="Expression"/> representing the fault block.
         /// </summary>
-        public Expression Fault => _fault;
+        public Expression Fault { get; }
 
         /// <summary>
         /// Dispatches to the specific visit method for this node type.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -15,15 +15,11 @@ namespace System.Linq.Expressions
     [DebuggerTypeProxy(typeof(TypeBinaryExpressionProxy))]
     public sealed class TypeBinaryExpression : Expression
     {
-        private readonly Expression _expression;
-        private readonly Type _typeOperand;
-        private readonly ExpressionType _nodeKind;
-
-        internal TypeBinaryExpression(Expression expression, Type typeOperand, ExpressionType nodeKind)
+        internal TypeBinaryExpression(Expression expression, Type typeOperand, ExpressionType nodeType)
         {
-            _expression = expression;
-            _typeOperand = typeOperand;
-            _nodeKind = nodeKind;
+            Expression = expression;
+            TypeOperand = typeOperand;
+            NodeType = nodeType;
         }
 
         /// <summary>
@@ -37,17 +33,17 @@ namespace System.Linq.Expressions
         /// ExpressionType.Extension when overriding this method.
         /// </summary>
         /// <returns>The <see cref="ExpressionType"/> of the expression.</returns>
-        public sealed override ExpressionType NodeType => _nodeKind;
+        public sealed override ExpressionType NodeType { get; }
 
         /// <summary>
         /// Gets the expression operand of a type test operation.
         /// </summary>
-        public Expression Expression => _expression;
+        public Expression Expression { get; }
 
         /// <summary>
         /// Gets the type operand of a type test operation.
         /// </summary>
-        public Type TypeOperand => _typeOperand;
+        public Type TypeOperand { get; }
 
         #region Reduce TypeEqual
 
@@ -62,7 +58,7 @@ namespace System.Linq.Expressions
                     // If the expression type is a a nullable type, it will match if
                     // the value is not null and the type operand
                     // either matches or is its type argument (T to its T?).
-                    if (cType.GetNonNullableType() != _typeOperand.GetNonNullableType())
+                    if (cType.GetNonNullableType() != TypeOperand.GetNonNullableType())
                     {
                         return Expression.Block(Expression, Expression.Constant(false));
                     }
@@ -75,7 +71,7 @@ namespace System.Linq.Expressions
                 {
                     // For other value types (including Void), we can
                     // determine the result now
-                    return Expression.Block(Expression, Expression.Constant(cType == _typeOperand.GetNonNullableType()));
+                    return Expression.Block(Expression, Expression.Constant(cType == TypeOperand.GetNonNullableType()));
                 }
             }
 
@@ -114,7 +110,7 @@ namespace System.Linq.Expressions
             // causing it to always return false.
             // We workaround this optimization by generating different, less optimal IL
             // if TypeOperand is an interface.
-            if (_typeOperand.GetTypeInfo().IsInterface)
+            if (TypeOperand.GetTypeInfo().IsInterface)
             {
                 ParameterExpression temp = Expression.Parameter(typeof(Type));
                 getType = Expression.Block(new[] { temp }, Expression.Assign(temp, getType), temp);
@@ -127,7 +123,7 @@ namespace System.Linq.Expressions
                 Expression.ReferenceNotEqual(value, Expression.Constant(null)),
                 Expression.ReferenceEqual(
                     getType,
-                    Expression.Constant(_typeOperand.GetNonNullableType(), typeof(Type))
+                    Expression.Constant(TypeOperand.GetNonNullableType(), typeof(Type))
                 )
             );
         }
@@ -142,7 +138,7 @@ namespace System.Linq.Expressions
             }
             else
             {
-                return Expression.Constant(_typeOperand.GetNonNullableType() == ce.Value.GetType());
+                return Expression.Constant(TypeOperand.GetNonNullableType() == ce.Value.GetType());
             }
         }
 


### PR DESCRIPTION
With the introduction of expression-bodied members in a previous PR, we took first steps to make the code more concise. In this PR, I'm continuing on this theme by using read-only properties on `Expression` subtypes where applicable.

I'm omitting `LambdaExpression` because I have changes pending to that type to allow for more compact representations (see https://github.com/dotnet/corefx/issues/11400).