### PR TITLE
Xml serialization: Avoid unnecessary string allocation

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -666,7 +666,6 @@ namespace System.Xml.Serialization
             }
             else
             {
-                string methodName = $"To{mapping.TypeDesc.FormatterName}";
                 if (!mapping.TypeDesc.HasCustomFormatter)
                 {
                     string value = readFunc();
@@ -726,6 +725,7 @@ namespace System.Xml.Serialization
                 }
                 else
                 {
+                    string methodName = "To" + mapping.TypeDesc.FormatterName;
                     MethodInfo method = typeof(XmlSerializationReader).GetMethod(methodName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, new Type[] { typeof(string) });
                     if (method == null)
                     {


### PR DESCRIPTION
Minor nit: `methodName` is only used in the else branch, so move it there, and change it to use string concatenation instead of a less efficient interpolated string, while changing this line.

cc: @shmao 