### PR TITLE
Fix several refs to use throw null

### DIFF
--- a/src/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
+++ b/src/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
@@ -48,7 +48,7 @@ namespace System.Diagnostics
         public StackTrace(int skipFrames) { }
         public StackTrace(int skipFrames, bool fNeedFileInfo) { }
         public virtual int FrameCount { get { throw null; } }
-        public virtual System.Diagnostics.StackFrame[] GetFrames() { return default(System.Diagnostics.StackFrame[]); }
+        public virtual System.Diagnostics.StackFrame[] GetFrames() { throw null; }
     }
 }
 
@@ -174,7 +174,7 @@ namespace System.Diagnostics.SymbolStore
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct SymbolToken
     {
-        public SymbolToken(int val) { throw null;}
+        public SymbolToken(int val) { throw null; }
         public bool Equals(System.Diagnostics.SymbolStore.SymbolToken obj) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }

--- a/src/System.Runtime.Serialization.Xml/ref/System.Runtime.Serialization.Xml.cs
+++ b/src/System.Runtime.Serialization.Xml/ref/System.Runtime.Serialization.Xml.cs
@@ -67,8 +67,8 @@ namespace System.Runtime.Serialization
     }
     public static partial class XPathQueryGenerator
     {
-        public static string CreateFromDataContractSerializer(System.Type type, System.Reflection.MemberInfo[] pathToMember, System.Text.StringBuilder rootElementXpath, out System.Xml.XmlNamespaceManager namespaces) { namespaces = default(System.Xml.XmlNamespaceManager); throw null; }
-        public static string CreateFromDataContractSerializer(System.Type type, System.Reflection.MemberInfo[] pathToMember, out System.Xml.XmlNamespaceManager namespaces) { namespaces = default(System.Xml.XmlNamespaceManager); throw null; }
+        public static string CreateFromDataContractSerializer(System.Type type, System.Reflection.MemberInfo[] pathToMember, System.Text.StringBuilder rootElementXpath, out System.Xml.XmlNamespaceManager namespaces) { throw null; }
+        public static string CreateFromDataContractSerializer(System.Type type, System.Reflection.MemberInfo[] pathToMember, out System.Xml.XmlNamespaceManager namespaces) { throw null; }
     }
     public partial class XsdDataContractExporter
     {
@@ -234,14 +234,14 @@ namespace System.Xml
         public static System.Xml.XmlDictionaryReader CreateTextReader(System.IO.Stream stream, System.Xml.XmlDictionaryReaderQuotas quotas) { throw null; }
         public virtual void EndCanonicalization() { }
         public virtual string GetAttribute(System.Xml.XmlDictionaryString localName, System.Xml.XmlDictionaryString namespaceUri) { throw null; }
-        public virtual void GetNonAtomizedNames(out string localName, out string namespaceUri) { localName = default(string); namespaceUri = default(string); }
+        public virtual void GetNonAtomizedNames(out string localName, out string namespaceUri) { throw null; }
         public virtual int IndexOfLocalName(string[] localNames, string namespaceUri) { throw null; }
         public virtual int IndexOfLocalName(System.Xml.XmlDictionaryString[] localNames, System.Xml.XmlDictionaryString namespaceUri) { throw null; }
         public virtual bool IsLocalName(string localName) { throw null; }
         public virtual bool IsLocalName(System.Xml.XmlDictionaryString localName) { throw null; }
         public virtual bool IsNamespaceUri(string namespaceUri) { throw null; }
         public virtual bool IsNamespaceUri(System.Xml.XmlDictionaryString namespaceUri) { throw null; }
-        public virtual bool IsStartArray(out System.Type type) { type = default(System.Type); throw null; }
+        public virtual bool IsStartArray(out System.Type type) { throw null; }
         public virtual bool IsStartElement(System.Xml.XmlDictionaryString localName, System.Xml.XmlDictionaryString namespaceUri) { throw null; }
         protected bool IsTextNode(System.Xml.XmlNodeType nodeType) { throw null; }
         public virtual void MoveToStartElement() { }
@@ -278,11 +278,11 @@ namespace System.Xml
         public override decimal ReadContentAsDecimal() { throw null; }
         public override float ReadContentAsFloat() { throw null; }
         public virtual System.Guid ReadContentAsGuid() { throw null; }
-        public virtual void ReadContentAsQualifiedName(out string localName, out string namespaceUri) { localName = default(string); namespaceUri = default(string); }
+        public virtual void ReadContentAsQualifiedName(out string localName, out string namespaceUri) { throw null; }
         public override string ReadContentAsString() { throw null; }
         protected string ReadContentAsString(int maxStringContentLength) { throw null; }
-        public virtual string ReadContentAsString(string[] strings, out int index) { index = default(int); throw null; }
-        public virtual string ReadContentAsString(System.Xml.XmlDictionaryString[] strings, out int index) { index = default(int); throw null; }
+        public virtual string ReadContentAsString(string[] strings, out int index) { throw null; }
+        public virtual string ReadContentAsString(System.Xml.XmlDictionaryString[] strings, out int index) { throw null; }
         public virtual System.TimeSpan ReadContentAsTimeSpan() { throw null; }
         public virtual System.Xml.UniqueId ReadContentAsUniqueId() { throw null; }
         public virtual System.DateTime[] ReadDateTimeArray(string localName, string namespaceUri) { throw null; }
@@ -325,11 +325,11 @@ namespace System.Xml
         public virtual System.TimeSpan[] ReadTimeSpanArray(System.Xml.XmlDictionaryString localName, System.Xml.XmlDictionaryString namespaceUri) { throw null; }
         public virtual int ReadValueAsBase64(byte[] buffer, int offset, int count) { throw null; }
         public virtual void StartCanonicalization(System.IO.Stream stream, bool includeComments, string[] inclusivePrefixes) { }
-        public virtual bool TryGetArrayLength(out int count) { count = default(int); throw null; }
-        public virtual bool TryGetBase64ContentLength(out int length) { length = default(int); throw null; }
-        public virtual bool TryGetLocalNameAsDictionaryString(out System.Xml.XmlDictionaryString localName) { localName = default(System.Xml.XmlDictionaryString); throw null; }
-        public virtual bool TryGetNamespaceUriAsDictionaryString(out System.Xml.XmlDictionaryString namespaceUri) { namespaceUri = default(System.Xml.XmlDictionaryString); throw null; }
-        public virtual bool TryGetValueAsDictionaryString(out System.Xml.XmlDictionaryString value) { value = default(System.Xml.XmlDictionaryString); throw null; }
+        public virtual bool TryGetArrayLength(out int count) { throw null; }
+        public virtual bool TryGetBase64ContentLength(out int length) { throw null; }
+        public virtual bool TryGetLocalNameAsDictionaryString(out System.Xml.XmlDictionaryString localName) { throw null; }
+        public virtual bool TryGetNamespaceUriAsDictionaryString(out System.Xml.XmlDictionaryString namespaceUri) { throw null; }
+        public virtual bool TryGetValueAsDictionaryString(out System.Xml.XmlDictionaryString value) { throw null; }
     }
     public sealed partial class XmlDictionaryReaderQuotas
     {

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -3567,9 +3567,9 @@ namespace System.Diagnostics
     {
         public DebuggableAttribute(bool isJITTrackingEnabled, bool isJITOptimizerDisabled) { }
         public DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes modes) { }
-        public System.Diagnostics.DebuggableAttribute.DebuggingModes DebuggingFlags { get { return default(System.Diagnostics.DebuggableAttribute.DebuggingModes); } }
-        public bool IsJITOptimizerDisabled { get { return default(bool); } }
-        public bool IsJITTrackingEnabled { get { return default(bool); } }
+        public System.Diagnostics.DebuggableAttribute.DebuggingModes DebuggingFlags { get { throw null; } }
+        public bool IsJITOptimizerDisabled { get { throw null; } }
+        public bool IsJITTrackingEnabled { get { throw null; } }
         [System.FlagsAttribute]
         public enum DebuggingModes
         {
@@ -5639,7 +5639,7 @@ namespace System.Reflection
         public StrongNameKeyPair(byte[] keyPairArray) { }
         protected StrongNameKeyPair(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public StrongNameKeyPair(string keyPairContainer) { }
-        public byte[] PublicKey { [System.Security.SecuritySafeCriticalAttribute]get { return default(byte[]); } }
+        public byte[] PublicKey { [System.Security.SecuritySafeCriticalAttribute]get { throw null; } }
         void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }

--- a/src/System.Xml.XDocument/ref/System.Xml.XDocument.cs
+++ b/src/System.Xml.XDocument/ref/System.Xml.XDocument.cs
@@ -462,8 +462,8 @@ namespace System.Xml.Schema
 {
     public static partial class Extensions
     {
-        public static System.Xml.Schema.IXmlSchemaInfo GetSchemaInfo(this System.Xml.Linq.XAttribute source) { return default(System.Xml.Schema.IXmlSchemaInfo); }
-        public static System.Xml.Schema.IXmlSchemaInfo GetSchemaInfo(this System.Xml.Linq.XElement source) { return default(System.Xml.Schema.IXmlSchemaInfo); }
+        public static System.Xml.Schema.IXmlSchemaInfo GetSchemaInfo(this System.Xml.Linq.XAttribute source) { throw null; }
+        public static System.Xml.Schema.IXmlSchemaInfo GetSchemaInfo(this System.Xml.Linq.XElement source) { throw null; }
         public static void Validate(this System.Xml.Linq.XAttribute source, System.Xml.Schema.XmlSchemaObject partialValidationType, System.Xml.Schema.XmlSchemaSet schemas, System.Xml.Schema.ValidationEventHandler validationEventHandler) { }
         public static void Validate(this System.Xml.Linq.XAttribute source, System.Xml.Schema.XmlSchemaObject partialValidationType, System.Xml.Schema.XmlSchemaSet schemas, System.Xml.Schema.ValidationEventHandler validationEventHandler, bool addSchemaInfo) { }
         public static void Validate(this System.Xml.Linq.XDocument source, System.Xml.Schema.XmlSchemaSet schemas, System.Xml.Schema.ValidationEventHandler validationEventHandler) { }


### PR DESCRIPTION
These snuck in after we did the global change to use ```throw null;``` in all refs.