### PR TITLE
Add X509Certificate SecureString members

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs12.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs12.cs
@@ -22,7 +22,7 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs12Create", CharSet = CharSet.Ansi)]
         internal static extern SafePkcs12Handle Pkcs12Create(
-            string pass,
+            SafePasswordHandle pass,
             SafeEvpPKeyHandle pkey,
             SafeX509Handle cert,
             SafeX509StackHandle ca);
@@ -33,11 +33,11 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EncodePkcs12")]
         internal static extern int EncodePkcs12(SafePkcs12Handle p12, byte[] buf);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs12Parse", CharSet = CharSet.Ansi)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs12Parse")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool Pkcs12Parse(
             SafePkcs12Handle p12,
-            string pass,
+            SafePasswordHandle pass,
             out SafeEvpPKeyHandle pkey,
             out SafeX509Handle cert,
             out SafeX509StackHandle ca);

--- a/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -100,14 +100,18 @@ namespace System.Security.Cryptography.X509Certificates
     {
         public X509Certificate() { }
         public X509Certificate(byte[] data) { }
+        public X509Certificate(byte[] rawData, System.Security.SecureString password) { }
+        public X509Certificate(byte[] rawData, System.Security.SecureString password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
         public X509Certificate(byte[] rawData, string password) { }
         public X509Certificate(byte[] rawData, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
         public X509Certificate(System.IntPtr handle) { }
+        public X509Certificate(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public X509Certificate(System.Security.Cryptography.X509Certificates.X509Certificate cert) { }
         public X509Certificate(string fileName) { }
+        public X509Certificate(string fileName, System.Security.SecureString password) { }
+        public X509Certificate(string fileName, System.Security.SecureString password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
         public X509Certificate(string fileName, string password) { }
         public X509Certificate(string fileName, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
-        public X509Certificate(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public System.IntPtr Handle { get { throw null; } }
         public string Issuer { get { throw null; } }
         public string Subject { get { throw null; } }
@@ -116,6 +120,7 @@ namespace System.Security.Cryptography.X509Certificates
         public override bool Equals(object obj) { throw null; }
         public virtual bool Equals(System.Security.Cryptography.X509Certificates.X509Certificate other) { throw null; }
         public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType) { throw null; }
+        public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, System.Security.SecureString password) { throw null; }
         public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, string password) { throw null; }
         public virtual byte[] GetCertHash() { throw null; }
         public virtual string GetCertHashString() { throw null; }
@@ -145,14 +150,18 @@ namespace System.Security.Cryptography.X509Certificates
     {
         public X509Certificate2() { }
         public X509Certificate2(byte[] rawData) { }
+        public X509Certificate2(byte[] rawData, System.Security.SecureString password) { }
+        public X509Certificate2(byte[] rawData, System.Security.SecureString password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
         public X509Certificate2(byte[] rawData, string password) { }
         public X509Certificate2(byte[] rawData, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
         public X509Certificate2(System.IntPtr handle) { }
+        protected X509Certificate2(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public X509Certificate2(System.Security.Cryptography.X509Certificates.X509Certificate cert) { }
         public X509Certificate2(string fileName) { }
+        public X509Certificate2(string fileName, System.Security.SecureString password) { }
+        public X509Certificate2(string fileName, System.Security.SecureString password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
         public X509Certificate2(string fileName, string password) { }
         public X509Certificate2(string fileName, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
-        protected X509Certificate2(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public bool Archived { get { throw null; } set { } }
         public System.Security.Cryptography.X509Certificates.X509ExtensionCollection Extensions { get { throw null; } }
         public string FriendlyName { get { throw null; } set { } }

--- a/src/System.Security.Cryptography.X509Certificates/ref/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/ref/project.json
@@ -3,7 +3,8 @@
     "System.Runtime": "4.4.0-beta-24629-01",
     "System.Security.Cryptography.Algorithms": "4.4.0-beta-24629-01",
     "System.Security.Cryptography.Encoding": "4.4.0-beta-24629-01",
-    "System.Security.Cryptography.Primitives": "4.4.0-beta-24629-01"
+    "System.Security.Cryptography.Primitives": "4.4.0-beta-24629-01",
+    "System.Security.SecureString": "4.4.0-beta-24629-01"
   },
   "frameworks": {
     "netstandard1.7": {},

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/IExportPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/IExportPal.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Win32.SafeHandles;
 using System;
 using System.Security.Cryptography.X509Certificates;
 
@@ -9,6 +10,6 @@ namespace Internal.Cryptography.Pal
 {
     internal interface IExportPal : IDisposable
     {
-        byte[] Export(X509ContentType contentType, string password);
+        byte[] Export(X509ContentType contentType, SafePasswordHandle password);
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificatePal.cs
@@ -29,8 +29,10 @@ namespace Internal.Cryptography.Pal
             return certPal.DuplicateHandles();
         }
 
-        public static ICertificatePal FromBlob(byte[] rawData, string password, X509KeyStorageFlags keyStorageFlags)
+        public static ICertificatePal FromBlob(byte[] rawData, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
         {
+            Debug.Assert(password != null);
+
             ICertificatePal cert;
 
             if (TryReadX509Der(rawData, out cert) ||
@@ -52,7 +54,7 @@ namespace Internal.Cryptography.Pal
             throw Interop.Crypto.CreateOpenSslCryptographicException();
         }
 
-        public static ICertificatePal FromFile(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
+        public static ICertificatePal FromFile(string fileName, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
         {
             // If we can't open the file, fail right away.
             using (SafeBioHandle fileBio = Interop.Crypto.BioNewFile(fileName, "rb"))
@@ -63,7 +65,7 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        private static ICertificatePal FromBio(SafeBioHandle bio, string password)
+        private static ICertificatePal FromBio(SafeBioHandle bio, SafePasswordHandle password)
         {
             int bioPosition = Interop.Crypto.BioTell(bio);
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ExportProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ExportProvider.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Win32.SafeHandles;
 using System;
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using Microsoft.Win32.SafeHandles;
 
 namespace Internal.Cryptography.Pal
 {
@@ -33,8 +34,9 @@ namespace Internal.Cryptography.Pal
             _certs = null;
         }
 
-        public byte[] Export(X509ContentType contentType, string password)
+        public byte[] Export(X509ContentType contentType, SafePasswordHandle password)
         {
+            Debug.Assert(password != null);
             switch (contentType)
             {
                 case X509ContentType.Cert:
@@ -70,7 +72,7 @@ namespace Internal.Cryptography.Pal
             return _certs[0].RawData;
         }
 
-        private byte[] ExportPfx(string password)
+        private byte[] ExportPfx(SafePasswordHandle password)
         {
             using (SafeX509StackHandle publicCerts = Interop.Crypto.NewX509Stack())
             {

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
-using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
 
 namespace Internal.Cryptography.Pal
 {
@@ -77,7 +78,7 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        public void Decrypt(string password)
+        public void Decrypt(SafePasswordHandle password)
         {
             bool parsed = Interop.Crypto.Pkcs12Parse(
                 _pkcs12Handle,

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
@@ -218,7 +218,7 @@ namespace Internal.Cryptography.Pal
             return true;
         }
 
-        internal static bool TryReadPkcs12(byte[] rawData, string password, out ICertificatePal certPal)
+        internal static bool TryReadPkcs12(byte[] rawData, SafePasswordHandle password, out ICertificatePal certPal)
         {
             List<ICertificatePal> ignored;
 
@@ -226,21 +226,21 @@ namespace Internal.Cryptography.Pal
 
         }
 
-        internal static bool TryReadPkcs12(SafeBioHandle bio, string password, out ICertificatePal certPal)
+        internal static bool TryReadPkcs12(SafeBioHandle bio, SafePasswordHandle password, out ICertificatePal certPal)
         {
             List<ICertificatePal> ignored;
 
             return TryReadPkcs12(bio, password, true, out certPal, out ignored);
         }
 
-        internal static bool TryReadPkcs12(byte[] rawData, string password, out List<ICertificatePal> certPals)
+        internal static bool TryReadPkcs12(byte[] rawData, SafePasswordHandle password, out List<ICertificatePal> certPals)
         {
             ICertificatePal ignored;
 
             return TryReadPkcs12(rawData, password, false, out ignored, out certPals);
         }
 
-        internal static bool TryReadPkcs12(SafeBioHandle bio, string password, out List<ICertificatePal> certPals)
+        internal static bool TryReadPkcs12(SafeBioHandle bio, SafePasswordHandle password, out List<ICertificatePal> certPals)
         {
             ICertificatePal ignored;
 
@@ -249,7 +249,7 @@ namespace Internal.Cryptography.Pal
 
         private static bool TryReadPkcs12(
             byte[] rawData,
-            string password,
+            SafePasswordHandle password,
             bool single,
             out ICertificatePal readPal,
             out List<ICertificatePal> readCerts)
@@ -272,7 +272,7 @@ namespace Internal.Cryptography.Pal
 
         private static bool TryReadPkcs12(
             SafeBioHandle bio,
-            string password,
+            SafePasswordHandle password,
             bool single,
             out ICertificatePal readPal,
             out List<ICertificatePal> readCerts)
@@ -295,7 +295,7 @@ namespace Internal.Cryptography.Pal
 
         private static bool TryReadPkcs12(
             OpenSslPkcs12Reader pfx,
-            string password,
+            SafePasswordHandle password,
             bool single,
             out ICertificatePal readPal,
             out List<ICertificatePal> readCerts)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -18,8 +18,10 @@ namespace Internal.Cryptography.Pal
         private static CollectionBackedStoreProvider s_machineIntermediateStore;
         private static readonly object s_machineLoadLock = new object();
 
-        public static ILoaderPal FromBlob(byte[] rawData, string password, X509KeyStorageFlags keyStorageFlags)
+        public static ILoaderPal FromBlob(byte[] rawData, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
         {
+            Debug.Assert(password != null);
+
             ICertificatePal singleCert;
 
             if (CertificatePal.TryReadX509Der(rawData, out singleCert) ||
@@ -46,7 +48,7 @@ namespace Internal.Cryptography.Pal
             throw Interop.Crypto.CreateOpenSslCryptographicException();
         }
 
-        public static ILoaderPal FromFile(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
+        public static ILoaderPal FromFile(string fileName, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
         {
             using (SafeBioHandle bio = Interop.Crypto.BioNewFile(fileName, "rb"))
             {
@@ -56,7 +58,7 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        private static ILoaderPal FromBio(SafeBioHandle bio, string password)
+        private static ILoaderPal FromBio(SafeBioHandle bio, SafePasswordHandle password)
         {
             int bioPosition = Interop.Crypto.BioTell(bio);
             Debug.Assert(bioPosition >= 0);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
@@ -16,6 +16,7 @@ using SafeNCryptKeyHandle = Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle;
 
 using Internal.Cryptography;
 using Internal.Cryptography.Pal.Native;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
@@ -129,7 +130,7 @@ internal static partial class Interop
         private static extern unsafe SafeCertContextHandle CertEnumCertificatesInStore(SafeCertStoreHandle hCertStore, CERT_CONTEXT* pPrevCertContext);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern SafeCertStoreHandle PFXImportCertStore([In] ref CRYPTOAPI_BLOB pPFX, string szPassword, PfxCertStoreFlags dwFlags);
+        public static extern SafeCertStoreHandle PFXImportCertStore([In] ref CRYPTOAPI_BLOB pPFX, SafePasswordHandle password, PfxCertStoreFlags dwFlags);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern bool CryptMsgGetParam(SafeCryptMsgHandle hCryptMsg, CryptMessageParameterType dwParamType, int dwIndex, [Out] byte[] pvData, [In, Out] ref int pcbData);
@@ -141,7 +142,7 @@ internal static partial class Interop
         public static extern bool CertSerializeCertificateStoreElement(SafeCertContextHandle pCertContext, int dwFlags, [Out] byte[] pbElement, [In, Out] ref int pcbElement);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern bool PFXExportCertStore(SafeCertStoreHandle hStore, [In, Out] ref CRYPTOAPI_BLOB pPFX, string szPassword, PFXExportFlags dwFlags);
+        public static extern bool PFXExportCertStore(SafeCertStoreHandle hStore, [In, Out] ref CRYPTOAPI_BLOB pPFX, SafePasswordHandle szPassword, PFXExportFlags dwFlags);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertNameToStrW")]
         public static extern int CertNameToStr(CertEncodingType dwCertEncodingType, [In] ref CRYPTOAPI_BLOB pName, CertNameStrTypeAndFlags dwStrType, StringBuilder psz, int csz);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Export.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Export.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Cryptography.Pal.Native;
+using Microsoft.Win32.SafeHandles;
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-
-using Internal.Cryptography.Pal.Native;
 
 namespace Internal.Cryptography.Pal
 {
@@ -21,8 +22,9 @@ namespace Internal.Cryptography.Pal
             Dispose();
         }
 
-        public byte[] Export(X509ContentType contentType, string password)
+        public byte[] Export(X509ContentType contentType, SafePasswordHandle password)
         {
+            Debug.Assert(password != null);
             switch (contentType)
             {
                 case X509ContentType.Cert:

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Import.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Import.cs
@@ -2,29 +2,32 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Cryptography.Pal.Native;
+using Microsoft.Win32.SafeHandles;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
-
-using Internal.Cryptography.Pal.Native;
+using System.Diagnostics;
 
 namespace Internal.Cryptography.Pal
 {
     internal sealed partial class StorePal : IDisposable, IStorePal, IExportPal, ILoaderPal
     {
-        public static ILoaderPal FromBlob(byte[] rawData, string password, X509KeyStorageFlags keyStorageFlags)
+        public static ILoaderPal FromBlob(byte[] rawData, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
         {
             return FromBlobOrFile(rawData, null, password, keyStorageFlags);
         }
 
-        public static ILoaderPal FromFile(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
+        public static ILoaderPal FromFile(string fileName, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
         {
             return FromBlobOrFile(null, fileName, password, keyStorageFlags);
         }
 
-        private static StorePal FromBlobOrFile(byte[] rawData, string fileName, string password, X509KeyStorageFlags keyStorageFlags)
+        private static StorePal FromBlobOrFile(byte[] rawData, string fileName, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
         {
+            Debug.Assert(password != null);
+
             bool fromFile = fileName != null;
 
             unsafe

--- a/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafePasswordHandle.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafePasswordHandle.Unix.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal partial class SafePasswordHandle
+    {
+        private IntPtr CreateHandle(string password)
+        {
+            return Marshal.StringToHGlobalAnsi(password);
+        }
+
+        private IntPtr CreateHandle(SecureString password)
+        {
+            return SecureStringMarshal.SecureStringToGlobalAllocAnsi(password);
+        }
+
+        private void FreeHandle()
+        {
+            Marshal.ZeroFreeGlobalAllocAnsi(handle);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafePasswordHandle.Windows.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafePasswordHandle.Windows.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal partial class SafePasswordHandle
+    {
+        private IntPtr CreateHandle(string password)
+        {
+            return Marshal.StringToHGlobalUni(password);
+        }
+
+        private IntPtr CreateHandle(SecureString password)
+        {
+            return SecureStringMarshal.SecureStringToGlobalAllocUnicode(password);
+        }
+
+        private void FreeHandle()
+        {
+            Marshal.ZeroFreeGlobalAllocUnicode(handle);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafePasswordHandle.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafePasswordHandle.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    /// <summary>
+    /// Wrap a string- or SecureString-based object. A null value indicates IntPtr.Zero should be used.
+    /// </summary>
+    internal sealed partial class SafePasswordHandle : SafeHandle
+    {
+        public SafePasswordHandle(string password)
+            : base(IntPtr.Zero, ownsHandle: true)
+        {
+            if (password != null)
+            {
+                SetHandle(CreateHandle(password));
+            }
+        }
+
+        public SafePasswordHandle(SecureString password)
+            : base(IntPtr.Zero, ownsHandle: true)
+        {
+            if (password != null)
+            {
+                SetHandle(CreateHandle(password));
+            }
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            if (handle != IntPtr.Zero)
+            {
+                FreeHandle();
+            }
+            SetHandle((IntPtr)(-1));
+            return true;
+        }
+
+        public override bool IsInvalid => handle == (IntPtr)(-1);
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Internal\Cryptography\IStorePal.cs" />
     <Compile Include="Internal\Cryptography\IX509Pal.cs" />
     <Compile Include="Internal\Cryptography\Oids.cs" />
+    <Compile Include="Microsoft\Win32\SafeHandles\SafePasswordHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeX509ChainHandle.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\ECDsaCertificateExtensions.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\OpenFlags.cs" />
@@ -106,6 +107,7 @@
     <Compile Include="Internal\Cryptography\Pal.Windows\X509Pal.GetCertContentType.cs" />
     <Compile Include="Internal\Cryptography\Pal.Windows\X509Pal.PublicKey.cs" />
     <Compile Include="Internal\Cryptography\Pal.Windows\X509Pal.X500DistinguishedName.cs" />
+    <Compile Include="Microsoft\Win32\SafeHandles\SafePasswordHandle.Windows.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.FindOidInfo.cs</Link>
     </Compile>
@@ -162,6 +164,7 @@
     <Compile Include="Internal\Cryptography\Pal.Unix\X500NameEncoder.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\X509Pal.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\X509Persistence.cs" />
+    <Compile Include="Microsoft\Win32\SafeHandles\SafePasswordHandle.Unix.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -4,9 +4,11 @@
 
 using Internal.Cryptography;
 using Internal.Cryptography.Pal;
+using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.Serialization;
+using System.Security;
 using System.Text;
 
 namespace System.Security.Cryptography.X509Certificates
@@ -21,10 +23,20 @@ namespace System.Security.Cryptography.X509Certificates
         public X509Certificate(byte[] data)
         {
             if (data != null && data.Length != 0)  // For compat reasons, this constructor treats passing a null or empty data set as the same as calling the nullary constructor.
-                Pal = CertificatePal.FromBlob(data, null, X509KeyStorageFlags.DefaultKeySet);
+            {
+                using (var safePasswordHandle = new SafePasswordHandle((string)null))
+                {
+                    Pal = CertificatePal.FromBlob(data, safePasswordHandle, X509KeyStorageFlags.DefaultKeySet);
+                }
+            }
         }
 
         public X509Certificate(byte[] rawData, string password)
+            : this(rawData, password, X509KeyStorageFlags.DefaultKeySet)
+        {
+        }
+
+        public X509Certificate(byte[] rawData, SecureString password)
             : this(rawData, password, X509KeyStorageFlags.DefaultKeySet)
         {
         }
@@ -36,7 +48,23 @@ namespace System.Security.Cryptography.X509Certificates
  
             ValidateKeyStorageFlags(keyStorageFlags);
 
-            Pal = CertificatePal.FromBlob(rawData, password, keyStorageFlags);
+            using (var safePasswordHandle = new SafePasswordHandle(password))
+            {
+                Pal = CertificatePal.FromBlob(rawData, safePasswordHandle, keyStorageFlags);
+            }
+        }
+
+        public X509Certificate(byte[] rawData, SecureString password, X509KeyStorageFlags keyStorageFlags)
+        {
+            if (rawData == null || rawData.Length == 0)
+                throw new ArgumentException(SR.Arg_EmptyOrNullArray, nameof(rawData));
+
+            ValidateKeyStorageFlags(keyStorageFlags);
+
+            using (var safePasswordHandle = new SafePasswordHandle(password))
+            {
+                Pal = CertificatePal.FromBlob(rawData, safePasswordHandle, keyStorageFlags);
+            }
         }
 
         public X509Certificate(IntPtr handle)
@@ -51,7 +79,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509Certificate(string fileName)
-            : this(fileName, null, X509KeyStorageFlags.DefaultKeySet)
+            : this(fileName, (string)null, X509KeyStorageFlags.DefaultKeySet)
         {
         }
 
@@ -60,14 +88,35 @@ namespace System.Security.Cryptography.X509Certificates
         {
         }
 
+        public X509Certificate(string fileName, SecureString password)
+            : this(fileName, password, X509KeyStorageFlags.DefaultKeySet)
+        {
+        }
+
         public X509Certificate(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
         {
             if (fileName == null)
                 throw new ArgumentNullException(nameof(fileName));
-            
+
             ValidateKeyStorageFlags(keyStorageFlags);
 
-            Pal = CertificatePal.FromFile(fileName, password, keyStorageFlags);
+            using (var safePasswordHandle = new SafePasswordHandle(password))
+            {
+                Pal = CertificatePal.FromFile(fileName, safePasswordHandle, keyStorageFlags);
+            }
+        }
+
+        public X509Certificate(string fileName, SecureString password, X509KeyStorageFlags keyStorageFlags) : this()
+        {
+            if (fileName == null)
+                throw new ArgumentNullException(nameof(fileName));
+
+            ValidateKeyStorageFlags(keyStorageFlags);
+
+            using (var safePasswordHandle = new SafePasswordHandle(password))
+            {
+                Pal = CertificatePal.FromFile(fileName, safePasswordHandle, keyStorageFlags);
+            }
         }
 
         public X509Certificate(X509Certificate cert)
@@ -86,7 +135,10 @@ namespace System.Security.Cryptography.X509Certificates
             byte[] rawData = (byte[])info.GetValue("RawData", typeof(byte[]));
             if (rawData != null)
             {
-                Pal = CertificatePal.FromBlob(rawData, null, X509KeyStorageFlags.DefaultKeySet);
+                using (var safePasswordHandle = new SafePasswordHandle((string)null))
+                {
+                    Pal = CertificatePal.FromBlob(rawData, safePasswordHandle, X509KeyStorageFlags.DefaultKeySet);
+                }
             }
         }
 
@@ -185,20 +237,34 @@ namespace System.Security.Cryptography.X509Certificates
 
         public virtual byte[] Export(X509ContentType contentType)
         {
-            return Export(contentType, null);
+            return Export(contentType, (string)null);
         }
 
         public virtual byte[] Export(X509ContentType contentType, string password)
         {
-            if (!(contentType == X509ContentType.Cert || contentType == X509ContentType.SerializedCert || contentType == X509ContentType.Pkcs12))
-                throw new CryptographicException(SR.Cryptography_X509_InvalidContentType);
+            VerifyContentType(contentType);
 
             if (Pal == null)
                 throw new CryptographicException(ErrorCode.E_POINTER);  // Not the greatest error, but needed for backward compat.
 
+            using (var safePasswordHandle = new SafePasswordHandle(password))
             using (IExportPal storePal = StorePal.FromCertificate(Pal))
             {
-                return storePal.Export(contentType, password);
+                return storePal.Export(contentType, safePasswordHandle);
+            }
+        }
+
+        public virtual byte[] Export(X509ContentType contentType, SecureString password)
+        {
+            VerifyContentType(contentType);
+
+            if (Pal == null)
+                throw new CryptographicException(ErrorCode.E_POINTER);  // Not the greatest error, but needed for backward compat.
+
+            using (var safePasswordHandle = new SafePasswordHandle(password))
+            using (IExportPal storePal = StorePal.FromCertificate(Pal))
+            {
+                return storePal.Export(contentType, safePasswordHandle);
             }
         }
 
@@ -464,6 +530,12 @@ namespace System.Security.Cryptography.X509Certificates
                     SR.Format(SR.Cryptography_X509_InvalidFlagCombination, persistenceFlags),
                     nameof(keyStorageFlags));
             }
+        }
+
+        private void VerifyContentType(X509ContentType contentType)
+        {
+            if (!(contentType == X509ContentType.Cert || contentType == X509ContentType.SerializedCert || contentType == X509ContentType.Pkcs12))
+                throw new CryptographicException(SR.Cryptography_X509_InvalidContentType);
         }
 
         private volatile byte[] _lazyCertHash;

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -29,7 +29,17 @@ namespace System.Security.Cryptography.X509Certificates
         {
         }
 
+        public X509Certificate2(byte[] rawData, SecureString password)
+            : base(rawData, password)
+        {
+        }
+
         public X509Certificate2(byte[] rawData, string password, X509KeyStorageFlags keyStorageFlags)
+            : base(rawData, password, keyStorageFlags)
+        {
+        }
+
+        public X509Certificate2(byte[] rawData, SecureString password, X509KeyStorageFlags keyStorageFlags)
             : base(rawData, password, keyStorageFlags)
         {
         }
@@ -54,7 +64,18 @@ namespace System.Security.Cryptography.X509Certificates
         {
         }
 
+        public X509Certificate2(string fileName, SecureString password)
+            : base(fileName, password)
+        {
+        }
+
+
         public X509Certificate2(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
+            : base(fileName, password, keyStorageFlags)
+        {
+        }
+
+        public X509Certificate2(string fileName, SecureString password, X509KeyStorageFlags keyStorageFlags)
             : base(fileName, password, keyStorageFlags)
         {
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Internal.Cryptography.Pal;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.Security.Cryptography.X509Certificates
 {
@@ -109,9 +110,10 @@ namespace System.Security.Cryptography.X509Certificates
 
         public byte[] Export(X509ContentType contentType, string password)
         {
+            using (var safePasswordHandle = new SafePasswordHandle(password))
             using (IExportPal storePal = StorePal.LinkFromCertificateCollection(this))
             {
-                return storePal.Export(contentType, password);
+                return storePal.Export(contentType, safePasswordHandle);
             }
         }
 
@@ -140,7 +142,8 @@ namespace System.Security.Cryptography.X509Certificates
 
             X509Certificate.ValidateKeyStorageFlags(keyStorageFlags);
 
-            using (ILoaderPal storePal = StorePal.FromBlob(rawData, password, keyStorageFlags))
+            using (var safePasswordHandle = new SafePasswordHandle(password))
+            using (ILoaderPal storePal = StorePal.FromBlob(rawData, safePasswordHandle, keyStorageFlags))
             {
                 storePal.MoveTo(this);
             }
@@ -158,7 +161,8 @@ namespace System.Security.Cryptography.X509Certificates
 
             X509Certificate.ValidateKeyStorageFlags(keyStorageFlags);
 
-            using (ILoaderPal storePal = StorePal.FromFile(fileName, password, keyStorageFlags))
+            using (var safePasswordHandle = new SafePasswordHandle(password))
+            using (ILoaderPal storePal = StorePal.FromFile(fileName, safePasswordHandle, keyStorageFlags))
             {
                 storePal.MoveTo(this);
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/unix/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/unix/project.json
@@ -18,6 +18,7 @@
     "System.Security.Cryptography.Encoding": "4.4.0-beta-24629-01",
     "System.Security.Cryptography.OpenSsl": "4.4.0-beta-24629-01",
     "System.Security.Cryptography.Primitives": "4.4.0-beta-24629-01",
+    "System.Security.SecureString": "4.4.0-beta-24629-01",
     "System.Text.Encoding": "4.4.0-beta-24629-01",
     "System.Threading": "4.4.0-beta-24629-01",
     "System.Threading.Tasks": "4.4.0-beta-24629-01"

--- a/src/System.Security.Cryptography.X509Certificates/src/win/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/win/project.json
@@ -20,6 +20,7 @@
     "System.Security.Cryptography.Csp": "4.4.0-beta-24629-01",
     "System.Security.Cryptography.Encoding": "4.4.0-beta-24629-01",
     "System.Security.Cryptography.Primitives": "4.4.0-beta-24629-01",
+    "System.Security.SecureString": "4.4.0-beta-24629-01",
     "System.Text.Encoding": "4.4.0-beta-24629-01",
     "System.Threading": "4.4.0-beta-24629-01",
     "System.Threading.Tasks": "4.4.0-beta-24629-01"

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -640,6 +640,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             TestExportSingleCert(X509ContentType.Cert);
         }
 
+#if netcoreapp11
+        [Fact]
+        public static void ExportCert_SecureString()
+        {
+            TestExportSingleCert_SecureStringPassword(X509ContentType.Cert);
+        }
+#endif
+
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
         public static void ExportSerializedCert_Windows()
@@ -764,7 +772,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             var collection = new X509Certificate2Collection();
             try
             {
-                collection.Import(Path.Combine("TestData", "DummyTcpServer.pfx"), null, Cert.EphemeralIfPossible);
+                collection.Import(Path.Combine("TestData", "DummyTcpServer.pfx"), (string)null, Cert.EphemeralIfPossible);
                 collection.Import(TestData.PfxData, TestData.PfxDataPassword, Cert.EphemeralIfPossible);
                 Assert.Equal(3, collection.Count);
             }
@@ -785,7 +793,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
             try
             {
-                collection.Import(Path.Combine("TestData", "DummyTcpServer.pfx"), null, X509KeyStorageFlags.Exportable | Cert.EphemeralIfPossible);
+                collection.Import(Path.Combine("TestData", "DummyTcpServer.pfx"), (string)null, X509KeyStorageFlags.Exportable | Cert.EphemeralIfPossible);
                 collection.Import(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.Exportable | Cert.EphemeralIfPossible);
 
                 // Pre-condition, we have multiple private keys
@@ -1379,10 +1387,27 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+#if netcoreapp11
+        private static void TestExportSingleCert_SecureStringPassword(X509ContentType ct)
+        {
+            using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.CreatePfxDataPasswordSecureString(), Cert.EphemeralIfPossible))
+            {
+                TestExportSingleCert(ct, pfxCer);
+            }
+        }
+#endif
+
         private static void TestExportSingleCert(X509ContentType ct)
         {
-            using (var msCer = new X509Certificate2(TestData.MsCertificate))
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, Cert.EphemeralIfPossible))
+            {
+                TestExportSingleCert(ct, pfxCer);
+            }
+        }
+
+        private static void TestExportSingleCert(X509ContentType ct, X509Certificate2 pfxCer)
+        {
+            using (var msCer = new X509Certificate2(TestData.MsCertificate))
             {
                 X509Certificate2Collection cc = new X509Certificate2Collection(new X509Certificate2[] { msCer, pfxCer });
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -28,16 +28,34 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [MemberData(nameof(StorageFlags))]
         public static void TestConstructor(X509KeyStorageFlags keyStorageFlags)
         {
-            byte[] expectedThumbprint = "71cb4e2b02738ad44f8b382c93bd17ba665f9914".HexToByteArray();
-
             using (var c = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, keyStorageFlags))
             {
+                byte[] expectedThumbprint = "71cb4e2b02738ad44f8b382c93bd17ba665f9914".HexToByteArray();
+
                 string subject = c.Subject;
                 Assert.Equal("CN=MyName", subject);
                 byte[] thumbPrint = c.GetCertHash();
                 Assert.Equal(expectedThumbprint, thumbPrint);
             }
         }
+
+#if netcoreapp11
+        [Theory]
+        [MemberData(nameof(StorageFlags))]
+        public static void TestConstructor_SecureString(X509KeyStorageFlags keyStorageFlags)
+        {
+            using (SecureString password = TestData.CreatePfxDataPasswordSecureString())
+            using (var c = new X509Certificate2(TestData.PfxData, password, keyStorageFlags))
+            {
+                byte[] expectedThumbprint = "71cb4e2b02738ad44f8b382c93bd17ba665f9914".HexToByteArray();
+
+                string subject = c.Subject;
+                Assert.Equal("CN=MyName", subject);
+                byte[] thumbPrint = c.GetCertHash();
+                Assert.Equal(expectedThumbprint, thumbPrint);
+            }
+        }
+#endif
 
         [Theory]
         [MemberData(nameof(StorageFlags))]

--- a/src/System.Security.Cryptography.X509Certificates/tests/TestData.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/TestData.cs
@@ -84,6 +84,23 @@ Og7vtpU6pzjkJZIIpohmgg==
 
         public const string PfxDataPassword = "12345";
 
+        public static SecureString CreatePfxDataPasswordSecureString()
+        {
+            var s = new SecureString();
+
+            // WARNING:
+            // A key value of SecureString is in keeping string data off of the GC heap, such that it can
+            // be reliably cleared when no longer needed.  Creating a SecureString from a string or converting
+            // a SecureString to a string diminishes that value. These conversion functions are for testing that 
+            // SecureString works, and does not represent a pattern to follow in any non-test situation.
+            foreach (char c in PfxDataPassword.ToCharArray())
+            {
+                s.AppendChar(c);
+            }
+
+            return s;
+        }
+
         public static readonly byte[] PfxSha1Empty_ExpectedSig = (
             "44b15120b8c7de19b4968d761600ffb8c54e5d0c1bcaba0880a20ab48912c8fd" + 
             "fa81b28134eabf58f3211a0d1eefdaae115e7872d5a67045c3b62a5da4393940" +


### PR DESCRIPTION
Adds constructors to X509Certificate  and X509Certificate2 that use SecureStrings.

Partial implementation of issue https://github.com/dotnet/corefx/issues/12295

Implementation is same as netfx where `object` password is passed which can either be a `string` or `SecureString` and is converted to an `IntPtr` (that points to a temporary clear text password) in order to pass to the native method.

@bartonjs please review
