### PR TITLE
Using named parameter syntax when passing literals in System.Linq.Expressions

### DIFF
--- a/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
+++ b/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
@@ -26,7 +26,7 @@ namespace System.Linq.Expressions.Compiler
             {
                 if (s_assembly == null)
                 {
-                    Interlocked.CompareExchange(ref s_assembly, new AssemblyGen(), null);
+                    Interlocked.CompareExchange(ref s_assembly, new AssemblyGen(), comparand: null);
                 }
                 return s_assembly;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -842,7 +842,7 @@ namespace System.Linq.Expressions
         /// <returns>The BinaryExpression that results from calling the appropriate factory method.</returns>
         public static BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right)
         {
-            return MakeBinary(binaryType, left, right, false, null, null);
+            return MakeBinary(binaryType, left, right, liftToNull: false, method: null, conversion: null);
         }
 
         /// <summary>
@@ -856,7 +856,7 @@ namespace System.Linq.Expressions
         /// <returns>The BinaryExpression that results from calling the appropriate factory method.</returns>
         public static BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right, bool liftToNull, MethodInfo method)
         {
-            return MakeBinary(binaryType, left, right, liftToNull, method, null);
+            return MakeBinary(binaryType, left, right, liftToNull, method, conversion: null);
         }
 
         ///
@@ -969,7 +969,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Equal(Expression left, Expression right)
         {
-            return Equal(left, right, false, null);
+            return Equal(left, right, liftToNull: false, method: null);
         }
 
         /// <summary>
@@ -1021,7 +1021,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression NotEqual(Expression left, Expression right)
         {
-            return NotEqual(left, right, false, null);
+            return NotEqual(left, right, liftToNull: false, method: null);
         }
 
         /// <summary>
@@ -1114,7 +1114,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression GreaterThan(Expression left, Expression right)
         {
-            return GreaterThan(left, right, false, null);
+            return GreaterThan(left, right, liftToNull: false, method: null);
         }
 
         /// <summary>
@@ -1148,7 +1148,7 @@ namespace System.Linq.Expressions
 
         public static BinaryExpression LessThan(Expression left, Expression right)
         {
-            return LessThan(left, right, false, null);
+            return LessThan(left, right, liftToNull: false, method: null);
         }
 
         /// <summary>
@@ -1181,7 +1181,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression GreaterThanOrEqual(Expression left, Expression right)
         {
-            return GreaterThanOrEqual(left, right, false, null);
+            return GreaterThanOrEqual(left, right, liftToNull: false, method: null);
         }
 
         /// <summary>
@@ -1214,7 +1214,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression LessThanOrEqual(Expression left, Expression right)
         {
-            return LessThanOrEqual(left, right, false, null);
+            return LessThanOrEqual(left, right, liftToNull: false, method: null);
         }
 
         /// <summary>
@@ -1267,7 +1267,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression AndAlso(Expression left, Expression right)
         {
-            return AndAlso(left, right, null);
+            return AndAlso(left, right, method: null);
         }
 
         /// <summary>
@@ -1320,7 +1320,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression OrElse(Expression left, Expression right)
         {
-            return OrElse(left, right, null);
+            return OrElse(left, right, method: null);
         }
 
         /// <summary>
@@ -1377,7 +1377,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Coalesce(Expression left, Expression right)
         {
-            return Coalesce(left, right, null);
+            return Coalesce(left, right, conversion: null);
         }
 
         /// <summary>
@@ -1476,7 +1476,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Add(Expression left, Expression right)
         {
-            return Add(left, right, null);
+            return Add(left, right, method: null);
         }
 
         /// <summary>
@@ -1498,9 +1498,9 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.Add, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Add, "op_Addition", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Add, "op_Addition", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.Add, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.Add, left, right, method, liftToNull: true);
         }
 
         /// <summary>
@@ -1512,7 +1512,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression AddAssign(Expression left, Expression right)
         {
-            return AddAssign(left, right, null, null);
+            return AddAssign(left, right, method: null, conversion: null);
         }
 
         /// <summary>
@@ -1526,7 +1526,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression AddAssign(Expression left, Expression right, MethodInfo method)
         {
-            return AddAssign(left, right, method, null);
+            return AddAssign(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -1556,9 +1556,9 @@ namespace System.Linq.Expressions
                     }
                     return new SimpleBinaryExpression(ExpressionType.AddAssign, left, right, left.Type);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.AddAssign, "op_Addition", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.AddAssign, "op_Addition", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.AddAssign, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.AddAssign, left, right, method, conversion, liftToNull: true);
         }
 
         private static void ValidateOpAssignConversionLambda(LambdaExpression conversion, Expression left, MethodInfo method, ExpressionType nodeType)
@@ -1597,7 +1597,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression AddAssignChecked(Expression left, Expression right)
         {
-            return AddAssignChecked(left, right, null);
+            return AddAssignChecked(left, right, method: null);
         }
 
         /// <summary>
@@ -1611,7 +1611,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression AddAssignChecked(Expression left, Expression right, MethodInfo method)
         {
-            return AddAssignChecked(left, right, method, null);
+            return AddAssignChecked(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -1642,9 +1642,9 @@ namespace System.Linq.Expressions
                     }
                     return new SimpleBinaryExpression(ExpressionType.AddAssignChecked, left, right, left.Type);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.AddAssignChecked, "op_Addition", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.AddAssignChecked, "op_Addition", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.AddAssignChecked, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.AddAssignChecked, left, right, method, conversion, liftToNull: true);
         }
 
         /// <summary>
@@ -1656,7 +1656,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression AddChecked(Expression left, Expression right)
         {
-            return AddChecked(left, right, null);
+            return AddChecked(left, right, method: null);
         }
 
         /// <summary>
@@ -1678,9 +1678,9 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.AddChecked, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.AddChecked, "op_Addition", left, right, false);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.AddChecked, "op_Addition", left, right, liftToNull: false);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.AddChecked, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.AddChecked, left, right, method, liftToNull: true);
         }
 
         /// <summary>
@@ -1692,7 +1692,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Subtract(Expression left, Expression right)
         {
-            return Subtract(left, right, null);
+            return Subtract(left, right, method: null);
         }
 
         /// <summary>
@@ -1714,9 +1714,9 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.Subtract, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Subtract, "op_Subtraction", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Subtract, "op_Subtraction", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.Subtract, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.Subtract, left, right, method, liftToNull: true);
         }
 
         /// <summary>
@@ -1728,7 +1728,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression SubtractAssign(Expression left, Expression right)
         {
-            return SubtractAssign(left, right, null, null);
+            return SubtractAssign(left, right, method: null, conversion: null);
         }
 
         /// <summary>
