### PR TITLE
Redirect to System.Private.CoreLib

### DIFF
--- a/src/System.Buffers/System.Buffers.sln
+++ b/src/System.Buffers/System.Buffers.sln
@@ -1,10 +1,18 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22609.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Buffers", "src\System.Buffers.csproj", "{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Buffers.Tests", "tests\System.Buffers.Tests.csproj", "{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E7DDD72A-4A83-40E5-82E3-C24CB3B2C317}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{08302462-FA63-4153-9D08-0567D18237E7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{26C2E4C8-032B-44AA-964D-154FEF4F4F7D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "pkg", "pkg", "{5BB3B990-6048-4153-A647-3F2958467EF5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,10 +26,14 @@ Global
 		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B} = {E7DDD72A-4A83-40E5-82E3-C24CB3B2C317}
+		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C} = {08302462-FA63-4153-9D08-0567D18237E7}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Buffers/System.Buffers.sln
+++ b/src/System.Buffers/System.Buffers.sln
@@ -13,6 +13,12 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{26C2E4C8-032B-44AA-964D-154FEF4F4F7D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "pkg", "pkg", "{5BB3B990-6048-4153-A647-3F2958467EF5}"
+	ProjectSection(SolutionItems) = preProject
+		pkg\System.Buffers.builds = pkg\System.Buffers.builds
+		pkg\System.Buffers.pkgproj = pkg\System.Buffers.pkgproj
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Buffers", "ref\System.Buffers.csproj", "{11AE73F7-3532-47B9-8FF6-B4F22D76456C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,6 +34,10 @@ Global
 		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -35,5 +45,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B} = {E7DDD72A-4A83-40E5-82E3-C24CB3B2C317}
 		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C} = {08302462-FA63-4153-9D08-0567D18237E7}
+		{11AE73F7-3532-47B9-8FF6-B4F22D76456C} = {26C2E4C8-032B-44AA-964D-154FEF4F4F7D}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Buffers/pkg/System.Buffers.pkgproj
+++ b/src/System.Buffers/pkg/System.Buffers.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Buffers.builds">
-      <SupportedFramework>netcoreapp1.1;uap10.1;net463;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netcoreapp1.0;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Buffers.builds" />
   </ItemGroup>

--- a/src/System.Buffers/pkg/System.Buffers.pkgproj
+++ b/src/System.Buffers/pkg/System.Buffers.pkgproj
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
-    <ProjectReference Include="..\src\System.Buffers.builds">
-      <SupportedFramework>net45;netcore45;netcoreapp1.0;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
+    <ProjectReference Include="..\ref\System.Buffers.builds">
+      <SupportedFramework>netcoreapp1.1;uap10.1;net463;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
+    <ProjectReference Include="..\src\System.Buffers.builds" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Buffers/ref/System.Buffers.builds
+++ b/src/System.Buffers/ref/System.Buffers.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Buffers.csproj">
-      <TargetGroup>netstandard1.1</TargetGroup>
-    </Project>
+    <Project Include="System.Buffers.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Buffers/ref/System.Buffers.builds
+++ b/src/System.Buffers/ref/System.Buffers.builds
@@ -2,12 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Buffers.Tests.csproj">
-      <TargetGroup>netcoreapp1.1</TargetGroup>
-    </Project>
-    <Project Include="System.Buffers.Tests.csproj">
-      <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+    <Project Include="System.Buffers.csproj">
+      <TargetGroup>netstandard1.1</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Buffers/ref/System.Buffers.cs
+++ b/src/System.Buffers/ref/System.Buffers.cs
@@ -9,7 +9,7 @@ namespace System.Buffers
 {
     public abstract class ArrayPool<T>
     {
-        public static ArrayPool<T> Shared { [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] get { throw null; } }
+        public static ArrayPool<T> Shared { get { throw null; } }
         public static ArrayPool<T> Create() { throw null; }
         public static ArrayPool<T> Create(int maxArrayLength, int maxArraysPerBucket) { throw null; }
         public abstract T[] Rent(int minimumLength);

--- a/src/System.Buffers/ref/System.Buffers.cs
+++ b/src/System.Buffers/ref/System.Buffers.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.Buffers
+{
+    public abstract class ArrayPool<T>
+    {
+        public static ArrayPool<T> Shared { [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] get { throw null; } }
+        public static ArrayPool<T> Create() { throw null; }
+        public static ArrayPool<T> Create(int maxArrayLength, int maxArraysPerBucket) { throw null; }
+        public abstract T[] Rent(int minimumLength);
+        public abstract void Return(T[] array, bool clearArray = false);
+    }
+}

--- a/src/System.Buffers/ref/System.Buffers.csproj
+++ b/src/System.Buffers/ref/System.Buffers.csproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.1</NuGetTargetMoniker>
+    <ProjectGuid>{11AE73F7-3532-47B9-8FF6-B4F22D76456C}</ProjectGuid>
+    <UseOpenKey Condition="'$(UseOpenKey)'==''">true</UseOpenKey>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System.Buffers.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Buffers/ref/project.json
+++ b/src/System.Buffers/ref/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+      "System.Runtime": "4.4.0-beta-24625-01"
+    },
+  "frameworks": {
+    "netstandard1.1": {}
+  }
+}

--- a/src/System.Buffers/ref/project.json
+++ b/src/System.Buffers/ref/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-      "System.Runtime": "4.4.0-beta-24625-01"
+      "System.Runtime": "4.4.0-beta-24626-02"
     },
   "frameworks": {
     "netstandard1.1": {}

--- a/src/System.Buffers/src/System.Buffers.builds
+++ b/src/System.Buffers/src/System.Buffers.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Buffers.csproj">
-      <TargetGroup>netstandard1.1</TargetGroup>
-    </Project>
+    <Project Include="System.Buffers.csproj" />
     <Project Include="System.Buffers.csproj">
       <TargetGroup>netcoreapp1.1</TargetGroup>
     </Project>

--- a/src/System.Buffers/src/System.Buffers.builds
+++ b/src/System.Buffers/src/System.Buffers.builds
@@ -2,7 +2,12 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Buffers.csproj" />
+    <Project Include="System.Buffers.csproj">
+      <TargetGroup>netstandard1.1</TargetGroup>
+    </Project>
+    <Project Include="System.Buffers.csproj">
+      <TargetGroup>netcoreapp1.1</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -6,17 +6,22 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <UseOpenKey Condition="'$(UseOpenKey)'==''">true</UseOpenKey>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.1</NuGetTargetMoniker>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == '' or '$(TargetGroup)' == 'netcoreapp1.1'">true</IsPartialFacadeAssembly>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netcoreapp1.1</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != '' and '$(TargetGroup)' != 'netcoreapp1.1'">
     <Compile Include="System\Buffers\ArrayPool.cs" />
     <Compile Include="System\Buffers\ArrayPoolEventSource.cs" />
     <Compile Include="System\Buffers\DefaultArrayPool.cs" />
     <Compile Include="System\Buffers\DefaultArrayPoolBucket.cs" />
     <Compile Include="System\Buffers\Utilities.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == '' or '$(TargetGroup)' == 'netcoreapp1.1'">
+    <TargetingPackReference Include="System.Private.CoreLib" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -6,21 +6,20 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <UseOpenKey Condition="'$(UseOpenKey)'==''">true</UseOpenKey>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == '' or '$(TargetGroup)' == 'netcoreapp1.1'">true</IsPartialFacadeAssembly>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
-    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netcoreapp1.1</PackageTargetFramework>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp1.1'">true</IsPartialFacadeAssembly>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.1</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != '' and '$(TargetGroup)' != 'netcoreapp1.1'">
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="System\Buffers\ArrayPool.cs" />
     <Compile Include="System\Buffers\ArrayPoolEventSource.cs" />
     <Compile Include="System\Buffers\DefaultArrayPool.cs" />
     <Compile Include="System\Buffers\DefaultArrayPoolBucket.cs" />
     <Compile Include="System\Buffers\Utilities.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == '' or '$(TargetGroup)' == 'netcoreapp1.1'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp1.1'">
     <TargetingPackReference Include="System.Private.CoreLib" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Buffers/src/project.json
+++ b/src/System.Buffers/src/project.json
@@ -12,7 +12,7 @@
     },
     "netcoreapp1.1": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24625-02"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24626-02"
       }
     }
   }

