### PR TITLE
Implement two ctors of DataContractJsonSerializer's.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
@@ -61,13 +61,13 @@ namespace System.Runtime.Serialization.Json
         }
 
         public DataContractJsonSerializer(Type type, string rootName, IEnumerable<Type> knownTypes)
+            : this(type, new DataContractJsonSerializerSettings() { RootName = rootName, KnownTypes = knownTypes })
         {
-            throw new PlatformNotSupportedException();
         }
 
         public DataContractJsonSerializer(Type type, XmlDictionaryString rootName, IEnumerable<Type> knownTypes)
         {
-            throw new PlatformNotSupportedException();
+            _serializer = new DataContractJsonSerializerImpl(type, rootName, knownTypes);
         }
 
         public DataContractJsonSerializer(Type type, DataContractJsonSerializerSettings settings)
@@ -473,19 +473,26 @@ namespace System.Runtime.Serialization.Json
         }
 
         public DataContractJsonSerializerImpl(Type type, IEnumerable<Type> knownTypes)
-            : this(type, knownTypes, int.MaxValue, false, false)
+            : this(type, null, knownTypes, int.MaxValue, false, false)
         {
         }
 
-        internal DataContractJsonSerializerImpl(Type type,
+        public DataContractJsonSerializerImpl(Type type, XmlDictionaryString rootName, IEnumerable<Type> knownTypes)
+            : this(type, rootName, knownTypes, int.MaxValue, false, false)
+        {
+        }
+
+        internal DataContractJsonSerializerImpl(Type type, 
+            XmlDictionaryString rootName,
             IEnumerable<Type> knownTypes,
             int maxItemsInObjectGraph,
             bool ignoreExtensionDataObject,
             bool alwaysEmitTypeInformation)
         {
             EmitTypeInformation emitTypeInformation = alwaysEmitTypeInformation ? EmitTypeInformation.Always : EmitTypeInformation.AsNeeded;
-            Initialize(type, knownTypes, maxItemsInObjectGraph, ignoreExtensionDataObject, emitTypeInformation, false, null, false);
+            Initialize(type, rootName, knownTypes, maxItemsInObjectGraph, ignoreExtensionDataObject, emitTypeInformation, false, null, false);
         }
+
         public DataContractJsonSerializerImpl(Type type, DataContractJsonSerializerSettings settings)
         {
             if (settings == null)

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2255,6 +2255,45 @@ public static partial class DataContractJsonSerializerTests
         Assert.Equal(value.StringValue, actual.StringValue);
     }
 
+    [Fact]
+    public static void DCJS_ConstructorWithRootName()
+    {
+        var value = new TypeForRootNameTest() { StringProperty = "Test String" };
+        var serializer = new DataContractJsonSerializer(typeof(TypeForRootNameTest), typeof(TypeForRootNameTest).Name);
+        string actualString = ConstructorWithRootNameTestHelper(value, serializer);
+        string expectedString = "{\"TypeForRootNameTest\":{\"StringProperty\":\"Test String\"}}";
+        Utils.CompareResult result = Utils.Compare(expectedString, actualString, false);
+        Assert.True(result.Equal, $"The serialization payload was not as expected.{Environment.NewLine}Expected: {expectedString}.{Environment.NewLine}Actual: {actualString}");
+    }
+
+
+    [Fact]
+    public static void DCJS_ConstructorWithRootNameAsXmlDictionaryString()
+    {
+        var value = new TypeForRootNameTest() { StringProperty = "Test String" };
+        XmlDictionary dict = new XmlDictionary();
+        XmlDictionaryString rootName = dict.Add(typeof(TypeForRootNameTest).Name);
+        var serializer = new DataContractJsonSerializer(typeof(TypeForRootNameTest), rootName);
+        string actualString = ConstructorWithRootNameTestHelper(value, serializer);
+        string expectedString = "{\"TypeForRootNameTest\":{\"StringProperty\":\"Test String\"}}";
+        Utils.CompareResult result = Utils.Compare(expectedString, actualString, false);
+        Assert.True(result.Equal, $"The serialization payload was not as expected.{Environment.NewLine}Expected: {expectedString}.{Environment.NewLine}Actual: {actualString}");
+    }
+
+    private static string ConstructorWithRootNameTestHelper(TypeForRootNameTest value, DataContractJsonSerializer serializer)
+    {
+        using (var ms = new MemoryStream())
+        {
+            XmlDictionaryWriter w = JsonReaderWriterFactory.CreateJsonWriter(ms);
+            w.WriteStartElement("root");
+            w.WriteAttributeString("type", "object");
+            serializer.WriteObject(w, value);
+            w.WriteEndElement();
+            w.Flush();
+            return Encoding.Default.GetString(ms.ToArray());
+        }
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractJsonSerializer dcjs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -3932,3 +3932,10 @@ public class MyISerializableType : ISerializable
         _stringValue = (string)info.GetValue(nameof(_stringValue), typeof(string));
     }
 }
+
+[DataContract]
+public class TypeForRootNameTest
+{
+    [DataMember]
+    public string StringProperty { get; set; }
+}


### PR DESCRIPTION
The fix enables DataContractJsonSerializer's constructors that take root name as parameter.

Fix #12639 