### PR TITLE
Enable S.R.CS.Unsafe tests that depend on ref locals and returns

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
@@ -418,9 +418,6 @@ namespace System.Runtime.CompilerServices
             Assert.Equal(new IntPtr(-3), Unsafe.ByteOffset(ref byte4.B3, ref byte4.B0));
         }
 
-        // Active Issue: https://github.com/dotnet/coreclr/issues/6505
-        // These tests require C# compiler with support for ref returns and locals
-#if false
         [Fact]
         public unsafe static void AsRef()
         {
@@ -473,7 +470,7 @@ namespace System.Runtime.CompilerServices
             ref int r2 = ref Unsafe.Add(ref r1, (IntPtr)2);
             Assert.Equal(0x456, r2);
 
-            ref int r3 = ref Unsafe.Add(ref r2, (IntPtr)-3);
+            ref int r3 = ref Unsafe.Add(ref r2, (IntPtr)(-3));
             Assert.Equal(0x123, r3);
         }
 
@@ -482,13 +479,13 @@ namespace System.Runtime.CompilerServices
         {
             byte[] a = new byte[] { 0x12, 0x34, 0x56, 0x78 };
 
-            ref int r1 = ref Unsafe.AddByteOffset(ref a[0], (IntPtr)1);
+            ref byte r1 = ref Unsafe.AddByteOffset(ref a[0], (IntPtr)1);
             Assert.Equal(0x34, r1);
 
-            ref int r2 = ref Unsafe.AddByteOffset(ref r1, (IntPtr)2);
+            ref byte r2 = ref Unsafe.AddByteOffset(ref r1, (IntPtr)2);
             Assert.Equal(0x78, r2);
 
-            ref int r3 = ref Unsafe.AddByteOffset(ref r2, (IntPtr) - 3);
+            ref byte r3 = ref Unsafe.AddByteOffset(ref r2, (IntPtr)(-3));
             Assert.Equal(0x12, r3);
         }
 
@@ -512,10 +509,10 @@ namespace System.Runtime.CompilerServices
         {
             string[] a = new string[] { "abc", "def", "ghi", "jkl" };
 
-            ref string r1 = ref Unsafe.Subtract(ref a[0], (IntPtr)-2);
+            ref string r1 = ref Unsafe.Subtract(ref a[0], (IntPtr)(-2));
             Assert.Equal("ghi", r1);
 
-            ref string r2 = ref Unsafe.Subtract(ref r1, (IntPtr)-1);
+            ref string r2 = ref Unsafe.Subtract(ref r1, (IntPtr)(-1));
             Assert.Equal("jkl", r2);
 
             ref string r3 = ref Unsafe.Subtract(ref r2, (IntPtr)3);
@@ -527,13 +524,13 @@ namespace System.Runtime.CompilerServices
         {
             byte[] a = new byte[] { 0x12, 0x34, 0x56, 0x78 };
 
-            ref int r1 = ref Unsafe.SubtractByteOffset(ref a[0], (IntPtr)-1);
+            ref byte r1 = ref Unsafe.SubtractByteOffset(ref a[0], (IntPtr)(-1));
             Assert.Equal(0x34, r1);
 
-            ref int r2 = ref Unsafe.SubtractByteOffset(ref r1, (IntPtr)-2);
+            ref byte r2 = ref Unsafe.SubtractByteOffset(ref r1, (IntPtr)(-2));
             Assert.Equal(0x78, r2);
 
-            ref int r3 = ref Unsafe.SubtractByteOffset(ref r2, (IntPtr)3);
+            ref byte r3 = ref Unsafe.SubtractByteOffset(ref r2, (IntPtr)3);
             Assert.Equal(0x12, r3);
         }
 
@@ -545,7 +542,6 @@ namespace System.Runtime.CompilerServices
             Assert.True(Unsafe.AreSame(ref a[0], ref a[0]));
             Assert.False(Unsafe.AreSame(ref a[0], ref a[1]));
         }
-#endif
     }
 
     [StructLayout(LayoutKind.Explicit)]


### PR DESCRIPTION
Fix https://github.com/dotnet/coreclr/issues/6505