### PR TITLE
Fixing liftToNull behavior in AddChecked and adding tests

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -1678,7 +1678,7 @@ namespace System.Linq.Expressions
                 {
                     return new SimpleBinaryExpression(ExpressionType.AddChecked, left, right, left.Type);
                 }
-                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.AddChecked, "op_Addition", left, right, liftToNull: false);
+                return GetUserDefinedBinaryOperatorOrThrow(ExpressionType.AddChecked, "op_Addition", left, right, liftToNull: true);
             }
             return GetMethodBasedBinaryOperator(ExpressionType.AddChecked, left, right, method, liftToNull: true);
         }

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -360,4 +360,38 @@ namespace System.Linq.Expressions.Tests
         public override ExpressionType NodeType => CustomNodeType;
         public override Type Type => CustomType;
     }
+
+    public struct Number : IEquatable<Number>
+    {
+        private readonly int _value;
+
+        public Number(int value)
+        {
+            _value = value;
+        }
+
+        public static readonly Number MinValue = new Number(int.MinValue);
+        public static readonly Number MaxValue = new Number(int.MaxValue);
+
+        public static Number operator +(Number l, Number r) => new Number(l._value + r._value);
+        public static Number operator -(Number l, Number r) => new Number(l._value - r._value);
+        public static Number operator *(Number l, Number r) => new Number(l._value * r._value);
+        public static Number operator /(Number l, Number r) => new Number(l._value / r._value);
+        public static Number operator %(Number l, Number r) => new Number(l._value % r._value);
+
+        public static Number operator &(Number l, Number r) => new Number(l._value & r._value);
+        public static Number operator |(Number l, Number r) => new Number(l._value | r._value);
+        public static Number operator ^(Number l, Number r) => new Number(l._value ^ r._value);
+
+        public static bool operator >(Number l, Number r) => l._value > r._value;
+        public static bool operator >=(Number l, Number r) => l._value >= r._value;
+        public static bool operator <(Number l, Number r) => l._value < r._value;
+        public static bool operator <=(Number l, Number r) => l._value <= r._value;
+        public static bool operator ==(Number l, Number r) => l._value == r._value;
+        public static bool operator !=(Number l, Number r) => l._value != r._value;
+
+        public override bool Equals(object obj) => obj is Number && Equals((Number)obj);
+        public bool Equals(Number other) => _value == other._value;
+        public override int GetHashCode() => _value;
+    }
 }

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedAddCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedAddCheckedNullableTests.cs
@@ -168,6 +168,34 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLiftedAddCheckedNullableNumberTest(bool useInterpreter)
+        {
+            Number?[] values = new Number?[] { null, new Number(0), new Number(1), Number.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    VerifyAddCheckedNullableNumber(values[i], values[j], useInterpreter);
+                }
+            }
+        }
+
+        [Fact] // See https://github.com/dotnet/corefx/issues/13048
+        public static void CheckLiftedAddCheckedRegressionTest()
+        {
+            // Regression test for an issue where `liftToNull` was set to `false` in `AddChecked`,
+            // causing the return type not to get lifted to null, unlike for other binary node types.
+
+            BinaryExpression expr =
+                Expression.AddChecked(
+                    Expression.Parameter(typeof(PeculiarAddable?)),
+                    Expression.Parameter(typeof(PeculiarAddable?))
+                );
+
+            Assert.Equal(typeof(bool?), expr.Type);
+        }
+
         #endregion
 
         #region Helpers
@@ -452,6 +480,29 @@ namespace System.Linq.Expressions.Tests
                 Assert.Throws<OverflowException>(() => f());
             else
                 Assert.Equal(expected, f());
