### PR TITLE
Fix incorrect Marshal.GetHRFromException usages and cleanup pending I…

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -266,7 +266,7 @@ namespace System.Diagnostics
                     }
                     catch (IOException e)
                     {
-                        error = Marshal.GetHRForException(e);
+                        error = e.HResult;
                         switch (error)
                         {
                             case Interop.mincore.RPCStatus.RPC_S_CALL_FAILED:

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalTests.cs
@@ -132,11 +132,25 @@ namespace System.Runtime.InteropServices
         [Fact]
         public static void GetHRForException()
         {
-            Assert.Equal(0, Marshal.GetHRForException(null));
-
             Exception e = new Exception();
-            Assert.InRange(Marshal.GetHRForException(e), int.MinValue, -1);
-            Assert.Equal(e.HResult, Marshal.GetHRForException(e));
+
+            try
+            {
+                Assert.Equal(0, Marshal.GetHRForException(null));
+                
+                Assert.InRange(Marshal.GetHRForException(e), int.MinValue, -1);            
+                Assert.Equal(e.HResult, Marshal.GetHRForException(e));
+            }
+            finally
+            {
+                // This GetExceptionForHR call is needed to 'eat' the IErrorInfo put to TLS by 
+                // Marshal.GetHRForException call above. Otherwise other Marshal.GetExceptionForHR 
+                // calls would randomly return previous exception objects passed to 
+                // Marshal.GetHRForException.
+                // The correct way is to use Marshal.GetHRForException at interop boundary only, but for the
+                // time being we'll keep this code as-is.
+                Marshal.GetExceptionForHR(e.HResult);
+            }
         }
     }
 }

--- a/src/System.Runtime/tests/System/IO/DirectoryNotFoundException.InteropTests.cs
+++ b/src/System.Runtime/tests/System/IO/DirectoryNotFoundException.InteropTests.cs
@@ -13,10 +13,9 @@ namespace System.IO.Tests
         [InlineData(HResults.COR_E_DIRECTORYNOTFOUND)]
         [InlineData(HResults.STG_E_PATHNOTFOUND)]
         [InlineData(HResults.CTL_E_PATHNOTFOUND)]
-        [ActiveIssue(13025)]
         public static void From_HR(int hr)
         {
-            DirectoryNotFoundException exception = Assert.IsAssignableFrom<DirectoryNotFoundException>(Marshal.GetExceptionForHR(hr));
+            DirectoryNotFoundException exception = Assert.IsAssignableFrom<DirectoryNotFoundException>(Marshal.GetExceptionForHR(hr, new IntPtr(-1)));
 
             // Don't validate the message.  Currently .NET Native does not produce HR-specific messages
             ExceptionUtility.ValidateExceptionProperties(exception, hResult: hr, validateMessage: false);

--- a/src/System.Runtime/tests/System/IO/FileLoadException.InteropTests.cs
+++ b/src/System.Runtime/tests/System/IO/FileLoadException.InteropTests.cs
@@ -39,7 +39,7 @@ namespace System.IO.Tests
         [InlineData(HResults.ERROR_FILE_INVALID)]
         public static void Fom_HR(int hr)
         {
-            var fileLoadException = Marshal.GetExceptionForHR(hr) as FileLoadException;
+            var fileLoadException = Marshal.GetExceptionForHR(hr, new IntPtr(-1)) as FileLoadException;
             Assert.NotNull(fileLoadException);
 
             // Don't validate the message.  Currently .NET Native does not produce HR-specific messages

--- a/src/System.Runtime/tests/System/IO/FileNotFoundException.InteropTests.cs
+++ b/src/System.Runtime/tests/System/IO/FileNotFoundException.InteropTests.cs
@@ -12,10 +12,9 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(HResults.COR_E_FILENOTFOUND)]
         [InlineData(HResults.CTL_E_FILENOTFOUND)]
-        [ActiveIssue(13025)]
         public static void From_HR(int hr)
         {
-            FileNotFoundException exception = Assert.IsAssignableFrom<FileNotFoundException>(Marshal.GetExceptionForHR(hr));
+            FileNotFoundException exception = Assert.IsAssignableFrom<FileNotFoundException>(Marshal.GetExceptionForHR(hr, new IntPtr(-1)));
 
             // Don't validate the message.  Currently .NET Native does not produce HR-specific messages
             ExceptionUtility.ValidateExceptionProperties(exception, hResult: hr, validateMessage: false);

--- a/src/System.Runtime/tests/System/IO/PathTooLongException.InteropTests.cs
+++ b/src/System.Runtime/tests/System/IO/PathTooLongException.InteropTests.cs
@@ -10,11 +10,10 @@ namespace System.IO.Tests
     public static class PathTooLongExceptionInteropTests
     {
         [Fact]
-        [ActiveIssue(13025)]        
         public static void From_HR()
         {
             int hr = HResults.COR_E_PATHTOOLONG;
-            PathTooLongException exception = Assert.IsAssignableFrom<PathTooLongException>(Marshal.GetExceptionForHR(hr));
+            PathTooLongException exception = Assert.IsAssignableFrom<PathTooLongException>(Marshal.GetExceptionForHR(hr, new IntPtr(-1)));
             ExceptionUtility.ValidateExceptionProperties(exception, hResult: hr, validateMessage: false);
         }
     }

--- a/src/System.Threading.Overlapped/src/System/Threading/Win32ThreadPoolBoundHandle.cs
+++ b/src/System.Threading.Overlapped/src/System/Threading/Win32ThreadPoolBoundHandle.cs
@@ -54,7 +54,7 @@ namespace System.Threading
                 if (hr == System.HResults.E_INVALIDARG)     // Handle already bound or sync handle
                     throw new ArgumentException(SR.Argument_AlreadyBoundOrSyncHandle, nameof(handle));
 
-                throw Marshal.GetExceptionForHR(hr);
+                throw Marshal.GetExceptionForHR(hr, new IntPtr(-1));
             }
 
             return new ThreadPoolBoundHandle(handle, threadPoolHandle);


### PR DESCRIPTION
…ErrorInfo in Marshal.GetHRFromException tests. Otherwise we might leak IErrorInfo to other tests that use Marshal.GetExceptionFromHR and return a totally unexpected exception.

I've verified that if I put the (bad) MarshalTest into System.IO test directory manually, I can see FileTooLongException test failing due to Marshal.GetExceptionFromHR returning the Exception type 'set' by MarshalTest. However, I'm not completely convinced that this will fix all instances as it appears that there are other places that we might be callilng Marshal.GetHRFromException. I suspect somewhere in our infrastructure code (such as XUnit) might be making similar mistakes. We can get this in and see if we are still getting issues.  