### PR TITLE
Correct how BitArray.CopyTo handles starting from a non-zero index.

### DIFF
--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 
@@ -413,7 +412,7 @@ namespace System.Collections
                     Array.Copy(m_array, 0, intArray, index, GetArrayLength(m_length, BitsPerInt32) - 1);
 
                     // the last int needs to be masked
-                    intArray[last] = m_array[last] & ((1 << extraBits) - 1);
+                    intArray[index + last] = m_array[last] & ((1 << extraBits) - 1);
                 }
             }
             else if (array is byte[])

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -245,6 +245,29 @@ namespace System.Collections.Tests
                     }
                 }
             }
+
+            foreach (int bitArraySize in new[] { BitsPerInt32 - 1, BitsPerInt32 * 2 - 1 })
+            {
+                BitArray allTrue = new BitArray(Enumerable.Repeat(true, bitArraySize).ToArray());
+                BitArray allFalse = new BitArray(Enumerable.Repeat(false, bitArraySize).ToArray());
+                BitArray alternating = new BitArray(Enumerable.Range(0, bitArraySize).Select(i => i % 2 == 1).ToArray());
+
+                foreach (var d in new[] { Tuple.Create(bitArraySize, 0),
+                    Tuple.Create(bitArraySize * 2 + 1, 0),
+                    Tuple.Create(bitArraySize * 2 + 1, bitArraySize + 1),
+                    Tuple.Create(bitArraySize * 2 + 1, bitArraySize / 2 + 1)})
+                {
+                    int arraySize = d.Item1;
+                    int index = d.Item2;
+
+                    if (bitArraySize >= BitsPerInt32)
+                    {
+                        yield return new object[] { allTrue, (arraySize - 1) / BitsPerInt32 + 1, index / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xffffffff), bitArraySize / BitsPerInt32).Concat(new[] { unchecked((int)(0xffffffffu >> 1)) }).ToArray(), default(int) };
+                        yield return new object[] { allFalse, (arraySize - 1) / BitsPerInt32 + 1, index / BitsPerInt32, Enumerable.Repeat(0x00000000, bitArraySize / BitsPerInt32 + 1).ToArray(), default(int) };
+                        yield return new object[] { alternating, (arraySize - 1) / BitsPerInt32 + 1, index / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xaaaaaaaa), bitArraySize / BitsPerInt32).Concat(new[] { unchecked((int)(0xaaaaaaaau >> 2)) }).ToArray(), default(int) };
+                    }
+                }
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Introduced in #12597 

Missed this on review.  
Due to the changes, `BitArray.CopyTo` copies the last block of data when:
 - The array type is an int.
 - The number of elements in BitArray is not a multiple of 32
 - The starting index for the copy was not 0.

The critical line reads like this: 
```
intArray[last] = m_array[last] & ((1 << extraBits) - 1);
``` 
... but this is incorrect, since the destination array needs the source index adjusted.

cc @mareklinka , @stephentoub , @ianhays , @Priya91 

Added some initial tests showing this, as well as the fix.