### PR TITLE
Allow querying other user processes by id.

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
@@ -27,7 +27,9 @@ namespace System.Diagnostics
         {
             // kill with signal==0 means to not actually send a signal.
             // If we get back 0, the process is still alive.
-            return 0 == Interop.Sys.Kill(processId, Interop.Sys.Signals.None);
+            int output = Interop.Sys.Kill(processId, Interop.Sys.Signals.None);
+            // If kill set errno=EPERM, assume querying process is alive.
+            return 0 == output || (-1 == output && Interop.Error.EPERM == Interop.Sys.GetLastError());
         }
 
         /// <summary>Gets the ProcessInfo for the specified process ID on the specified machine.</summary>

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -548,6 +548,14 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void TestRootGetProcessById()
+        {
+            Process p = Process.GetProcessById(1);
+            Assert.Equal(1, p.Id);
+        }
+
+        [Fact]
         public void TestGetProcesses()
         {
             Process currentProcess = Process.GetCurrentProcess();


### PR DESCRIPTION
cc @stephentoub @karelz 

Assuming that the process queried by ID, is alive if kill with signal=0 returns -1 and sets errno=EPERM. This behavior is similar to Process Wait checking for exit [here](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs#L350)

fixes #13135 