### PR TITLE
Update Microsoft.DotNet.BuildTools.TestSuite, Microsoft.xunit.netcore.extensions

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -105,7 +105,7 @@
     </StaticDependency>
    
     <StaticDependency Include="Microsoft.xunit.netcore.extensions;Microsoft.DotNet.BuildTools.TestSuite">
-      <Version>1.0.0-prerelease-00921-01</Version>
+      <Version>1.0.0-prerelease-00925-01</Version>
     </StaticDependency>
 
     <PerformancePackDependency Include="Microsoft.DotNet.xunit.performance" />

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -5,9 +5,9 @@
     "ReportGenerator": "2.4.3",
     "Microsoft.NETCore.TestHost": "1.2.0-beta-24625-02",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24625-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
     "xunit.console.netcore": "1.0.3-prerelease-00921-01",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
     "perf": {
       "target": "project",
       "include": "compile,runtime"

--- a/src/System.Console/tests/ManualTests/project.json
+++ b/src/System.Console/tests/ManualTests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -9,8 +9,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -24,8 +24,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Http/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/unix/project.json
@@ -24,8 +24,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Net.Http/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/win/project.json
@@ -25,8 +25,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Net.Http/tests/UnitTests/project.json
+++ b/src/System.Net.Http/tests/UnitTests/project.json
@@ -21,8 +21,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Net.Mail/tests/Functional/project.json
+++ b/src/System.Net.Mail/tests/Functional/project.json
@@ -26,8 +26,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Net.Mail/tests/Unit/project.json
+++ b/src/System.Net.Mail/tests/Unit/project.json
@@ -25,8 +25,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Net.NameResolution/tests/PalTests/project.json
+++ b/src/System.Net.NameResolution/tests/PalTests/project.json
@@ -32,8 +32,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NameResolution/tests/UnitTests/project.json
+++ b/src/System.Net.NameResolution/tests/UnitTests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NetworkInformation/tests/UnitTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/UnitTests/project.json
@@ -10,8 +10,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Net.Primitives/tests/PalTests/project.json
+++ b/src/System.Net.Primitives/tests/PalTests/project.json
@@ -23,8 +23,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Net.Primitives/tests/PerformanceTests/project.json
+++ b/src/System.Net.Primitives/tests/PerformanceTests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {

--- a/src/System.Net.Primitives/tests/UnitTests/project.json
+++ b/src/System.Net.Primitives/tests/UnitTests/project.json
@@ -24,8 +24,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.7": {},

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -25,8 +25,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -21,8 +21,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Net.Security/tests/UnitTests/project.json
+++ b/src/System.Net.Security/tests/UnitTests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Private.Xml.Linq/tests/Schema/project.json
+++ b/src/System.Private.Xml.Linq/tests/Schema/project.json
@@ -8,8 +8,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.7": {},

--- a/src/System.Private.Xml.Linq/tests/XDocument.Common/project.json
+++ b/src/System.Private.Xml.Linq/tests/XDocument.Common/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/project.json
+++ b/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlReaderLib/project.json
+++ b/src/System.Private.Xml/tests/XmlReaderLib/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Metadata/tests/project.json
+++ b/src/System.Reflection.Metadata/tests/project.json
@@ -26,8 +26,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Reflection/tests/CoreCLR/project.json
+++ b/src/System.Reflection/tests/CoreCLR/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Runtime.Loader/tests/DefaultContext/project.json
+++ b/src/System.Runtime.Loader/tests/DefaultContext/project.json
@@ -19,8 +19,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Runtime.Loader/tests/RefEmitLoadContext/project.json
+++ b/src/System.Runtime.Loader/tests/RefEmitLoadContext/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Runtime.Loader/tests/project.json
+++ b/src/System.Runtime.Loader/tests/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Runtime.Serialization.Json/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/project.json
@@ -27,8 +27,8 @@
       "exclude": "compile"
     },
     "Newtonsoft.Json": "8.0.4-beta1",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Json/tests/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/project.json
@@ -27,8 +27,8 @@
       "exclude": "compile"
     },
     "Newtonsoft.Json": "8.0.4-beta1",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -27,8 +27,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {

--- a/src/System.Threading.Thread/tests/project.json
+++ b/src/System.Threading.Thread/tests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00921-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {


### PR DESCRIPTION
Fixes not restoring TestILC package during package restore.

@weshaggard  @karajas 