@@ -1742,7 +1742,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression SubtractAssign(Expression left, Expression right, MethodInfo method)
         {
-            return SubtractAssign(left, right, method, null);
+            return SubtractAssign(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -1772,9 +1772,9 @@ namespace System.Linq.Expressions
                     }
                     return new SimpleBinaryExpression(ExpressionType.SubtractAssign, left, right, left.Type);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.SubtractAssign, "op_Subtraction", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.SubtractAssign, "op_Subtraction", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.SubtractAssign, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.SubtractAssign, left, right, method, conversion, liftToNull: true);
         }
         
         /// <summary>
@@ -1786,7 +1786,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression SubtractAssignChecked(Expression left, Expression right)
         {
-            return SubtractAssignChecked(left, right, null);
+            return SubtractAssignChecked(left, right, method: null);
         }
 
         /// <summary>
@@ -1800,7 +1800,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression SubtractAssignChecked(Expression left, Expression right, MethodInfo method)
         {
-            return SubtractAssignChecked(left, right, method, null);
+            return SubtractAssignChecked(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -1830,9 +1830,9 @@ namespace System.Linq.Expressions
                     }
                     return new SimpleBinaryExpression(ExpressionType.SubtractAssignChecked, left, right, left.Type);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.SubtractAssignChecked, "op_Subtraction", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.SubtractAssignChecked, "op_Subtraction", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.SubtractAssignChecked, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.SubtractAssignChecked, left, right, method, conversion, liftToNull: true);
         }
         
         /// <summary>
@@ -1844,7 +1844,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression SubtractChecked(Expression left, Expression right)
         {
-            return SubtractChecked(left, right, null);
+            return SubtractChecked(left, right, method: null);
         }
 
         /// <summary>
@@ -1866,9 +1866,9 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.SubtractChecked, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.SubtractChecked, "op_Subtraction", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.SubtractChecked, "op_Subtraction", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.SubtractChecked, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.SubtractChecked, left, right, method, liftToNull: true);
         }
 
         /// <summary>
@@ -1880,7 +1880,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Divide(Expression left, Expression right)
         {
-            return Divide(left, right, null);
+            return Divide(left, right, method: null);
         }
 
         /// <summary>
@@ -1902,9 +1902,9 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.Divide, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Divide, "op_Division", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Divide, "op_Division", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.Divide, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.Divide, left, right, method, liftToNull: true);
         }
         
         /// <summary>
@@ -1916,7 +1916,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression DivideAssign(Expression left, Expression right)
         {
-            return DivideAssign(left, right, null, null);
+            return DivideAssign(left, right, method: null, conversion: null);
         }
 
         /// <summary>
@@ -1930,7 +1930,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression DivideAssign(Expression left, Expression right, MethodInfo method)
         {
-            return DivideAssign(left, right, method, null);
+            return DivideAssign(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -1960,9 +1960,9 @@ namespace System.Linq.Expressions
                     }
                     return new SimpleBinaryExpression(ExpressionType.DivideAssign, left, right, left.Type);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.DivideAssign, "op_Division", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.DivideAssign, "op_Division", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.DivideAssign, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.DivideAssign, left, right, method, conversion, liftToNull: true);
         }
 
         /// <summary>
@@ -1974,7 +1974,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Modulo(Expression left, Expression right)
         {
-            return Modulo(left, right, null);
+            return Modulo(left, right, method: null);
         }
 
         /// <summary>
@@ -1996,9 +1996,9 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.Modulo, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Modulo, "op_Modulus", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Modulo, "op_Modulus", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.Modulo, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.Modulo, left, right, method, liftToNull: true);
         }
         
         /// <summary>
@@ -2010,7 +2010,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression ModuloAssign(Expression left, Expression right)
         {
-            return ModuloAssign(left, right, null, null);
+            return ModuloAssign(left, right, method: null, conversion: null);
         }
 
         /// <summary>
@@ -2024,7 +2024,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression ModuloAssign(Expression left, Expression right, MethodInfo method)
         {
-            return ModuloAssign(left, right, method, null);
+            return ModuloAssign(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -2054,9 +2054,9 @@ namespace System.Linq.Expressions
                     }
                     return new SimpleBinaryExpression(ExpressionType.ModuloAssign, left, right, left.Type);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.ModuloAssign, "op_Modulus", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.ModuloAssign, "op_Modulus", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.ModuloAssign, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.ModuloAssign, left, right, method, conversion, liftToNull: true);
         }
         
         /// <summary>
@@ -2068,7 +2068,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Multiply(Expression left, Expression right)
         {
-            return Multiply(left, right, null);
+            return Multiply(left, right, method: null);
         }
 
         /// <summary>
@@ -2090,9 +2090,9 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.Multiply, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Multiply, "op_Multiply", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Multiply, "op_Multiply", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.Multiply, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.Multiply, left, right, method, liftToNull: true);
         }
         
         /// <summary>
@@ -2104,7 +2104,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression MultiplyAssign(Expression left, Expression right)
         {
-            return MultiplyAssign(left, right, null, null);
+            return MultiplyAssign(left, right, method: null, conversion: null);
         }
 
         /// <summary>
@@ -2118,7 +2118,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression MultiplyAssign(Expression left, Expression right, MethodInfo method)
         {
-            return MultiplyAssign(left, right, method, null);
+            return MultiplyAssign(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -2148,9 +2148,9 @@ namespace System.Linq.Expressions
                     }
                     return new SimpleBinaryExpression(ExpressionType.MultiplyAssign, left, right, left.Type);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.MultiplyAssign, "op_Multiply", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.MultiplyAssign, "op_Multiply", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.MultiplyAssign, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.MultiplyAssign, left, right, method, conversion, liftToNull: true);
         }
         
         /// <summary>
@@ -2162,7 +2162,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression MultiplyAssignChecked(Expression left, Expression right)
         {
-            return MultiplyAssignChecked(left, right, null);
+            return MultiplyAssignChecked(left, right, method: null);
         }
 
         /// <summary>
@@ -2176,7 +2176,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression MultiplyAssignChecked(Expression left, Expression right, MethodInfo method)
         {
-            return MultiplyAssignChecked(left, right, method, null);
+            return MultiplyAssignChecked(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -2206,9 +2206,9 @@ namespace System.Linq.Expressions
                     }
                     return new SimpleBinaryExpression(ExpressionType.MultiplyAssignChecked, left, right, left.Type);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.MultiplyAssignChecked, "op_Multiply", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.MultiplyAssignChecked, "op_Multiply", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.MultiplyAssignChecked, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.MultiplyAssignChecked, left, right, method, conversion, liftToNull: true);
         }
         
         /// <summary>
