### PR TITLE
Add additional diagnostics to DummyTcpServer

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/DummyTcpServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/DummyTcpServer.cs
@@ -22,6 +22,7 @@ namespace System.Net.Security.Tests
     // specified by a callback method.
     public class DummyTcpServer : IDisposable
     {
+        private readonly string _creationStack = Environment.StackTrace;
         private VerboseTestLogging _log;
         private TcpListener _listener;
         private bool _useSsl;
@@ -233,6 +234,12 @@ namespace System.Net.Security.Tests
             {
                 state.Dispose();
                 return;
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new InvalidOperationException(
+                    $"Exception in {nameof(DummyTcpServer)} created with stack: {_creationStack}",
+                    e);
             }
         }
 


### PR DESCRIPTION
To help track down an unhandled exception that's occurred sporadically in System.Net.Security tests.

Contributes to https://github.com/dotnet/corefx/issues/12939
cc: @davidsh
