### PR TITLE
Add minimum RAM requirements to Unix instructions

### DIFF
--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -12,6 +12,9 @@ Only use it when the parameters that you are passing to the script apply for bot
 
 For more information about the different options when building, run `build.sh -?` and look at examples in the [developer-guide](../project-docs/developer-guide.md).
 
+## Environment
+An environment with at least 2GB RAM is required to complete the managed build.
+
 ## Prerequisites (native build)
 
 ### Linux

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -12,8 +12,8 @@ Only use it when the parameters that you are passing to the script apply for bot
 
 For more information about the different options when building, run `build.sh -?` and look at examples in the [developer-guide](../project-docs/developer-guide.md).
 
-## Environment
-An environment with at least 2GB RAM is required to complete the managed build.
+## Minimum Hardware Requirements
+- 2GB RAM
 
 ## Prerequisites (native build)
 


### PR DESCRIPTION
My VM only had 1GB RAM (since that's the minimum req'd for CoreCLR) and the CoreFX build kept crashing.
I eventually saw via monitoring that it was running out of memory, and increasing RAM to 2GB solved this for me, so I figured it should be documented to save others the same trouble(shooting).