### PR TITLE
Cleanup include: compile usage in test-runtime

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -170,10 +170,6 @@
         "System.IO.FileSystem.AccessControl": "4.4.0-beta-24629-01",
         "System.IO.FileSystem.DriveInfo": "4.4.0-beta-24629-01",
         "System.IO.FileSystem.Watcher": "4.4.0-beta-24629-01",
-        "System.IO.IsolatedStorage": {
-          "version": "4.4.0-beta-24629-01",
-          "include": "compile"
-        },
         "System.IO.Pipes": "4.4.0-beta-24629-01",
         "System.IO.Pipes.AccessControl": "4.4.0-beta-24629-01",
         "System.Net.Http.WinHttpHandler": "4.4.0-beta-24629-01",
@@ -199,10 +195,6 @@
         "System.IO.FileSystem.AccessControl": "4.4.0-beta-24629-01",
         "System.IO.FileSystem.DriveInfo": "4.4.0-beta-24629-01",
         "System.IO.FileSystem.Watcher": "4.4.0-beta-24629-01",
-        "System.IO.IsolatedStorage": {
-          "version": "4.4.0-beta-24629-01",
-          "include": "compile"
-        },
         "System.IO.Pipes": "4.4.0-beta-24629-01",
         "System.IO.Pipes.AccessControl": "4.4.0-beta-24629-01",
         "System.Net.Http.WinHttpHandler": "4.4.0-beta-24629-01",
@@ -217,11 +209,7 @@
         "System.ServiceProcess.ServiceController": "4.4.0-beta-24629-01",
         "System.Reflection.Emit": "4.4.0-beta-24629-01",
         "System.Reflection.Emit.ILGeneration": "4.4.0-beta-24629-01",
