### PR TITLE
Attribute default Equality/HashCode tests

### DIFF
--- a/src/System.Runtime/tests/System/AttributeTests.cs
+++ b/src/System.Runtime/tests/System/AttributeTests.cs
@@ -13,6 +13,139 @@ namespace System.Tests
     public static partial class AttributeTests
     {
         [Fact]
+        public static void DefaultEquality()
+        {
+            var a1 = new ParentAttribute { Prop = 1 };
+            var a2 = new ParentAttribute { Prop = 42 };
+            var a3 = new ParentAttribute { Prop = 1 };
+            
+            var d1 = new ChildAttribute { Prop = 1 };
+            var d2 = new ChildAttribute { Prop = 42 };
+            var d3 = new ChildAttribute { Prop = 1 };
+
+            var s1 = new GrandchildAttribute { Prop = 1 };
+            var s2 = new GrandchildAttribute { Prop = 42 };
+            var s3 = new GrandchildAttribute { Prop = 1 };
+
+            var f1 = new ChildAttributeWithField { Prop = 1 };
+            var f2 = new ChildAttributeWithField { Prop = 42 };
+            var f3 = new ChildAttributeWithField { Prop = 1 };            
+
+            Assert.NotEqual(a1, a2);
+            Assert.NotEqual(a2, a3);
+            Assert.Equal(a1, a3);
+
+            Assert.NotEqual(d1, d2);
+            Assert.NotEqual(d2, d3);
+            Assert.Equal(d1, d3);
+
+            Assert.NotEqual(s1, s2);
+            Assert.NotEqual(s2, s3);
+            Assert.Equal(s1, s3);
+
+            Assert.NotEqual(f1, f2);
+            Assert.NotEqual(f2, f3);
+            Assert.Equal(f1, f3);
+
+            Assert.NotEqual(d1, a1);
+            Assert.NotEqual(d2, a2);
+            Assert.NotEqual(d3, a3);
+            Assert.NotEqual(d1, a3);
+            Assert.NotEqual(d3, a1);
+            
+            Assert.NotEqual(d1, s1);
+            Assert.NotEqual(d2, s2);
+            Assert.NotEqual(d3, s3);
+            Assert.NotEqual(d1, s3);
+            Assert.NotEqual(d3, s1);
+
+            Assert.NotEqual(f1, a1);
+            Assert.NotEqual(f2, a2);
+            Assert.NotEqual(f3, a3);
+            Assert.NotEqual(f1, a3);
+            Assert.NotEqual(f3, a1);
+        }
+
+        [Fact]
+        public static void DefaultHashCode()
+        {
+            var a1 = new ParentAttribute { Prop = 1 };
+            var a2 = new ParentAttribute { Prop = 42 };
+            var a3 = new ParentAttribute { Prop = 1 };
+            
+            var d1 = new ChildAttribute { Prop = 1 };
+            var d2 = new ChildAttribute { Prop = 42 };
+            var d3 = new ChildAttribute { Prop = 1 };
+
+            var s1 = new GrandchildAttribute { Prop = 1 };
+            var s2 = new GrandchildAttribute { Prop = 42 };
+            var s3 = new GrandchildAttribute { Prop = 1 };
+
+            var f1 = new ChildAttributeWithField { Prop = 1 };
+            var f2 = new ChildAttributeWithField { Prop = 42 };
+            var f3 = new ChildAttributeWithField { Prop = 1 }; 
+
+            Assert.NotEqual(a1.GetHashCode(), 0);
+            Assert.NotEqual(a2.GetHashCode(), 0);
+            Assert.NotEqual(a3.GetHashCode(), 0);
+            Assert.NotEqual(d1.GetHashCode(), 0);
+            Assert.NotEqual(d2.GetHashCode(), 0);
+            Assert.NotEqual(d3.GetHashCode(), 0);
+            Assert.NotEqual(s1.GetHashCode(), 0);
+            Assert.NotEqual(s2.GetHashCode(), 0);
+            Assert.NotEqual(s3.GetHashCode(), 0);
+            Assert.Equal(f1.GetHashCode(), 0);
+            Assert.Equal(f2.GetHashCode(), 0);
+            Assert.Equal(f3.GetHashCode(), 0);
+
+            Assert.NotEqual(a1.GetHashCode(), a2.GetHashCode());
+            Assert.NotEqual(a2.GetHashCode(), a3.GetHashCode());
+            Assert.Equal(a1.GetHashCode(), a3.GetHashCode());
+
+            Assert.NotEqual(s1.GetHashCode(), s2.GetHashCode());
+            Assert.NotEqual(s2.GetHashCode(), s3.GetHashCode());
+            Assert.Equal(s1.GetHashCode(), s3.GetHashCode());
+
+            Assert.NotEqual(d1.GetHashCode(), d2.GetHashCode());
+            Assert.NotEqual(d2.GetHashCode(), d3.GetHashCode());
+            Assert.Equal(d1.GetHashCode(), d3.GetHashCode());
+
+            Assert.Equal(f1.GetHashCode(), f2.GetHashCode());
+            Assert.Equal(f2.GetHashCode(), f3.GetHashCode());
+            Assert.Equal(f1.GetHashCode(), f3.GetHashCode());
+
+            Assert.Equal(d1.GetHashCode(), a1.GetHashCode());
+            Assert.Equal(d2.GetHashCode(), a2.GetHashCode());
+            Assert.Equal(d3.GetHashCode(), a3.GetHashCode());
+            Assert.Equal(d1.GetHashCode(), a3.GetHashCode());
+            Assert.Equal(d3.GetHashCode(), a1.GetHashCode());
+            
+            Assert.Equal(d1.GetHashCode(), s1.GetHashCode());
+            Assert.Equal(d2.GetHashCode(), s2.GetHashCode());
+            Assert.Equal(d3.GetHashCode(), s3.GetHashCode());
+            Assert.Equal(d1.GetHashCode(), s3.GetHashCode());
+            Assert.Equal(d3.GetHashCode(), s1.GetHashCode());
+
+            Assert.NotEqual(f1.GetHashCode(), a1.GetHashCode());
+            Assert.NotEqual(f2.GetHashCode(), a2.GetHashCode());
+            Assert.NotEqual(f3.GetHashCode(), a3.GetHashCode());
+            Assert.NotEqual(f1.GetHashCode(), a3.GetHashCode());
+            Assert.NotEqual(f3.GetHashCode(), a1.GetHashCode());            
+        }
+
+        class ParentAttribute : Attribute
+        {
+            public int Prop {get;set;}
+        }
+
+        class ChildAttribute : ParentAttribute { }
+        class GrandchildAttribute : ChildAttribute { }
+        class ChildAttributeWithField : ParentAttribute 
+        { 
+            public int Field = 0;
+        }
+
+        [Fact]
         [StringValue("\uDFFF")]
         public static void StringArgument_InvalidCodeUnits_FallbackUsed()
         {


### PR DESCRIPTION
See:
https://github.com/dotnet/coreclr/issues/6232
https://github.com/dotnet/coreclr/pull/6240

/cc @jkotas 

edit: Needs more tests, WIP

edit: Hashing is failing for some derived types. (probably a bug with the fix, see commented cases)

edit: Nope, as intended, just unfortunate side effect
