### PR TITLE
Moving HttpVersion to System.Net.Primitives.

### DIFF
--- a/src/Common/src/System/Net/HttpVersion.cs
+++ b/src/Common/src/System/Net/HttpVersion.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace System.Net
 {
-    internal static class HttpVersion
+    public static class HttpVersion
     {
         public static readonly Version Unknown = new Version(0, 0);
         public static readonly Version Version10 = new Version(1, 0);

--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -266,6 +266,18 @@ namespace System.Net
         protected TransportContext() { }
         public abstract System.Security.Authentication.ExtendedProtection.ChannelBinding GetChannelBinding(System.Security.Authentication.ExtendedProtection.ChannelBindingKind kind);
     }
+
+    public static class HttpVersion
+    {
+#if netcoreapp11
+        public static readonly Version Unknown = new Version(0, 0);
+#endif
+        public static readonly Version Version10 = new Version(1, 0);
+        public static readonly Version Version11 = new Version(1, 1);
+#if netcoreapp11
+        public static readonly Version Version20 = new Version(2, 0);
+#endif
+    }
 }
 namespace System.Net.Cache
 {

--- a/src/System.Net.Primitives/ref/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
     <PackageTargetFramework>netstandard1.7;uap10.1</PackageTargetFramework>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp1.1'">$(DefineConstants);netcoreapp11</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Net.Primitives.cs" />

--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -67,6 +67,9 @@
     <Compile Include="$(CommonPath)\System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\HttpVersion.cs">
+      <Link>\System\Net\HttpVersion.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs">
       <Link>Common\System\Net\ByteOrder.cs</Link>
     </Compile>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/12510
All private copies of HttpVersion from other
projects need to be removed.I am not sure how to
use an unpublished API , the doc talks about adding
direct csproj reference , but not clear if i can check-in
that way.