### PR TITLE
Re-add test configurations that were not being tested by CI anymore

### DIFF
--- a/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.builds
+++ b/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.builds
@@ -5,7 +5,7 @@
     <!-- Temporary workaround, VisualBasic projects cannot be built on non-Windows platforms. See issue #5230. -->
     <Project Include="Microsoft.VisualBasic.Tests.csproj" Condition="'$(OS)'=='Windows_NT'">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;netcoreapp1.0;net46;net461;net462;net463</TestTFMs>
+      <TestTFMs>netcore50;netcoreapp1.0;netcoreapp1.1;net46;net461;net462;net463</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/Microsoft.Win32.Registry.AccessControl.Tests.builds
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/Microsoft.Win32.Registry.AccessControl.Tests.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="Microsoft.Win32.Registry.AccessControl.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.0;netcoreapp1.1;net46</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.builds
+++ b/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="Microsoft.Win32.Registry.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.0;netcoreapp1.1;net46</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.builds
+++ b/src/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.IO.FileSystem.AccessControl.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcoreapp1.0;net46</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.IO.Pipes.AccessControl/tests/System.IO.Pipes.AccessControl.Tests.builds
+++ b/src/System.IO.Pipes.AccessControl/tests/System.IO.Pipes.AccessControl.Tests.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.IO.Pipes.AccessControl.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcoreapp1.0;net46</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.builds
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.Net.Http.WinHttpHandler.Functional.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcoreapp1.0;net46</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.builds
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.Net.Http.WinHttpHandler.Unit.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcoreapp1.0;net46</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Private.Xml.Linq/tests/System.Private.Xml.Linq.Tests.builds
+++ b/src/System.Private.Xml.Linq/tests/System.Private.Xml.Linq.Tests.builds
@@ -4,51 +4,56 @@
   <ItemGroup>
     <Project Include="axes\System.Xml.Linq.Axes.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;net46</TestTFMs>
     </Project>
+    <!-- ToDo: Add netcoreapp1.1 to the TestTFMs once issue is fixed https://github.com/dotnet/corefx/issues/13085 -->
     <Project Include="events\System.Xml.Linq.Events.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcore50;net46</TestTFMs>
     </Project>
     <Project Include="misc\System.Xml.Linq.Misc.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
+    <!-- ToDo: Add netcoreapp1.1 to the TestTFMs once issue is fixed https://github.com/dotnet/corefx/issues/13085 -->
     <Project Include="Properties\System.Xml.Linq.Properties.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcore50;net46</TestTFMs>
     </Project>
     <Project Include="SDMSample\System.Xml.Linq.SDMSample.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
+    <!-- ToDo: Add netcoreapp1.1 to the TestTFMs once issue is fixed https://github.com/dotnet/corefx/issues/13085 -->
     <Project Include="Streaming\System.Xml.Linq.Streaming.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcore50;net46</TestTFMs>
     </Project>
     <Project Include="TreeManipulation\System.Xml.Linq.TreeManipulation.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
     <Project Include="XDocument.Common\XDocument.Common.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
     <Project Include="XDocument.Test.ModuleCore\XDocument.Test.ModuleCore.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
+    <!-- ToDo: Add netcoreapp1.1 to the TestTFMs once issue is fixed https://github.com/dotnet/corefx/issues/13085 -->
     <Project Include="xNodeBuilder\System.Xml.Linq.xNodeBuilder.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcore50;net46</TestTFMs>
     </Project>
+    <!-- ToDo: Add netcoreapp1.1 to the TestTFMs once issue is fixed https://github.com/dotnet/corefx/issues/13085 -->
     <Project Include="xNodeReader\System.Xml.Linq.xNodeReader.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcore50;net46</TestTFMs>
     </Project>
     <Project Include="XPath\XDocument\System.Xml.XPath.XDocument.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
     <Project Include="Schema\System.Xml.Schema.Extensions.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>

--- a/src/System.Private.Xml/tests/System.Private.Xml.Tests.builds
+++ b/src/System.Private.Xml/tests/System.Private.Xml.Tests.builds
@@ -84,6 +84,7 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="XmlSerializer\System.Xml.XmlSerializer.Tests.csproj" />
+    <Project Include="XmlSerializer\Performance\System.Xml.XmlSerializer.Performance.Tests.csproj" />
     <Project Include="XmlWriter\System.Xml.RW.XmlWriter.Tests.csproj" />
     <Project Include="XmlWriter\System.Xml.RW.XmlWriter.Tests.csproj">
       <TargetGroup>netstandard1.3</TargetGroup>

--- a/src/System.Security.Cryptography.ProtectedData/tests/System.Security.Cryptography.ProtectedData.Tests.builds
+++ b/src/System.Security.Cryptography.ProtectedData/tests/System.Security.Cryptography.ProtectedData.Tests.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.Security.Cryptography.ProtectedData.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;netcoreapp1.0;net46</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.builds
+++ b/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.builds
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Security.SecureString.Tests.csproj">
-      <TestTFMs>netcore50;netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;netcoreapp1.0;net46</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Threading.AccessControl/tests/System.Threading.AccessControl.Tests.builds
+++ b/src/System.Threading.AccessControl/tests/System.Threading.AccessControl.Tests.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.Threading.AccessControl.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcoreapp1.0;net46</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.builds
+++ b/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.Threading.Overlapped.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;netcoreapp1.0;net46</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Web.HttpUtility/tests/System.Web.HttpUtility.Tests.builds
+++ b/src/System.Web.HttpUtility/tests/System.Web.HttpUtility.Tests.builds
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Web.HttpUtility.Tests.csproj">
-      <TestTFMs>netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcoreapp1.0;net46</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />


### PR DESCRIPTION
Adding back all of the test configurations that were not being tested by CI after our move to test in netcoreapp1.1

cc: @weshaggard @stephentoub @danmosemsft 

Note that there are a few test projects that are still not being tested:
```
System.Data.SqlClient.Stress.Tests.csproj -> no .builds file is referencing this project. Not sure why.
XsltScenarios.Tests.csproj -> When adding this back to System.Private.Xml.Tests.builds, project woundl't compile anymore.
System.Xml.Linq.Events.Tests.csproj -> has test failures
System.Xml.Linq.Properties.Tests.csproj -> has test failures
System.Xml.Linq.Streaming.Tests.csproj -> has test failures
System.Xml.Linq.xNodeBuilder.Tests.csproj -> has test failures
System.Xml.Linq.xNodeReader.Tests.csproj -> has test failures
System.Security.AccessControl.Tests.csproj -> has test failures
```

cc: @sepidehMS @krwq for the System.Private.Xml.Linq test failures. For now I kept the tests disabled in netcoreapp1.1 and will log an issue so that we can fix those failures and then re-add netcoreapp1.1 to the test configurations