### PR TITLE
Add missing APM methods to Pipes assembly

### DIFF
--- a/src/System.IO.Pipes/ref/System.IO.Pipes.cs
+++ b/src/System.IO.Pipes/ref/System.IO.Pipes.cs
@@ -70,6 +70,8 @@ namespace System.IO.Pipes
         public NamedPipeServerStream(string pipeName, System.IO.Pipes.PipeDirection direction, int maxNumberOfServerInstances, System.IO.Pipes.PipeTransmissionMode transmissionMode, System.IO.Pipes.PipeOptions options, int inBufferSize, int outBufferSize) : base(default(System.IO.Pipes.PipeDirection), default(int)) { }
         public void Disconnect() { }
         ~NamedPipeServerStream() { }
+        public System.IAsyncResult BeginWaitForConnection(System.AsyncCallback callback, object state) { throw null; }
+        public void EndWaitForConnection(System.IAsyncResult asyncResult) { throw null; }
         public string GetImpersonationUserName() { throw null; }
         public void RunAsClient(System.IO.Pipes.PipeStreamImpersonationWorker impersonationWorker) { }
         public void WaitForConnection() { }
@@ -106,11 +108,15 @@ namespace System.IO.Pipes
         public virtual System.IO.Pipes.PipeTransmissionMode ReadMode { get { throw null; } set { } }
         public Microsoft.Win32.SafeHandles.SafePipeHandle SafePipeHandle { get { throw null; } }
         public virtual System.IO.Pipes.PipeTransmissionMode TransmissionMode { get { throw null; } }
+        public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { throw null; }
+        public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { throw null; }
         protected internal virtual void CheckPipePropertyOperations() { }
         protected internal void CheckReadOperations() { }
         protected internal void CheckWriteOperations() { }
         protected bool IsHandleExposed { get { throw null; } }
         protected override void Dispose(bool disposing) { }
+        public override int EndRead(System.IAsyncResult asyncResult) { throw null; }
+        public override void EndWrite(System.IAsyncResult asyncResult) { throw null; }
         public override void Flush() { }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override int ReadByte() { throw null; }

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -40,6 +40,9 @@
     <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
       <Link>Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
+      <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'net463' ">
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
@@ -156,6 +156,12 @@ namespace System.IO.Pipes
             return WaitForConnectionAsync(CancellationToken.None);
         }
 
+        public System.IAsyncResult BeginWaitForConnection(AsyncCallback callback, object state) =>
+            TaskToApm.Begin(WaitForConnectionAsync(), callback, state);
+
+        public void EndWaitForConnection(IAsyncResult asyncResult) =>
+            TaskToApm.End(asyncResult);
+
         // Server can only connect from Disconnected state
         [SecurityCritical]
         [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Consistent with security model")]

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -164,6 +164,22 @@ namespace System.IO.Pipes
             return ReadAsyncCore(buffer, offset, count, cancellationToken);
         }
 
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            if (_isAsync)
+                return TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), callback, state);
+            else
+                return base.BeginRead(buffer, offset, count, callback, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            if (_isAsync)
+                return TaskToApm.End<int>(asyncResult);
+            else
+                return base.EndRead(asyncResult);
+        }
+
         [SecurityCritical]
         public override void Write(byte[] buffer, int offset, int count)
         {
@@ -210,6 +226,22 @@ namespace System.IO.Pipes
             }
 
             return WriteAsyncCore(buffer, offset, count, cancellationToken);
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            if (_isAsync)
+                return TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), callback, state);
+            else
+                return base.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            if (_isAsync)
+                TaskToApm.End(asyncResult);
+            else
+                base.EndWrite(asyncResult);
         }
 
         private void CheckReadWriteArgs(byte[] buffer, int offset, int count)

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Read.netstandard17.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Read.netstandard17.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace System.IO.Pipes.Tests
+{
+    public class NamedPipeTest_Read_ServerInOut_ClientInOut_APMWaitForConnection : PipeTest_Read
+    {
+        protected override ServerClientPair CreateServerClientPair()
+        {
+            ServerClientPair ret = new ServerClientPair();
+            string pipeName = GetUniquePipeName();
+            var readablePipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            var writeablePipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+            Task serverConnect = Task.Factory.FromAsync(readablePipe.BeginWaitForConnection, readablePipe.EndWaitForConnection, null);
+            writeablePipe.Connect();
+            serverConnect.Wait();
+
+            ret.readablePipe = readablePipe;
+            ret.writeablePipe = writeablePipe;
+            return ret;
+        }
+
+        // InOut pipes can be written/read from either direction
+        public override void WriteToReadOnlyPipe_Throws_NotSupportedException() { }
+    }
+}

--- a/src/System.IO.Pipes/tests/PipeTest.Read.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Read.cs
@@ -14,7 +14,7 @@ namespace System.IO.Pipes.Tests
     /// Tests that cover Read and ReadAsync behaviors that are shared between
     /// AnonymousPipes and NamedPipes
     /// </summary>
