### PR TITLE
Add missing members of Debugger class

### DIFF
--- a/src/System.Diagnostics.Debug/ref/System.Diagnostics.Debug.cs
+++ b/src/System.Diagnostics.Debug/ref/System.Diagnostics.Debug.cs
@@ -59,13 +59,13 @@ namespace System.Diagnostics
     }
     public static partial class Debugger
     {
-        public static readonly string DefaultCategory = null;
+        public static readonly string DefaultCategory;
         public static bool IsAttached { get { throw null; } }
         public static void Break() { }
         public static bool IsLogging() { throw null; }
         public static bool Launch() { throw null; }
-        public static void Log(int level, string category, string message) { throw null; }
-        public static void NotifyOfCrossThreadDependency() { throw null; }
+        public static void Log(int level, string category, string message) {}
+        public static void NotifyOfCrossThreadDependency() { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(384), AllowMultiple = false)]
     public sealed partial class DebuggerBrowsableAttribute : System.Attribute

--- a/src/System.Diagnostics.Debug/ref/System.Diagnostics.Debug.cs
+++ b/src/System.Diagnostics.Debug/ref/System.Diagnostics.Debug.cs
@@ -59,9 +59,13 @@ namespace System.Diagnostics
     }
     public static partial class Debugger
     {
+        public static readonly string DefaultCategory = null;
         public static bool IsAttached { get { throw null; } }
         public static void Break() { }
+        public static bool IsLogging() { throw null; }
         public static bool Launch() { throw null; }
+        public static void Log(int level, string category, string message) { throw null; }
+        public static void NotifyOfCrossThreadDependency() { throw null; }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(384), AllowMultiple = false)]
     public sealed partial class DebuggerBrowsableAttribute : System.Attribute

--- a/src/System.Diagnostics.Debug/tests/DebuggerTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebuggerTests.cs
@@ -15,13 +15,6 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        public void Break()
-        {
-            if (!Debugger.IsAttached)
-                Debugger.Break();
-        }
-
-        [Fact]
         public void IsLogging()
         {
             if (Debugger.IsAttached)

--- a/src/System.Diagnostics.Debug/tests/DebuggerTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebuggerTests.cs
@@ -11,19 +11,35 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void IsAttached()
         {
-            // TODO: Implement this when Debugger is properly implemented
-        }
-
-        [Fact]
-        public void Launch()
-        {
-            // TODO: Implement this when Debugger is properly implemented
+            bool b = Debugger.IsAttached;
         }
 
         [Fact]
         public void Break()
         {
-            // TODO: Implement this when Debugger is properly implemented
+            if (!Debugger.IsAttached)
+                Debugger.Break();
+        }
+
+        [Fact]
+        public void IsLogging()
+        {
+            if (Debugger.IsAttached)
+                Debugger.IsLogging();
+            else
+                Assert.False(Debugger.IsLogging());
+        }
+
+        [Fact]
+        public void Log()
+        {
+            Debugger.Log(10, "category", "This is a test log message raised in the System.Diagnostics.Debug tests for the .NET Debugger class.");
+        }
+
+        [Fact]
+        public void NotifyOfCrossThreadDependency()
+        {
+            Debugger.NotifyOfCrossThreadDependency();
         }
     }
 }

--- a/src/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
+++ b/src/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AttributeTests.cs" />
-    <Compile Include="DebuggerTests.cs" />
+    <Compile Include="DebuggerTests.cs" Condition="'$(TargetGroup)'==''"/>
     <Compile Include="DebugTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>


### PR DESCRIPTION
- Exposes the remaining missing members of the Debugger class in System.Diagnostics.Debug.
- Adds VERY basic tests for the Debugger functions that for the most part just call the functions without any assertion of expected behavior.

resolves https://github.com/dotnet/corefx/issues/12795

@alexperovich @joperezr @AlexGhiondea 