### PR TITLE
Disable XSLT Compiler tests (conditionally)

### DIFF
--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/CommonScenarios/XsltcTestBasicFunctionality.cs
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/CommonScenarios/XsltcTestBasicFunctionality.cs
@@ -50,20 +50,9 @@ namespace System.Xml.Tests
         //[InlineData("bft26.xsl", "bft26", "bft26.txt")] /*sd problems \u0400\u0400\u0400\u0400bft26.xsl, coverage addded to other test cases*/ //Skipping this, it tries to load System.dll
         //[Variation("31", Desc = "Exercise options with “-“", Pri = 1, Params = new object[] { "-out:bft31.dll /class:bft31 -debug- bft31.xsl", "bft31", "bft31.txt" })]
         //[InlineData("-out:bft31.dll /class:bft31 -debug- bft31.xsl", "bft31", "bft31.txt")] //Skipping this, it tries to load System.dll
-        [Theory]
+        [ConditionalTheory(nameof(xsltcExeFound))]
         public void Var1(object param0, object param1, object param2)
         {
-            try
-            {
-                // Verify xsltc.exe is available
-                XmlCoreTest.Common.XsltVerificationLibrary.SearchPath("xsltc.exe");
-            }
-            catch (FileNotFoundException)
-            {
-                _output.WriteLine("Could not find 'xsltc.exe'.  Make sure that the .NET SDK is installed");
-                Assert.True(false);
-            }
-
             String cmdLine = ReplaceCurrentWorkingDirectory(param0.ToString());
             String asmName = param1 + ".dll";
             String typeName = param1.ToString();
@@ -110,20 +99,9 @@ namespace System.Xml.Tests
         [InlineData("/debug+", "bft37.txt")]
         //[Variation("38", Desc = "Empty string in arguments", Pri = 1, Params = new object[] { "\"\"", "bft38.txt" })]
         [InlineData("\"\"", "bft38.txt")]
-        [Theory]
+        [ConditionalTheory(nameof(xsltcExeFound))]
         public void Var2(object param0, object param1)
         {
-            try
-            {
-                // Verify xsltc.exe is available
-                XmlCoreTest.Common.XsltVerificationLibrary.SearchPath("xsltc.exe");
-            }
-            catch (FileNotFoundException)
-            {
-                _output.WriteLine("Could not find 'xsltc.exe'.  Make sure that the .NET SDK is installed");
-                Assert.True(false);
-            }
-
             if (ShouldSkip(new object[] { param0, param1 }))
             {
                 return;// TEST_SKIPPED;

--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/CommonScenarios/XsltcTestCaseBase.cs
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/CommonScenarios/XsltcTestCaseBase.cs
@@ -43,6 +43,20 @@ namespace System.Xml.Tests
             s_output = output;
         }
 
+        public static bool xsltcExeFound()
+        {
+            try
+            {
+                // Verify xsltc.exe is available
+                XmlCoreTest.Common.XsltVerificationLibrary.SearchPath("xsltc.exe");
+            }
+            catch (FileNotFoundException)
+            {
+                return false;
+            }
+            return true;
+        }
+
         public override int Init(object objParam)
         {
             // initialize whether this run is in proc or not

--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/CommonScenarios/XsltcTestFile.cs
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/CommonScenarios/XsltcTestFile.cs
@@ -56,7 +56,7 @@ namespace System.Xml.Tests
         [InlineData("@", "fft20.dll", "no", "fft20", "fft20.pdb", "no", "fft20.txt")]
         //[Variation("21", Desc = "Exercise @ with not existing filename", Pri = 1, Params = new object[] { "@IDontExist", "fft21.dll", "no", "fft21", "fft21.pdb", "no", "fft21.txt" })]
         [InlineData("@IDontExist", "fft21.dll", "no", "fft21", "fft21.pdb", "no", "fft21.txt")]
-        [Theory]
+        [ConditionalTheory(nameof(xsltcExeFound))]
         public void Var1(object param0, object param1, object param2, object param3, object param4, object param5, object param6)
         {
             if (ShouldSkip(new object[] { param0, param1, param2, param3, param4, param5, param6 }))

--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/CommonScenarios/XsltcTestPlatform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/CommonScenarios/XsltcTestPlatform.cs
@@ -33,7 +33,7 @@ namespace System.Xml.Tests
         [InlineData("/PLAtforM:AnyCpU pft10.xsl", "", "pft10.dll", "pft10.txt")]
         //[Variation("17", Desc = "Compile an assembly for anycpu and load", Pri = 1, Params = new object[] { "/platform:anycpu pft17.xsl", "pft17", "pft17.dll", "pft17.txt" })]
         //[InlineData("/platform:anycpu pft17.xsl", "pft17", "pft17.dll", "pft17.txt")] //Skipping this, it tries to load System.dll
-        [Theory]
+        [ConditionalTheory(nameof(xsltcExeFound))]
         public void Var1(object param0, object param1, object param2, object param3)
         {
             String cmdLine = param0.ToString();
@@ -63,7 +63,7 @@ namespace System.Xml.Tests
         //[InlineData("/platform:x86,x64 pft15.xsl", "pft15.txt")] //Skipping this, it tries to load System.dll
         //[Variation("16", Desc = "Exercise basic use case, an unsupported option value -6", Pri = 1, Params = new object[] { "/platform:x86;x64 pft16.xsl", "pft16.txt" })]
         [InlineData("/platform:x86;x64 pft16.xsl", "pft16.txt")]
-        [Theory]
+        [ConditionalTheory(nameof(xsltcExeFound))]
         public void Var2(object param0, object param1)
         {
             String cmdLine = param0.ToString();
@@ -78,7 +78,7 @@ namespace System.Xml.Tests
         [InlineData("pft19.xsl", "pft19.dll", "yes", "", "pft19.pdb", "no", "pft19.txt", "no")]
         //[Variation("20", Desc = "Exercise multiple /platform: flags", Pri = 1, Params = new object[] { "/platform:X64 pft20.xsl" /*+ " /platform:<current>*/, "pft20.dll", "yes", "pft20", "pft20.pdb", "no", "pft20.txt", "yes" })]
         //[InlineData("/platform:X64 pft20.xsl" /*+ " /platform:<current>*/, "pft20.dll", "yes", "pft20", "pft20.pdb", "no", "pft20.txt", "yes")] //Skipping this, it tries to load System.dll
-        [Theory]
+        [ConditionalTheory(nameof(xsltcExeFound))]
         public void Var3(object param0, object param1, object param2, object param3, object param4, object param5, object param6, object param7)
         {
             String platform = "X86"; //CModInfo.Options["Arc"] as String;

--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/CommonScenarios/XsltcTestSettings.cs
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/CommonScenarios/XsltcTestSettings.cs
@@ -91,7 +91,7 @@ namespace System.Xml.Tests
         //[InlineData("/document- sft50.xsl", "sft50.dll", "no", "sft50", "sft50.pdb", "no", "sft50.txt")] //Skipping this, it tries to load System.dll
         //[Variation("51", Desc = "Regression: Basic /settings test cases, two stylesheet with the same script block", Pri = 0, Params = new object[] { "/settings:script+ sft3.xsl sft4.xsl", "sft3.dll", "yes", "", "sft3.pdb", "no", "sft3.txt" })]
         [InlineData("/settings:script+ sft3.xsl sft4.xsl", "sft3.dll", "yes", "", "sft3.pdb", "no", "sft3.txt")]
-        [Theory]
+        [ConditionalTheory(nameof(xsltcExeFound))]
         public void Var1(object param0, object param1, object param2, object param3, object param4, object param5, object param6)
         {
             String cmdLine = param0.ToString();


### PR DESCRIPTION
Addresses https://github.com/dotnet/corefx/issues/12221
Some XsltCompiler tests which were ported from Desktop are testing/using the behavior of xsltc.exe which is not available in CoreFX. These tests currently use the exe installed with SDK (if available). Since xsltc.exe is using CodeDom to generate an assembly from a given xsl and that part of CodeDom is not available on CoreFX, we cannot port it. For that reason, I'm changing those tests to look for xsltc.exe first and I skip the test if it's not available.

@danmosemsft @weshaggard @stephentoub 