--- a/src/System.Buffers/src/project.json
+++ b/src/System.Buffers/src/project.json
@@ -1,13 +1,19 @@
 {
-  "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1",
-    "System.Diagnostics.Debug": "4.0.11",
-    "System.Diagnostics.Tracing": "4.1.0",
-    "System.Resources.ResourceManager": "4.0.1",
-    "System.Runtime": "4.1.0",
-    "System.Threading": "4.0.11"
-  },
   "frameworks": {
-    "netstandard1.1": {}
+    "netstandard1.1": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Diagnostics.Debug": "4.0.11",
+        "System.Diagnostics.Tracing": "4.1.0",
+        "System.Resources.ResourceManager": "4.0.1",
+        "System.Runtime": "4.1.0",
+        "System.Threading": "4.0.11"
+      }
+    },
+    "netcoreapp1.1": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24625-02"
+      }
+    }
   }
 }

--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -425,11 +425,12 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
+        [ActiveIssue(13064)]
         public static void ReturningANonPooledBufferOfDifferentSizeToThePoolThrows()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
             byte[] buffer = pool.Rent(15);
-            Assert.Throws<ArgumentException>(null, () => pool.Return(new byte[1]));
+            Assert.Throws<ArgumentException>("array", () => pool.Return(new byte[1]));
             buffer = pool.Rent(15);
             Assert.Equal(buffer.Length, 16);
         }

--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -429,7 +429,7 @@ namespace System.Buffers.ArrayPool.Tests
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
             byte[] buffer = pool.Rent(15);
-            Assert.Throws<ArgumentException>("array", () => pool.Return(new byte[1]));
+            Assert.Throws<ArgumentException>(null, () => pool.Return(new byte[1]));
             buffer = pool.Rent(15);
             Assert.Equal(buffer.Length, 16);
         }

--- a/src/System.Buffers/tests/System.Buffers.Tests.builds
+++ b/src/System.Buffers/tests/System.Buffers.Tests.builds
@@ -2,12 +2,13 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Buffers.Tests.csproj">
-      <TargetGroup>netcoreapp1.1</TargetGroup>
-    </Project>
+    <Project Include="System.Buffers.Tests.csproj" />
     <Project Include="System.Buffers.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcore50;net46</TestTFMs>
+    </Project>
+    <Project Include="System.Buffers.Tests.csproj">
+      <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Buffers/tests/System.Buffers.Tests.csproj
+++ b/src/System.Buffers/tests/System.Buffers.Tests.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Buffers.Tests</AssemblyName>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
+    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ArrayPool\UnitTests.cs" />

--- a/src/System.Buffers/tests/System.Buffers.Tests.csproj
+++ b/src/System.Buffers/tests/System.Buffers.Tests.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Buffers.Tests</AssemblyName>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ArrayPool\UnitTests.cs" />


### PR DESCRIPTION
We've moved the implementation down to System.Private.CoreLib, use
it when the target is NetCoreApp1.1.

@weshaggard, @ericstj, @joperezr 