### PR TITLE
Faster ImmutableArray.InsertRange for well-known ICollections and lazy enumerables

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -121,18 +121,10 @@ namespace System.Collections.Immutable
             int count;
             if (items.TryGetCount(out count))
             {
-                if (count == 0)
-                {
-                    // Return a wrapper around the singleton empty array.
-                    return Create<T>();
-                }
-                else
-                {
-                    // We know how long the sequence is. Linq's built-in ToArray extension method
-                    // isn't as comprehensive in finding the length as we are, so call our own method
-                    // to avoid reallocating arrays as the sequence is enumerated.
-                    return new ImmutableArray<T>(items.ToArray(count));
-                }
+                // We know how long the sequence is. Linq's built-in ToArray extension method
+                // isn't as comprehensive in finding the length as we are, so call our own method
+                // to avoid reallocating arrays as the sequence is enumerated.
+                return new ImmutableArray<T>(items.ToArray(count));
             }
             else
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
@@ -566,14 +566,31 @@ namespace System.Collections.Immutable
             }
 
             T[] tmp = new T[self.Length + count];
-            Array.Copy(self.array, 0, tmp, 0, index);
-            int sequenceIndex = index;
-            foreach (var item in items)
+            
+            if (index != 0)
             {
-                tmp[sequenceIndex++] = item;
+                Array.Copy(self.array, 0, tmp, 0, index);
+            }
+            if (index != self.Length)
+            {
+                Array.Copy(self.array, index, tmp, index + count, self.Length - index);
             }
 
-            Array.Copy(self.array, index, tmp, index + count, self.Length - index);
+            // We want to copy over the items we need to insert.
+            // Check first to see if items is a well-known collection we can call CopyTo
+            // on to the array, which is an order of magnitude faster than foreach.
+            // Otherwise, go to the fallback route where we manually enumerate the sequence
+            // and place the items in the array one-by-one.
+
+            if (!items.TryCopyTo(tmp, index))
+            {
+                int sequenceIndex = index;
+                foreach (var item in items)
+                {
+                    tmp[sequenceIndex++] = item;
+                }
+            }
+
             return new ImmutableArray<T>(tmp);
         }
 
@@ -600,7 +617,20 @@ namespace System.Collections.Immutable
                 return self;
             }
 
-            return self.InsertRange(index, items.array);
+            T[] tmp = new T[self.Length + items.Length];
+            
+            if (index != 0)
+            {
+                Array.Copy(self.array, 0, tmp, 0, index);
+            }
+            if (index != self.Length)
+            {
+                Array.Copy(self.array, index, tmp, index + items.Length, self.Length - index);
+            }
+
+            Array.Copy(items.array, 0, tmp, index, items.Length);
+
+            return new ImmutableArray<T>(tmp);
         }
 
         /// <summary>
