### PR TITLE
Remove use of runtimes from project.json

### DIFF
--- a/src/System.AppContext/src/netcore50aot/project.json
+++ b/src/System.AppContext/src/netcore50aot/project.json
@@ -11,9 +11,5 @@
         "System.Threading": "4.0.11"
       }
     }
-  },
-  "runtimes": {
-    "win8-x86": {},
-    "win8-x64": {}
   }
 }

--- a/src/System.Collections/src/redist/project.json
+++ b/src/System.Collections/src/redist/project.json
@@ -5,9 +5,5 @@
   },
   "frameworks": {
     "netcore50": {}
-  },
-  "runtimes": {
-    "win8": {},
-    "win8-aot": {}
   }
 }

--- a/src/System.IO.FileSystem/src/netcore50/project.json
+++ b/src/System.IO.FileSystem/src/netcore50/project.json
@@ -32,9 +32,5 @@
         "System.Runtime.WindowsRuntime": "4.0.11"
       }
     }
-  },
-  "runtimes": {
-    "win8-x86": {},
-    "win8-x64": {}
   }
 }

--- a/src/System.Net.Http.Rtc/src/netcore50/project.json
+++ b/src/System.Net.Http.Rtc/src/netcore50/project.json
@@ -9,9 +9,5 @@
         "System.Runtime": "4.1.0"
       }
     }
-  },
-  "runtimes": {
-    "win8-x86": {},
-    "win8-x64": {}
   }
 }

--- a/src/System.Net.NameResolution/src/netcore50/project.json
+++ b/src/System.Net.NameResolution/src/netcore50/project.json
@@ -22,9 +22,5 @@
         "System.Threading.Tasks": "4.0.11"
       }
     }
-  },
-  "runtimes": {
-    "win8-x86": {},
-    "win8-x64": {}
   }
 }

--- a/src/System.Net.Sockets/src/netcore50/project.json
+++ b/src/System.Net.Sockets/src/netcore50/project.json
@@ -27,9 +27,5 @@
         "System.Threading.Tasks": "4.0.11"
       }
     }
-  },
-  "runtimes": {
-    "win8-x86": {},
-    "win8-x64": {}
   }
 }

--- a/src/System.Numerics.Vectors.WindowsRuntime/src/project.json
+++ b/src/System.Numerics.Vectors.WindowsRuntime/src/project.json
@@ -8,9 +8,5 @@
   },
   "frameworks": {
     "uap10.0": {}
-  },
-  "runtimes": {
-    "win8-x86": {},
-    "win8-x64": {}
   }
 }

--- a/src/System.ObjectModel/src/redist/project.json
+++ b/src/System.ObjectModel/src/redist/project.json
@@ -5,8 +5,5 @@
   },
   "frameworks": {
     "netcore50": {}
-  },
-  "runtimes": {
-    "win8": {}
   }
 }

--- a/src/System.Private.DataContractSerialization/src/uap101aot/project.json
+++ b/src/System.Private.DataContractSerialization/src/uap101aot/project.json
@@ -33,9 +33,5 @@
         "System.Xml.XmlSerializer": "4.0.11"
       }
     }
-  },
-  "runtimes": {
-    "win8-x86": {},
-    "win8-x64": {}
   }
 }

--- a/src/System.Runtime.Extensions/src/redist/project.json
+++ b/src/System.Runtime.Extensions/src/redist/project.json
@@ -5,9 +5,5 @@
   },
   "frameworks": {
     "netcore50": {}
-  },
-  "runtimes": {
-    "win8": {},
-    "win8-aot": {}
   }
 }

--- a/src/System.Runtime/src/redist/project.json
+++ b/src/System.Runtime/src/redist/project.json
@@ -5,9 +5,5 @@
   },
   "frameworks": {
     "netcore50": {}
-  },
-  "runtimes": {
-    "win8": {},
-    "win8-aot": {}
   }
 }

--- a/src/System.Security.Cryptography.Pkcs/src/netcore50/project.json
+++ b/src/System.Security.Cryptography.Pkcs/src/netcore50/project.json
@@ -18,9 +18,5 @@
   },
   "frameworks": {
     "netcore50": {}
-  },
-  "runtimes": {
-    "win8-x86": {},
-    "win8-x64": {}
   }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/netcore50/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/netcore50/project.json
@@ -21,9 +21,5 @@
   },
   "frameworks": {
     "netcore50": {}
-  },
-  "runtimes": {
-    "win8-x86": {},
-    "win8-x64": {}
   }
 }


### PR DESCRIPTION
All tests use supports clauses, the only remaining use of runtimes was
left over from when it was needed to avoid guardrails errors.

/cc @dagood @weshaggard 