### PR TITLE
Fix crypto shim so path within packages

### DIFF
--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.Apple/osx/runtime.native.System.Security.Cryptography.Apple.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.Apple/osx/runtime.native.System.Security.Cryptography.Apple.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.osx.10.10-$(PackagePlatform).</IdPrefix>
+    <PackageRid>osx.10.10-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OSXNativePath)System.Security.Cryptography.Native.Apple.dylib">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/alpine/3.4.3/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/alpine/3.4.3/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.alpine.3.4.3-$(PackagePlatform).</IdPrefix>
+    <PackageRid>alpine.3.4.3-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Alpine343NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/debian/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/debian/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.debian.8-$(PackagePlatform).</IdPrefix>
+    <PackageRid>debian.8-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(DebianNativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/23/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/23/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.fedora.23-$(PackagePlatform).</IdPrefix>
+    <PackageRid>fedora.23-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Fedora23NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/24/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/24/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.fedora.24-$(PackagePlatform).</IdPrefix>
+    <PackageRid>fedora.24-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Fedora24NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/13.2/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/13.2/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.opensuse.13.2-$(PackagePlatform).</IdPrefix>
+    <PackageRid>opensuse.13.2-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OpenSuse132NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/42.1/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/42.1/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.opensuse.42.1-$(PackagePlatform).</IdPrefix>
+    <PackageRid>opensuse.42.1-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OpenSuse421NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/osx/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/osx/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.osx.10.10-$(PackagePlatform).</IdPrefix>
+    <PackageRid>osx.10.10-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OSXNativePath)System.Security.Cryptography.Native.OpenSsl.dylib">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/rhel/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/rhel/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.rhel.7-$(PackagePlatform).</IdPrefix>
+    <PackageRid>rhel.7-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(RHELNativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/14.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/14.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.ubuntu.14.04-$(PackagePlatform).</IdPrefix>
+    <PackageRid>ubuntu.14.04-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1404NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/16.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/16.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.ubuntu.16.04-$(PackagePlatform).</IdPrefix>
+    <PackageRid>ubuntu.16.04-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1604NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/16.10/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/16.10/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.ubuntu.16.10-$(PackagePlatform).</IdPrefix>
+    <PackageRid>ubuntu.16.10-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1610NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/alpine/3.4.3/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/alpine/3.4.3/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.alpine.3.4.3-$(PackagePlatform).</IdPrefix>
+    <PackageRid>alpine.3.4.3-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Alpine343NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.debian.8-$(PackagePlatform).</IdPrefix>
+    <PackageRid>debian.8-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(DebianNativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.fedora.23-$(PackagePlatform).</IdPrefix>
+    <PackageRid>fedora.23-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Fedora23NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/24/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/24/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.fedora.24-$(PackagePlatform).</IdPrefix>
+    <PackageRid>fedora.24-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Fedora24NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.opensuse.13.2-$(PackagePlatform).</IdPrefix>
+    <PackageRid>opensuse.13.2-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OpenSuse132NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/42.1/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/42.1/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.opensuse.42.1-$(PackagePlatform).</IdPrefix>
+    <PackageRid>opensuse.42.1-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OpenSuse421NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.osx.10.10-$(PackagePlatform).</IdPrefix>
+    <PackageRid>osx.10.10-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OSXNativePath)System.Security.Cryptography.Native.dylib">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.rhel.7-$(PackagePlatform).</IdPrefix>
+    <PackageRid>rhel.7-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(RHELNativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.ubuntu.14.04-$(PackagePlatform).</IdPrefix>
+    <PackageRid>ubuntu.14.04-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1404NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.ubuntu.16.04-$(PackagePlatform).</IdPrefix>
+    <PackageRid>ubuntu.16.04-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1604NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.10/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.10/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <IdPrefix>runtime.ubuntu.16.10-$(PackagePlatform).</IdPrefix>
+    <PackageRid>ubuntu.16.10-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1610NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
The recent change to direct dependencies had an unassigned variable which
was involved in placing the .so (or .dylib) in the right place, which caused
package restore to not map it into the dependency graph.

Instead of
runtimes/RID/native
it was
runtimes/native

This resulted in the .so not being "needed" and therefore things failed in the official build.

This puts the package rid back into the TargetPath for those packages.

cc: @ericstj 
fyi: @MattGal