-    public abstract class PipeTest_Read : PipeTestBase
+    public abstract partial class PipeTest_Read : PipeTestBase
     {
         [Fact]
         public void ReadWithNullBuffer_Throws_ArgumentNullException()
@@ -277,6 +277,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Theory]
+        [OuterLoop]
         [MemberData(nameof(AsyncReadWriteChain_MemberData))]
         public async Task AsyncReadWriteChain_ReadWrite(int iterations, int writeBufferSize, int readBufferSize, bool cancelableToken)
         {
@@ -312,6 +313,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Theory]
+        [OuterLoop]
         [MemberData(nameof(AsyncReadWriteChain_MemberData))]
         public async Task AsyncReadWriteChain_CopyToAsync(int iterations, int writeBufferSize, int readBufferSize, bool cancelableToken)
         {

--- a/src/System.IO.Pipes/tests/PipeTest.Read.netstandard17.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Read.netstandard17.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Pipes.Tests
+{
+    /// <summary>
+    /// Tests that cover Read and ReadAsync behaviors that are shared between
+    /// AnonymousPipes and NamedPipes
+    /// </summary>
+    public abstract partial class PipeTest_Read : PipeTestBase
+    {
+        [Fact]
+        public async Task ValidWriteAsync_ValidReadAsync_APM()
+        {
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                Assert.True(pair.writeablePipe.IsConnected);
+                Assert.True(pair.readablePipe.IsConnected);
+
+                byte[] sent = new byte[] { 123, 0, 5 };
+                byte[] received = new byte[] { 0, 0, 0 };
+
+                Task write = Task.Factory.FromAsync<byte[], int, int>(pair.writeablePipe.BeginWrite, pair.writeablePipe.EndWrite, sent, 0, sent.Length, null);
+                Task<int> read = Task.Factory.FromAsync<byte[], int, int, int>(pair.readablePipe.BeginRead, pair.readablePipe.EndRead, received, 0, received.Length, null);
+                Assert.Equal(sent.Length, await read);
+                Assert.Equal(sent, received);
+                await write;
+            }
+        }
+
+        [Theory]
+        [OuterLoop]
+        [MemberData(nameof(AsyncReadWriteChain_MemberData))]
+        public async Task AsyncReadWriteChain_ReadWrite_APM(int iterations, int writeBufferSize, int readBufferSize, bool cancelableToken)
+        {
+            var writeBuffer = new byte[writeBufferSize];
+            var readBuffer = new byte[readBufferSize];
+            var rand = new Random();
+            var cancellationToken = cancelableToken ? new CancellationTokenSource().Token : CancellationToken.None;
+
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                // Repeatedly and asynchronously write to the writable pipe and read from the readable pipe,
+                // verifying that the correct data made it through.
+                for (int iter = 0; iter < iterations; iter++)
+                {
+                    rand.NextBytes(writeBuffer);
+                    Task write = Task.Factory.FromAsync<byte[], int, int>(pair.writeablePipe.BeginWrite, pair.writeablePipe.EndWrite, writeBuffer, 0, writeBuffer.Length, null);
+
+                    int totalRead = 0;
+                    while (totalRead < writeBuffer.Length)
+                    {
+                        Task<int> read = Task.Factory.FromAsync<byte[], int, int, int>(pair.readablePipe.BeginRead, pair.readablePipe.EndRead, readBuffer, 0, readBuffer.Length, null);
+                        int numRead = await read;
+                        Assert.True(numRead > 0);
+                        Assert.Equal<byte>(
+                            new ArraySegment<byte>(writeBuffer, totalRead, numRead),
+                            new ArraySegment<byte>(readBuffer, 0, numRead));
+                        totalRead += numRead;
+                    }
+                    Assert.Equal(writeBuffer.Length, totalRead);
+
+                    await write;
+                }
+            }
+        }
+    }
+}

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -22,7 +22,9 @@
   <!-- Compiled Source Files -->
   <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="NamedPipeTests\NamedPipeTest.RunAsClient.cs" />
+    <Compile Include="NamedPipeTests\NamedPipeTest.Read.netstandard17.cs" />
     <Compile Include="PipeTest.netstandard17.cs" />
+    <Compile Include="PipeTest.Read.netstandard17.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AnonymousPipeTests\AnonymousPipeTest.CreateServer.cs" />


### PR DESCRIPTION
- Adds the last missing Pipes members to ref/src/tests
- I also outerlooped some tests that were accounting for the majority of the Pipes execution time. Total run time with these tests Outerlooped is 1.6s (down from 10s).
- I looked into having the APM methods share tests with the non-APM async methods (like [here](https://github.com/dotnet/corefx/blob/master/src/System.Net.Requests/tests/FileWebRequestTest.cs#L273-L287)) but determined it to not blend well with the structure of the current Pipes test as they already heavily use inheritance. I instead copied and modified some of the tests to run on the APM methods.
- resolves https://github.com/dotnet/corefx/issues/12349

cc: @joperezr @stephentoub @AlexGhiondea 