### PR TITLE
Enable sockets perf tests to run on Unix

### DIFF
--- a/src/Common/tests/System/Net/Sockets/Performance/SocketTestClient.cs
+++ b/src/Common/tests/System/Net/Sockets/Performance/SocketTestClient.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
-using System.Net;
-using System.Net.Sockets;
 using System.Net.Sockets.Tests;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -70,9 +67,12 @@ namespace System.Net.Sockets.Performance.Tests
 
             _timeProgramStart = timeProgramStart;
 
-            _timeInit.Start();
-            _s = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            _timeInit.Stop();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // on Unix, socket will be created in Socket.ConnectAsync
+            {
+                _timeInit.Start();
+                _s = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                _timeInit.Stop();
+            }
 
             _iterations = iterations;
         }
@@ -239,8 +239,8 @@ namespace System.Net.Sockets.Performance.Tests
                     ImplementationName(),
                     _bufferLen,
                     _receive_iterations,
-                    _timeInit.ElapsedMilliseconds,
-                    _timeConnect.ElapsedMilliseconds,
+                    _timeInit.ElapsedMilliseconds, // only relevant on Windows
+                    _timeConnect.ElapsedMilliseconds, // on Unix this includes socket creation time
                     _timeSendRecv.ElapsedMilliseconds,
                     _timeClose.ElapsedMilliseconds,
                     _timeProgramStart.ElapsedMilliseconds);

--- a/src/Common/tests/System/Net/Sockets/Performance/SocketTestClientAsync.cs
+++ b/src/Common/tests/System/Net/Sockets/Performance/SocketTestClientAsync.cs
@@ -32,7 +32,9 @@ namespace System.Net.Sockets.Performance.Tests
             connectEventArgs.UserToken = onConnectCallback;
             connectEventArgs.Completed += OnConnect;
 
-            bool willRaiseEvent = _s.ConnectAsync(connectEventArgs);
+            bool willRaiseEvent = _s != null ?
+                _s.ConnectAsync(connectEventArgs) :
+                Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, connectEventArgs);
             if (!willRaiseEvent)
             {
                 ProcessConnect(connectEventArgs);
@@ -46,6 +48,10 @@ namespace System.Net.Sockets.Performance.Tests
 
         private void ProcessConnect(SocketAsyncEventArgs e)
         {
+            if (_s == null)
+            {
+                _s = e.ConnectSocket;
+            }
             Action<SocketError> callback = (Action<SocketError>)e.UserToken;
             callback(e.SocketError);
         }
@@ -82,7 +88,7 @@ namespace System.Net.Sockets.Performance.Tests
 
         public override void Close(Action onCloseCallback)
         {
-            _s.Dispose();
+            _s?.Dispose();
             onCloseCallback();
         }
 

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -2418,7 +2418,7 @@ static Error WaitForSocketEventsInner(int32_t port, SocketEvent* buffer, int32_t
     // that case, the wait will block until a file descriptor is added and an event occurs
     // on the added file descriptor.
     assert(numEvents != 0);
-    assert(numEvents < *count);
+    assert(numEvents <= *count);
 
     if (sizeof(epoll_event) < sizeof(SocketEvent))
     {

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -20,7 +20,6 @@ namespace System.Net.Sockets.Performance.Tests
             _log = TestLogging.GetInstance();
         }
 
-        [ActiveIssue(13110, TestPlatforms.AnyUnix)]
         [OuterLoop]
         [Fact]
         public void SocketPerformance_SingleSocketClientAsync_LocalHostServerAsync()
@@ -42,7 +41,6 @@ namespace System.Net.Sockets.Performance.Tests
                 socket_instances);
         }
 
-        [ActiveIssue(13110, TestPlatforms.AnyUnix)]
         [OuterLoop]
         [Fact]
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync()


### PR DESCRIPTION
The tests fail on Unix due to the instance Socket.Connect{Async} methods not being supported with DNS endpoints.  This fix addresses that by changing the code on Unix to use the static ConnectAsync method.

Fixes https://github.com/dotnet/corefx/issues/13110
cc: @cipop, @davidsh, @geoffkizer, @ericeil