### PR TITLE
Re-enable Attributes tests

### DIFF
--- a/src/System.Runtime/tests/System/Attributes.netstandard1.7.cs
+++ b/src/System.Runtime/tests/System/Attributes.netstandard1.7.cs
@@ -112,7 +112,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(12759)]
         public static void RunPosTests()
         {
             Type clsType2 = typeof(TestClass2);
@@ -240,7 +239,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(12759)]
         public static void NegTest1()
         {
             Assembly element = null;
@@ -283,7 +281,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(12759)]
         public static void NegTest2()
         {
             Assembly element = null;

--- a/src/System.Runtime/tests/TestAssembly/project.json
+++ b/src/System.Runtime/tests/TestAssembly/project.json
@@ -9,6 +9,7 @@
   "frameworks": {
     ".NETCoreApp,Version=v1.0": {},
     ".NETCoreApp,Version=v1.1": {},
-    "netstandard1.3": {}
+    "netstandard1.3": {},
+    "netstandard1.5": {}
   }
 }


### PR DESCRIPTION
fixes #12759 

Re-enabling Attributes tests now that we have the new coreclr and also removing newly introduced warning by adding a missing framework to a project.json.

cc: @AlexGhiondea @danmosemsft 