### PR TITLE
Block zero-byte calls to encrypt for Unix SslStream

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -185,7 +185,7 @@ internal static partial class Interop
         {
             Debug.Assert(input != null);
             Debug.Assert(offset >= 0);
-            Debug.Assert(count >= 0);
+            Debug.Assert(count > 0);
             Debug.Assert(offset <= input.Length);
             Debug.Assert(input.Length - offset >= count);
 

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -395,6 +395,13 @@ namespace System.Net.Security
 
                 do
                 {
+                    if (count == 0 && !SslStreamPal.CanEncryptEmptyMessage)
+                    {
+                        // If it's an empty message and the PAL doesn't support that,
+                        // we're done.
+                        return;
+                    }
+
                     // Request a write IO slot.
                     if (_sslState.CheckEnqueueWrite(asyncRequest))
                     {

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -22,6 +22,7 @@ namespace System.Net.Security
         }
 
         internal const bool StartMutualAuthAsAnonymous = false;
+        internal const bool CanEncryptEmptyMessage = false;
 
         public static void VerifyPackageInfo()
         {

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -34,6 +34,7 @@ namespace System.Net.Security
         }
 
         internal const bool StartMutualAuthAsAnonymous = true;
+        internal const bool CanEncryptEmptyMessage = true;
 
         public static void VerifyPackageInfo()
         {


### PR DESCRIPTION
SSL_write is described as having an undefined behavior.
The observed behavior is that it returns 0 (which is ambiguous for "wrote 0/0 bytes" or "writing failed"), and that we then try to read the framed message and the message buffer is empty.

Trying to detect this case once inside the PAL seemed to violate assumptions of the common code, so instead a PAL-capability check is done in SslStreamInternal.StartWriting.  Windows will continue to write the framed empty message, non-Windows will do nothing.

Fixes #10858.
cc: @stephentoub @ericeil @CIPop @davidsh 