### PR TITLE
Re-enable exception serialization tests

### DIFF
--- a/src/System.Resources.ResourceManager/tests/MissingSatelliteAssemblyException.cs
+++ b/src/System.Resources.ResourceManager/tests/MissingSatelliteAssemblyException.cs
@@ -45,7 +45,6 @@ namespace System.Resources.Tests
         }
 
         [Fact]
-        [ActiveIssue(12467)]
         public void Serialization()
         {
             const string cultureName = "fr-FR";

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/COMExceptionTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/COMExceptionTests.cs
@@ -11,7 +11,6 @@ namespace System.Runtime.InteropServices.Tests
 {
     public class COMExceptionTests
     {
-        [ActiveIssue(12467)]
         [Fact]
         public void SerializationRoundTrip()
         {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/InvalidComObjectExceptionTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/InvalidComObjectExceptionTests.cs
@@ -11,7 +11,6 @@ namespace System.Runtime.InteropServices.Tests
 {
     public class InvalidComObjectExceptionTests
     {
-        [ActiveIssue(12467)]
         [Fact]
         public void SerializationRoundTrip()
         {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/InvalidOleVariantTypeExceptionTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/InvalidOleVariantTypeExceptionTests.cs
@@ -11,7 +11,6 @@ namespace System.Runtime.InteropServices.Tests
 {
     public class InvalidOleVariantTypeExceptionTests
     {
-        [ActiveIssue(12467)]
         [Fact]
         public void SerializationRoundTrip()
         {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalDirectiveExceptionTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalDirectiveExceptionTests.cs
@@ -11,7 +11,6 @@ namespace System.Runtime.InteropServices.Tests
 {
     public class MarshalDirectiveExceptionTests
     {
-        [ActiveIssue(12467)]
         [Fact]
         public void SerializationRoundTrip()
         {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SEHExceptionTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SEHExceptionTests.cs
@@ -11,7 +11,6 @@ namespace System.Runtime.InteropServices.Tests
 {
     public class SEHExceptionTests
     {
-        [ActiveIssue(12467)]
         [Fact]
         public void SerializationRoundTrip()
         {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeArrayRankMismatchExceptionTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeArrayRankMismatchExceptionTests.cs
@@ -11,7 +11,6 @@ namespace System.Runtime.InteropServices.Tests
 {
     public class SafeArrayRankMismatchExceptionTests
     {
-        [ActiveIssue(12467)]
         [Fact]
         public void SerializationRoundTrip()
         {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeArrayTypeMismatchExceptionTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeArrayTypeMismatchExceptionTests.cs
@@ -11,7 +11,6 @@ namespace System.Runtime.InteropServices.Tests
 {
     public class SafeArrayTypeMismatchExceptionTests
     {
-        [ActiveIssue(12467)]
         [Fact]
         public void SerializationRoundTrip()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/12467
These should have been fixed by https://github.com/dotnet/coreclr/pull/7856.