### PR TITLE
Fixing packageIndex to include alpine.3.4.3-x64 package entries

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -82,6 +82,12 @@
       ],
       "BaselineVersion": "1.6.2"
     },
+    "runtime.alpine.3.4.3-x64.runtime.native.System.Security.Cryptography": {
+      "BaselineVersion": "4.4.0"
+    },
+    "runtime.alpine.3.4.3-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+      "BaselineVersion": "4.4.0"
+    },
     "runtime.any.System.Collections": {
       "StableVersions": [
         "4.0.11"


### PR DESCRIPTION
I'm not sure how this got passed CI, but it's failing consistently for me when I try to build src\packages.builds.

cc: @ericstj @weshaggard 