### PR TITLE
Add netcoreapp1.1 configurations for System.Xml.Linq tests

### DIFF
--- a/src/System.Private.Xml.Linq/tests/Properties/System.Xml.Linq.Properties.Tests.csproj
+++ b/src/System.Private.Xml.Linq/tests/Properties/System.Xml.Linq.Properties.Tests.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
     <ProjectReference Include="..\XDocument.Common\XDocument.Common.csproj" />
     <ProjectReference Include="..\XDocument.Test.ModuleCore\XDocument.Test.ModuleCore.csproj" />
   </ItemGroup>

--- a/src/System.Private.Xml.Linq/tests/System.Private.Xml.Linq.Tests.builds
+++ b/src/System.Private.Xml.Linq/tests/System.Private.Xml.Linq.Tests.builds
@@ -6,28 +6,25 @@
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcoreapp1.1;net46</TestTFMs>
     </Project>
-    <!-- ToDo: Add netcoreapp1.1 to the TestTFMs once issue is fixed https://github.com/dotnet/corefx/issues/13085 -->
     <Project Include="events\System.Xml.Linq.Events.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
     <Project Include="misc\System.Xml.Linq.Misc.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
-    <!-- ToDo: Add netcoreapp1.1 to the TestTFMs once issue is fixed https://github.com/dotnet/corefx/issues/13085 -->
     <Project Include="Properties\System.Xml.Linq.Properties.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
     <Project Include="SDMSample\System.Xml.Linq.SDMSample.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
-    <!-- ToDo: Add netcoreapp1.1 to the TestTFMs once issue is fixed https://github.com/dotnet/corefx/issues/13085 -->
     <Project Include="Streaming\System.Xml.Linq.Streaming.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
     <Project Include="TreeManipulation\System.Xml.Linq.TreeManipulation.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
@@ -41,15 +38,13 @@
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
-    <!-- ToDo: Add netcoreapp1.1 to the TestTFMs once issue is fixed https://github.com/dotnet/corefx/issues/13085 -->
     <Project Include="xNodeBuilder\System.Xml.Linq.xNodeBuilder.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
-    <!-- ToDo: Add netcoreapp1.1 to the TestTFMs once issue is fixed https://github.com/dotnet/corefx/issues/13085 -->
     <Project Include="xNodeReader\System.Xml.Linq.xNodeReader.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;net46</TestTFMs>
+      <TestTFMs>netcoreapp1.1;netcore50;net46</TestTFMs>
     </Project>
     <Project Include="XPath\XDocument\System.Xml.XPath.XDocument.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
@@ -3403,7 +3403,6 @@ namespace CoreXml.Test.XLinq
 
                 //[Variation(Id = 5, Desc = "WriteCData with ]]>", Priority = 1)]
                 [Fact]
-                //[ActiveIssue(4054)]
                 public void WriteCDataWithTwoClosingBrackets_5()
                 {
                     XDocument doc = new XDocument();
@@ -3414,11 +3413,12 @@ namespace CoreXml.Test.XLinq
                         w.WriteEndElement();
                     }
 
-                    string expectedXml = "<Root><![CDATA[test ]]]]><![CDATA[> test]]></Root>";
+                    string expectedMsg = "Cannot have ']]>' inside an XML CDATA block.";
 
                     using (XmlReader reader = doc.CreateReader())
                     {
-                        Assert.Equal(expectedXml, MoveToFirstElement(reader).ReadOuterXml());
+                        Exception exception = Assert.Throws<ArgumentException>(() => MoveToFirstElement(reader).ReadOuterXml());
+                        Assert.Equal(expectedMsg, exception.Message);
                     }
                 }
 
@@ -3595,7 +3595,6 @@ namespace CoreXml.Test.XLinq
 
                 //[Variation(Id = 6, Desc = "WriteComment with -- in value", Priority = 1)]
                 [Fact]
-                //[ActiveIssue(4057)]
                 public void WriteCommentWithDoubleHyphensInValue()
                 {
                     XDocument doc = new XDocument();
@@ -3606,11 +3605,12 @@ namespace CoreXml.Test.XLinq
                         w.WriteEndElement();
                     }
 
-                    string expectedXml = "<Root><!--test - - --></Root>";
+                    string expectedMsg = "An XML comment cannot contain '--', and '-' cannot be the last character.";
 
                     using (XmlReader reader = doc.CreateReader())
                     {
-                        Assert.Equal(expectedXml, MoveToFirstElement(reader).ReadOuterXml());
+                        Exception exception = Assert.Throws<ArgumentException>(() => MoveToFirstElement(reader).ReadOuterXml());
+                        Assert.Equal(expectedMsg, exception.Message);
                     }
                 }
             }
@@ -4196,7 +4196,6 @@ namespace CoreXml.Test.XLinq
 
                 //[Variation(Id = 11, Desc = "Include PI end tag ?> as part of the text value", Priority = 1)]
                 [Fact]
-                //[ActiveIssue(4063)]
                 public void IncludePIEndTagAsPartOfTextValue()
                 {
                     XDocument doc = new XDocument();
@@ -4207,11 +4206,12 @@ namespace CoreXml.Test.XLinq
                         w.WriteEndElement();
                     }
 
-                    string expectedXml = "<Root><?badpi text ? >?></Root>";
+                    string expectedMsg = "Cannot have '?>' inside an XML processing instruction.";
 
                     using (XmlReader reader = doc.CreateReader())
                     {
-                        Assert.Equal(expectedXml, MoveToFirstElement(reader).ReadOuterXml());
+                        Exception exception = Assert.Throws<ArgumentException>(() => MoveToFirstElement(reader).ReadOuterXml());
+                        Assert.Equal(expectedMsg, exception.Message);
                     }
                 }
 

--- a/src/System.Private.Xml.Linq/tests/xNodeReader/System.Xml.Linq.xNodeReader.Tests.csproj
+++ b/src/System.Private.Xml.Linq/tests/xNodeReader/System.Xml.Linq.xNodeReader.Tests.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
     <ProjectReference Include="..\XDocument.Common\XDocument.Common.csproj" />
     <ProjectReference Include="..\XDocument.Test.ModuleCore\XDocument.Test.ModuleCore.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Addresses https://github.com/dotnet/corefx/issues/13085

The three XNodeBuilder tests used to have ActiveIssues which we are not going to fix as the behaviour is compatible with Desktop: 
https://github.com/dotnet/corefx/issues/4054 https://github.com/dotnet/corefx/issues/4057 https://github.com/dotnet/corefx/issues/4063
[These issues were initially created because the behaviour does not match the specification and is by design]

cc: @danmosemsft @joperezr @weshaggard 
