### PR TITLE
Optimize DeflateStream.CopyToAsync

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -95,7 +96,6 @@ namespace System.IO.Compression
             _stream = stream;
             _mode = CompressionMode.Decompress;
             _leaveOpen = leaveOpen;
-            _buffer = new byte[DefaultBufferSize];
         }
 
         /// <summary>
@@ -112,7 +112,21 @@ namespace System.IO.Compression
             _stream = stream;
             _mode = CompressionMode.Compress;
             _leaveOpen = leaveOpen;
+            IntializeBuffer();
+        }
+
+        private void IntializeBuffer()
+        {
+            Debug.Assert(_buffer == null);
             _buffer = new byte[DefaultBufferSize];
+        }
+
+        private void EnsureBufferInitialized()
+        {
+            if (_buffer == null)
+            {
+                IntializeBuffer();
+            }
         }
 
         #endregion
@@ -202,7 +216,7 @@ namespace System.IO.Compression
 
         private async Task FlushAsyncCore(CancellationToken cancellationToken)
         {
-            Interlocked.Increment(ref _asyncOperations);
+            IncrementAsyncOperations();
             try
             {
                 // Compress any bytes left:
@@ -223,7 +237,7 @@ namespace System.IO.Compression
             }
             finally
             {
-                Interlocked.Decrement(ref _asyncOperations);
+                DecrementAsyncOperations();
             }
         }
 
@@ -253,6 +267,7 @@ namespace System.IO.Compression
             EnsureDecompressionMode();
             ValidateParameters(array, offset, count);
             EnsureNotDisposed();
+            EnsureBufferInitialized();
 
             int bytesRead;
             int currentOffset = offset;
@@ -369,7 +384,8 @@ namespace System.IO.Compression
                 return Task.FromCanceled<int>(cancellationToken);
             }
 
-            Interlocked.Increment(ref _asyncOperations);
+            IncrementAsyncOperations();
+            EnsureBufferInitialized();
             Task<int> readTask = null;
 
             try
@@ -403,7 +419,7 @@ namespace System.IO.Compression
                 // if we haven't started any async work, decrement the counter to end the transaction
                 if (readTask == null)
                 {
-                    Interlocked.Decrement(ref _asyncOperations);
+                    DecrementAsyncOperations();
                 }
             }
         }
@@ -453,7 +469,7 @@ namespace System.IO.Compression
             }
             finally
             {
-                Interlocked.Decrement(ref _asyncOperations);
+                DecrementAsyncOperations();
             }
         }
 
@@ -622,7 +638,7 @@ namespace System.IO.Compression
 
         private async Task WriteAsyncCore(Byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
-            Interlocked.Increment(ref _asyncOperations);
+            IncrementAsyncOperations();
             try
             {
                 await WriteDeflaterOutputAsync(cancellationToken).ConfigureAwait(false);
@@ -636,7 +652,7 @@ namespace System.IO.Compression
             }
             finally
             {
-                Interlocked.Decrement(ref _asyncOperations);
+                DecrementAsyncOperations();
             }
         }
 