@@ -2220,7 +2220,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression MultiplyChecked(Expression left, Expression right)
         {
-            return MultiplyChecked(left, right, null);
+            return MultiplyChecked(left, right, method: null);
         }
 
         /// <summary>
@@ -2242,9 +2242,9 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.MultiplyChecked, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.MultiplyChecked, "op_Multiply", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.MultiplyChecked, "op_Multiply", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.MultiplyChecked, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.MultiplyChecked, left, right, method, liftToNull: true);
         }
 
         private static bool IsSimpleShift(Type left, Type right)
@@ -2272,7 +2272,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression LeftShift(Expression left, Expression right)
         {
-            return LeftShift(left, right, null);
+            return LeftShift(left, right, method: null);
         }
 
         /// <summary>
@@ -2295,9 +2295,9 @@ namespace System.Linq.Expressions
                     Type resultType = GetResultTypeOfShift(left.Type, right.Type);
                     return new SimpleBinaryExpression(ExpressionType.LeftShift, left, right, resultType);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.LeftShift, "op_LeftShift", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.LeftShift, "op_LeftShift", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.LeftShift, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.LeftShift, left, right, method, liftToNull: true);
         }
 
         /// <summary>
@@ -2309,7 +2309,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression LeftShiftAssign(Expression left, Expression right)
         {
-            return LeftShiftAssign(left, right, null, null);
+            return LeftShiftAssign(left, right, method: null, conversion: null);
         }
 
         /// <summary>
@@ -2323,7 +2323,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression LeftShiftAssign(Expression left, Expression right, MethodInfo method)
         {
-            return LeftShiftAssign(left, right, method, null);
+            return LeftShiftAssign(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -2354,9 +2354,9 @@ namespace System.Linq.Expressions
                     Type resultType = GetResultTypeOfShift(left.Type, right.Type);
                     return new SimpleBinaryExpression(ExpressionType.LeftShiftAssign, left, right, resultType);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.LeftShiftAssign, "op_LeftShift", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.LeftShiftAssign, "op_LeftShift", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.LeftShiftAssign, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.LeftShiftAssign, left, right, method, conversion, liftToNull: true);
         }
         
         /// <summary>
@@ -2368,7 +2368,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression RightShift(Expression left, Expression right)
         {
-            return RightShift(left, right, null);
+            return RightShift(left, right, method: null);
         }
 
         /// <summary>
@@ -2391,9 +2391,9 @@ namespace System.Linq.Expressions
                     Type resultType = GetResultTypeOfShift(left.Type, right.Type);
                     return new SimpleBinaryExpression(ExpressionType.RightShift, left, right, resultType);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.RightShift, "op_RightShift", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.RightShift, "op_RightShift", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.RightShift, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.RightShift, left, right, method, liftToNull: true);
         }
 
         /// <summary>
@@ -2405,7 +2405,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression RightShiftAssign(Expression left, Expression right)
         {
-            return RightShiftAssign(left, right, null, null);
+            return RightShiftAssign(left, right, method: null, conversion: null);
         }
 
         /// <summary>
@@ -2419,7 +2419,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression RightShiftAssign(Expression left, Expression right, MethodInfo method)
         {
-            return RightShiftAssign(left, right, method, null);
+            return RightShiftAssign(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -2450,9 +2450,9 @@ namespace System.Linq.Expressions
                     Type resultType = GetResultTypeOfShift(left.Type, right.Type);
                     return new SimpleBinaryExpression(ExpressionType.RightShiftAssign, left, right, resultType);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.RightShiftAssign, "op_RightShift", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.RightShiftAssign, "op_RightShift", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.RightShiftAssign, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.RightShiftAssign, left, right, method, conversion, liftToNull: true);
         }
         
         /// <summary>
@@ -2464,7 +2464,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression And(Expression left, Expression right)
         {
-            return And(left, right, null);
+            return And(left, right, method: null);
         }
 
         /// <summary>
@@ -2486,9 +2486,9 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.And, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.And, "op_BitwiseAnd", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.And, "op_BitwiseAnd", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.And, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.And, left, right, method, liftToNull: true);
         }
 
         /// <summary>
@@ -2500,7 +2500,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression AndAssign(Expression left, Expression right)
         {
-            return AndAssign(left, right, null, null);
+            return AndAssign(left, right, method: null, conversion: null);
         }
 
         /// <summary>
@@ -2514,7 +2514,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression AndAssign(Expression left, Expression right, MethodInfo method)
         {
-            return AndAssign(left, right, method, null);
+            return AndAssign(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -2544,9 +2544,9 @@ namespace System.Linq.Expressions
                     }
                     return new SimpleBinaryExpression(ExpressionType.AndAssign, left, right, left.Type);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.AndAssign, "op_BitwiseAnd", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.AndAssign, "op_BitwiseAnd", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.AndAssign, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.AndAssign, left, right, method, conversion, liftToNull: true);
         }
         
         /// <summary>
@@ -2558,7 +2558,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Or(Expression left, Expression right)
         {
-            return Or(left, right, null);
+            return Or(left, right, method: null);
         }
 
         /// <summary>
@@ -2580,9 +2580,9 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.Or, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Or, "op_BitwiseOr", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.Or, "op_BitwiseOr", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.Or, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.Or, left, right, method, liftToNull: true);
         }
 
         /// <summary>
@@ -2594,7 +2594,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression OrAssign(Expression left, Expression right)
         {
-            return OrAssign(left, right, null, null);
+            return OrAssign(left, right, method: null, conversion: null);
         }
 
         /// <summary>
@@ -2608,7 +2608,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression OrAssign(Expression left, Expression right, MethodInfo method)
         {
-            return OrAssign(left, right, method, null);
+            return OrAssign(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -2638,9 +2638,9 @@ namespace System.Linq.Expressions
                     }
                     return new SimpleBinaryExpression(ExpressionType.OrAssign, left, right, left.Type);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.OrAssign, "op_BitwiseOr", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.OrAssign, "op_BitwiseOr", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.OrAssign, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.OrAssign, left, right, method, conversion, liftToNull: true);
         }
 
         /// <summary>
@@ -2652,7 +2652,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression ExclusiveOr(Expression left, Expression right)
         {
-            return ExclusiveOr(left, right, null);
+            return ExclusiveOr(left, right, method: null);
         }
 
         /// <summary>
