### PR TITLE
Clean up some unneeded unsafe and fixed statements

### DIFF
--- a/src/System.IO/src/System/IO/BinaryReader.cs
+++ b/src/System.IO/src/System/IO/BinaryReader.cs
@@ -421,14 +421,7 @@ namespace System.IO
                 }
 
                 Debug.Assert(byteBuffer != null, "expected byteBuffer to be non-null");
-                unsafe
-                {
-                    fixed (byte* pBytes = byteBuffer)
-                    fixed (char* pChars = buffer)
-                    {
-                        charsRead = _decoder.GetChars(byteBuffer, position, numBytes, buffer, index, false);
-                    }
-                }
+                charsRead = _decoder.GetChars(byteBuffer, position, numBytes, buffer, index, flush: false);
 
                 charsRemaining -= charsRead;
                 index += charsRead;

--- a/src/System.IO/src/System/IO/BinaryWriter.cs
+++ b/src/System.IO/src/System/IO/BinaryWriter.cs
@@ -178,7 +178,7 @@ namespace System.IO
         // advanced by two.
         // Note this method cannot handle surrogates properly in UTF-8.
         // 
-        public unsafe virtual void Write(char ch)
+        public virtual void Write(char ch)
         {
             if (char.IsSurrogate(ch))
             {
@@ -367,7 +367,7 @@ namespace System.IO
         // a four-byte unsigned integer, and then writes that many characters 
         // to the stream.
         // 
-        public unsafe virtual void Write(string value)
+        public virtual void Write(string value)
         {
             if (value == null)
             {


### PR DESCRIPTION
CoreFx's StreamReader/StreamWriter inherited some code from CoreCLR where
we used fixed blocks to operate on raw pointers. However, unlike CoreCLR
we actually did everything using managed code, so the unsafe and fixed
blocks were not needed.  Simply remove them.