### PR TITLE
Disable tests to unblock CI

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
@@ -22,6 +22,7 @@ namespace System.Net.Http.Functional.Tests
             _output = output;
         }
 
+        [ActiveIssue(10504)]
         [OuterLoop] // includes seconds of delay
         [Theory]
         [InlineData(false, false)]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1746,6 +1746,7 @@ namespace System.Net.Http.Functional.Tests
         #endregion
         
         #region Proxy tests
+        [ActiveIssue(13188)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(CredentialsForProxy))]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -382,6 +382,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Fact]
         [OuterLoop]
+        [ActiveIssue(12778)]
         public void Timeout_SetTo60AndGetResponseFromServerWhichTakes40_Success()
         {
             // TODO: This is a placeholder until GitHub Issue #2383 gets resolved.

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -111,6 +111,7 @@ namespace System.Net.Tests
             Assert.True(request.AllowReadStreamBuffering);
         }
 
+        [ActiveIssue(12637)]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task ContentLength_Get_ExpectSameAsGetResponseStream(Uri remoteServer)
         {


### PR DESCRIPTION
Disabling tests for #12637, #12778, #10504, and #13188