### PR TITLE
[release/1.1.0] Change the cryptography shims to use direct package dependencies

### DIFF
--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.Apple/osx/runtime.native.System.Security.Cryptography.Apple.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.Apple/osx/runtime.native.System.Security.Cryptography.Apple.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>osx.10.10-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OSXNativePath)System.Security.Cryptography.Native.Apple.dylib">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/debian/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/debian/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>debian.8-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>debian.8-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(DebianNativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/23/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/23/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>fedora.23-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Fedora23NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/24/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/fedora/24/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>fedora.24-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>fedora.24-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Fedora24NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/13.2/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/13.2/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>opensuse.13.2-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OpenSuse132NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/42.1/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/opensuse/42.1/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>opensuse.42.1-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>opensuse.42.1-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OpenSuse421NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/osx/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/osx/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>osx.10.10-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OSXNativePath)System.Security.Cryptography.Native.OpenSsl.dylib">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/rhel/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/rhel/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>rhel.7-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>rhel.7-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(RHELNativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/14.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/14.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>ubuntu.14.04-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1404NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/16.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/16.04/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>ubuntu.16.04-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1604NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/16.10/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/ubuntu/16.10/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>ubuntu.16.10-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>ubuntu.16.10-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1610NativePath)System.Security.Cryptography.Native.OpenSsl.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>debian.8-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>debian.8-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(DebianNativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>fedora.23-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Fedora23NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/24/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/24/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>fedora.24-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>fedora.24-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Fedora24NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>opensuse.13.2-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OpenSuse132NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/42.1/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/42.1/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>opensuse.42.1-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>opensuse.42.1-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OpenSuse421NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>osx.10.10-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(OSXNativePath)System.Security.Cryptography.Native.dylib">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>rhel.7-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>rhel.7-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(RHELNativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>ubuntu.14.04-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1404NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>ubuntu.16.04-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1604NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.10/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.10/runtime.native.System.Security.Cryptography.pkgproj
@@ -2,13 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime>ubuntu.16.10-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageRid>ubuntu.16.10-$(PackagePlatform)</PackageRid>
+    <IdPrefix>runtime.$(PackageRid).</IdPrefix>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(Ubuntu1610NativePath)System.Security.Cryptography.Native.so">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <TargetPath>runtimes/$(PackageRid)/native</TargetPath>
     </NativeFile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
The use of runtime dependencies for the platform-specific native shims causes
some upgrade complications.  The design of the shared framework results in
the dependency being considered to be satisfied even when a higher version
was needed.  So if someone has .NET Core 1.0 installed and pulls in a daily build
of a cryptography library they might be missing native code changes that were
assumed to be present as dependencies of the managed code.

By changing to direct dependencies (changing the platform-specific package
files to use IdPrefix instead of PackageTargetRuntime) the new .so files will be
downloaded and deployed with the app (if they're a higher version that what
is present in the shared framework).

Fixes #12517.
cc: @ericstj 