+        }
+
+        private static void VerifyAddCheckedNullableNumber(Number? a, Number? b, bool useInterpreter)
+        {
+            Expression<Func<Number?>> e =
+                Expression.Lambda<Func<Number?>>(
+                    Expression.AddChecked(
+                        Expression.Constant(a, typeof(Number?)),
+                        Expression.Constant(b, typeof(Number?))));
+            Assert.Equal(typeof(Number?), e.Body.Type);
+            Func<Number?> f = e.Compile(useInterpreter);
+
+            Number? expected = a + b;
+            Assert.Equal(expected, f()); // NB: checked behavior doesn't apply to non-primitive types
+        }
+
+        #endregion
+
+        #region Helper types
+
+        struct PeculiarAddable
+        {
+            public static bool operator +(PeculiarAddable l, PeculiarAddable r) => true;
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
@@ -168,6 +168,19 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLiftedAddNullableNumberTest(bool useInterpreter)
+        {
+            Number?[] values = new Number?[] { null, new Number(0), new Number(1), Number.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    VerifyAddNullableNumber(values[i], values[j], useInterpreter);
+                }
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -401,6 +414,20 @@ namespace System.Linq.Expressions.Tests
             Func<ushort?> f = e.Compile(useInterpreter);
 
             Assert.Equal((ushort?)(a + b), f());
+        }
+
+        private static void VerifyAddNullableNumber(Number? a, Number? b, bool useInterpreter)
+        {
+            Expression<Func<Number?>> e =
+                Expression.Lambda<Func<Number?>>(
+                    Expression.Add(
+                        Expression.Constant(a, typeof(Number?)),
+                        Expression.Constant(b, typeof(Number?))));
+            Assert.Equal(typeof(Number?), e.Body.Type);
+            Func<Number?> f = e.Compile(useInterpreter);
+
+            Number? expected = a + b;
+            Assert.Equal(expected, f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseAndNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseAndNullableTests.cs
@@ -116,6 +116,19 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLiftedBitwiseAndNullableNumberTest(bool useInterpreter)
+        {
+            Number?[] values = new Number?[] { null, new Number(0), new Number(1), Number.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    VerifyBitwiseAndNullableNumber(values[i], values[j], useInterpreter);
+                }
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -266,6 +279,20 @@ namespace System.Linq.Expressions.Tests
             Func<ushort?> f = e.Compile(useInterpreter);
 
             Assert.Equal(a & b, f());
+        }
+
+        private static void VerifyBitwiseAndNullableNumber(Number? a, Number? b, bool useInterpreter)
+        {
+            Expression<Func<Number?>> e =
+                Expression.Lambda<Func<Number?>>(
+                    Expression.And(
+                        Expression.Constant(a, typeof(Number?)),
+                        Expression.Constant(b, typeof(Number?))));
+            Assert.Equal(typeof(Number?), e.Body.Type);
+            Func<Number?> f = e.Compile(useInterpreter);
+
+            Number? expected = a & b;
+            Assert.Equal(expected, f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseExclusiveOrNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseExclusiveOrNullableTests.cs
@@ -116,6 +116,19 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLiftedBitwiseExclusiveOrNullableNumberTest(bool useInterpreter)
+        {
+            Number?[] values = new Number?[] { null, new Number(0), new Number(1), Number.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    VerifyBitwiseExclusiveOrNullableNumber(values[i], values[j], useInterpreter);
+                }
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -266,6 +279,20 @@ namespace System.Linq.Expressions.Tests
             Func<ushort?> f = e.Compile(useInterpreter);
 
             Assert.Equal(a ^ b, f());
+        }
+
+        private static void VerifyBitwiseExclusiveOrNullableNumber(Number? a, Number? b, bool useInterpreter)
+        {
+            Expression<Func<Number?>> e =
+                Expression.Lambda<Func<Number?>>(
+                    Expression.ExclusiveOr(
+                        Expression.Constant(a, typeof(Number?)),
+                        Expression.Constant(b, typeof(Number?))));
+            Assert.Equal(typeof(Number?), e.Body.Type);
+            Func<Number?> f = e.Compile(useInterpreter);
+
+            Number? expected = a ^ b;
+            Assert.Equal(expected, f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseOrNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseOrNullableTests.cs
@@ -116,6 +116,19 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLiftedBitwiseOrNullableNumberTest(bool useInterpreter)
+        {
+            Number?[] values = new Number?[] { null, new Number(0), new Number(1), Number.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    VerifyBitwiseOrNullableNumber(values[i], values[j], useInterpreter);
+                }
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -266,6 +279,20 @@ namespace System.Linq.Expressions.Tests
             Func<ushort?> f = e.Compile(useInterpreter);
 
             Assert.Equal(a | b, f());
+        }
+
+        private static void VerifyBitwiseOrNullableNumber(Number? a, Number? b, bool useInterpreter)
+        {
+            Expression<Func<Number?>> e =
+                Expression.Lambda<Func<Number?>>(
+                    Expression.Or(
+                        Expression.Constant(a, typeof(Number?)),
+                        Expression.Constant(b, typeof(Number?))));
+            Assert.Equal(typeof(Number?), e.Body.Type);
+            Func<Number?> f = e.Compile(useInterpreter);
+
+            Number? expected = a | b;
+            Assert.Equal(expected, f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
@@ -177,6 +177,20 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/513
+        [ClassData(typeof(CompilationTypes))]
+        public static void CheckLiftedDivideNullableNumberTest(bool useInterpreter)
+        {
+            Number?[] values = new Number?[] { null, new Number(0), new Number(1), Number.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    VerifyDivideNullableNumber(values[i], values[j], useInterpreter);
+                }
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -433,6 +447,22 @@ namespace System.Linq.Expressions.Tests
                 Assert.Throws<DivideByZeroException>(() => f());
             else
                 Assert.Equal((ushort?)(a / b), f());
+        }
+
+        private static void VerifyDivideNullableNumber(Number? a, Number? b, bool useInterpreter)
+        {
+            Expression<Func<Number?>> e =
+                Expression.Lambda<Func<Number?>>(
+                    Expression.Divide(
+                        Expression.Constant(a, typeof(Number?)),
+                        Expression.Constant(b, typeof(Number?))));
+            Assert.Equal(typeof(Number?), e.Body.Type);
+            Func<Number?> f = e.Compile(useInterpreter);
+
+            if (a.HasValue && b == new Number(0))
+                Assert.Throws<DivideByZeroException>(() => f());
+            else
+                Assert.Equal(a / b, f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedModuloNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedModuloNullableTests.cs
@@ -177,6 +177,20 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/513
+        [ClassData(typeof(CompilationTypes))]
+        public static void CheckLiftedModuloNullableNumberTest(bool useInterpreter)
+        {
+            Number?[] values = new Number?[] { null, new Number(0), new Number(1), Number.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    VerifyModuloNullableNumber(values[i], values[j], useInterpreter);
+                }
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -433,6 +447,22 @@ namespace System.Linq.Expressions.Tests
                 Assert.Throws<DivideByZeroException>(() => f());
             else
                 Assert.Equal((ushort?)(a % b), f());
+        }
+
+        private static void VerifyModuloNullableNumber(Number? a, Number? b, bool useInterpreter)
+        {
+            Expression<Func<Number?>> e =
+                Expression.Lambda<Func<Number?>>(
+                    Expression.Modulo(
+                        Expression.Constant(a, typeof(Number?)),
+                        Expression.Constant(b, typeof(Number?))));
+            Assert.Equal(typeof(Number?), e.Body.Type);
+            Func<Number?> f = e.Compile(useInterpreter);
+
+            if (a.HasValue && b == new Number(0))
+                Assert.Throws<DivideByZeroException>(() => f());
+            else
+                Assert.Equal(a % b, f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyCheckedNullableTests.cs
@@ -168,6 +168,19 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLiftedMultiplyCheckedNullableNumberTest(bool useInterpreter)
+        {
+            Number?[] values = new Number?[] { null, new Number(0), new Number(1), Number.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    VerifyMultiplyCheckedNullableNumber(values[i], values[j], useInterpreter);
+                }
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -500,6 +513,20 @@ namespace System.Linq.Expressions.Tests
             }
 
             Assert.Equal(expected, f());
+        }
+        
+        private static void VerifyMultiplyCheckedNullableNumber(Number? a, Number? b, bool useInterpreter)
+        {
+            Expression<Func<Number?>> e =
+                Expression.Lambda<Func<Number?>>(
+                    Expression.MultiplyChecked(
+                        Expression.Constant(a, typeof(Number?)),
+                        Expression.Constant(b, typeof(Number?))));
+            Assert.Equal(typeof(Number?), e.Body.Type);
+            Func<Number?> f = e.Compile(useInterpreter);
+
+            Number? expected = a * b;
+            Assert.Equal(expected, f()); // NB: checked behavior doesn't apply to non-primitive types
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
@@ -168,6 +168,19 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLiftedMultiplyNullableNumberTest(bool useInterpreter)
+        {
+            Number?[] values = new Number?[] { null, new Number(0), new Number(1), Number.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    VerifyMultiplyNullableNumber(values[i], values[j], useInterpreter);
+                }
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -401,6 +414,20 @@ namespace System.Linq.Expressions.Tests
             Func<ushort?> f = e.Compile(useInterpreter);
 
             Assert.Equal((ushort?)(a * b), f());
+        }
+
+        private static void VerifyMultiplyNullableNumber(Number? a, Number? b, bool useInterpreter)
+        {
+            Expression<Func<Number?>> e =
+                Expression.Lambda<Func<Number?>>(
+                    Expression.Multiply(
+                        Expression.Constant(a, typeof(Number?)),
+                        Expression.Constant(b, typeof(Number?))));
+            Assert.Equal(typeof(Number?), e.Body.Type);
+            Func<Number?> f = e.Compile(useInterpreter);
+
+            Number? expected = a * b;
+            Assert.Equal(expected, f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractCheckedNullableTests.cs
@@ -168,6 +168,19 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLiftedSubtractCheckedNullableNumberTest(bool useInterpreter)
+        {
+            Number?[] values = new Number?[] { null, new Number(0), new Number(1), Number.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    VerifySubtractCheckedNullableNumber(values[i], values[j], useInterpreter);
+                }
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -440,6 +453,20 @@ namespace System.Linq.Expressions.Tests
                 Assert.Throws<OverflowException>(() => f());
             else
                 Assert.Equal(a - b, f());
+        }
+
+        private static void VerifySubtractCheckedNullableNumber(Number? a, Number? b, bool useInterpreter)
+        {
+            Expression<Func<Number?>> e =
+                Expression.Lambda<Func<Number?>>(
+                    Expression.Subtract(
+                        Expression.Constant(a, typeof(Number?)),
+                        Expression.Constant(b, typeof(Number?))));
+            Assert.Equal(typeof(Number?), e.Body.Type);
+            Func<Number?> f = e.Compile(useInterpreter);
+
+            Number? expected = a - b;
+            Assert.Equal(expected, f()); // NB: checked behavior doesn't apply to non-primitive types
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
@@ -168,6 +168,19 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLiftedSubtractNullableNumberTest(bool useInterpreter)
+        {
+            Number?[] values = new Number?[] { null, new Number(0), new Number(1), Number.MaxValue };
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    VerifySubtractNullableNumber(values[i], values[j], useInterpreter);
+                }
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -401,6 +414,20 @@ namespace System.Linq.Expressions.Tests
             Func<ushort?> f = e.Compile(useInterpreter);
 
             Assert.Equal((ushort?)(a - b), f());
+        }
+
+        private static void VerifySubtractNullableNumber(Number? a, Number? b, bool useInterpreter)
+        {
+            Expression<Func<Number?>> e =
+                Expression.Lambda<Func<Number?>>(
+                    Expression.Subtract(
+                        Expression.Constant(a, typeof(Number?)),
+                        Expression.Constant(b, typeof(Number?))));
+            Assert.Equal(typeof(Number?), e.Body.Type);
+            Func<Number?> f = e.Compile(useInterpreter);
+
+            Number? expected = a - b;
+            Assert.Equal(expected, f());
         }
 
         #endregion


### PR DESCRIPTION
This fixes issue #13048 where `AddChecked` was the only node type that didn't pass `liftToNull: true` to the `GetUserDefinedAssignOperatorOrThrow` method used to find a user-defined addition operator. A regression test for this particular case is added in the PR, as well as additional tests for lifting behavior.

CC @VSadov, @stephentoub