-        "System.Reflection.Emit.Lightweight": "4.4.0-beta-24629-01",
-        "System.Runtime.Loader": {
-          "version": "4.4.0-beta-24629-01",
-          "include": "compile"
-        }
+        "System.Reflection.Emit.Lightweight": "4.4.0-beta-24629-01"
       }
     },
     "netstandard1.6": {
@@ -232,10 +220,6 @@
         "System.IO.FileSystem.AccessControl": "4.4.0-beta-24629-01",
         "System.IO.FileSystem.DriveInfo": "4.4.0-beta-24629-01",
         "System.IO.FileSystem.Watcher": "4.4.0-beta-24629-01",
-        "System.IO.IsolatedStorage": {
-          "version": "4.4.0-beta-24629-01",
-          "include": "compile"
-        },
         "System.IO.Pipes": "4.4.0-beta-24629-01",
         "System.IO.Pipes.AccessControl": "4.4.0-beta-24629-01",
         "System.Net.Http.WinHttpHandler": "4.4.0-beta-24629-01",
@@ -251,8 +235,7 @@
         "System.Security.Cryptography.OpenSsl": "4.4.0-beta-24629-01",
         "System.Reflection.Emit": "4.4.0-beta-24629-01",
         "System.Reflection.Emit.ILGeneration": "4.4.0-beta-24629-01",
-        "System.Reflection.Emit.Lightweight": "4.4.0-beta-24629-01",
-        "System.Runtime.Loader": "4.4.0-beta-24629-01"
+        "System.Reflection.Emit.Lightweight": "4.4.0-beta-24629-01"
       }
     },
     "netstandard1.7": {
@@ -263,10 +246,7 @@
         "System.IO.FileSystem.AccessControl": "4.4.0-beta-24629-01",
         "System.IO.FileSystem.DriveInfo": "4.4.0-beta-24629-01",
         "System.IO.FileSystem.Watcher": "4.4.0-beta-24629-01",
-        "System.IO.IsolatedStorage": {
-          "version": "4.4.0-beta-24629-01",
-          "include": "compile"
-        },
+        "System.IO.IsolatedStorage": "4.4.0-beta-24629-01",
         "System.IO.Pipes": "4.4.0-beta-24629-01",
         "System.IO.Pipes.AccessControl": "4.4.0-beta-24629-01",
         "System.Net.Http.WinHttpHandler": "4.4.0-beta-24629-01",
@@ -287,13 +267,36 @@
         "System.Runtime.Serialization.Formatters": "4.4.0-beta-24629-01",
         "System.Security.Permissions": "4.4.0-beta-24629-01",
         "System.Transactions": "4.4.0-beta-24629-01",
-        "System.Runtime.Loader": {
-          "version": "4.4.0-beta-24629-01",
-          "include": "compile"
-        },
         "System.Reflection.Emit": "4.4.0-beta-24629-01",
         "System.Reflection.Emit.ILGeneration": "4.4.0-beta-24629-01",
         "System.Reflection.Emit.Lightweight": "4.4.0-beta-24629-01"
+      }
+    },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.Win32.Registry": "4.4.0-beta-24629-01",
+        "Microsoft.Win32.Registry.AccessControl": "4.4.0-beta-24629-01",
+        "System.Diagnostics.Process": "4.4.0-beta-24629-01",
+        "System.IO.FileSystem.AccessControl": "4.4.0-beta-24629-01",
+        "System.IO.FileSystem.DriveInfo": "4.4.0-beta-24629-01",
+        "System.IO.FileSystem.Watcher": "4.4.0-beta-24629-01",
+        "System.IO.Pipes": "4.4.0-beta-24629-01",
+        "System.IO.Pipes.AccessControl": "4.4.0-beta-24629-01",
+        "System.Net.Http.WinHttpHandler": "4.4.0-beta-24629-01",
+        "System.Net.Ping": "4.4.0-beta-24629-01",
+        "System.Net.Security": "4.4.0-beta-24629-01",
+        "System.Runtime.CompilerServices.VisualC": "4.4.0-beta-24629-01",
+        "System.Security.AccessControl": "4.4.0-beta-24629-01",
+        "System.Security.Cryptography.Csp": "4.4.0-beta-24629-01",
+        "System.Threading.AccessControl": "4.4.0-beta-24629-01",
+        "System.Threading.Thread": "4.4.0-beta-24629-01",
+        "System.Threading.ThreadPool": "4.4.0-beta-24629-01",
+        "System.ServiceProcess.ServiceController": "4.4.0-beta-24629-01",
+        "System.Security.Cryptography.OpenSsl": "4.4.0-beta-24629-01",
+        "System.Reflection.Emit": "4.4.0-beta-24629-01",
+        "System.Reflection.Emit.ILGeneration": "4.4.0-beta-24629-01",
+        "System.Reflection.Emit.Lightweight": "4.4.0-beta-24629-01",
+        "System.Runtime.Loader": "4.4.0-beta-24629-01"
       }
     },
     "netcoreapp1.1": {
@@ -304,10 +307,7 @@
         "System.IO.FileSystem.AccessControl": "4.4.0-beta-24629-01",
         "System.IO.FileSystem.DriveInfo": "4.4.0-beta-24629-01",
         "System.IO.FileSystem.Watcher": "4.4.0-beta-24629-01",
-        "System.IO.IsolatedStorage": {
-          "version": "4.4.0-beta-24629-01",
-          "include": "compile"
-        },
+        "System.IO.IsolatedStorage": "4.4.0-beta-24629-01",
         "System.IO.Pipes": "4.4.0-beta-24629-01",
         "System.IO.Pipes.AccessControl": "4.4.0-beta-24629-01",
         "System.Net.Http.WinHttpHandler": "4.4.0-beta-24629-01",

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.Xsl.XslCompiledTransformApi.Tests</AssemblyName>
     <RootNamespace>System.Xml.Tests</RootNamespace>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCompiler.Tests.csproj
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCompiler.Tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>XsltCompiler.Tests</AssemblyName>
     <RootNamespace>System.Xml.Tests</RootNamespace>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This was being used for packages that were platform-specific.

Instead of using this hack don't include those in the netstandard
dependency sections.  Make sure we do include them (without using
the `"include": "compile"` constraint) in the frameworks that do support
them.

Make a netcoreapp1.0 specific section that includes Loader, otherwise
this is just a copy of netstandard1.6 section which was previously being
used.

Fixes #12780

/cc @karajas