@@ -657,8 +673,134 @@ namespace System.IO.Compression
 
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            return StreamHelpers.ArrayPoolCopyToAsync(this, destination, bufferSize, cancellationToken: cancellationToken);
+            // Validation as base CopyToAsync would do
+            StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
+
+            // Validation as ReadAsync would do
+            EnsureDecompressionMode();
+            if (_asyncOperations != 0) throw new InvalidOperationException(SR.InvalidBeginCall);
+            EnsureNotDisposed();
+
+            // Early check for cancellation
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<int>(cancellationToken);
+            }
+
+            // The caller asked for a specific bufferSize, but we're going to end up potentially using two buffers:
+            // a buffer for storing the inflated output and passing along to the destination stream, and whatever
+            // buffer the source stream creates in its CopyToAsync implementation.  As such, we halve the buffer size,
+            // to split it across the two.
+            bufferSize = Math.Max(1, bufferSize / 2);
+
+            // Do the copy
+            return new CopyToAsyncStream(this, destination, ArrayPool<byte>.Shared.Rent(bufferSize), cancellationToken).CopyFromSourceToDestination();
+        }
+
+        private sealed class CopyToAsyncStream : Stream
+        {
+            private readonly DeflateStream _deflateStream;
+            private readonly Stream _destination;
+            private readonly CancellationToken _cancellationToken;
+            private readonly byte[] _arrayPoolBuffer;
+            private int _arrayPoolBufferHighWaterMark;
+
+            public CopyToAsyncStream(DeflateStream deflateStream, Stream destination, byte[] arrayPoolBuffer, CancellationToken cancellationToken)
+            {
+                Debug.Assert(deflateStream != null);
+                Debug.Assert(destination != null);
+                Debug.Assert(arrayPoolBuffer != null && arrayPoolBuffer.Length > 0);
+
+                _deflateStream = deflateStream;
+                _destination = destination;
+                _arrayPoolBuffer = arrayPoolBuffer;
+                _cancellationToken = cancellationToken;
+            }
+
+            public async Task CopyFromSourceToDestination()
+            {
+                _deflateStream.IncrementAsyncOperations();
+                try
+                {
+                    // Flush any existing data in the inflater to the destination stream.
+                    while (true)
+                    {
+                        int bytesRead = _deflateStream._inflater.Inflate(_arrayPoolBuffer, 0, _arrayPoolBuffer.Length);
+                        if (bytesRead > 0)
+                        {
+                            if (bytesRead > _arrayPoolBufferHighWaterMark) _arrayPoolBufferHighWaterMark = bytesRead;
+                            await _destination.WriteAsync(_arrayPoolBuffer, 0, bytesRead, _cancellationToken).ConfigureAwait(false);
+                        }
+                        else break;
+                    }
+
+                    // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
+                    await _deflateStream._stream.CopyToAsync(this, _arrayPoolBuffer.Length, _cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _deflateStream.DecrementAsyncOperations();
+
+                    Array.Clear(_arrayPoolBuffer, 0, _arrayPoolBufferHighWaterMark); // clear only the most we used
+                    ArrayPool<byte>.Shared.Return(_arrayPoolBuffer, clearArray: false);
+                }
+            }
+
+            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                // Validate inputs
+                Debug.Assert(buffer != _arrayPoolBuffer);
+                _deflateStream.EnsureNotDisposed();
+                if (count <= 0)
+                {
+                    return;
+                }
+                else if (count > buffer.Length - offset)
+                {
+                    // The source stream is either malicious or poorly implemented and returned a number of
+                    // bytes larger than the buffer supplied to it.
+                    throw new InvalidDataException(SR.GenericInvalidData);
+                }
+
+                // Feed the data from base stream into the decompression engine.
+                _deflateStream._inflater.SetInput(buffer, offset, count);
+
+                // While there's more decompressed data available, forward it to the destination stream.
+                while (true)
+                {
+                    int bytesRead = _deflateStream._inflater.Inflate(_arrayPoolBuffer, 0, _arrayPoolBuffer.Length);
+                    if (bytesRead > 0)
+                    {
+                        if (bytesRead > _arrayPoolBufferHighWaterMark) _arrayPoolBufferHighWaterMark = bytesRead;
+                        await _destination.WriteAsync(_arrayPoolBuffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+                    }
+                    else break;
+                }
+            }
+
+            public override void Write(byte[] buffer, int offset, int count) => WriteAsync(buffer, offset, count, default(CancellationToken)).GetAwaiter().GetResult();
+            public override bool CanWrite => true;
+            public override void Flush() { }
+
+            public override bool CanRead => false;
+            public override bool CanSeek => false;
+            public override long Length { get { throw new NotSupportedException(); } }
+            public override long Position { get { throw new NotSupportedException(); } set { throw new NotSupportedException(); } }
+            public override int Read(byte[] buffer, int offset, int count) { throw new NotSupportedException(); }
+            public override long Seek(long offset, SeekOrigin origin) { throw new NotSupportedException(); }
+            public override void SetLength(long value) { throw new NotSupportedException(); }
+        }
+
+        private void IncrementAsyncOperations()
+        {
+            int newCount = Interlocked.Increment(ref _asyncOperations);
+            Debug.Assert(newCount == 1, $"DeflateStream was misused, with multiple pending async operations");
+        }
+
+        private void DecrementAsyncOperations()
+        {
+            int newCount = Interlocked.Decrement(ref _asyncOperations);
+            Debug.Assert(newCount >= 0, $"DeflateStream was misused, with the number of active ops dropping to negative");
         }
     }
 }