@@ -2674,9 +2674,9 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.ExclusiveOr, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.ExclusiveOr, "op_ExclusiveOr", left, right, true);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.ExclusiveOr, "op_ExclusiveOr", left, right, liftToNull: true);
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.ExclusiveOr, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.ExclusiveOr, left, right, method, liftToNull: true);
         }
 
         /// <summary>
@@ -2688,7 +2688,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression ExclusiveOrAssign(Expression left, Expression right)
         {
-            return ExclusiveOrAssign(left, right, null, null);
+            return ExclusiveOrAssign(left, right, method: null, conversion: null);
         }
 
         /// <summary>
@@ -2702,7 +2702,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression ExclusiveOrAssign(Expression left, Expression right, MethodInfo method)
         {
-            return ExclusiveOrAssign(left, right, method, null);
+            return ExclusiveOrAssign(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -2732,9 +2732,9 @@ namespace System.Linq.Expressions
                     }
                     return new SimpleBinaryExpression(ExpressionType.ExclusiveOrAssign, left, right, left.Type);
                 }
-                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.ExclusiveOrAssign, "op_ExclusiveOr", left, right, conversion, true);
+                return GetUserDefinedAssignOperatorOrThrow(ExpressionType.ExclusiveOrAssign, "op_ExclusiveOr", left, right, conversion, liftToNull: true);
             }
-            return GetMethodBasedAssignOperator(ExpressionType.ExclusiveOrAssign, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.ExclusiveOrAssign, left, right, method, conversion, liftToNull: true);
         }
 
         /// <summary>
@@ -2746,7 +2746,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Power(Expression left, Expression right)
         {
-            return Power(left, right, null);
+            return Power(left, right, method: null);
         }
 
         /// <summary>
@@ -2770,7 +2770,7 @@ namespace System.Linq.Expressions
                     throw Error.BinaryOperatorNotDefined(ExpressionType.Power, left.Type, right.Type);
                 }
             }
-            return GetMethodBasedBinaryOperator(ExpressionType.Power, left, right, method, true);
+            return GetMethodBasedBinaryOperator(ExpressionType.Power, left, right, method, liftToNull: true);
         }
 
         /// <summary>
@@ -2782,7 +2782,7 @@ namespace System.Linq.Expressions
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression PowerAssign(Expression left, Expression right)
         {
-            return PowerAssign(left, right, null, null);
+            return PowerAssign(left, right, method: null, conversion: null);
         }
 
         /// <summary>
@@ -2796,7 +2796,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression PowerAssign(Expression left, Expression right, MethodInfo method)
         {
-            return PowerAssign(left, right, method, null);
+            return PowerAssign(left, right, method, conversion: null);
         }
 
         /// <summary>
@@ -2823,7 +2823,7 @@ namespace System.Linq.Expressions
                     throw Error.BinaryOperatorNotDefined(ExpressionType.PowerAssign, left.Type, right.Type);
                 }
             }
-            return GetMethodBasedAssignOperator(ExpressionType.PowerAssign, left, right, method, conversion, true);
+            return GetMethodBasedAssignOperator(ExpressionType.PowerAssign, left, right, method, conversion, liftToNull: true);
         }
 
         #endregion

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
@@ -82,7 +82,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="CatchBlock"/>.</returns>
         public static CatchBlock Catch(Type type, Expression body)
         {
-            return MakeCatchBlock(type, null, body, null);
+            return MakeCatchBlock(type, null, body, filter: null);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace System.Linq.Expressions
         public static CatchBlock Catch(ParameterExpression variable, Expression body)
         {
             ContractUtils.RequiresNotNull(variable, nameof(variable));
-            return MakeCatchBlock(variable.Type, variable, body, null);
+            return MakeCatchBlock(variable.Type, variable, body, filter: null);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/HoistedLocals.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/HoistedLocals.cs
@@ -72,7 +72,7 @@ namespace System.Linq.Expressions.Compiler
                 indexes.Add(vars[i], i);
             }
 
-            SelfVariable = Expression.Variable(typeof(object[]), null);
+            SelfVariable = Expression.Variable(typeof(object[]), name: null);
             Parent = parent;
             Variables = vars;
             Indexes = new ReadOnlyDictionary<Expression, int>(indexes);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
@@ -84,7 +84,7 @@ namespace System.Linq.Expressions.Compiler
                 Type indexType = TypeUtils.GetNonNullableType(rightType);
                 if (indexType != typeof(int))
                 {
-                    _ilg.EmitConvertToType(indexType, typeof(int), true);
+                    _ilg.EmitConvertToType(indexType, typeof(int), isChecked: true);
                 }
                 _ilg.Emit(OpCodes.Ldelema, node.Type);
             }
@@ -290,7 +290,7 @@ namespace System.Linq.Expressions.Compiler
             PropertyInfo pi = (PropertyInfo)node.Member;
 
             // emit the get
-            EmitCall(instanceType, pi.GetGetMethod(true));
+            EmitCall(instanceType, pi.GetGetMethod(nonPublic: true));
 
             // emit the address of the value
             LocalBuilder valueLocal = GetLocal(node.Type);
@@ -308,7 +308,7 @@ namespace System.Linq.Expressions.Compiler
                 }
                 @this._ilg.Emit(OpCodes.Ldloc, valueLocal);
                 @this.FreeLocal(valueLocal);
