### PR TITLE
Fix exception handling in reverse PInvokes in GetAllNetworkInterfaces

### DIFF
--- a/src/Common/src/System/Net/NetworkInformation/NetworkInformationException.cs
+++ b/src/Common/src/System/Net/NetworkInformation/NetworkInformationException.cs
@@ -47,6 +47,10 @@ namespace System.Net.NetworkInformation
         {
         }
 
+        internal NetworkInformationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -136,7 +136,7 @@ namespace System.Net.NetworkInformation
                     Interop.LinuxNetDeviceFlags flags = (Interop.LinuxNetDeviceFlags)StringParsingHelpers.ParseRawHexFileAsInt(path);
                     return (flags & Interop.LinuxNetDeviceFlags.IFF_MULTICAST) == Interop.LinuxNetDeviceFlags.IFF_MULTICAST;
                 }
-                catch (FileNotFoundException)
+                catch (Exception) // Ignore any problems accessing or parsing the file.
                 {
                 }
             }
@@ -185,7 +185,7 @@ namespace System.Net.NetworkInformation
                 string path = Path.Combine(NetworkFiles.SysClassNetFolder, name, NetworkFiles.SpeedFileName);
                 return StringParsingHelpers.ParseRawLongFile(path);
             }
-            catch (IOException) // Some interfaces may give an "Invalid argument" error when opening this file.
+            catch (Exception) // Ignore any problems accessing or parsing the file.
             {
                 return null;
             }
@@ -202,7 +202,7 @@ namespace System.Net.NetworkInformation
                     string state = File.ReadAllText(path).Trim();
                     return MapState(state);
                 }
-                catch (FileNotFoundException)
+                catch (Exception) // Ignore any problems accessing or parsing the file.
                 {
                 }
             }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxNetworkInterface.cs
@@ -30,22 +30,51 @@ namespace System.Net.NetworkInformation
             const int MaxTries = 3;
             for (int attempt = 0; attempt < MaxTries; attempt++)
             {
+                // Because these callbacks are executed in a reverse-PInvoke, we do not want any exceptions
+                // to propogate out, because they will not be catchable. Instead, we track all the exceptions
+                // that are thrown in these callbacks, and aggregate them at the end.
+                List<Exception> exceptions = new List<Exception>();
                 int result = Interop.Sys.EnumerateInterfaceAddresses(
                     (name, ipAddr, maskAddr) =>
                     {
-                        OsxNetworkInterface oni = GetOrCreate(interfacesByName, name);
-                        oni.ProcessIpv4Address(ipAddr, maskAddr);
+                        try
+                        {
+                            OsxNetworkInterface oni = GetOrCreate(interfacesByName, name);
+                            oni.ProcessIpv4Address(ipAddr, maskAddr);
+                        }
+                        catch (Exception e)
+                        {
+                            exceptions.Add(e);
+                        }
                     },
                     (name, ipAddr, scopeId) =>
                     {
-                        OsxNetworkInterface oni = GetOrCreate(interfacesByName, name);
-                        oni.ProcessIpv6Address( ipAddr, *scopeId);
+                        try
+                        {
+                            OsxNetworkInterface oni = GetOrCreate(interfacesByName, name);
+                            oni.ProcessIpv6Address(ipAddr, *scopeId);
+                        }
+                        catch (Exception e)
+                        {
+                            exceptions.Add(e);
+                        }
                     },
                     (name, llAddr) =>
                     {
-                        OsxNetworkInterface oni = GetOrCreate(interfacesByName, name);
-                        oni.ProcessLinkLayerAddress(llAddr);
+                        try
+                        {
+                            OsxNetworkInterface oni = GetOrCreate(interfacesByName, name);
+                            oni.ProcessLinkLayerAddress(llAddr);
+                        }
+                        catch (Exception e)
+                        {
+                            exceptions.Add(e);
+                        }
                     });
+                if (exceptions.Count > 0)
+                {
+                    throw new NetworkInformationException(SR.net_PInvokeError, new AggregateException(exceptions));
+                }
                 if (result == 0)
                 {
                     return interfacesByName.Values.ToArray();


### PR DESCRIPTION
Related to #12969 

CoreCLR cannot propagate exceptions across native-managed boundaries. In `GetAllNetworkInterfaces`, we use reverse PInvokes, which under rare cases can throw exceptions. If the managed callbacks do not handle those exceptions, the process will crash, because application code cannot catch the exception. To fix this, I've aggregated all exceptions encountered during all callbacks, and thrown them after the completion of the shim call.

I've also changed the `LinuxNetworkInterface` constructor code to ignore all exceptions encountered while reading and parsing network files. Any exception encountered in those blocks indicates that the data is either inaccessible or invalid.

@stephentoub 

I'm still trying to run some manual tests against this code.