### PR TITLE
cross/build-rootfs.sh: install LLDB for ARM when no BuildArch arg is supplied

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -49,7 +49,6 @@ for i in "$@" ; do
         arm)
             __BuildArch=arm
             __UbuntuArch=armhf
-            __UbuntuPackages+=" ${__LLDB_Package:-}"
             __MachineTriple=arm-linux-gnueabihf
             ;;
         arm64)
@@ -80,6 +79,10 @@ for i in "$@" ; do
             ;;
     esac
 done
+
+if [[ "$__BuildArch" == "arm" ]]; then
+    __UbuntuPackages+=" ${__LLDB_Package:-}"
+fi
 
 __RootfsDir="$__CrossDir/rootfs/$__BuildArch"
 


### PR DESCRIPTION
The CoreFX copy of `cross/build-rootfs.sh` is subject to the same problem as dotnet/coreclr#7643 (fixed in dotnet/coreclr#7644) where supplying no `BuildArch` arg to the script will create a valid ARM(HF) chroot, but LLDB won't be installed since that package only gets added to the list when `arm` is explicitly called out as the build arch.

This PR fixes that by checking `$__BuildArch` itself, rather than the CLI arg.