### PR TITLE
Add deserialization ctors to several permissions types

### DIFF
--- a/src/System.Security.Permissions/src/System/Security/PermissionSet.cs
+++ b/src/System.Security.Permissions/src/System/Security/PermissionSet.cs
@@ -29,7 +29,7 @@ namespace System.Security
         public void Deny() { throw new NotSupportedException(); }
         public override bool Equals(object o) => base.Equals(o);
         public virtual void FromXml(SecurityElement et) { }
-        public IEnumerator GetEnumerator() { return default(IEnumerator); }
+        public IEnumerator GetEnumerator() { return Array.Empty<object>().GetEnumerator(); }
         public override int GetHashCode() => base.GetHashCode();
         public IPermission GetPermission(Type permClass) { return default(IPermission); }
         public PermissionSet Intersect(PermissionSet other) { return default(PermissionSet); }

--- a/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrustCollection.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/ApplicationTrustCollection.cs
@@ -19,11 +19,11 @@ namespace System.Security.Policy
         public void AddRange(ApplicationTrustCollection trusts) { }
         public void Clear() { }
         public void CopyTo(ApplicationTrust[] array, int index) { }
-        public ApplicationTrustEnumerator GetEnumerator() { return default(ApplicationTrustEnumerator); }
+        public ApplicationTrustEnumerator GetEnumerator() { return new ApplicationTrustEnumerator(); }
         public void Remove(ApplicationTrust trust) { }
         public void RemoveRange(ApplicationTrust[] trusts) { }
         public void RemoveRange(ApplicationTrustCollection trusts) { }
         void ICollection.CopyTo(Array array, int index) { }
-        IEnumerator IEnumerable.GetEnumerator() { return default(IEnumerator); }
+        IEnumerator IEnumerable.GetEnumerator() { return GetEnumerator(); }
     }
 }

--- a/src/System.Security.Permissions/src/System/Security/Policy/Evidence.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Evidence.cs
@@ -27,10 +27,10 @@ namespace System.Security.Policy
         public Evidence Clone() { return default(Evidence); }
         [Obsolete("Evidence should not be treated as an ICollection. Please use the GetHostEnumerator and GetAssemblyEnumerator methods rather than using CopyTo.")]
         public void CopyTo(Array array, int index) { }
-        public IEnumerator GetAssemblyEnumerator() { return default(IEnumerator); }
+        public IEnumerator GetAssemblyEnumerator() { return Array.Empty<object>().GetEnumerator(); }
         [Obsolete("GetEnumerator is obsolete. Please use GetAssemblyEnumerator and GetHostEnumerator instead.")]
-        public IEnumerator GetEnumerator() { return default(IEnumerator); }
-        public IEnumerator GetHostEnumerator() { return default(IEnumerator); }
+        public IEnumerator GetEnumerator() { return Array.Empty<object>().GetEnumerator(); }
+        public IEnumerator GetHostEnumerator() { return Array.Empty<object>().GetEnumerator(); }
         public void Merge(Evidence evidence) { }
         public void RemoveType(Type t) { }
     }

