### PR TITLE
Add ActiveIssue attribute to GetResponseAsync_ResourceNotFound_ThrowsWebException

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -380,6 +380,7 @@ namespace System.Net.Tests
             new object[] { System.Net.Test.Common.Configuration.Http.StatusCodeUri(true, 404) },
         };
 
+        [ActiveIssue(12236, TestPlatforms.Linux)]
         [Theory, MemberData(nameof(StatusCodeServers))]
         public async Task GetResponseAsync_ResourceNotFound_ThrowsWebException(Uri remoteServer)
         {


### PR DESCRIPTION
This test has been failing on CentOS and RedHat for some time now.  See #12236.

@davidsh @stephentoub 