### PR TITLE
Fix mocked LazyAsyncResult in System.Net.Security unit tests

### DIFF
--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeLazyAsyncResult.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeLazyAsyncResult.cs
@@ -10,15 +10,11 @@ namespace System.Net.Security
     {
         public LazyAsyncResult(SslState sslState, object asyncState, AsyncCallback asyncCallback)
         {
+            AsyncState = asyncState;
+            asyncCallback?.Invoke(this);
         }
 
-        public object AsyncState
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
+        public object AsyncState { get; }
 
         public WaitHandle AsyncWaitHandle
         {

--- a/src/System.Net.Security/tests/UnitTests/SslStreamAllowedProtocolsTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/SslStreamAllowedProtocolsTest.cs
@@ -27,7 +27,6 @@ namespace System.Net.Security.Tests
         }
 
         [Theory]
-        [ActiveIssue(12893)]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
         public void SslStream_AuthenticateAsClientAsync_Supported_Success(SslProtocols protocol)
         {
@@ -36,7 +35,6 @@ namespace System.Net.Security.Tests
         }
 
         [Theory]
-        [ActiveIssue(12893)]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
         public void SslStream_AuthenticateAsClient_Supported_Success(SslProtocols protocol)
         {
@@ -65,7 +63,6 @@ namespace System.Net.Security.Tests
             Assert.Throws<NotSupportedException>(() => AuthenticateAsClient(stream, false, "host", null, SslProtocolSupport.UnsupportedSslProtocols, false));
         }
 
-        [ActiveIssue(12893)]
         [Fact]
         public void SslStream_AuthenticateAsClientAsync_AllSupported_Success()
         {
@@ -73,7 +70,6 @@ namespace System.Net.Security.Tests
             AuthenticateAsClient(stream, true, "host", null, SslProtocolSupport.SupportedSslProtocols, false);
         }
 
-        [ActiveIssue(12893)]
         [Fact]
         public void SslStream_AuthenticateAsClientAsync_None_Success()
         {
@@ -81,7 +77,6 @@ namespace System.Net.Security.Tests
             AuthenticateAsClient(stream, true, "host", null, SslProtocols.None, false);
         }
 
-        [ActiveIssue(12893)]
         [Fact]
         public void SslStream_AuthenticateAsClientAsync_Default_Success()
         {


### PR DESCRIPTION
The APM pattern requires that the AsyncCallback always be invoked, even for synchronously completed IAsyncResult instance.

Fixes https://github.com/dotnet/corefx/issues/12893
cc: @davidsh, @cipop, @ericeil, @joperezr 