--- a/src/System.Security.Permissions/src/System/Security/Policy/Hash.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/Hash.cs
@@ -11,6 +11,7 @@ namespace System.Security.Policy
     public sealed partial class Hash : EvidenceBase, System.Runtime.Serialization.ISerializable
     {
         public Hash(System.Reflection.Assembly assembly) { }
+        private Hash(SerializationInfo info, StreamingContext context) { }
         public byte[] MD5 { get { return null; } }
         public byte[] SHA1 { get { return null; } }
         public static Hash CreateMD5(byte[] md5) { return default(Hash); }

--- a/src/System.Security.Permissions/src/System/Security/Policy/HashMembershipCondition.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/HashMembershipCondition.cs
@@ -8,9 +8,10 @@ using System.Security.Cryptography;
 namespace System.Security.Policy
 {
     [Serializable]
-    public sealed partial class HashMembershipCondition : IDeserializationCallback, System.Runtime.Serialization.ISerializable, ISecurityEncodable, ISecurityPolicyEncodable, IMembershipCondition
+    public sealed partial class HashMembershipCondition : IDeserializationCallback, ISerializable, ISecurityEncodable, ISecurityPolicyEncodable, IMembershipCondition
     {
         public HashMembershipCondition(HashAlgorithm hashAlg, byte[] value) { }
+        private HashMembershipCondition(SerializationInfo info, StreamingContext context) { }
         public HashAlgorithm HashAlgorithm { get; set; }
         public byte[] HashValue { get; set; }
         public bool Check(Evidence evidence) { return false; }

--- a/src/System.Security.Permissions/src/System/Security/XmlSyntaxException.cs
+++ b/src/System.Security.Permissions/src/System/Security/XmlSyntaxException.cs
@@ -7,13 +7,13 @@ using System.Runtime.Serialization;
 namespace System.Security
 {
     [Serializable]
-    public sealed partial class XmlSyntaxException : System.SystemException
+    public sealed partial class XmlSyntaxException : SystemException
     {
         public XmlSyntaxException() { }
         public XmlSyntaxException(int lineNumber) { }
         public XmlSyntaxException(int lineNumber, string message) { }
         public XmlSyntaxException(string message) { }
         public XmlSyntaxException(string message, Exception inner) { }
-        internal XmlSyntaxException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        private XmlSyntaxException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Security.Permissions/tests/ApplicationTrustTests.cs
+++ b/src/System.Security.Permissions/tests/ApplicationTrustTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Policy;
 using Xunit;
 
 namespace System.Security.Permissions.Tests
@@ -11,23 +12,24 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void ApplicationTrustCollectionCallMethods()
         {
-            Policy.ApplicationTrustCollection atc = (Policy.ApplicationTrustCollection)Activator.CreateInstance(typeof(Policy.ApplicationTrustCollection), true);
-            Policy.ApplicationTrust at = new Policy.ApplicationTrust();
+            ApplicationTrustCollection atc = (ApplicationTrustCollection)Activator.CreateInstance(typeof(ApplicationTrustCollection), true);
+            ApplicationTrust at = new ApplicationTrust();
             int testint = atc.Add(at);
-            Policy.ApplicationTrust[] atarray = new Policy.ApplicationTrust[1];
+            ApplicationTrust[] atarray = new ApplicationTrust[1];
             atc.AddRange(atarray);
             atc.AddRange(atc);
             atc.Clear();
             atc.CopyTo(atarray, 0);
-            Policy.ApplicationTrustEnumerator ate = atc.GetEnumerator();
+            ApplicationTrustEnumerator ate = atc.GetEnumerator();
             atc.Remove(at);
             atc.RemoveRange(atarray);
             atc.RemoveRange(atc);
         }
+
         [Fact]
         public static void ApplicationTrustEnumeratorCallMethods()
         {
-            Policy.ApplicationTrustEnumerator ate = (Policy.ApplicationTrustEnumerator)Activator.CreateInstance(typeof(Policy.ApplicationTrustEnumerator), true);
+            ApplicationTrustEnumerator ate = (ApplicationTrustEnumerator)Activator.CreateInstance(typeof(ApplicationTrustEnumerator), true);
             bool testbool = ate.MoveNext();
             ate.Reset();
         }

--- a/src/System.Security.Permissions/tests/CodeConnectAccessTests.cs
+++ b/src/System.Security.Permissions/tests/CodeConnectAccessTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Policy;
 using Xunit;
 
 namespace System.Security.Permissions.Tests
@@ -11,14 +12,14 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void CodeConnectAccessCallMethods()
         {
-            Policy.CodeConnectAccess cca = new Policy.CodeConnectAccess("test", 0);
-            string teststring = Policy.CodeConnectAccess.AnyScheme;
-            int testint = Policy.CodeConnectAccess.DefaultPort;
-            testint = Policy.CodeConnectAccess.OriginPort;
-            teststring = Policy.CodeConnectAccess.OriginScheme;
-            cca = Policy.CodeConnectAccess.CreateAnySchemeAccess(0);
-            cca = Policy.CodeConnectAccess.CreateOriginSchemeAccess(0);
-            cca = new Policy.CodeConnectAccess("test", 0);
+            CodeConnectAccess cca = new CodeConnectAccess("test", 0);
+            string teststring = CodeConnectAccess.AnyScheme;
+            int testint = CodeConnectAccess.DefaultPort;
+            testint = CodeConnectAccess.OriginPort;
+            teststring = CodeConnectAccess.OriginScheme;
+            cca = CodeConnectAccess.CreateAnySchemeAccess(0);
+            cca = CodeConnectAccess.CreateOriginSchemeAccess(0);
+            cca = new CodeConnectAccess("test", 0);
             bool testbool = cca.Equals(new object());
             testint = cca.GetHashCode();
         }

--- a/src/System.Security.Permissions/tests/CodeGroupTests.cs
+++ b/src/System.Security.Permissions/tests/CodeGroupTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Policy;
 using Xunit;
 
 namespace System.Security.Permissions.Tests
@@ -11,43 +12,46 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void FileCodeGroupCallMethods()
         {
-            Policy.FileCodeGroup fcg = new Policy.FileCodeGroup(new Policy.GacMembershipCondition(), new FileIOPermissionAccess());
-            Policy.CodeGroup cg = fcg.Copy();
+            FileCodeGroup fcg = new FileCodeGroup(new GacMembershipCondition(), new FileIOPermissionAccess());
+            CodeGroup cg = fcg.Copy();
             bool equals = fcg.Equals(new object());
             int hash = fcg.GetHashCode();
-            Policy.PolicyStatement ps = fcg.Resolve(new Policy.Evidence());
-            cg = fcg.ResolveMatchingCodeGroups(new Policy.Evidence());
+            PolicyStatement ps = fcg.Resolve(new Evidence());
+            cg = fcg.ResolveMatchingCodeGroups(new Evidence());
         }
+
         [Fact]
         public static void FirstMatchCodeGroupCallMethods()
         {
-            Policy.FirstMatchCodeGroup fmcg = new Policy.FirstMatchCodeGroup(new Policy.GacMembershipCondition(), new Policy.PolicyStatement(new PermissionSet(new PermissionState())));
-            Policy.CodeGroup cg = fmcg.Copy();
-            Policy.PolicyStatement ps = fmcg.Resolve(new Policy.Evidence());
-            cg = fmcg.ResolveMatchingCodeGroups(new Policy.Evidence());
+            FirstMatchCodeGroup fmcg = new FirstMatchCodeGroup(new GacMembershipCondition(), new PolicyStatement(new PermissionSet(new PermissionState())));
+            CodeGroup cg = fmcg.Copy();
+            PolicyStatement ps = fmcg.Resolve(new Evidence());
+            cg = fmcg.ResolveMatchingCodeGroups(new Evidence());
         }
+
         [Fact]
         public static void NetCodeGroupCallMethods()
         {
-            Policy.NetCodeGroup ncg = new Policy.NetCodeGroup(new Policy.GacMembershipCondition());
-            string teststring = Policy.NetCodeGroup.AbsentOriginScheme;
-            teststring = Policy.NetCodeGroup.AnyOtherOriginScheme;
-            ncg.AddConnectAccess("test", new Policy.CodeConnectAccess("test", 0));
-            Policy.CodeGroup cg = ncg.Copy();
+            NetCodeGroup ncg = new NetCodeGroup(new GacMembershipCondition());
+            string teststring = NetCodeGroup.AbsentOriginScheme;
+            teststring = NetCodeGroup.AnyOtherOriginScheme;
+            ncg.AddConnectAccess("test", new CodeConnectAccess("test", 0));
+            CodeGroup cg = ncg.Copy();
             bool equals = ncg.Equals(new object());
             System.Collections.DictionaryEntry[] de = ncg.GetConnectAccessRules();
             int hash = ncg.GetHashCode();
             ncg.ResetConnectAccess();
-            Policy.PolicyStatement ps = ncg.Resolve(new Policy.Evidence());
-            cg = ncg.ResolveMatchingCodeGroups(new Policy.Evidence());
+            PolicyStatement ps = ncg.Resolve(new Evidence());
+            cg = ncg.ResolveMatchingCodeGroups(new Evidence());
         }
+
         [Fact]
         public static void UnionCodeGroupCallMethods()
         {
-            Policy.UnionCodeGroup ucg = new Policy.UnionCodeGroup(new Policy.GacMembershipCondition(), new Policy.PolicyStatement(new PermissionSet(new PermissionState())));
-            Policy.CodeGroup cg = ucg.Copy();
-            Policy.PolicyStatement ps = ucg.Resolve(new Policy.Evidence());
-            cg = ucg.ResolveMatchingCodeGroups(new Policy.Evidence());
+            UnionCodeGroup ucg = new UnionCodeGroup(new GacMembershipCondition(), new PolicyStatement(new PermissionSet(new PermissionState())));
+            CodeGroup cg = ucg.Copy();
+            PolicyStatement ps = ucg.Resolve(new Evidence());
+            cg = ucg.ResolveMatchingCodeGroups(new Evidence());
         }
     }
 }

--- a/src/System.Security.Permissions/tests/EvidenceBaseTests.cs
+++ b/src/System.Security.Permissions/tests/EvidenceBaseTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Policy;
 using Xunit;
 
 namespace System.Security.Permissions.Tests
@@ -11,45 +12,49 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void ApplicationDirectoryCallMethods()
         {
-            Policy.ApplicationDirectory ad = new Policy.ApplicationDirectory("test");
+            ApplicationDirectory ad = new ApplicationDirectory("test");
             object obj = ad.Copy();
             bool check = ad.Equals(new object());
             int hash = ad.GetHashCode();
             string str = ad.ToString();
         }
+
         [Fact]
         public static void ApplicationTrustCallMethods()
         {
-            Policy.ApplicationTrust at = new Policy.ApplicationTrust();
+            ApplicationTrust at = new ApplicationTrust();
             SecurityElement se = new SecurityElement("");
             at.FromXml(se);
             se = at.ToXml();
         }
+
         [Fact]
         public static void GacInstalledCallMethods()
         {
-            Policy.GacInstalled gi = new Policy.GacInstalled();
+            GacInstalled gi = new GacInstalled();
             object obj = gi.Copy();
-            IPermission ip = gi.CreateIdentityPermission(new Policy.Evidence());
+            IPermission ip = gi.CreateIdentityPermission(new Evidence());
             bool check = gi.Equals(new object());
             int hash = gi.GetHashCode();
             string str = gi.ToString();
         }
+
         [Fact]
         public static void HashCallMethods()
         {
-            Policy.Hash hash = new Policy.Hash(Reflection.Assembly.Load(new Reflection.AssemblyName("System.Reflection")));
+            Hash hash = new Hash(Reflection.Assembly.Load(new Reflection.AssemblyName("System.Reflection")));
             byte[] barr = hash.GenerateHash(Cryptography.SHA1.Create());
             string str = hash.ToString();
-            hash = Policy.Hash.CreateMD5(new byte[1]);
-            hash = Policy.Hash.CreateSHA1(new byte[1]);
+            hash = Hash.CreateMD5(new byte[1]);
+            hash = Hash.CreateSHA1(new byte[1]);
         }
+
         [Fact]
         public static void PermissionRequestEvidenceCallMethods()
         {
             PermissionSet ps = new PermissionSet(new PermissionState());
-            Policy.PermissionRequestEvidence pre = new Policy.PermissionRequestEvidence(ps, ps, ps);
-            Policy.PermissionRequestEvidence obj = pre.Copy();
+            PermissionRequestEvidence pre = new PermissionRequestEvidence(ps, ps, ps);
+            PermissionRequestEvidence obj = pre.Copy();
             string str = ps.ToString();
             SecurityElement se = new SecurityElement("");
             ps.FromXml(se);

--- a/src/System.Security.Permissions/tests/EvidenceTests.cs
+++ b/src/System.Security.Permissions/tests/EvidenceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Policy;
 using Xunit;
 
 namespace System.Security.Permissions.Tests
@@ -11,10 +12,10 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void EvidenceCallMethods()
         {
-            Policy.Evidence e = new Policy.Evidence();
-            e = new Policy.Evidence(new Policy.Evidence());
+            Evidence e = new Evidence();
+            e = new Evidence(new Evidence());
             e.Clear();
-            Policy.Evidence e2 = e.Clone();
+            Evidence e2 = e.Clone();
             System.Collections.IEnumerator ie = e.GetAssemblyEnumerator();
             ie = e.GetHostEnumerator();
             e.Merge(e2);

--- a/src/System.Security.Permissions/tests/HostProtectionTests.cs
+++ b/src/System.Security.Permissions/tests/HostProtectionTests.cs
@@ -14,6 +14,7 @@ namespace System.Security.Permissions.Tests
             HostProtectionException hpe = new HostProtectionException();
             hpe.ToString();
         }
+
         [Fact]
         public static void HostProtectionAttributeCallMethods()
         {

--- a/src/System.Security.Permissions/tests/HostSecurityManagerTests.cs
+++ b/src/System.Security.Permissions/tests/HostSecurityManagerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Policy;
 using Xunit;
 
 namespace System.Security.Permissions.Tests
@@ -12,8 +13,8 @@ namespace System.Security.Permissions.Tests
         public static void CallMethods()
         {
             HostSecurityManager hsm = new HostSecurityManager();
-            Policy.ApplicationTrust at = hsm.DetermineApplicationTrust(new Policy.Evidence(), new Policy.Evidence(), new Policy.TrustManagerContext());
-            Policy.Evidence e = hsm.ProvideAppDomainEvidence(new Policy.Evidence());
+            ApplicationTrust at = hsm.DetermineApplicationTrust(new Evidence(), new Evidence(), new TrustManagerContext());
+            Evidence e = hsm.ProvideAppDomainEvidence(new Evidence());
         }
     }
 }

--- a/src/System.Security.Permissions/tests/MembershipConditionTests.cs
+++ b/src/System.Security.Permissions/tests/MembershipConditionTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Policy;
 using Xunit;
 
 namespace System.Security.Permissions.Tests
@@ -11,110 +12,116 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void AllMembershipConditionCallMethods()
         {
-            Policy.AllMembershipCondition amc = new Policy.AllMembershipCondition();
-            bool check = amc.Check(new Policy.Evidence());
-            Policy.IMembershipCondition imc = amc.Copy();
+            AllMembershipCondition amc = new AllMembershipCondition();
+            bool check = amc.Check(new Evidence());
+            IMembershipCondition imc = amc.Copy();
             check = amc.Equals(new object());
             int hash = amc.GetHashCode();
             string str = amc.ToString();
             SecurityElement se = new SecurityElement("");
-            Policy.PolicyLevel pl = (Policy.PolicyLevel)Activator.CreateInstance(typeof(Policy.PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
             amc.FromXml(se);
             amc.FromXml(se, pl);
             se = amc.ToXml();
             se = amc.ToXml(pl);
         }
+
         [Fact]
         public static void ApplicationDirectoryMembershipConditionCallMethods()
         {
-            Policy.ApplicationDirectoryMembershipCondition admc = new Policy.ApplicationDirectoryMembershipCondition();
-            bool check = admc.Check(new Policy.Evidence());
-            Policy.IMembershipCondition obj = admc.Copy();
+            ApplicationDirectoryMembershipCondition admc = new ApplicationDirectoryMembershipCondition();
+            bool check = admc.Check(new Evidence());
+            IMembershipCondition obj = admc.Copy();
             check = admc.Equals(new object());
             int hash = admc.GetHashCode();
             string str = admc.ToString();
             SecurityElement se = new SecurityElement("");
-            Policy.PolicyLevel pl = (Policy.PolicyLevel)Activator.CreateInstance(typeof(Policy.PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
             admc.FromXml(se);
             admc.FromXml(se, pl);
             se = admc.ToXml();
             se = admc.ToXml(pl);
         }
+
         [Fact]
         public static void GacMembershipConditionCallMethods()
         {
-            Policy.GacMembershipCondition gmc = new Policy.GacMembershipCondition();
-            bool check = gmc.Check(new Policy.Evidence());
-            Policy.IMembershipCondition obj = gmc.Copy();
+            GacMembershipCondition gmc = new GacMembershipCondition();
+            bool check = gmc.Check(new Evidence());
+            IMembershipCondition obj = gmc.Copy();
             check = gmc.Equals(new object());
             int hash = gmc.GetHashCode();
             string str = gmc.ToString();
             SecurityElement se = new SecurityElement("");
-            Policy.PolicyLevel pl = (Policy.PolicyLevel)Activator.CreateInstance(typeof(Policy.PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
             gmc.FromXml(se);
             gmc.FromXml(se, pl);
             se = gmc.ToXml();
             se = gmc.ToXml(pl);
         }
+
         [Fact]
         public static void HashMembershipConditionCallMethods()
         {
-            Policy.HashMembershipCondition hmc = new Policy.HashMembershipCondition(Cryptography.SHA1.Create(), new byte[1]);
-            bool check = hmc.Check(new Policy.Evidence());
-            Policy.IMembershipCondition obj = hmc.Copy();
+            HashMembershipCondition hmc = new HashMembershipCondition(Cryptography.SHA1.Create(), new byte[1]);
+            bool check = hmc.Check(new Evidence());
+            IMembershipCondition obj = hmc.Copy();
             check = hmc.Equals(new object());
             int hash = hmc.GetHashCode();
             string str = hmc.ToString();
             SecurityElement se = new SecurityElement("");
-            Policy.PolicyLevel pl = (Policy.PolicyLevel)Activator.CreateInstance(typeof(Policy.PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
             hmc.FromXml(se);
             hmc.FromXml(se, pl);
             se = hmc.ToXml();
             se = hmc.ToXml(pl);
         }
+
         [Fact]
         public static void PublisherMembershipConditionCallMethods()
         {
-            Policy.PublisherMembershipCondition pmc = new Policy.PublisherMembershipCondition(new System.Security.Cryptography.X509Certificates.X509Certificate());
-            bool check = pmc.Check(new Policy.Evidence());
-            Policy.IMembershipCondition obj = pmc.Copy();
+            PublisherMembershipCondition pmc = new PublisherMembershipCondition(new System.Security.Cryptography.X509Certificates.X509Certificate());
+            bool check = pmc.Check(new Evidence());
+            IMembershipCondition obj = pmc.Copy();
             check = pmc.Equals(new object());
             int hash = pmc.GetHashCode();
             string str = pmc.ToString();
             SecurityElement se = new SecurityElement("");
-            Policy.PolicyLevel pl = (Policy.PolicyLevel)Activator.CreateInstance(typeof(Policy.PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
             pmc.FromXml(se);
             pmc.FromXml(se, pl);
             se = pmc.ToXml();
             se = pmc.ToXml(pl);
         }
+
         [Fact]
         public static void SiteMembershipConditionCallMethods()
         {
-            Policy.SiteMembershipCondition smc = new Policy.SiteMembershipCondition("test");
-            bool check = smc.Check(new Policy.Evidence());
-            Policy.IMembershipCondition obj = smc.Copy();
+            SiteMembershipCondition smc = new SiteMembershipCondition("test");
+            bool check = smc.Check(new Evidence());
+            IMembershipCondition obj = smc.Copy();
             check = smc.Equals(new object());
             int hash = smc.GetHashCode();
             string str = smc.ToString();
             SecurityElement se = new SecurityElement("");
-            Policy.PolicyLevel pl = (Policy.PolicyLevel)Activator.CreateInstance(typeof(Policy.PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
             smc.FromXml(se);
             smc.FromXml(se, pl);
             se = smc.ToXml();
             se = smc.ToXml(pl);
         }
+
         [Fact]
         public static void StrongNameMembershipConditionCallMethods()
         {
-            Policy.StrongNameMembershipCondition snmc = new Policy.StrongNameMembershipCondition(new StrongNamePublicKeyBlob(new byte[1]), "test", new Version(0, 1));
-            bool check = snmc.Check(new Policy.Evidence());
-            Policy.IMembershipCondition obj = snmc.Copy();
+            StrongNameMembershipCondition snmc = new StrongNameMembershipCondition(new StrongNamePublicKeyBlob(new byte[1]), "test", new Version(0, 1));
+            bool check = snmc.Check(new Evidence());
+            IMembershipCondition obj = snmc.Copy();
             check = snmc.Equals(new object());
             int hash = snmc.GetHashCode();
             string str = snmc.ToString();
             SecurityElement se = new SecurityElement("");
-            Policy.PolicyLevel pl = (Policy.PolicyLevel)Activator.CreateInstance(typeof(Policy.PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
             snmc.FromXml(se);
             snmc.FromXml(se, pl);
             se = snmc.ToXml();

--- a/src/System.Security.Permissions/tests/PermissionSetTests.cs
+++ b/src/System.Security.Permissions/tests/PermissionSetTests.cs
@@ -30,6 +30,7 @@ namespace System.Security.Permissions.Tests
             ps.FromXml(se);
             se = ps.ToXml();
         }
+
         [Fact]
         public static void PermissionSetAttributeCallMethods()
         {
@@ -37,6 +38,7 @@ namespace System.Security.Permissions.Tests
             IPermission ip = psa.CreatePermission();
             PermissionSet ps = psa.CreatePermissionSet();
         }
+
         [Fact]
         public static void NamedPermissionSetCallMethods()
         {

--- a/src/System.Security.Permissions/tests/PermissionTests.cs
+++ b/src/System.Security.Permissions/tests/PermissionTests.cs
@@ -21,12 +21,14 @@ namespace System.Security.Permissions.Tests
             ep.FromXml(se);
             se = ep.ToXml();
         }
+
         [Fact]
         public static void EnvironmentPermissionsAttributeCallMethods()
         {
             EnvironmentPermissionAttribute epa = new EnvironmentPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = epa.CreatePermission();
         }
+
         [Fact]
         public static void FileDialogPermissionCallMethods()
         {
@@ -40,12 +42,14 @@ namespace System.Security.Permissions.Tests
             fdp.FromXml(se);
             se = fdp.ToXml();
         }
+
         [Fact]
         public static void FileDialogPermissionAttributeCallMethods()
         {
             FileDialogPermissionAttribute fspa = new FileDialogPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = fspa.CreatePermission();
         }
+
         [Fact]
         public static void FileIOPermissionCallMethods()
         {
@@ -68,6 +72,7 @@ namespace System.Security.Permissions.Tests
             fiop.FromXml(se);
             se = fiop.ToXml();
         }
+
         [Fact]
         public static void GacIdentityPermissionCallMethods()
         {
@@ -80,12 +85,14 @@ namespace System.Security.Permissions.Tests
             gip.FromXml(se);
             se = gip.ToXml();
         }
+
         [Fact]
         public static void GacIdentityPermissionAttributeCallMethods()
         {
             GacIdentityPermissionAttribute gipa = new GacIdentityPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = gipa.CreatePermission();
         }
+
         [Fact]
         public static void PrincipalPermissionCallMethods()
         {
@@ -104,12 +111,14 @@ namespace System.Security.Permissions.Tests
             pp.FromXml(se);
             se = pp.ToXml();
         }
+
         [Fact]
         public static void PrincipalPermissionAttributeCallMethods()
         {
             PrincipalPermissionAttribute ppa = new PrincipalPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = ppa.CreatePermission();
         }
+
         [Fact]
         public static void PublisherIdentityPermissionCallMethods()
         {
@@ -123,12 +132,14 @@ namespace System.Security.Permissions.Tests
             pip.FromXml(se);
             se = pip.ToXml();
         }
+
         [Fact]
         public static void PublisherIdentityPermissionAttributeCallMethods()
         {
             PublisherIdentityPermissionAttribute pipa = new PublisherIdentityPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = pipa.CreatePermission();
         }
+
         [Fact]
         public static void ReflectionPermissionCallMethods()
         {
@@ -143,12 +154,14 @@ namespace System.Security.Permissions.Tests
             rp.FromXml(se);
             se = rp.ToXml();
         }
+
         [Fact]
         public static void ReflectionPermissionAttributeCallMethods()
         {
             ReflectionPermissionAttribute rpa = new ReflectionPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = rpa.CreatePermission();
         }
+
         [Fact]
         public static void RegistryPermissionCallMethods()
         {
@@ -168,12 +181,14 @@ namespace System.Security.Permissions.Tests
             rp.FromXml(se);
             se = rp.ToXml();
         }
+
         [Fact]
         public static void RegistryPermissionAttributeCallMethods()
         {
             RegistryPermissionAttribute rpa = new RegistryPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = rpa.CreatePermission();
         }
+
         [Fact]
         public static void SecurityPermissionCallMethods()
         {
@@ -188,12 +203,14 @@ namespace System.Security.Permissions.Tests
             sp.FromXml(se);
             se = sp.ToXml();
         }
+
         [Fact]
         public static void SecurityPermissionAttributeCallMethods()
         {
             SecurityPermissionAttribute spa = new SecurityPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = spa.CreatePermission();
         }
+
         [Fact]
         public static void SiteIdentityPermissionCallMethods()
         {
@@ -207,12 +224,14 @@ namespace System.Security.Permissions.Tests
             sip.FromXml(se);
             se = sip.ToXml();
         }
+
         [Fact]
         public static void SiteIdentityPermissionAttributeCallMethods()
         {
             SiteIdentityPermissionAttribute sipa = new SiteIdentityPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = sipa.CreatePermission();
         }
+
         [Fact]
         public static void StrongNameIdentityPermissionCallMethods()
         {
@@ -226,12 +245,14 @@ namespace System.Security.Permissions.Tests
             snip.FromXml(se);
             se = snip.ToXml();
         }
+
         [Fact]
         public static void StrongNameIdentityPermissionAttributeCallMethods()
         {
             StrongNameIdentityPermissionAttribute snipa = new StrongNameIdentityPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = snipa.CreatePermission();
         }
+
         [Fact]
         public static void StrongNamePublicKeyBlobTests()
         {
@@ -240,6 +261,7 @@ namespace System.Security.Permissions.Tests
             int hash = snpkb.GetHashCode();
             string teststring = snpkb.ToString();
         }
+
         [Fact]
         public static void TypeDescriptorPermissionCallMethods()
         {
@@ -254,6 +276,7 @@ namespace System.Security.Permissions.Tests
             tdp.FromXml(se);
             se = tdp.ToXml();
         }
+
         [Fact]
         public static void UIPermissionCallMethods()
         {
@@ -270,12 +293,14 @@ namespace System.Security.Permissions.Tests
             uip.FromXml(se);
             se = uip.ToXml();
         }
+
         [Fact]
         public static void UIPermissionAttributeCallMethods()
         {
             UIPermissionAttribute uipa = new UIPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = uipa.CreatePermission();
         }
+
         [Fact]
         public static void UrlIdentityPermissionCallMethods()
         {
@@ -289,12 +314,14 @@ namespace System.Security.Permissions.Tests
             uip.FromXml(se);
             se = uip.ToXml();
         }
+
         [Fact]
         public static void UrlIdentityPermissionAttributeCallMethods()
         {
             UrlIdentityPermissionAttribute uipa = new UrlIdentityPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = uipa.CreatePermission();
         }
+
         [Fact]
         public static void ZoneIdentityPermissionCallMethods()
         {
@@ -307,6 +334,7 @@ namespace System.Security.Permissions.Tests
             zip.FromXml(se);
             se = zip.ToXml();
         }
+
         [Fact]
         public static void ZoneIdentityPermissionAttributeCallMethods()
         {

--- a/src/System.Security.Permissions/tests/PolicyTests.cs
+++ b/src/System.Security.Permissions/tests/PolicyTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Policy;
 using Xunit;
 
 namespace System.Security.Permissions.Tests
@@ -11,38 +12,40 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void PolicyExceptionCallMethods()
         {
-            Policy.PolicyException pe = new Policy.PolicyException();
-            pe = new Policy.PolicyException("test");
+            PolicyException pe = new PolicyException();
+            pe = new PolicyException("test");
         }
+
         [Fact]
         public static void PolicyLevelCallMethods()
         {
-            Policy.PolicyLevel pl = (Policy.PolicyLevel)Activator.CreateInstance(typeof(Policy.PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
             NamedPermissionSet nps = new NamedPermissionSet("test");
             pl.AddNamedPermissionSet(nps);
             nps = pl.ChangeNamedPermissionSet("test", new PermissionSet(new Permissions.PermissionState()));
-            Policy.PolicyLevel.CreateAppDomainLevel();
+            PolicyLevel.CreateAppDomainLevel();
             nps = pl.GetNamedPermissionSet("test");
             pl.Recover();
             NamedPermissionSet nps2 = pl.RemoveNamedPermissionSet(nps);
             nps2 = pl.RemoveNamedPermissionSet("test");
             pl.Reset();
-            Policy.Evidence evidence = new Policy.Evidence();
-            Policy.PolicyStatement ps = pl.Resolve(evidence);
-            Policy.CodeGroup cg = pl.ResolveMatchingCodeGroups(evidence);
+            Evidence evidence = new Evidence();
+            PolicyStatement ps = pl.Resolve(evidence);
+            CodeGroup cg = pl.ResolveMatchingCodeGroups(evidence);
             SecurityElement se = new SecurityElement("");
             pl.FromXml(se);
             se = pl.ToXml();
         }
+
         [Fact]
         public static void PolicyStatementCallMethods()
         {
-            Policy.PolicyStatement ps = new Policy.PolicyStatement(new PermissionSet(new PermissionState()));
-            Policy.PolicyStatement ps2 = ps.Copy();
+            PolicyStatement ps = new PolicyStatement(new PermissionSet(new PermissionState()));
+            PolicyStatement ps2 = ps.Copy();
             bool equals = ps.Equals(ps2);
             int hash = ps.GetHashCode();
             SecurityElement se = new SecurityElement("");
-            Policy.PolicyLevel pl = (Policy.PolicyLevel)Activator.CreateInstance(typeof(Policy.PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
             ps.FromXml(se);
             ps.FromXml(se, pl);
             se = ps.ToXml();

--- a/src/System.Security.Permissions/tests/SerializationTests.cs
+++ b/src/System.Security.Permissions/tests/SerializationTests.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Tests;
+using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class SerializationTests
+    {
+        public static IEnumerable<object[]> GetAllSerializableObjectsInAssembly()
+        {
+            IEnumerable<Type> serializableTypes = typeof(CodeAccessPermission).Assembly
+                .GetTypes()
+                .Where(t => !t.IsAbstract && (t.Attributes & TypeAttributes.Serializable) != 0);
+
+            foreach (Type serializableType in serializableTypes)
+            {
+                // Create an instance of the object, with its default ctor if possible, or worst case unitialized (we don't
+                // care about functionality for these types, so an uninitialized object suits our needs).
+                object obj;
+                try
+                {
+                    obj = Activator.CreateInstance(serializableType);
+                }
+                catch
+                {
+                    obj = FormatterServices.GetUninitializedObject(serializableType);
+                }
+                yield return new[] { serializableType, obj };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAllSerializableObjectsInAssembly))]
+        public static void SerializeDeserialize_Succeeds(Type t, object obj)
+        {
+            // None of these objects are truly functional, so we don't need to verify equality
+            // or the like.  We simply want to make sure that we're able to serialize and
+            // deserialize without exceptions being thrown.
+            Assert.IsType(t, BinaryFormatterHelpers.Clone(obj));
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -31,12 +31,16 @@
     <Compile Include="CodeGroupTests.cs" />
     <Compile Include="MembershipConditionTests.cs" />
     <Compile Include="EvidenceBaseTests.cs" />
+    <Compile Include="SerializationTests.cs" />
     <Compile Include="PolicyTests.cs" />
     <Compile Include="TrustManagerContextTests.cs" />
     <Compile Include="PermissionSetTests.cs" />
     <Compile Include="PermissionTests.cs" />
     <Compile Include="HostSecurityManagerTests.cs" />
     <Compile Include="HostProtectionTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Permissions/tests/TrustManagerContextTests.cs
+++ b/src/System.Security.Permissions/tests/TrustManagerContextTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Policy;
 using Xunit;
 
 namespace System.Security.Permissions.Tests
@@ -11,8 +12,8 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void TrustManagerContextCallMethods()
         {
-            Policy.TrustManagerContext tmc = new Policy.TrustManagerContext();
-            tmc = new Policy.TrustManagerContext(new Policy.TrustManagerUIContext());
+            TrustManagerContext tmc = new TrustManagerContext();
+            tmc = new TrustManagerContext(new TrustManagerUIContext());
         }
     }
 }


### PR DESCRIPTION
- Adds deserialization ctors to several permissions types that were missing them.
- Added a test to ensure that every [Serializable] permissions object can be serialized/deserialized.
- In doing so hit an issue where xunit failed due to trying to enumerate the collection objects being provided but where those collections returned null from GetEnumerator methods, so I changed such methods to return empty enumerators rather than returning null.
- And fixed a bit of formatting in the tests while I was there.

Fixes https://github.com/dotnet/corefx/issues/13103
cc: @danmosemsft, @alexperovich 
