### PR TITLE
Add X509Certificate PublicKey.Key and X509Certificate2.PrivateKey properties

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -37,6 +37,7 @@ namespace System.Security.Cryptography.X509Certificates
         public PublicKey(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedData parameters, System.Security.Cryptography.AsnEncodedData keyValue) { }
         public System.Security.Cryptography.AsnEncodedData EncodedKeyValue { get { throw null; } }
         public System.Security.Cryptography.AsnEncodedData EncodedParameters { get { throw null; } }
+        public System.Security.Cryptography.AsymmetricAlgorithm Key { get { throw null; } }
         public System.Security.Cryptography.Oid Oid { get { throw null; } }
     }
     public static partial class RSACertificateExtensions
@@ -160,6 +161,7 @@ namespace System.Security.Cryptography.X509Certificates
         public System.DateTime NotAfter { get { throw null; } }
         public System.DateTime NotBefore { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.PublicKey PublicKey { get { throw null; } }
+        public System.Security.Cryptography.AsymmetricAlgorithm PrivateKey { get { throw null; } set { } }
         public byte[] RawData { get { throw null; } }
         public string SerialNumber { get { throw null; } }
         public System.Security.Cryptography.Oid SignatureAlgorithm { get { throw null; } }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/ICertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/ICertificatePal.cs
@@ -31,7 +31,9 @@ namespace Internal.Cryptography
         X500DistinguishedName SubjectName { get; }
         X500DistinguishedName IssuerName { get; }
         IEnumerable<X509Extension> Extensions { get; }
+        AsymmetricAlgorithm GetPrivateKey();
         RSA GetRSAPrivateKey();
+        DSA GetDSAPrivateKey();
         ECDsa GetECDsaPrivateKey();
         string GetNameInfo(X509NameType nameType, bool forIssuer);
         void AppendPrivateKeyInfo(StringBuilder sb);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Oids.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Oids.cs
@@ -28,6 +28,7 @@ namespace Internal.Cryptography
         public const string InhibitAnyPolicyExtension   = "2.5.29.54";
         public const string Ecc                         = "1.2.840.10045.2.1";
         public const string RsaRsa                      = "1.2.840.113549.1.1.1";
+        public const string DsaDsa                      = "1.2.840.10040.4.1";
         public const string EmailAddress                = "1.2.840.113549.1.9.1";
         public const string EnrollCertTypeExtension     = "1.3.6.1.4.1.311.20.2";
         public const string CertificateTemplate         = "1.3.6.1.4.1.311.21.7";

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -255,6 +255,21 @@ namespace Internal.Cryptography.Pal
             get { return _privateKey; }
         }
 
+        public AsymmetricAlgorithm GetPrivateKey()
+        {
+            switch (KeyAlgorithm)
+            {
+                case Oids.RsaRsa:
+                    return GetRSAPrivateKey();
+                case Oids.DsaDsa:
+                    return GetDSAPrivateKey();
+                case Oids.Ecc:
+                    return GetECDsaPrivateKey();
+            }
+
+            throw new NotSupportedException(SR.NotSupported_KeyAlgorithm);
+        }
+
         public RSA GetRSAPrivateKey()
         {
             if (_privateKey == null || _privateKey.IsInvalid)
@@ -263,6 +278,16 @@ namespace Internal.Cryptography.Pal
             }
 
             return new RSAOpenSsl(_privateKey);
