### PR TITLE
Update sporadically failing exception tests to provide more info

### DIFF
--- a/src/System.Runtime/tests/System/IO/DirectoryNotFoundException.InteropTests.cs
+++ b/src/System.Runtime/tests/System/IO/DirectoryNotFoundException.InteropTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -16,8 +15,7 @@ namespace System.IO.Tests
         [InlineData(HResults.CTL_E_PATHNOTFOUND)]
         public static void From_HR(int hr)
         {
-            DirectoryNotFoundException exception = Marshal.GetExceptionForHR(hr) as DirectoryNotFoundException;
-            Assert.NotNull(exception);
+            DirectoryNotFoundException exception = Assert.IsAssignableFrom<DirectoryNotFoundException>(Marshal.GetExceptionForHR(hr));
 
             // Don't validate the message.  Currently .NET Native does not produce HR-specific messages
             ExceptionUtility.ValidateExceptionProperties(exception, hResult: hr, validateMessage: false);

--- a/src/System.Runtime/tests/System/IO/FileNotFoundException.InteropTests.cs
+++ b/src/System.Runtime/tests/System/IO/FileNotFoundException.InteropTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -15,8 +14,7 @@ namespace System.IO.Tests
         [InlineData(HResults.CTL_E_FILENOTFOUND)]
         public static void From_HR(int hr)
         {
-            FileNotFoundException exception = Marshal.GetExceptionForHR(hr) as FileNotFoundException;
-            Assert.NotNull(exception);
+            FileNotFoundException exception = Assert.IsAssignableFrom<FileNotFoundException>(Marshal.GetExceptionForHR(hr));
 
             // Don't validate the message.  Currently .NET Native does not produce HR-specific messages
             ExceptionUtility.ValidateExceptionProperties(exception, hResult: hr, validateMessage: false);

--- a/src/System.Runtime/tests/System/IO/PathTooLongException.InteropTests.cs
+++ b/src/System.Runtime/tests/System/IO/PathTooLongException.InteropTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -14,8 +13,7 @@ namespace System.IO.Tests
         public static void From_HR()
         {
             int hr = HResults.COR_E_PATHTOOLONG;
-            PathTooLongException exception = Marshal.GetExceptionForHR(hr) as PathTooLongException;
-            Assert.NotNull(exception);
+            PathTooLongException exception = Assert.IsAssignableFrom<PathTooLongException>(Marshal.GetExceptionForHR(hr));
             ExceptionUtility.ValidateExceptionProperties(exception, hResult: hr, validateMessage: false);
         }
     }


### PR DESCRIPTION
Use Assert.IsAssignableFrom rather than using as, which then just tells us that the cast failed.  The former gives us detailed type information as well.

#13025 
cc: @ianhays, @JeremyKuhne 