@@ -641,19 +671,7 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> AddRange(ImmutableArray<T> items)
         {
             var self = this;
-            self.ThrowNullRefIfNotInitialized();
-            ThrowNullRefIfNotInitialized(items);
-            if (self.IsEmpty)
-            {
-                // Be sure what we return is marked as initialized.
-                return items;
-            }
-            else if (items.IsEmpty)
-            {
-                return self;
-            }
-
-            return self.AddRange(items.array);
+            return self.InsertRange(self.Length, items);
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
@@ -106,20 +106,10 @@ namespace System.Collections.Immutable
         /// </remarks>
         internal static bool TryCopyTo<T>(this IEnumerable<T> sequence, T[] array, int arrayIndex)
         {
-            // IList is the GCD of what the following 3 types implement.
+            // IList is the GCD of what the following 2 types implement.
             var listInterface = sequence as IList<T>;
             if (listInterface != null)
             {
-                var sourceArray = sequence as T[];
-                if (sourceArray != null)
-                {
-                    // Note: This can have issues if T is a value type, but the underlying type
-                    // of the T[] is not typeof(T[]).
-                    // More discussion here: https://github.com/dotnet/corefx/issues/2241
-                    Array.Copy(sourceArray, 0, array, arrayIndex, sourceArray.Length);
-                    return true;
-                }
-
                 var list = sequence as List<T>;
                 if (list != null)
                 {

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -720,25 +720,10 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
-        public void InsertRangeNoOpIdentity()
-        {
-            Assert.Equal(s_empty, s_empty.InsertRange(0, s_empty));
-            Assert.Equal(s_oneElement, s_empty.InsertRange(0, s_oneElement)); // struct overload
-            Assert.Equal(s_oneElement, s_empty.InsertRange(0, (IEnumerable<int>)s_oneElement)); // enumerable overload
-            Assert.Equal(s_oneElement, s_oneElement.InsertRange(0, s_empty));
-        }
-
-        [Fact]
-        public void InsertRangeEmpty()
+        public void InsertRangeEmptyInvalid()
         {
             Assert.Throws<NullReferenceException>(() => s_emptyDefault.Insert(-1, 10));
             Assert.Throws<NullReferenceException>(() => s_emptyDefault.Insert(1, 10));
-            Assert.Equal(new int[0], s_empty.InsertRange(0, Enumerable.Empty<int>()));
-            Assert.Equal(s_empty, s_empty.InsertRange(0, Enumerable.Empty<int>()));
-            Assert.Equal(new[] { 1 }, s_empty.InsertRange(0, new[] { 1 }));
-            Assert.Equal(new[] { 2, 3, 4 }, s_empty.InsertRange(0, new[] { 2, 3, 4 }));
-            Assert.Equal(new[] { 2, 3, 4 }, s_empty.InsertRange(0, Enumerable.Range(2, 3)));
-            Assert.Equal(s_manyElements, s_manyElements.InsertRange(0, Enumerable.Empty<int>()));
             Assert.Throws<ArgumentOutOfRangeException>("index", () => s_empty.InsertRange(1, s_oneElement));
             Assert.Throws<ArgumentOutOfRangeException>("index", () => s_empty.InsertRange(-1, s_oneElement));
             Assert.Throws<ArgumentOutOfRangeException>("index", () => s_empty.InsertRange(1, (IEnumerable<int>)s_oneElement));
@@ -790,33 +775,72 @@ namespace System.Collections.Immutable.Tests
             Assert.Throws<InvalidOperationException>(() => s_oneElement.InsertRange(0, emptyDefaultBoxed));
         }
 
-        [Fact]
-        public void InsertRangeLeft()
+        public static IEnumerable<object[]> InsertRangeLeft()
         {
-            Assert.Equal(new[] { 7, 1, 2, 3 }, s_manyElements.InsertRange(0, new[] { 7 }));
-            Assert.Equal(new[] { 7, 8, 1, 2, 3 }, s_manyElements.InsertRange(0, new[] { 7, 8 }));
+            yield return new object[] { new[] { 7, 1, 2, 3 }, s_manyElements, 0, new[] { 7 } };
+            yield return new object[] { new[] { 7, 8, 1, 2, 3 }, s_manyElements, 0, new[] { 7, 8 } };
         }
 
-        [Fact]
-        public void InsertRangeMid()
+        public static IEnumerable<object[]> InsertRangeMiddle()
         {
-            Assert.Equal(new[] { 1, 7, 2, 3 }, s_manyElements.InsertRange(1, new[] { 7 }));
-            Assert.Equal(new[] { 1, 7, 8, 2, 3 }, s_manyElements.InsertRange(1, new[] { 7, 8 }));
+            yield return new object[] { new[] { 1, 7, 2, 3 }, s_manyElements, 1, new[] { 7 } };
+            yield return new object[] { new[] { 1, 7, 8, 2, 3 }, s_manyElements, 1, new[] { 7, 8 } };
         }
 
-        [Fact]
-        public void InsertRangeRight()
+        public static IEnumerable<object[]> InsertRangeRight()
         {
-            Assert.Equal(new[] { 1, 2, 3, 7 }, s_manyElements.InsertRange(3, new[] { 7 }));
-            Assert.Equal(new[] { 1, 2, 3, 7, 8 }, s_manyElements.InsertRange(3, new[] { 7, 8 }));
+            yield return new object[] { new[] { 1, 2, 3, 7 }, s_manyElements, 3, new[] { 7 } };
+            yield return new object[] { new[] { 1, 2, 3, 7, 8 }, s_manyElements, 3, new[] { 7, 8 } };
         }
 
-        [Fact]
-        public void InsertRangeImmutableArray()
+        public static IEnumerable<object[]> InsertRangeEmpty()
         {
-            Assert.Equal(new[] { 7, 8, 1, 2, 3 }, s_manyElements.InsertRange(0, ImmutableArray.Create(7, 8)));
-            Assert.Equal(new[] { 1, 7, 2, 3 }, s_manyElements.InsertRange(1, ImmutableArray.Create(7)));
-            Assert.Equal(new[] { 1, 2, 3, 7 }, s_manyElements.InsertRange(3, ImmutableArray.Create(7)));
+            yield return new object[] { new int[0], s_empty, 0, Enumerable.Empty<int>() };
+            yield return new object[] { s_empty, s_empty, 0, Enumerable.Empty<int>() };
+            yield return new object[] { new[] { 1 }, s_empty, 0, new[] { 1 } };
+            yield return new object[] { new[] { 2, 3, 4 }, s_empty, 0, new[] { 2, 3, 4 } };
+            yield return new object[] { new[] { 2, 3, 4 }, s_empty, 0, Enumerable.Range(2, 3) };
+            yield return new object[] { s_manyElements, s_manyElements, 0, Enumerable.Empty<int>() };
+        }
+
+        public static IEnumerable<object[]> InsertRangeIdentity()
+        {
+            yield return new object[] { s_empty, s_empty, 0, s_empty };
+            yield return new object[] { s_oneElement, s_empty, 0, s_oneElement };
+            yield return new object[] { s_oneElement, s_oneElement, 0, s_empty };
+        }
+
+        [Theory]
+        [MemberData(nameof(InsertRangeLeft))]
+        [MemberData(nameof(InsertRangeMiddle))]
+        [MemberData(nameof(InsertRangeRight))]
+        [MemberData(nameof(InsertRangeEmpty))]
+        [MemberData(nameof(InsertRangeIdentity))]
+        public void InsertRange(IEnumerable<int> expected, ImmutableArray<int> array, int index, IEnumerable<int> items)
+        {
+            // All of these functions should take an enumerable and produce another w/ the same contents.
+            var identityTransforms = new List<Func<IEnumerable<int>, IEnumerable<int>>>
+            {
+                e => e,
+                e => e.ToArray(), // Array
+                e => e.ToList(), // List
+                e => new LinkedList<int>(e), // Non-array, non-List, non-ImmutableArray IList
+                e => e.ToImmutableArray(), // ImmutableArray
+                e => e.Select(i => i), // Lazy enumerable
+                e => new Queue<int>(e) // IReadOnlyCollection / non-generic ICollection
+            };
+
+            foreach (var equivalentItems in identityTransforms.Select(t => t(items)))
+            {
+                Assert.Equal(expected, array.InsertRange(index, equivalentItems));
+                Assert.Equal(expected, array.InsertRange(index, equivalentItems.ToImmutableArray())); // Call the ImmutableArray overload.
+
+                if (index == array.Length) // Insertion @ the end should be equivalent to adding.
+                {
+                    Assert.Equal(expected, array.AddRange(equivalentItems));
+                    Assert.Equal(expected, array.AddRange(equivalentItems.ToImmutableArray()));
+                }
+            }
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -810,6 +810,13 @@ namespace System.Collections.Immutable.Tests
             yield return new object[] { s_oneElement, s_oneElement, 0, s_empty };
         }
 
+        public static IEnumerable<object[]> InsertRangeDifferentUnderlyingType()
+        {
+            yield return new object[] { new int[] { 1, 2, 3 }, s_empty, 0, (int[])(object)new uint[] { 1, 2, 3 } };
+            yield return new object[] { new int[] { 4, 5, 6, 1, 2, 3 }, s_manyElements, 0, (int[])(object)new uint[] { 4, 5, 6 } };
+            yield return new object[] { new int[] { 1, 2, 3, 4, 5, 6 }, s_manyElements, 3, (int[])(object)new uint[] { 4, 5, 6 } };
+        }
+
         [Theory]
         [MemberData(nameof(InsertRangeLeft))]
         [MemberData(nameof(InsertRangeMiddle))]


### PR DESCRIPTION
**edit:** The optimization for inserting arrays has been removed temporarily. See comment at https://github.com/dotnet/corefx/pull/13158#discussion_r87054718

A couple of changes:
- The `InsertRange` overload accepting an `ImmutableArray` is specialized to just use `Array.Copy` instead of deferring to the `IEnumerable` overload.
  - The `AddRange` that accepts an `ImmutableArray` now defers to this instead of the `AddRange` that takes an enumerable.
- `ImmutableArray.CreateRange` optimization where we return an empty array for 0-length sequences has been moved downstream to `ImmutableExtensions.ToArray`.
- For use by `AddRange`, introduce an `ImmutableExtensions.CopyTo` method which copies directly to the underlying array if possible.
  - We only do this for well-known types since a bad ICollection implementation might hold on to the array; if the addend is not an array, List, or ImmutableArray, then we fallback to using foreach.
  - This optimization also benefits lazy enumerables since they are captured into a list during `ImmutableExtensions.GetCount`.
  - It penalizes slightly types that implement ICollection/IReadOnlyCollection but not IList, like Queue (1 extra typecast), and significantly for types that implement IList but aren't well known, like LinkedList (4 extra typecasts).
- Add testing and convert related tests to use `Theory` for brevity

cc @stephentoub, @AArnott 