-

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -12,7 +12,7 @@ namespace System.IO.Compression
 {
     public partial class DeflateStream : Stream
     {
-        internal const int DefaultBufferSize = 8192;
+        private const int DefaultBufferSize = 8192;
 
         private Stream _stream;
         private CompressionMode _mode;

--- a/src/System.IO.Compression/tests/DeflateStreamTests.cs
+++ b/src/System.IO.Compression/tests/DeflateStreamTests.cs
@@ -898,6 +898,53 @@ namespace System.IO.Compression.Tests
                 Assert.Equal(0, await ds.ReadAsync(new byte[1024], 0, 1024));
         }
 
+        public static IEnumerable<object[]> CopyToAsync_Roundtrip_OutputMatchesInput_MemberData()
+        {
+            var rand = new Random();
+            foreach (int dataSize in new[] { 1, 1024, 4095, 1024 * 1024 })
+            {
+                var data = new byte[dataSize];
+                rand.NextBytes(data);
+
+                var compressed = new MemoryStream();
+                using (var ds = new DeflateStream(compressed, CompressionMode.Compress, leaveOpen: true))
+                {
+                    ds.Write(data, 0, data.Length);
+                }
+                byte[] compressedData = compressed.ToArray();
+
+                foreach (int copyBufferSize in new[] { 1, 4096, 80 * 1024 })
+                {
+                    // Memory source
+                    var m = new MemoryStream(compressedData, writable: false);
+                    yield return new object[] { data, copyBufferSize, m };
+
+                    // File sources, sync and async
+                    foreach (bool useAsync in new[] { true, false })
+                    {
+                        string path = Path.GetTempFileName();
+                        File.WriteAllBytes(path, compressedData);
+
+                        FileOptions options = FileOptions.DeleteOnClose;
+                        if (useAsync) options |= FileOptions.Asynchronous;
+                        yield return new object[] { data, copyBufferSize, new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 0x1000, options) };
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CopyToAsync_Roundtrip_OutputMatchesInput_MemberData))]
+        public async Task CopyToAsync_Roundtrip_OutputMatchesInput(byte[] expectedDecrypted, int copyBufferSize, Stream source)
+        {
+            var m = new MemoryStream();
+            using (DeflateStream ds = new DeflateStream(source, CompressionMode.Decompress))
+            {
+                await ds.CopyToAsync(m);
+            }
+            Assert.Equal(expectedDecrypted, m.ToArray());
+        }
+
         private sealed class BadWrappedStream : Stream
         {
             public enum Mode


### PR DESCRIPTION
Today, CopyToAsync on DeflateStream is the basic read/write loop.  However, all CopyToAsync really needs to do on DeflateStream is transform the source data (via a synchronous operation) and pass it along to the destination.  This means that we can improve its implementation by effectively having the source stream CopyToAsync to the destination stream, albeit with that transformation added in the middle.  Doing this has a three key benefits:
- It eliminates the read operations and the associated copy, allowing the source to effectively push directly to the inflater inside DeflateStream.
- It takes advantage of any optimizations the source stream has in its CopyToAsync implementation, e.g. MemoryStream simply passing its whole internal buffer, NetworkStream using a SocketAsyncEventArgs (https://github.com/dotnet/corefx/pull/12664), FileStream reusing its async state (https://github.com/dotnet/corefx/pull/11569), etc.
- CopyToAsync is typically used when no other reading has been done from the stream.  Since this change causes CopyToAsync to bypass the internal buffer used by DeflateStream before the inflater itself, we can avoid allocating that buffer at all if CopyToAsync is used by itself.  This avoids an 8K allocation per DeflateStream instance, and even if we switch to pulling this buffer from ArrayPool, it still avoids needing to rent/return with the ArrayPool in these cases.

(I also noticed an unnecessary allocation in Inflater, which I removed.)

The net effect of this change is a sizeable boost on throughput for many scenarios (I didn't find any scenarios where it regressed).  Here are a few examples.  In this table, "MS" is a memory stream, so "MS to MS" is using DeflateStream created around a compressed MemoryStream and using CopyToAsync on the DeflateStream to decompress it to another MemoryStream.  "CMS" is a "CustomMemoryStream", which is simply a type that derives from MemoryStream and doesn't add or override any logic; this derivation defeats some the CopyToAsync optimization in MemoryStream, so this is essentially the worst case for this DeflateStream optimization.  And "FS" is FileStream, where a "(true)" suffix means useAsync==true (in which case FileStream has its own CopyToAsync implementation) and a "(false)" suffix means useAsync==false (in which case it essentially delegates back to the base Stream's CopyToAsync). "Len" is the length of the original random input in bytes, and "Iters" is the number of iterations (the number of times positions were reset and CopyToAsync was called).

| Test                                              | Before (s) | After (s)|
|---------------------------------------------------|-----------|-----------|
| MS to MS (Len=1024     Iters=1024000)             |  2.767149 | 1.601566  |
| MS to MS (Len=1048576  Iters=1000)                |  0.419615 | 0.139993  |
| MS to MS (Len=10485760 Iters=100)                 |  0.358287 | 0.223764  |
| CMS to CMS (Len=1024     Iters=1024000)           |  2.832110 | 1.963891  |
| CMS to CMS (Len=1048576  Iters=1000)              |  0.271432 | 0.202536  |
| CMS to CMS (Len=10485760 Iters=100)               |  0.347356 | 0.316338  |
| FS(True) to FS(True) (Len=1024     Iters=102400)  | 10.315941 | 6.909713  |
| FS(True) to FS(True) (Len=1048576  Iters=100)     |  0.940410 | 0.124353  |
| FS(True) to FS(True) (Len=10485760 Iters=10)      |  1.000786 | 0.152991  |
| FS(True) to FS(False) (Len=1024     Iters=102400) |  9.936322 | 6.967522  |
| FS(True) to FS(False) (Len=1048576  Iters=100)    |  0.705946 | 0.085895  |
| FS(True) to FS(False) (Len=10485760 Iters=10)     |  0.925196 | 0.159865  |
| FS(False) toFS (True) (Len=1024     Iters=102400) |  8.630263 | 6.699364  |
| FS(False) toFS (True) (Len=1048576  Iters=100)    |  0.880577 | 0.116051  |
| FS(False) toFS (True) (Len=10485760 Iters=10)     |  0.862978 | 0.142838  |
| FS(False) toFS (False) (Len=1024     Iters=102400)|  5.260478 | 4.388572  |
| FS(False) toFS (False) (Len=1048576  Iters=100)   |  0.346608 | 0.078440  |
| FS(False) toFS (False) (Len=10485760 Iters=10)    |  0.432393 | 0.157312  | 

Fixes https://github.com/dotnet/corefx/issues/11571
Contributes to https://github.com/dotnet/corefx/issues/12549
cc: @ianhays, @JeremyKuhne, @geoffkizer, @benaadams, @davidfowl 

(@ianhays, please pay careful attention to my use of the inflater.  I essentially copied what was in ReadAsync and refactored it, and I want to make sure I'm using it correctly / didn't misunderstand anything about its behavior.)