### PR TITLE
Make InvalidDataException serialization ctor private

### DIFF
--- a/src/System.IO/src/System/IO/InvalidDataException.cs
+++ b/src/System.IO/src/System/IO/InvalidDataException.cs
@@ -24,7 +24,7 @@ namespace System.IO
         {
         }
 
-        internal InvalidDataException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private InvalidDataException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/13105
(The other part of that issue is just uncommenting this https://github.com/dotnet/corefx/blob/0fa3fdfd17247b877b8afbf219b8fc0385c49688/src/System.IO/src/System/IO/EndOfStreamException.cs#L30-L33 once the base ctor is available in uap10aot.)

cc: @alexperovich 