+        }
+
+        public DSA GetDSAPrivateKey()
+        {
+            if (_privateKey == null || _privateKey.IsInvalid)
+            {
+                return null;
+            }
+
+            return new DSAOpenSsl(_privateKey);
         }
 
         public ECDsa GetECDsaPublicKey()

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -15,12 +15,15 @@ namespace Internal.Cryptography.Pal
     {
         public AsymmetricAlgorithm DecodePublicKey(Oid oid, byte[] encodedKeyValue, byte[] encodedParameters, ICertificatePal certificatePal)
         {
+            if (oid.Value == Oids.Ecc && certificatePal != null)
+            {
+                return ((OpenSslX509CertificateReader)certificatePal).GetECDsaPublicKey();
+            }
+
             switch (oid.Value)
             {
                 case Oids.RsaRsa:
                     return BuildRsaPublicKey(encodedKeyValue);
-                case Oids.Ecc:
-                    return ((OpenSslX509CertificateReader)certificatePal).GetECDsaPublicKey();
             }
 
             // NotSupportedException is what desktop and CoreFx-Windows throw in this situation.

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -425,7 +425,7 @@ namespace Internal.Cryptography.Pal
             {
                 if (HasPrivateKey)
                 {
-                    CspParameters parameters = GetPrivateKey();
+                    CspParameters parameters = GetPrivateKeyCsp();
                     cspKeyContainerInfo = new CspKeyContainerInfo(parameters);
                 }
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
@@ -27,7 +27,7 @@ namespace Internal.Cryptography.Pal
 
         public AsymmetricAlgorithm DecodePublicKey(Oid oid, byte[] encodedKeyValue, byte[] encodedParameters, ICertificatePal certificatePal)
         {
-            if (oid.Value == Oids.Ecc)
+            if (oid.Value == Oids.Ecc && certificatePal != null)
             {
                 return DecodeECDsaPublicKey((CertificatePal)certificatePal);
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
@@ -2,10 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Cryptography.Pal;
+
 namespace System.Security.Cryptography.X509Certificates
 {
     public sealed class PublicKey
     {
+        private Oid _oid;
+        private AsymmetricAlgorithm _key = null;
+
         public PublicKey(Oid oid, AsnEncodedData parameters, AsnEncodedData keyValue)
         {
             _oid = new Oid(oid);
@@ -17,6 +22,18 @@ namespace System.Security.Cryptography.X509Certificates
 
         public AsnEncodedData EncodedParameters { get; private set; }
 
+        public AsymmetricAlgorithm Key
+        {
+            get
+            {
+                if (_key == null)
+                {
+                    _key = X509Pal.Instance.DecodePublicKey(_oid, EncodedKeyValue.RawData, EncodedParameters.RawData, null);
+                }
+                return _key;
+            }
+        }
+
         public Oid Oid
         {
             get
@@ -24,8 +41,5 @@ namespace System.Security.Cryptography.X509Certificates
                 return new Oid(_oid);
             }
         }
-
-        private Oid _oid;
     }
 }
-

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -4,6 +4,7 @@
 
 using Internal.Cryptography;
 using Internal.Cryptography.Pal;
+using System;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Text;
@@ -138,6 +139,22 @@ namespace System.Security.Cryptography.X509Certificates
                 ThrowIfInvalid();
 
                 return Pal.HasPrivateKey;
+            }
+        }
+
+        public AsymmetricAlgorithm PrivateKey
+        {
+            get
+            {
+                if (_lazyPrivateKey == null)
+                {
+                    _lazyPrivateKey = Pal.GetPrivateKey();
+                }
+                return _lazyPrivateKey;
+            }
+            set
+            {
+                throw new PlatformNotSupportedException();
             }
         }
 
@@ -525,6 +542,7 @@ namespace System.Security.Cryptography.X509Certificates
         private volatile X500DistinguishedName _lazySubjectName;
         private volatile X500DistinguishedName _lazyIssuer;
         private volatile PublicKey _lazyPublicKey;
+        private volatile AsymmetricAlgorithm _lazyPrivateKey;
         private volatile X509ExtensionCollection _lazyExtensions;
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -233,13 +233,24 @@ Wry5FNNo
         }
 
         [Fact]
-        public static void TestPrivateKey()
+        public static void TestHasPrivateKey()
         {
             using (var c = new X509Certificate2(TestData.MsCertificate))
             {
                 Assert.False(c.HasPrivateKey);
             }
         }
+
+#if netcoreapp11
+        [Fact]
+        public static void TestPrivateKey()
+        {
+            using (var c = new X509Certificate2(TestData.MsCertificate))
+            {
+                Assert.Null(c.PrivateKey);
+            }
+        }
+#endif
 
         [Fact]
         public static void TestVersion()


### PR DESCRIPTION
Address issue https://github.com/dotnet/corefx/issues/12369 - Port X509Certificates.PublicKey.Key and 509Certificate2.PrivateKey

PublicKey.Key only works for RSA, throws PNSE for others.
PrivateKey: setter throws PNSE; getter hooked up to RSA, DSA, ECC but no tests yet for DSA.

DSA support for PublicKey.Key and DSA PrivateKey tests will be added with: https://github.com/dotnet/corefx/issues/11802

@bartonjs please review
