### PR TITLE
fix inconsistent FtpWebRequest DNS test

### DIFF
--- a/src/System.Net.Requests/tests/FtpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/FtpWebRequestTest.cs
@@ -56,15 +56,16 @@ namespace System.Net.Tests
             Assert.True(request.UsePassive);
         }
 
+        [OuterLoop]
         [Fact]
         public void GetResponse_ServerNameNotInDns_ThrowsWebException()
         {
             string serverUrl = string.Format("ftp://www.{0}.com/", Guid.NewGuid().ToString());
             FtpWebRequest request = (FtpWebRequest)WebRequest.Create(serverUrl);
             WebException ex = Assert.Throws<WebException>(() => request.GetResponse());
-            Assert.Equal(WebExceptionStatus.NameResolutionFailure, ex.Status);
         }
 
+        [OuterLoop]
         [Fact]
         public void GetResponse_ConnectFailure_ThrowsWebException()
         {

--- a/src/System.Net.Requests/tests/FtpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/FtpWebRequestTest.cs
@@ -56,7 +56,7 @@ namespace System.Net.Tests
             Assert.True(request.UsePassive);
         }
 
-        [OuterLoop]
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void GetResponse_ServerNameNotInDns_ThrowsWebException()
         {
@@ -65,7 +65,7 @@ namespace System.Net.Tests
             WebException ex = Assert.Throws<WebException>(() => request.GetResponse());
         }
 
-        [OuterLoop]
+        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void GetResponse_ConnectFailure_ThrowsWebException()
         {


### PR DESCRIPTION
Fixes #12940 

Remove the WebException.Status check, since it is not consistent and some network setups generate ConnectFailure instead of NameResolutionFailure.

Also, mark tests that could depend on the network environment as OuterLoop.