-                @this.EmitCall(instanceLocal?.LocalType, pi.GetSetMethod(true));
+                @this.EmitCall(instanceLocal?.LocalType, pi.GetSetMethod(nonPublic: true));
             };
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -94,8 +94,8 @@ namespace System.Linq.Expressions.Compiler
         {
             if (b.IsLifted)
             {
-                ParameterExpression p1 = Expression.Variable(TypeUtils.GetNonNullableType(b.Left.Type), null);
-                ParameterExpression p2 = Expression.Variable(TypeUtils.GetNonNullableType(b.Right.Type), null);
+                ParameterExpression p1 = Expression.Variable(TypeUtils.GetNonNullableType(b.Left.Type), name: null);
+                ParameterExpression p2 = Expression.Variable(TypeUtils.GetNonNullableType(b.Right.Type), name: null);
                 MethodCallExpression mc = Expression.Call(null, b.Method, p1, p2);
                 Type resultType = null;
                 if (b.IsLiftedToNull)
@@ -549,7 +549,7 @@ namespace System.Linq.Expressions.Compiler
                 TypeUtils.GetNonNullableType(leftType),
                 TypeUtils.GetNonNullableType(rightType),
                 TypeUtils.GetNonNullableType(resultType),
-                false
+                liftedToNull: false
             );
 
             if (!liftedToNull)
@@ -559,7 +559,7 @@ namespace System.Linq.Expressions.Compiler
 
             if (!TypeUtils.AreEquivalent(resultType, TypeUtils.GetNonNullableType(resultType)))
             {
-                _ilg.EmitConvertToType(TypeUtils.GetNonNullableType(resultType), resultType, true);
+                _ilg.EmitConvertToType(TypeUtils.GetNonNullableType(resultType), resultType, isChecked: true);
             }
 
             if (liftedToNull)
@@ -632,7 +632,7 @@ namespace System.Linq.Expressions.Compiler
             FreeLocal(locLeft);
             FreeLocal(locRight);
 
-            EmitBinaryOperator(op, TypeUtils.GetNonNullableType(leftType), TypeUtils.GetNonNullableType(rightType), TypeUtils.GetNonNullableType(resultType), false);
+            EmitBinaryOperator(op, TypeUtils.GetNonNullableType(leftType), TypeUtils.GetNonNullableType(rightType), TypeUtils.GetNonNullableType(resultType), liftedToNull: false);
 
             // construct result type
             ConstructorInfo ci = resultType.GetConstructor(new Type[] { TypeUtils.GetNonNullableType(resultType) });

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -291,7 +291,7 @@ namespace System.Linq.Expressions.Compiler
             if (node.Indexer != null)
             {
                 // For indexed properties, just call the getter
-                MethodInfo method = node.Indexer.GetGetMethod(true);
+                MethodInfo method = node.Indexer.GetGetMethod(nonPublic: true);
                 EmitCall(objectType, method);
             }
             else
@@ -319,7 +319,7 @@ namespace System.Linq.Expressions.Compiler
             if (node.Indexer != null)
             {
                 // For indexed properties, just call the setter
-                MethodInfo method = node.Indexer.GetSetMethod(true);
+                MethodInfo method = node.Indexer.GetSetMethod(nonPublic: true);
                 EmitCall(objectType, method);
             }
             else
@@ -800,7 +800,7 @@ namespace System.Linq.Expressions.Compiler
                 // MemberExpression.Member can only be a FieldInfo or a PropertyInfo
                 Debug.Assert(member is PropertyInfo);
                 var prop = (PropertyInfo)member;
-                EmitCall(objectType, prop.GetSetMethod(true));
+                EmitCall(objectType, prop.GetSetMethod(nonPublic: true));
             }
 
             if (emitAs != CompilationFlags.EmitAsVoidType)
@@ -846,7 +846,7 @@ namespace System.Linq.Expressions.Compiler
                 // MemberExpression.Member or MemberBinding.Member can only be a FieldInfo or a PropertyInfo
                 Debug.Assert(member is PropertyInfo);
                 var prop = (PropertyInfo)member;
-                EmitCall(objectType, prop.GetGetMethod(true));
+                EmitCall(objectType, prop.GetGetMethod(nonPublic: true));
             }
         }
 
@@ -858,7 +858,7 @@ namespace System.Linq.Expressions.Compiler
 
             try
             {
-                value = fi.GetValue(null);
+                value = fi.GetValue(obj: null);
                 return true;
             }
             catch
@@ -908,7 +908,7 @@ namespace System.Linq.Expressions.Compiler
                 {
                     Expression x = expressions[i];
                     EmitExpression(x);
-                    _ilg.EmitConvertToType(x.Type, typeof(int), true);
+                    _ilg.EmitConvertToType(x.Type, typeof(int), isChecked: true);
                 }
                 _ilg.EmitArray(node.Type);
             }
