### PR TITLE
Cherry-pick commit 09a2d0022b46e7a5137002b88bb7334bfc43604a from Master

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -379,6 +379,7 @@ namespace System.Net.Tests
             new object[] { Configuration.Http.StatusCodeUri(true, 404) },
         };
 
+        [ActiveIssue(12236, TestPlatforms.Linux)]
         [Theory, MemberData(nameof(StatusCodeServers))]
         public async Task GetResponseAsync_ResourceNotFound_ThrowsWebException(Uri remoteServer)
         {

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -379,7 +379,7 @@ namespace System.Net.Tests
             new object[] { Configuration.Http.StatusCodeUri(true, 404) },
         };
 
-        [ActiveIssue(12236, TestPlatforms.Linux)]
+        [ActiveIssue(12236, PlatformID.Linux)]
         [Theory, MemberData(nameof(StatusCodeServers))]
         public async Task GetResponseAsync_ResourceNotFound_ThrowsWebException(Uri remoteServer)
         {


### PR DESCRIPTION
Adds ActiveIssue attribute to GetResponseAsync_ResourceNotFound_ThrowsWebException.

This test has been failing on CentOS and RedHat for some time now.  See #12236