### PR TITLE
Using IReadOnlyList<T> where possible in System.Linq.Expressions

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
@@ -14,9 +14,9 @@ namespace System.Dynamic.Utils
 {
     internal static class ExpressionUtils
     {
-        public static ReadOnlyCollection<T> ReturnReadOnly<T>(ref IList<T> collection)
+        public static ReadOnlyCollection<T> ReturnReadOnly<T>(ref IReadOnlyList<T> collection)
         {
-            IList<T> value = collection;
+            IReadOnlyList<T> value = collection;
 
             // if it's already read-only just return it.
             ReadOnlyCollection<T> res = value as ReadOnlyCollection<T>;
@@ -26,7 +26,7 @@ namespace System.Dynamic.Utils
             }
 
             // otherwise make sure only readonly collection every gets exposed
-            Interlocked.CompareExchange<IList<T>>(
+            Interlocked.CompareExchange<IReadOnlyList<T>>(
                 ref collection,
                 value.ToReadOnly(),
                 value

--- a/src/System.Dynamic.Runtime/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Dynamic.Runtime/src/System/Linq/Expressions/DynamicExpression.cs
@@ -478,9 +478,9 @@ namespace System.Linq.Expressions
 
     internal class DynamicExpressionN : DynamicExpression, IArgumentProvider
     {
-        private IList<Expression> _arguments;       // storage for the original IList or readonly collection.  See IArgumentProvider for more info.
+        private IReadOnlyList<Expression> _arguments;       // storage for the original IList or readonly collection.  See IArgumentProvider for more info.
 
-        internal DynamicExpressionN(Type delegateType, CallSiteBinder binder, IList<Expression> arguments)
+        internal DynamicExpressionN(Type delegateType, CallSiteBinder binder, IReadOnlyList<Expression> arguments)
             : base(delegateType, binder)
         {
             _arguments = arguments;
@@ -516,7 +516,7 @@ namespace System.Linq.Expressions
     {
         private readonly Type _returnType;
 
-        internal TypedDynamicExpressionN(Type returnType, Type delegateType, CallSiteBinder binder, IList<Expression> arguments)
+        internal TypedDynamicExpressionN(Type returnType, Type delegateType, CallSiteBinder binder, IReadOnlyList<Expression> arguments)
             : base(delegateType, binder, arguments)
         {
             Debug.Assert(delegateType.GetMethod("Invoke").GetReturnType() == returnType);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -323,9 +323,9 @@ namespace System.Linq.Expressions
 
     internal class BlockN : BlockExpression
     {
-        private IList<Expression> _expressions;         // either the original IList<Expression> or a ReadOnlyCollection if the user has accessed it.
+        private IReadOnlyList<Expression> _expressions;         // either the original IList<Expression> or a ReadOnlyCollection if the user has accessed it.
 
-        internal BlockN(IList<Expression> expressions)
+        internal BlockN(IReadOnlyList<Expression> expressions)
         {
             Debug.Assert(expressions.Count != 0);
 
@@ -357,9 +357,9 @@ namespace System.Linq.Expressions
 
     internal class ScopeExpression : BlockExpression
     {
-        private IList<ParameterExpression> _variables;      // list of variables or ReadOnlyCollection if the user has accessed the readonly collection
+        private IReadOnlyList<ParameterExpression> _variables;      // list of variables or ReadOnlyCollection if the user has accessed the readonly collection
 
-        internal ScopeExpression(IList<ParameterExpression> variables)
+        internal ScopeExpression(IReadOnlyList<ParameterExpression> variables)
         {
             _variables = variables;
         }
@@ -369,10 +369,10 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(ref _variables);
         }
 
-        protected IList<ParameterExpression> VariablesList => _variables;
+        protected IReadOnlyList<ParameterExpression> VariablesList => _variables;
 
         // Used for rewrite of the nodes to either reuse existing set of variables if not rewritten.
-        internal IList<ParameterExpression> ReuseOrValidateVariables(ReadOnlyCollection<ParameterExpression> variables)
+        internal IReadOnlyList<ParameterExpression> ReuseOrValidateVariables(ReadOnlyCollection<ParameterExpression> variables)
         {
             if (variables != null && variables != VariablesList)
             {
@@ -391,12 +391,12 @@ namespace System.Linq.Expressions
     {
         private object _body;
 
-        internal Scope1(IList<ParameterExpression> variables, Expression body)
+        internal Scope1(IReadOnlyList<ParameterExpression> variables, Expression body)
             : this(variables, (object)body)
         {
         }
 
-        private Scope1(IList<ParameterExpression> variables, object body)
+        private Scope1(IReadOnlyList<ParameterExpression> variables, object body)
             : base(variables)
         {
             _body = body;
@@ -435,15 +435,15 @@ namespace System.Linq.Expressions
 
     internal class ScopeN : ScopeExpression
     {
-        private IList<Expression> _body;
+        private IReadOnlyList<Expression> _body;
 
-        internal ScopeN(IList<ParameterExpression> variables, IList<Expression> body)
+        internal ScopeN(IReadOnlyList<ParameterExpression> variables, IReadOnlyList<Expression> body)
             : base(variables)
         {
             _body = body;
         }
 
-        protected IList<Expression> Body => _body;
+        protected IReadOnlyList<Expression> Body => _body;
 
         internal override Expression GetExpression(int index)
         {
@@ -476,7 +476,7 @@ namespace System.Linq.Expressions
     {
         private readonly Type _type;
 
-        internal ScopeWithType(IList<ParameterExpression> variables, IList<Expression> expressions, Type type)
+        internal ScopeWithType(IReadOnlyList<ParameterExpression> variables, IReadOnlyList<Expression> expressions, Type type)
             : base(variables, expressions)
         {
             _type = type;
@@ -922,7 +922,7 @@ namespace System.Linq.Expressions
                 case 4: return new Block4(expressions[0], expressions[1], expressions[2], expressions[3]);
                 case 5: return new Block5(expressions[0], expressions[1], expressions[2], expressions[3], expressions[4]);
                 default:
-                    return new BlockN(expressions as ReadOnlyCollection<Expression> ?? (IList<Expression>)expressions.ToArray());
+                    return new BlockN(expressions as ReadOnlyCollection<Expression> ?? (IReadOnlyList<Expression>)expressions.ToArray());
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
@@ -96,7 +96,7 @@ namespace System.Linq.Expressions.Compiler
         {
             Node = node;
             IsMethod = isMethod;
-            IList<ParameterExpression> variables = GetVariables(node);
+            IReadOnlyList<ParameterExpression> variables = GetVariables(node);
 
             Definitions = new Dictionary<ParameterExpression, VariableStorageKind>(variables.Count);
             foreach (ParameterExpression v in variables)
@@ -479,7 +479,7 @@ namespace System.Linq.Expressions.Compiler
             }
         }
 
-        private static IList<ParameterExpression> GetVariables(object scope)
+        private static IReadOnlyList<ParameterExpression> GetVariables(object scope)
         {
             var lambda = scope as LambdaExpression;
             if (lambda != null)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -925,7 +925,7 @@ namespace System.Linq.Expressions.Compiler
             throw Error.ExtensionNotReduced();
         }
 
-#region ListInit, MemberInit
+        #region ListInit, MemberInit
 
         private void EmitListInitExpression(Expression expr)
         {
@@ -1115,14 +1115,14 @@ namespace System.Linq.Expressions.Compiler
             throw Error.MemberNotFieldOrProperty(member, nameof(member));
         }
 
-#endregion
+        #endregion
 
-#region Expression helpers
+        #region Expression helpers
 
-        internal static void ValidateLift(IList<ParameterExpression> variables, IList<Expression> arguments)
+        internal static void ValidateLift(IReadOnlyList<ParameterExpression> variables, IReadOnlyList<Expression> arguments)
         {
-            System.Diagnostics.Debug.Assert(variables != null);
-            System.Diagnostics.Debug.Assert(arguments != null);
+            Debug.Assert(variables != null);
+            Debug.Assert(arguments != null);
 
             if (variables.Count != arguments.Count)
             {
@@ -1314,6 +1314,6 @@ namespace System.Linq.Expressions.Compiler
             }
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
@@ -363,7 +363,7 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         private static Expression MakeBlock(params Expression[] expressions)
         {
-            return MakeBlock((IList<Expression>)expressions);
+            return MakeBlock((IReadOnlyList<Expression>)expressions);
         }
 
         /// <summary>
@@ -371,7 +371,7 @@ namespace System.Linq.Expressions.Compiler
         /// This should not be used for rewriting BlockExpression itself, or
         /// anything else that supports jumping.
         /// </summary>
-        private static Expression MakeBlock(IList<Expression> expressions)
+        private static Expression MakeBlock(IReadOnlyList<Expression> expressions)
         {
             return new SpilledExpressionBlock(expressions);
         }
@@ -383,7 +383,7 @@ namespace System.Linq.Expressions.Compiler
     /// </summary>
     internal sealed class SpilledExpressionBlock : BlockN
     {
-        internal SpilledExpressionBlock(IList<Expression> expressions)
+        internal SpilledExpressionBlock(IReadOnlyList<Expression> expressions)
             : base(expressions)
         {
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
@@ -232,17 +232,17 @@ namespace System.Linq.Expressions
 
         #region The AST Output
 
-        private void VisitExpressions<T>(char open, IList<T> expressions) where T : Expression
+        private void VisitExpressions<T>(char open, IReadOnlyList<T> expressions) where T : Expression
         {
             VisitExpressions<T>(open, ',', expressions);
         }
 
-        private void VisitExpressions<T>(char open, char separator, IList<T> expressions) where T : Expression
+        private void VisitExpressions<T>(char open, char separator, IReadOnlyList<T> expressions) where T : Expression
         {
             VisitExpressions(open, separator, expressions, e => Visit(e));
         }
 
-        private void VisitDeclarations(IList<ParameterExpression> expressions)
+        private void VisitDeclarations(IReadOnlyList<ParameterExpression> expressions)
         {
             VisitExpressions('(', ',', expressions, variable =>
             {
@@ -256,7 +256,7 @@ namespace System.Linq.Expressions
             });
         }
 
-        private void VisitExpressions<T>(char open, char separator, IList<T> expressions, Action<T> visit)
+        private void VisitExpressions<T>(char open, char separator, IReadOnlyList<T> expressions, Action<T> visit)
         {
             Out(open.ToString());
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
@@ -240,7 +240,7 @@ namespace System.Linq.Expressions
         /// Ultimately this saves us from having to allocate a ReadOnlyCollection for our
         /// data types because the compiler is capable of going directly to the IList of T.
         /// </summary>
-        internal static ReadOnlyCollection<T> ReturnReadOnly<T>(ref IList<T> collection)
+        internal static ReadOnlyCollection<T> ReturnReadOnly<T>(ref IReadOnlyList<T> collection)
         {
             return ExpressionUtils.ReturnReadOnly<T>(ref collection);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
@@ -115,12 +115,12 @@ namespace System.Linq.Expressions
             return esb.ToString();
         }
 
-        private void VisitExpressions<T>(char open, IList<T> expressions, char close) where T : Expression
+        private void VisitExpressions<T>(char open, IReadOnlyList<T> expressions, char close) where T : Expression
         {
             VisitExpressions(open, expressions, close, ", ");
         }
 
-        private void VisitExpressions<T>(char open, IList<T> expressions, char close, string seperator) where T : Expression
+        private void VisitExpressions<T>(char open, IReadOnlyList<T> expressions, char close, string seperator) where T : Expression
         {
             Out(open);
             if (expressions != null)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -20,12 +20,12 @@ namespace System.Linq.Expressions
     {
         private readonly Expression _instance;
         private readonly PropertyInfo _indexer;
-        private IList<Expression> _arguments;
+        private IReadOnlyList<Expression> _arguments;
 
         internal IndexExpression(
             Expression instance,
             PropertyInfo indexer,
-            IList<Expression> arguments)
+            IReadOnlyList<Expression> arguments)
         {
             if (indexer == null)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -33,7 +33,7 @@ namespace System.Linq.Expressions.Interpreter
             return this;
         }
 
-        public override string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IList<object> objects)
+        public override string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IReadOnlyList<object> objects)
         {
             return ToString() + (_offset != Unknown ? " -> " + (instructionIndex + _offset) : "");
         }
@@ -209,7 +209,7 @@ namespace System.Linq.Expressions.Interpreter
             return frame.Interpreter._labels[_labelIndex];
         }
 
-        public override string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IList<object> objects)
+        public override string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IReadOnlyList<object> objects)
         {
             Debug.Assert(_labelIndex != UnknownInstrIndex);
             int targetIndex = labelIndexer(_labelIndex);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
@@ -25,7 +25,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string ToString() => InstructionName + "()";
 
-        public virtual string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IList<object> objects) => ToString();
+        public virtual string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IReadOnlyList<object> objects) => ToString();
 
         public virtual object GetDebugCookie(LightCompiler compiler) => null;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -106,8 +106,8 @@ namespace System.Linq.Expressions.Interpreter
                     );
             }
 
-            internal static InstructionView[] GetInstructionViews(IList<Instruction> instructions, IList<object> objects,
-                Func<int, int> labelIndexer, IList<KeyValuePair<int, object>> debugCookies)
+            internal static InstructionView[] GetInstructionViews(IReadOnlyList<Instruction> instructions, IReadOnlyList<object> objects,
+                Func<int, int> labelIndexer, IReadOnlyList<KeyValuePair<int, object>> debugCookies)
             {
                 var result = new List<InstructionView>();
                 int index = 0;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -23,7 +23,7 @@ namespace System.Linq.Expressions.Interpreter
             _index = index;
         }
 
-        public override string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IList<object> objects)
+        public override string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IReadOnlyList<object> objects)
         {
             return cookie == null ?
                 InstructionName + "(" + _index + ")" :

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
@@ -46,7 +46,7 @@ namespace System.Linq.Expressions.Interpreter
             return +1;
         }
 
-        public override string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IList<object> objects)
+        public override string ToDebugString(int instructionIndex, object cookie, Func<int, int> labelIndexer, IReadOnlyList<object> objects)
         {
             return string.Format(CultureInfo.InvariantCulture, "LoadCached({0}: {1})", _index, objects[(int)_index]);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -125,9 +125,9 @@ namespace System.Linq.Expressions
 
     internal sealed class InvocationExpressionN : InvocationExpression
     {
-        private IList<Expression> _arguments;
+        private IReadOnlyList<Expression> _arguments;
 
-        public InvocationExpressionN(Expression lambda, IList<Expression> arguments, Type returnType)
+        public InvocationExpressionN(Expression lambda, IReadOnlyList<Expression> arguments, Type returnType)
             : base(lambda, returnType)
         {
             _arguments = arguments;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions
         /// subclass of MethodCallExpression which is being used. 
         /// </summary>
         [ExcludeFromCodeCoverage] // Unreachable
-        internal virtual MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal virtual MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             throw ContractUtils.Unreachable;
         }
@@ -146,9 +146,9 @@ namespace System.Linq.Expressions
 
     internal sealed class MethodCallExpressionN : MethodCallExpression, IArgumentProvider
     {
-        private IList<Expression> _arguments;
+        private IReadOnlyList<Expression> _arguments;
 
-        public MethodCallExpressionN(MethodInfo method, IList<Expression> args)
+        public MethodCallExpressionN(MethodInfo method, IReadOnlyList<Expression> args)
             : base(method)
         {
             _arguments = args;
@@ -163,7 +163,7 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(ref _arguments);
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance == null);
             Debug.Assert(args == null || args.Count == _arguments.Count);
@@ -174,9 +174,9 @@ namespace System.Linq.Expressions
 
     internal sealed class InstanceMethodCallExpressionN : InstanceMethodCallExpression, IArgumentProvider
     {
-        private IList<Expression> _arguments;
+        private IReadOnlyList<Expression> _arguments;
 
-        public InstanceMethodCallExpressionN(MethodInfo method, Expression instance, IList<Expression> args)
+        public InstanceMethodCallExpressionN(MethodInfo method, Expression instance, IReadOnlyList<Expression> args)
             : base(method, instance)
         {
             _arguments = args;
@@ -191,7 +191,7 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(ref _arguments);
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance != null);
             Debug.Assert(args == null || args.Count == _arguments.Count);
@@ -219,7 +219,7 @@ namespace System.Linq.Expressions
             return EmptyReadOnlyCollection<Expression>.Instance;
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance == null);
             Debug.Assert(args == null || args.Count == 0);
@@ -254,7 +254,7 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(this, ref _arg0);
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance == null);
             Debug.Assert(args == null || args.Count == 1);
@@ -297,7 +297,7 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(this, ref _arg0);
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance == null);
             Debug.Assert(args == null || args.Count == 2);
@@ -341,7 +341,7 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(this, ref _arg0);
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance == null);
             Debug.Assert(args == null || args.Count == 3);
@@ -387,7 +387,7 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(this, ref _arg0);
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance == null);
             Debug.Assert(args == null || args.Count == 4);
@@ -435,7 +435,7 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(this, ref _arg0);
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance == null);
             Debug.Assert(args == null || args.Count == 5);
@@ -468,7 +468,7 @@ namespace System.Linq.Expressions
             return EmptyReadOnlyCollection<Expression>.Instance;
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance != null);
             Debug.Assert(args == null || args.Count == 0);
@@ -503,7 +503,7 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(this, ref _arg0);
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance != null);
             Debug.Assert(args == null || args.Count == 1);
@@ -545,7 +545,7 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(this, ref _arg0);
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance != null);
             Debug.Assert(args == null || args.Count == 2);
@@ -589,7 +589,7 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(this, ref _arg0);
         }
 
-        internal override MethodCallExpression Rewrite(Expression instance, IList<Expression> args)
+        internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance != null);
             Debug.Assert(args == null || args.Count == 3);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -18,10 +18,10 @@ namespace System.Linq.Expressions
     public class NewExpression : Expression, IArgumentProvider
     {
         private readonly ConstructorInfo _constructor;
-        private IList<Expression> _arguments;
+        private IReadOnlyList<Expression> _arguments;
         private readonly ReadOnlyCollection<MemberInfo> _members;
 
-        internal NewExpression(ConstructorInfo constructor, IList<Expression> arguments, ReadOnlyCollection<MemberInfo> members)
+        internal NewExpression(ConstructorInfo constructor, IReadOnlyList<Expression> arguments, ReadOnlyCollection<MemberInfo> members)
         {
             _constructor = constructor;
             _arguments = arguments;


### PR DESCRIPTION
While working on https://github.com/dotnet/corefx/issues/11400 I encountered the need to wrap an `IArgumentProvider` like interface (which provides access to a `Count` and `Get` method) in an `IList<T>` in order to pass it to `Rewrite` methods in visitors etc. However, these `Rewrite` methods could just take `IReadOnlyList<T>` because we never won't access mutating members, thus resulting in the implementation of a bunch of `IList<T>` members by simply throwing an exception.

In this PR, I'm changing (internal-only) occurrences of `IList<T>` which are used in a read-only manner into `IReadOnlyList<T>` to tighten the contracts. If `ReadOnlyCollection<T>` were to provide a constructor accepting `IReadOnlyList<T>` (see https://github.com/dotnet/corefx/issues/12998), we'd be able to remove a bunch of unreachable `IList<T>` implementation code in some other places as well.

CC @stephentoub