@@ -968,7 +968,7 @@ namespace System.Linq.Expressions.Compiler
                 PropertyInfo pi = binding.Member as PropertyInfo;
                 if (pi != null)
                 {
-                    EmitCall(objectType, pi.GetSetMethod(true));
+                    EmitCall(objectType, pi.GetSetMethod(nonPublic: true));
                 }
                 else
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -151,7 +151,7 @@ namespace System.Linq.Expressions.Compiler
             {
                 _ilg.Emit(OpCodes.Ldloca, loc);
                 _ilg.EmitGetValueOrDefault(b.Left.Type);
-                _ilg.EmitConvertToType(nnLeftType, b.Type, true);
+                _ilg.EmitConvertToType(nnLeftType, b.Type, isChecked: true);
             }
             else
             {
@@ -165,7 +165,7 @@ namespace System.Linq.Expressions.Compiler
             EmitExpression(b.Right);
             if (!TypeUtils.AreEquivalent(b.Right.Type, b.Type))
             {
-                _ilg.EmitConvertToType(b.Right.Type, b.Type, true);
+                _ilg.EmitConvertToType(b.Right.Type, b.Type, isChecked: true);
             }
             _ilg.MarkLabel(labEnd);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -937,7 +937,7 @@ namespace System.Linq.Expressions.Compiler
             // begin the catch, clear the exception, we've 
             // already saved it
             _ilg.MarkLabel(endFilter);
-            _ilg.BeginCatchBlock(null);
+            _ilg.BeginCatchBlock(exceptionType: null);
             _ilg.Emit(OpCodes.Pop);
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -78,10 +78,10 @@ namespace System.Linq.Expressions.Compiler
                 LocalBuilder loc = GetLocal(node.Operand.Type);
                 _ilg.Emit(OpCodes.Stloc, loc);
                 _ilg.EmitInt(0);
-                _ilg.EmitConvertToType(typeof(int), node.Operand.Type, false);
+                _ilg.EmitConvertToType(typeof(int), node.Operand.Type, isChecked: false);
                 _ilg.Emit(OpCodes.Ldloc, loc);
                 FreeLocal(loc);
-                EmitBinaryOperator(ExpressionType.SubtractChecked, node.Operand.Type, node.Operand.Type, node.Type, false);
+                EmitBinaryOperator(ExpressionType.SubtractChecked, node.Operand.Type, node.Operand.Type, node.Type, liftedToNull: false);
             }
             else
             {
@@ -366,12 +366,12 @@ namespace System.Linq.Expressions.Compiler
         {
             if (node.IsLifted)
             {
-                ParameterExpression v = Expression.Variable(TypeUtils.GetNonNullableType(node.Operand.Type), null);
+                ParameterExpression v = Expression.Variable(TypeUtils.GetNonNullableType(node.Operand.Type), name: null);
                 MethodCallExpression mc = Expression.Call(node.Method, v);
 
                 Type resultType = TypeUtils.GetNullableType(mc.Type);
                 EmitLift(node.NodeType, resultType, mc, new ParameterExpression[] { v }, new Expression[] { node.Operand });
-                _ilg.EmitConvertToType(resultType, node.Type, false);
+                _ilg.EmitConvertToType(resultType, node.Type, isChecked: false);
             }
             else
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
@@ -57,7 +57,7 @@ namespace System.Linq.Expressions
                 Interlocked.CompareExchange(
                     ref s_legacyCtorSupportTable,
                     new ConditionalWeakTable<Expression, ExtensionInfo>(),
-                    null
+comparand: null
                 );
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -285,7 +285,7 @@ namespace System.Linq.Expressions
         {
             MethodInfo mi;
 
-            mi = pi.GetGetMethod(true);
+            mi = pi.GetGetMethod(nonPublic: true);
             ParameterInfo[] parms;
             if (mi != null)
             {
@@ -293,7 +293,7 @@ namespace System.Linq.Expressions
             }
             else
             {
-                mi = pi.GetSetMethod(true);
+                mi = pi.GetSetMethod(nonPublic: true);
                 //The setter has an additional parameter for the value to set,
                 //need to remove the last type to match the arguments.
                 parms = mi.GetParametersCached().RemoveLast();
@@ -366,14 +366,14 @@ namespace System.Linq.Expressions
             if (property.PropertyType == typeof(void)) throw Error.PropertyTypeCannotBeVoid(nameof(property));
 
             ParameterInfo[] getParameters = null;
-            MethodInfo getter = property.GetGetMethod(true);
+            MethodInfo getter = property.GetGetMethod(nonPublic: true);
             if (getter != null)
             {
                 getParameters = getter.GetParametersCached();
                 ValidateAccessor(instance, getter, getParameters, ref argList, nameof(property));
             }
 
-            MethodInfo setter = property.GetSetMethod(true);
+            MethodInfo setter = property.GetSetMethod(nonPublic: true);
             if (setter != null)
             {
                 ParameterInfo[] setParameters = setter.GetParametersCached();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
@@ -22,7 +22,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            frame.Push(_field.GetValue(null));
+            frame.Push(_field.GetValue(obj: null));
             return +1;
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -321,7 +321,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public void EmitLoad(object value)
         {
-            EmitLoad(value, null);
+            EmitLoad(value, type: null);
         }
 
         public void EmitLoad(bool value)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightDelegateCreator.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightDelegateCreator.cs
@@ -25,7 +25,7 @@ namespace System.Linq.Expressions.Interpreter
 
         internal Interpreter Interpreter { get; }
 
-        public Delegate CreateDelegate() => CreateDelegate(null);
+        public Delegate CreateDelegate() => CreateDelegate(closure: null);
 
         internal Delegate CreateDelegate(IStrongBox[] closure)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelExpression.cs
@@ -79,7 +79,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="LabelExpression"/> with no default value.</returns>
         public static LabelExpression Label(LabelTarget target)
         {
-            return Label(target, null);
+            return Label(target, defaultValue: null);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="LabelExpression"/> with the given default value.</returns>
         public static LabelExpression Label(LabelTarget target, Expression defaultValue)
         {
-            ValidateGoto(target, ref defaultValue, nameof(target), nameof(defaultValue), null);
+            ValidateGoto(target, ref defaultValue, nameof(target), nameof(defaultValue), type: null);
             return new LabelExpression(target, defaultValue);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
@@ -48,7 +48,7 @@ namespace System.Linq.Expressions
         /// <returns>The new <see cref="LabelTarget"/>.</returns>
         public static LabelTarget Label()
         {
-            return Label(typeof(void), null);
+            return Label(typeof(void), name: null);
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace System.Linq.Expressions
         /// <returns>The new <see cref="LabelTarget"/>.</returns>
         public static LabelTarget Label(Type type)
         {
-            return Label(type, null);
+            return Label(type, name: null);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -71,7 +71,7 @@ namespace System.Linq.Expressions
         /// <returns>The reduced expression.</returns>
         public override Expression Reduce()
         {
-            return MemberInitExpression.ReduceListInit(NewExpression, Initializers, true);
+            return MemberInitExpression.ReduceListInit(NewExpression, Initializers, keepOnStack: true);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LoopExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LoopExpression.cs
@@ -83,7 +83,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="LoopExpression"/>.</returns>
         public static LoopExpression Loop(Expression body)
         {
-            return Loop(body, null);
+            return Loop(body, @break: null);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="LoopExpression"/>.</returns>
         public static LoopExpression Loop(Expression body, LabelTarget @break)
         {
-            return Loop(body, @break, null);
+            return Loop(body, @break, @continue: null);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -259,11 +259,11 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(property, nameof(property));
 
-            MethodInfo mi = property.GetGetMethod(true);
+            MethodInfo mi = property.GetGetMethod(nonPublic: true);
 
             if (mi == null)
             {
-                mi = property.GetSetMethod(true);
+                mi = property.GetSetMethod(nonPublic: true);
 
                 if (mi == null)
                 {
@@ -317,11 +317,11 @@ namespace System.Linq.Expressions
             PropertyInfo[] props = type.GetProperties(flags);
             foreach (PropertyInfo pi in props)
             {
-                if (pi.CanRead && CheckMethod(mi, pi.GetGetMethod(true)))
+                if (pi.CanRead && CheckMethod(mi, pi.GetGetMethod(nonPublic: true)))
                 {
                     return pi;
                 }
-                if (pi.CanWrite && CheckMethod(mi, pi.GetSetMethod(true)))
+                if (pi.CanWrite && CheckMethod(mi, pi.GetSetMethod(nonPublic: true)))
                 {
                     return pi;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
@@ -65,12 +65,12 @@ namespace System.Linq.Expressions
         /// <returns>The reduced expression.</returns>
         public override Expression Reduce()
         {
-            return ReduceMemberInit(NewExpression, Bindings, true);
+            return ReduceMemberInit(NewExpression, Bindings, keepOnStack: true);
         }
 
         internal static Expression ReduceMemberInit(Expression objExpression, ReadOnlyCollection<MemberBinding> bindings, bool keepOnStack)
         {
-            ParameterExpression objVar = Expression.Variable(objExpression.Type, null);
+            ParameterExpression objVar = Expression.Variable(objExpression.Type, name: null);
             int count = bindings.Count;
             var block = new Expression[count + 2];
             block[0] = Expression.Assign(objVar, objExpression);
@@ -84,7 +84,7 @@ namespace System.Linq.Expressions
 
         internal static Expression ReduceListInit(Expression listExpression, ReadOnlyCollection<ElementInit> initializers, bool keepOnStack)
         {
-            ParameterExpression listVar = Expression.Variable(listExpression.Type, null);
+            ParameterExpression listVar = Expression.Variable(listExpression.Type, name: null);
             int count = initializers.Count;
             var block = new Expression[count + 2];
             block[0] = Expression.Assign(listVar, listExpression);
@@ -105,9 +105,9 @@ namespace System.Linq.Expressions
                 case MemberBindingType.Assignment:
                     return Expression.Assign(member, ((MemberAssignment)binding).Expression);
                 case MemberBindingType.ListBinding:
-                    return ReduceListInit(member, ((MemberListBinding)binding).Initializers, false);
+                    return ReduceListInit(member, ((MemberListBinding)binding).Initializers, keepOnStack: false);
                 case MemberBindingType.MemberBinding:
-                    return ReduceMemberInit(member, ((MemberMemberBinding)binding).Bindings, false);
+                    return ReduceMemberInit(member, ((MemberMemberBinding)binding).Bindings, keepOnStack: false);
                 default: throw ContractUtils.Unreachable;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
@@ -156,7 +156,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ParameterExpression"/> node with the specified name and type.</returns>
         public static ParameterExpression Parameter(Type type)
         {
-            return Parameter(type, null);
+            return Parameter(type, name: null);
         }
 
         /// <summary>
@@ -166,7 +166,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ParameterExpression"/> node with the specified name and type.</returns>
         public static ParameterExpression Variable(Type type)
         {
-            return Variable(type, null);
+            return Variable(type, name: null);
         }
 
         /// <summary>
@@ -215,7 +215,7 @@ namespace System.Linq.Expressions
                 throw Error.TypeMustNotBePointer(nameof(type));
             }
 
-            return ParameterExpression.Make(type, name, false);
+            return ParameterExpression.Make(type, name, isByRef: false);
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
@@ -101,7 +101,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="TryExpression"/>.</returns>
         public static TryExpression TryFault(Expression body, Expression fault)
         {
-            return MakeTry(null, body, null, fault, null);
+            return MakeTry(null, body, null, fault, handlers: null);
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="TryExpression"/>.</returns>
         public static TryExpression TryFinally(Expression body, Expression @finally)
         {
-            return MakeTry(null, body, @finally, null, null);
+            return MakeTry(null, body, @finally, fault: null, handlers: null);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions
                     // either matches or is its type argument (T to its T?).
                     if (cType.GetNonNullableType() != TypeOperand.GetNonNullableType())
                     {
-                        return Expression.Block(Expression, Expression.Constant(false));
+                        return Expression.Block(Expression, Expression.Constant(value: false));
                     }
                     else
                     {
@@ -120,7 +120,7 @@ namespace System.Linq.Expressions
             // (don't invoke a user defined operator), and reference equality
             // on types for performance (so the JIT can optimize the IL).
             return Expression.AndAlso(
-                Expression.ReferenceNotEqual(value, Expression.Constant(null)),
+                Expression.ReferenceNotEqual(value, Expression.Constant(value: null)),
                 Expression.ReferenceEqual(
                     getType,
                     Expression.Constant(TypeOperand.GetNonNullableType(), typeof(Type))
@@ -134,7 +134,7 @@ namespace System.Linq.Expressions
             //TypeEqual(null, T) always returns false.
             if (ce.Value == null)
             {
-                return Expression.Constant(false);
+                return Expression.Constant(value: false);
             }
             else
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -168,7 +168,7 @@ namespace System.Linq.Expressions
             // temp = var
             // var = op(var)
             // temp
-            ParameterExpression temp = Parameter(Operand.Type, null);
+            ParameterExpression temp = Parameter(Operand.Type, name: null);
             return Block(
                 new[] { temp },
                 Assign(temp, Operand),
@@ -187,7 +187,7 @@ namespace System.Linq.Expressions
             }
             else
             {
-                ParameterExpression temp1 = Parameter(member.Expression.Type, null);
+                ParameterExpression temp1 = Parameter(member.Expression.Type, name: null);
                 BinaryExpression initTemp1 = Assign(temp1, member.Expression);
                 member = MakeMemberAccess(temp1, member.Member);
 
@@ -210,7 +210,7 @@ namespace System.Linq.Expressions
                 // temp2 = temp1.member
                 // temp1.member = op(temp2)
                 // temp2
-                ParameterExpression temp2 = Parameter(member.Type, null);
+                ParameterExpression temp2 = Parameter(member.Type, name: null);
                 return Block(
                     new[] { temp1, temp2 },
                     initTemp1,
@@ -243,20 +243,20 @@ namespace System.Linq.Expressions
             var args = new ParameterExpression[count];
 
             int i = 0;
-            temps[i] = Parameter(index.Object.Type, null);
+            temps[i] = Parameter(index.Object.Type, name: null);
             block[i] = Assign(temps[i], index.Object);
             i++;
             while (i <= count)
             {
                 Expression arg = index.GetArgument(i - 1);
-                args[i - 1] = temps[i] = Parameter(arg.Type, null);
+                args[i - 1] = temps[i] = Parameter(arg.Type, name: null);
                 block[i] = Assign(temps[i], arg);
                 i++;
             }
             index = MakeIndex(temps[0], index.Indexer, new TrueReadOnlyCollection<Expression>(args));
             if (!prefix)
             {
-                ParameterExpression lastTemp = temps[i] = Parameter(index.Type, null);
+                ParameterExpression lastTemp = temps[i] = Parameter(index.Type, name: null);
                 block[i] = Assign(temps[i], index);
                 i++;
                 Debug.Assert(i == temps.Length);
@@ -302,7 +302,7 @@ namespace System.Linq.Expressions
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="operand"/> is null.</exception>
         public static UnaryExpression MakeUnary(ExpressionType unaryType, Expression operand, Type type)
         {
-            return MakeUnary(unaryType, operand, type, null);
+            return MakeUnary(unaryType, operand, type, method: null);
         }
 
         /// <summary>
@@ -434,7 +434,7 @@ namespace System.Linq.Expressions
 
         private static UnaryExpression GetUserDefinedCoercion(ExpressionType coercionType, Expression expression, Type convertToType)
         {
-            MethodInfo method = TypeUtils.GetUserDefinedCoercionMethod(expression.Type, convertToType, false);
+            MethodInfo method = TypeUtils.GetUserDefinedCoercionMethod(expression.Type, convertToType, implicitOnly: false);
             if (method != null)
             {
                 return new UnaryExpression(coercionType, expression, convertToType, method);
@@ -477,7 +477,7 @@ namespace System.Linq.Expressions
         /// <exception cref="InvalidOperationException">Thrown when the unary minus operator is not defined for <paramref name="expression"/>.Type.</exception>
         public static UnaryExpression Negate(Expression expression)
         {
-            return Negate(expression, null);
+            return Negate(expression, method: null);
         }
 
         /// <summary>
@@ -512,7 +512,7 @@ namespace System.Linq.Expressions
         /// <exception cref="InvalidOperationException">Thrown when the unary minus operator is not defined for <paramref name="expression"/>.Type.</exception>
         public static UnaryExpression UnaryPlus(Expression expression)
         {
-            return UnaryPlus(expression, null);
+            return UnaryPlus(expression, method: null);
         }
 
         /// <summary>
@@ -545,7 +545,7 @@ namespace System.Linq.Expressions
         /// <exception cref="InvalidOperationException">Thrown when the unary minus operator is not defined for <paramref name="expression"/>.Type.</exception> 
         public static UnaryExpression NegateChecked(Expression expression)
         {
-            return NegateChecked(expression, null);
+            return NegateChecked(expression, method: null);
         }
 
         /// <summary>Creates a <see cref="UnaryExpression"/> that represents an arithmetic negation operation that has overflow checking. The implementing method can be specified.</summary>
@@ -580,7 +580,7 @@ namespace System.Linq.Expressions
         /// <exception cref="InvalidOperationException">The unary not operator is not defined for <paramref name="expression"/>.Type.</exception>
         public static UnaryExpression Not(Expression expression)
         {
-            return Not(expression, null);
+            return Not(expression, method: null);
         }
 
         /// <summary>Creates a <see cref="UnaryExpression"/> that represents a bitwise complement operation. The implementing method can be specified.</summary>
@@ -619,7 +619,7 @@ namespace System.Linq.Expressions
         /// <returns>An instance of <see cref="UnaryExpression"/>.</returns>
         public static UnaryExpression IsFalse(Expression expression)
         {
-            return IsFalse(expression, null);
+            return IsFalse(expression, method: null);
         }
 
         /// <summary>
@@ -649,7 +649,7 @@ namespace System.Linq.Expressions
         /// <returns>An instance of <see cref="UnaryExpression"/>.</returns>
         public static UnaryExpression IsTrue(Expression expression)
         {
-            return IsTrue(expression, null);
+            return IsTrue(expression, method: null);
         }
 
         /// <summary>
@@ -679,7 +679,7 @@ namespace System.Linq.Expressions
         /// <returns>An instance of <see cref="UnaryExpression"/>.</returns>
         public static UnaryExpression OnesComplement(Expression expression)
         {
-            return OnesComplement(expression, null);
+            return OnesComplement(expression, method: null);
         }
 
         /// <summary>
@@ -749,7 +749,7 @@ namespace System.Linq.Expressions
         /// <exception cref="InvalidOperationException">No conversion operator is defined between <paramref name="expression"/>.Type and <paramref name="type"/>.</exception>
         public static UnaryExpression Convert(Expression expression, Type type)
         {
-            return Convert(expression, type, null);
+            return Convert(expression, type, method: null);
         }
 
         /// <summary>Creates a <see cref="UnaryExpression"/> that represents a conversion operation for which the implementing method is specified.</summary>
@@ -799,7 +799,7 @@ namespace System.Linq.Expressions
         /// <exception cref="InvalidOperationException">No conversion operator is defined between <paramref name="expression"/>.Type and <paramref name="type"/>.</exception>
         public static UnaryExpression ConvertChecked(Expression expression, Type type)
         {
-            return ConvertChecked(expression, type, null);
+            return ConvertChecked(expression, type, method: null);
         }
 
         /// <summary>Creates a <see cref="UnaryExpression"/> that represents a conversion operation that throws an exception if the target type is overflowed and for which the implementing method is specified.</summary>
@@ -883,7 +883,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="UnaryExpression"/> that represents a rethrowing of an exception.</returns>
         public static UnaryExpression Rethrow()
         {
-            return Throw(null);
+            return Throw(value: null);
         }
 
         /// <summary>
@@ -932,7 +932,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="UnaryExpression"/> that represents the incremented expression.</returns>
         public static UnaryExpression Increment(Expression expression)
         {
-            return Increment(expression, null);
+            return Increment(expression, method: null);
         }
 
         /// <summary>
@@ -962,7 +962,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="UnaryExpression"/> that represents the decremented expression.</returns>
         public static UnaryExpression Decrement(Expression expression)
         {
-            return Decrement(expression, null);
+            return Decrement(expression, method: null);
         }
 
         /// <summary>
@@ -993,7 +993,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="UnaryExpression"/> that represents the resultant expression.</returns>
         public static UnaryExpression PreIncrementAssign(Expression expression)
         {
-            return MakeOpAssignUnary(ExpressionType.PreIncrementAssign, expression, null);
+            return MakeOpAssignUnary(ExpressionType.PreIncrementAssign, expression, method: null);
         }
 
         /// <summary>
@@ -1016,7 +1016,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="UnaryExpression"/> that represents the resultant expression.</returns>
         public static UnaryExpression PreDecrementAssign(Expression expression)
         {
-            return MakeOpAssignUnary(ExpressionType.PreDecrementAssign, expression, null);
+            return MakeOpAssignUnary(ExpressionType.PreDecrementAssign, expression, method: null);
         }
 
         /// <summary>
@@ -1039,7 +1039,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="UnaryExpression"/> that represents the resultant expression.</returns>
         public static UnaryExpression PostIncrementAssign(Expression expression)
         {
-            return MakeOpAssignUnary(ExpressionType.PostIncrementAssign, expression, null);
+            return MakeOpAssignUnary(ExpressionType.PostIncrementAssign, expression, method: null);
         }
 
         /// <summary>
@@ -1062,7 +1062,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="UnaryExpression"/> that represents the resultant expression.</returns>
         public static UnaryExpression PostDecrementAssign(Expression expression)
         {
-            return MakeOpAssignUnary(ExpressionType.PostDecrementAssign, expression, null);
+            return MakeOpAssignUnary(ExpressionType.PostDecrementAssign, expression, method: null);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
@@ -397,7 +397,7 @@ namespace System.Runtime.CompilerServices
             {
                 if (_syncRoot == null)
                 {
-                    System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new Object(), null);
+                    System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new Object(), comparand: null);
                 }
                 return _syncRoot;
             }


### PR DESCRIPTION
Used a Roslyn analyzer and code fix provider to find method invocations where the last 1..N arguments are `false`, `true`, or `null` literals without named parameter syntax. When found, the code fix rewrites them to include the parameter name.

I've applied the suggested changes pretty much everywhere, with the exception of the `Push` method in the interpreter, when we push `null` to the evaluation stack. That's pretty clear from context given it's the only argument.

I didn't want to deal with literals that occur in the middle of an argument list, to avoid worries about reordering evaluation and other complexities. I'll revisit that one day while also addressing indexers, delegate invocation, and object creation nodes.

CC @stephentoub