### PR TITLE
Use nameof in more places

### DIFF
--- a/src/Microsoft.Win32.Registry.AccessControl/src/System/Security/AccessControl/RegistrySecurity.cs
+++ b/src/Microsoft.Win32.Registry.AccessControl/src/System/Security/AccessControl/RegistrySecurity.cs
@@ -109,7 +109,7 @@ namespace System.Security.AccessControl
                     break;
 
                 case Interop.mincore.Errors.ERROR_INVALID_NAME:
-                    exception = new ArgumentException(SR.Format(SR.Arg_RegInvalidKeyName, "name"));
+                    exception = new ArgumentException(SR.Format(SR.Arg_RegInvalidKeyName, nameof(name)));
                     break;
 
                 case Interop.mincore.Errors.ERROR_INVALID_HANDLE:

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ColumnAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ColumnAttribute.cs
@@ -32,7 +32,7 @@ namespace System.ComponentModel.DataAnnotations.Schema
             if (string.IsNullOrWhiteSpace(name))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                    SR.ArgumentIsNullOrWhitespace, "name"));
+                    SR.ArgumentIsNullOrWhitespace, nameof(name)));
             }
 
             _name = name;
@@ -74,7 +74,7 @@ namespace System.ComponentModel.DataAnnotations.Schema
                 if (string.IsNullOrWhiteSpace(value))
                 {
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                        SR.ArgumentIsNullOrWhitespace, "value"));
+                        SR.ArgumentIsNullOrWhitespace, nameof(value)));
                 }
 
                 _typeName = value;

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ForeignKeyAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ForeignKeyAttribute.cs
@@ -29,7 +29,7 @@ namespace System.ComponentModel.DataAnnotations.Schema
             if (string.IsNullOrWhiteSpace(name))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                    SR.ArgumentIsNullOrWhitespace, "name"));
+                    SR.ArgumentIsNullOrWhitespace, nameof(name)));
             }
 
             _name = name;

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/InversePropertyAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/InversePropertyAttribute.cs
@@ -23,7 +23,7 @@ namespace System.ComponentModel.DataAnnotations.Schema
             if (string.IsNullOrWhiteSpace(property))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                    SR.ArgumentIsNullOrWhitespace, "property"));
+                    SR.ArgumentIsNullOrWhitespace, nameof(property)));
             }
             _property = property;
         }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/TableAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/TableAttribute.cs
@@ -24,7 +24,7 @@ namespace System.ComponentModel.DataAnnotations.Schema
             if (string.IsNullOrWhiteSpace(name))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                    SR.ArgumentIsNullOrWhitespace, "name"));
+                    SR.ArgumentIsNullOrWhitespace, nameof(name)));
             }
             _name = name;
         }
@@ -48,7 +48,7 @@ namespace System.ComponentModel.DataAnnotations.Schema
                 if (string.IsNullOrWhiteSpace(value))
                 {
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                        SR.ArgumentIsNullOrWhitespace, "value"));
+                        SR.ArgumentIsNullOrWhitespace, nameof(value)));
                 }
                 _schema = value;
             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComponentResourceManager.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComponentResourceManager.cs
@@ -70,11 +70,11 @@ namespace System.ComponentModel
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
             if (objectName == null)
             {
-                throw new ArgumentNullException("objectName");
+                throw new ArgumentNullException(nameof(objectName));
             }
             if (culture == null)
             {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
@@ -267,7 +267,7 @@ namespace System.ComponentModel
         {
             if (component == null)
             {
-                throw new ArgumentNullException("component");
+                throw new ArgumentNullException(nameof(component));
             }
 
             if (name != null)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
@@ -181,7 +181,7 @@ namespace System.ComponentModel
         {
             if (destinationType == null)
             {
-                throw new ArgumentNullException("destinationType");
+                throw new ArgumentNullException(nameof(destinationType));
             }
 
             if (destinationType == typeof(string))

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -48,12 +48,12 @@ namespace System.ComponentModel.Design
         {
             if (parent == null)
             {
-                throw new ArgumentNullException("parent");
+                throw new ArgumentNullException(nameof(parent));
             }
 
             if (name == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             if (name.Length == 0)
@@ -72,12 +72,12 @@ namespace System.ComponentModel.Design
         {
             if (pageName == null)
             {
-                throw new ArgumentNullException("pageName");
+                throw new ArgumentNullException(nameof(pageName));
             }
 
             if (valueName == null)
             {
-                throw new ArgumentNullException("valueName");
+                throw new ArgumentNullException(nameof(valueName));
             }
 
             string[] optionNames = pageName.Split(new char[] { '\\' });
@@ -267,7 +267,7 @@ namespace System.ComponentModel.Design
                     EnsurePopulated();
                     if (index < 0 || index >= _children.Count)
                     {
-                        throw new IndexOutOfRangeException("index");
+                        throw new IndexOutOfRangeException(nameof(index));
                     }
                     return (DesignerOptionCollection)_children[index];
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerVerbCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerVerbCollection.cs
@@ -58,7 +58,7 @@ namespace System.ComponentModel.Design
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
             for (int i = 0; ((i) < (value.Length)); i = ((i) + (1)))
             {
@@ -72,7 +72,7 @@ namespace System.ComponentModel.Design
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
             int currentCount = value.Count;
             for (int i = 0; i < currentCount; i = ((i) + (1)))

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/HelpKeywordAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/HelpKeywordAttribute.cs
@@ -68,7 +68,7 @@ namespace System.ComponentModel.Design
         {
             if (keyword == null)
             {
-                throw new ArgumentNullException("keyword");
+                throw new ArgumentNullException(nameof(keyword));
             }
             _contextKeyword = keyword;
         }
@@ -80,7 +80,7 @@ namespace System.ComponentModel.Design
         {
             if (t == null)
             {
-                throw new ArgumentNullException("t");
+                throw new ArgumentNullException(nameof(t));
             }
             _contextKeyword = t.FullName;
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/PropertyTabAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/PropertyTabAttribute.cs
@@ -64,7 +64,7 @@ namespace System.ComponentModel
             _tabClasses = new Type[] { tabClass };
             if (tabScope < PropertyTabScope.Document)
             {
-                throw new ArgumentException(SR.Format(SR.PropertyTabAttributeBadPropertyTabScope), "tabScope");
+                throw new ArgumentException(SR.Format(SR.PropertyTabAttributeBadPropertyTabScope), nameof(tabScope));
             }
             _tabScopes = new PropertyTabScope[] { tabScope };
         }
@@ -81,7 +81,7 @@ namespace System.ComponentModel
             _tabClassNames = new string[] { tabClassName };
             if (tabScope < PropertyTabScope.Document)
             {
-                throw new ArgumentException(SR.Format(SR.PropertyTabAttributeBadPropertyTabScope), "tabScope");
+                throw new ArgumentException(SR.Format(SR.PropertyTabAttributeBadPropertyTabScope), nameof(tabScope));
             }
             _tabScopes = new PropertyTabScope[] { tabScope };
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/ContextStack.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/ContextStack.cs
@@ -54,7 +54,7 @@ namespace System.ComponentModel.Design.Serialization
             {
                 if (level < 0)
                 {
-                    throw new ArgumentOutOfRangeException("level");
+                    throw new ArgumentOutOfRangeException(nameof(level));
                 }
                 if (_contextStack != null && level < _contextStack.Count)
                 {
@@ -75,7 +75,7 @@ namespace System.ComponentModel.Design.Serialization
             {
                 if (type == null)
                 {
-                    throw new ArgumentNullException("type");
+                    throw new ArgumentNullException(nameof(type));
                 }
 
                 if (_contextStack != null)
@@ -106,7 +106,7 @@ namespace System.ComponentModel.Design.Serialization
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             if (_contextStack == null)
@@ -141,7 +141,7 @@ namespace System.ComponentModel.Design.Serialization
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             if (_contextStack == null)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/DefaultSerializationProviderAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/DefaultSerializationProviderAttribute.cs
@@ -25,7 +25,7 @@ namespace System.ComponentModel.Design.Serialization
         {
             if (providerType == null)
             {
-                throw new ArgumentNullException("providerType");
+                throw new ArgumentNullException(nameof(providerType));
             }
 
             _providerTypeName = providerType.AssemblyQualifiedName;
@@ -38,7 +38,7 @@ namespace System.ComponentModel.Design.Serialization
         {
             if (providerTypeName == null)
             {
-                throw new ArgumentNullException("providerTypeName");
+                throw new ArgumentNullException(nameof(providerTypeName));
             }
 
             _providerTypeName = providerTypeName;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/MemberRelationshipService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/MemberRelationshipService.cs
@@ -65,15 +65,15 @@ namespace System.ComponentModel.Design.Serialization
         {
             get
             {
-                if (sourceOwner == null) throw new ArgumentNullException("sourceOwner");
-                if (sourceMember == null) throw new ArgumentNullException("sourceMember");
+                if (sourceOwner == null) throw new ArgumentNullException(nameof(sourceOwner));
+                if (sourceMember == null) throw new ArgumentNullException(nameof(sourceMember));
 
                 return GetRelationship(new MemberRelationship(sourceOwner, sourceMember));
             }
             set
             {
-                if (sourceOwner == null) throw new ArgumentNullException("sourceOwner");
-                if (sourceMember == null) throw new ArgumentNullException("sourceMember");
+                if (sourceOwner == null) throw new ArgumentNullException(nameof(sourceOwner));
+                if (sourceMember == null) throw new ArgumentNullException(nameof(sourceMember));
 
                 SetRelationship(new MemberRelationship(sourceOwner, sourceMember), value);
             }
@@ -192,8 +192,8 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public MemberRelationship(object owner, MemberDescriptor member)
         {
-            if (owner == null) throw new ArgumentNullException("owner");
-            if (member == null) throw new ArgumentNullException("member");
+            if (owner == null) throw new ArgumentNullException(nameof(owner));
+            if (member == null) throw new ArgumentNullException(nameof(member));
 
             _owner = owner;
             _member = member;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ServiceObjectContainer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ServiceObjectContainer.cs
@@ -111,8 +111,8 @@ namespace System.ComponentModel.Design
             // We're going to add this locally.  Ensure that the service instance
             // is correct.
             //
-            if (serviceType == null) throw new ArgumentNullException("serviceType");
-            if (serviceInstance == null) throw new ArgumentNullException("serviceInstance");
+            if (serviceType == null) throw new ArgumentNullException(nameof(serviceType));
+            if (serviceInstance == null) throw new ArgumentNullException(nameof(serviceInstance));
             if (!(serviceInstance is ServiceCreatorCallback) && !serviceInstance.GetType().IsCOMObject && !serviceType.IsAssignableFrom(serviceInstance.GetType()))
             {
                 throw new ArgumentException(SR.Format(SR.ErrorInvalidServiceInstance, serviceType.FullName));
@@ -120,7 +120,7 @@ namespace System.ComponentModel.Design
 
             if (Services.ContainsKey(serviceType))
             {
-                throw new ArgumentException(SR.Format(SR.ErrorServiceExists, serviceType.FullName), "serviceType");
+                throw new ArgumentException(SR.Format(SR.ErrorServiceExists, serviceType.FullName), nameof(serviceType));
             }
 
             Services[serviceType] = serviceInstance;
@@ -154,12 +154,12 @@ namespace System.ComponentModel.Design
             // We're going to add this locally.  Ensure that the service instance
             // is correct.
             //
-            if (serviceType == null) throw new ArgumentNullException("serviceType");
-            if (callback == null) throw new ArgumentNullException("callback");
+            if (serviceType == null) throw new ArgumentNullException(nameof(serviceType));
+            if (callback == null) throw new ArgumentNullException(nameof(callback));
 
             if (Services.ContainsKey(serviceType))
             {
-                throw new ArgumentException(SR.Format(SR.ErrorServiceExists, serviceType.FullName), "serviceType");
+                throw new ArgumentException(SR.Format(SR.ErrorServiceExists, serviceType.FullName), nameof(serviceType));
             }
 
             Services[serviceType] = callback;
@@ -291,7 +291,7 @@ namespace System.ComponentModel.Design
 
             // We're going to remove this from our local list.
             //
-            if (serviceType == null) throw new ArgumentNullException("serviceType");
+            if (serviceType == null) throw new ArgumentNullException(nameof(serviceType));
             Services.Remove(serviceType);
         }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseException.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseException.cs
@@ -83,7 +83,7 @@ namespace System.ComponentModel
         {
             if (info == null)
             {
-                throw new ArgumentNullException("info");
+                throw new ArgumentNullException(nameof(info));
             }
 
             info.AddValue("type", _type);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
@@ -233,7 +233,7 @@ namespace System.ComponentModel
         {
             if (string.IsNullOrEmpty(mask))
             {
-                throw new ArgumentException(SR.Format(SR.MaskedTextProviderMaskNullOrEmpty), "mask");
+                throw new ArgumentException(SR.Format(SR.MaskedTextProviderMaskNullOrEmpty), nameof(mask));
             }
 
             foreach (char c in mask)
@@ -959,7 +959,7 @@ namespace System.ComponentModel
         {
             if (input == null)
             {
-                throw new ArgumentNullException("input");
+                throw new ArgumentNullException(nameof(input));
             }
 
             testPosition = LastAssignedPosition + 1;
@@ -1339,7 +1339,7 @@ namespace System.ComponentModel
         {
             if (input == null)
             {
-                throw new ArgumentNullException("input");
+                throw new ArgumentNullException(nameof(input));
             }
 
             if (position < 0 || position >= _testString.Length)
@@ -1908,7 +1908,7 @@ namespace System.ComponentModel
         {
             if (input == null)
             {
-                throw new ArgumentNullException("input");
+                throw new ArgumentNullException(nameof(input));
             }
 
             if (position < 0 || position >= _testString.Length)
@@ -1947,7 +1947,7 @@ namespace System.ComponentModel
         {
             if (input == null)
             {
-                throw new ArgumentNullException("input");
+                throw new ArgumentNullException(nameof(input));
             }
 
             if (endPosition >= _testString.Length)
@@ -2136,7 +2136,7 @@ namespace System.ComponentModel
         {
             if (input == null)
             {
-                throw new ArgumentNullException("input");
+                throw new ArgumentNullException(nameof(input));
             }
 
             resultHint = MaskedTextResultHint.Unknown;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NestedContainer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NestedContainer.cs
@@ -28,7 +28,7 @@ namespace System.ComponentModel
         {
             if (owner == null)
             {
-                throw new ArgumentNullException("owner");
+                throw new ArgumentNullException(nameof(owner));
             }
             _owner = owner;
             _owner.Disposed += new EventHandler(OnOwnerDisposed);
@@ -80,7 +80,7 @@ namespace System.ComponentModel
         {
             if (component == null)
             {
-                throw new ArgumentNullException("component");
+                throw new ArgumentNullException(nameof(component));
             }
             return new Site(component, this, name);
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReferenceConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReferenceConverter.cs
@@ -95,7 +95,7 @@ namespace System.ComponentModel
         {
             if (destinationType == null)
             {
-                throw new ArgumentNullException("destinationType");
+                throw new ArgumentNullException(nameof(destinationType));
             }
 
             if (destinationType == typeof(string))

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
@@ -145,7 +145,7 @@ namespace System.ComponentModel
 
             if (componentClass == null)
             {
-                throw new ArgumentException(string.Format(SR.InvalidNullArgument, "componentClass"));
+                throw new ArgumentException(string.Format(SR.InvalidNullArgument, nameof(componentClass)));
             }
 
             // If the classes are the same, we can potentially optimize the method fetch because

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -572,7 +572,7 @@ namespace System.ComponentModel
         {
             if (instance == null)
             {
-                throw new ArgumentNullException("instance");
+                throw new ArgumentNullException(nameof(instance));
             }
 
             IComponent component = instance as IComponent;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/WarningException.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/WarningException.cs
@@ -106,7 +106,7 @@ namespace System.ComponentModel
         {
             if (info == null)
             {
-                throw new ArgumentNullException("info");
+                throw new ArgumentNullException(nameof(info));
             }
 
             info.AddValue("helpUrl", _helpUrl);

--- a/src/System.ComponentModel.TypeConverter/src/System/Timers/Timer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/Timers/Timer.cs
@@ -51,12 +51,12 @@ namespace System.Timers
         : this()
         {
             if (interval <= 0)
-                throw new ArgumentException(SR.Format(SR.InvalidParameter, "interval", interval));
+                throw new ArgumentException(SR.Format(SR.InvalidParameter, nameof(interval), interval));
 
             double roundedInterval = Math.Ceiling(interval);
             if (roundedInterval > int.MaxValue || roundedInterval <= 0)
             {
-                throw new ArgumentException(SR.Format(SR.InvalidParameter, "interval", interval));
+                throw new ArgumentException(SR.Format(SR.InvalidParameter, nameof(interval), interval));
             }
 
             _interval = (int)roundedInterval;

--- a/src/System.ComponentModel.TypeConverter/src/System/misc.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/misc.cs
@@ -78,7 +78,7 @@ namespace System
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             return Activator.CreateInstance(type, args);

--- a/src/System.Composition.Convention/src/System/Composition/Convention/PartConventionBuilderOfT.cs
+++ b/src/System.Composition.Convention/src/System/Composition/Convention/PartConventionBuilderOfT.cs
@@ -48,7 +48,7 @@ namespace System.Composition.Convention
                 }
 
                 // An error occurred the expression must be a void Method() Member Expression
-                throw ExceptionBuilder.Argument_ExpressionMustBeVoidMethodWithNoArguments("methodSelector");
+                throw ExceptionBuilder.Argument_ExpressionMustBeVoidMethodWithNoArguments(nameof(methodSelector));
             }
 
             protected static Expression<Func<T, object>> Reduce(Expression<Func<T, object>> expr)
@@ -122,7 +122,7 @@ namespace System.Composition.Convention
                 }
 
                 // An error occurred the expression must be a Property Member Expression
-                throw ExceptionBuilder.Argument_ExpressionMustBePropertyMember("propertySelector");
+                throw ExceptionBuilder.Argument_ExpressionMustBePropertyMember(nameof(propertySelector));
             }
 
             protected static Expression<Func<T, object>> Reduce(Expression<Func<T, object>> expr)
@@ -171,7 +171,7 @@ namespace System.Composition.Convention
                 var expr = Reduce(constructorSelector).Body;
                 if (expr.NodeType != ExpressionType.New)
                 {
-                    throw ExceptionBuilder.Argument_ExpressionMustBeNew("constructorSelector");
+                    throw ExceptionBuilder.Argument_ExpressionMustBeNew(nameof(constructorSelector));
                 }
                 var newExpression = (NewExpression)expr;
                 _constructorInfo = newExpression.Constructor;

--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -55,7 +55,7 @@ namespace System
             }
             set
             {
-                CheckNonNull(value, "value");
+                CheckNonNull(value, nameof(value));
                 lock (InternalSyncObject)
                 {
                     // Set the terminal console encoding.
@@ -79,7 +79,7 @@ namespace System
             }
             set
             {
-                CheckNonNull(value, "value");
+                CheckNonNull(value, nameof(value));
 
                 lock (InternalSyncObject)
                 {
@@ -414,7 +414,7 @@ namespace System
             // bufferSize is ignored, other than in argument validation, even in the .NET Framework
             if (bufferSize < 0)
             {
-                throw new ArgumentOutOfRangeException("bufferSize", SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             return OpenStandardInput();
         }
@@ -429,7 +429,7 @@ namespace System
             // bufferSize is ignored, other than in argument validation, even in the .NET Framework
             if (bufferSize < 0)
             {
-                throw new ArgumentOutOfRangeException("bufferSize", SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             return OpenStandardOutput();
         }
@@ -444,14 +444,14 @@ namespace System
             // bufferSize is ignored, other than in argument validation, even in the .NET Framework
             if (bufferSize < 0)
             {
-                throw new ArgumentOutOfRangeException("bufferSize", SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             return OpenStandardError();
         }
 
         public static void SetIn(TextReader newIn)
         {
-            CheckNonNull(newIn, "newIn");
+            CheckNonNull(newIn, nameof(newIn));
             newIn = SyncTextReader.GetSynchronizedTextReader(newIn);
             lock (InternalSyncObject)
             {
@@ -461,7 +461,7 @@ namespace System
 
         public static void SetOut(TextWriter newOut)
         {
-            CheckNonNull(newOut, "newOut");
+            CheckNonNull(newOut, nameof(newOut));
             newOut = SyncTextWriter.GetSynchronizedTextWriter(newOut);
             Volatile.Write(ref s_isOutTextWriterRedirected, true);
 
@@ -473,7 +473,7 @@ namespace System
 
         public static void SetError(TextWriter newError)
         {
-            CheckNonNull(newError, "newError");
+            CheckNonNull(newError, nameof(newError));
             newError = SyncTextWriter.GetSynchronizedTextWriter(newError);
             Volatile.Write(ref s_isErrorTextWriterRedirected, true);
 

--- a/src/System.Data.Common/src/System/Data/ProviderBase/SchemaMapping.cs
+++ b/src/System.Data.Common/src/System/Data/ProviderBase/SchemaMapping.cs
@@ -60,8 +60,8 @@ namespace System.Data.ProviderBase
                                     SchemaType schemaType, string sourceTableName, bool gettingData,
                                     DataColumn parentChapterColumn, object parentChapterValue)
         {
-            Debug.Assert(null != adapter, "adapter");
-            Debug.Assert(null != dataReader, "dataReader");
+            Debug.Assert(null != adapter, nameof(adapter));
+            Debug.Assert(null != dataReader, nameof(dataReader));
             Debug.Assert(0 < dataReader.FieldCount, "FieldCount");
             Debug.Assert(null != dataset || null != datatable, "SchemaMapping - null dataSet");
             Debug.Assert(SchemaType.Mapped == schemaType || SchemaType.Source == schemaType, "SetupSchema - invalid schemaType");

--- a/src/System.Data.Common/src/System/Data/SimpleType.cs
+++ b/src/System.Data.Common/src/System/Data/SimpleType.cs
@@ -358,7 +358,7 @@ namespace System.Data
         internal string HasConflictingDefinition(SimpleType otherSimpleType)
         {
             if (otherSimpleType == null)
-                return "otherSimpleType";
+                return nameof(otherSimpleType);
             if (MaxLength != otherSimpleType.MaxLength)
                 return ("MaxLength");
 

--- a/src/System.Data.Common/src/System/Data/XDRSchema.cs
+++ b/src/System.Data.Common/src/System/Data/XDRSchema.cs
@@ -508,7 +508,7 @@ namespace System.Data
                 }
                 catch (Exception e) when (ADP.IsCatchableExceptionType(e))
                 {
-                    throw ExceptionBuilder.AttributeValues("minOccurs", "0", "1");
+                    throw ExceptionBuilder.AttributeValues(nameof(minOccurs), "0", "1");
                 }
             }
             occurs = elNode.GetAttribute(Keywords.MAXOCCURS);
@@ -528,11 +528,11 @@ namespace System.Data
                     }
                     catch (Exception e) when (ADP.IsCatchableExceptionType(e))
                     {
-                        throw ExceptionBuilder.AttributeValues("maxOccurs", "1", Keywords.STAR);
+                        throw ExceptionBuilder.AttributeValues(nameof(maxOccurs), "1", Keywords.STAR);
                     }
                     if (maxOccurs != 1)
                     {
-                        throw ExceptionBuilder.AttributeValues("maxOccurs", "1", Keywords.STAR);
+                        throw ExceptionBuilder.AttributeValues(nameof(maxOccurs), "1", Keywords.STAR);
                     }
                 }
             }

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -444,16 +444,16 @@ namespace System.Drawing
 
         public static Color FromArgb(int alpha, int red, int green, int blue)
         {
-            CheckByte(alpha, "alpha");
-            CheckByte(red, "red");
-            CheckByte(green, "green");
-            CheckByte(blue, "blue");
+            CheckByte(alpha, nameof(alpha));
+            CheckByte(red, nameof(red));
+            CheckByte(green, nameof(green));
+            CheckByte(blue, nameof(blue));
             return new Color(MakeArgb((byte)alpha, (byte)red, (byte)green, (byte)blue), s_stateARGBValueValid, null, (KnownColor)0);
         }
 
         public static Color FromArgb(int alpha, Color baseColor)
         {
-            CheckByte(alpha, "alpha");
+            CheckByte(alpha, nameof(alpha));
             // unchecked - because we already checked that alpha is a byte in CheckByte above
             return new Color(MakeArgb(unchecked((byte)alpha), baseColor.R, baseColor.G, baseColor.B), s_stateARGBValueValid, null, (KnownColor)0);
         }

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -120,7 +120,7 @@ namespace System.IO
             set
             {
                 if (((int)value & ~c_notifyFiltersValidMask) != 0)
-                    throw new ArgumentException(SR.Format(SR.InvalidEnumArgument, "value", (int)value, nameof(NotifyFilters)));
+                    throw new ArgumentException(SR.Format(SR.InvalidEnumArgument, nameof(value), (int)value, nameof(NotifyFilters)));
 
                 if (_notifyFilters != value)
                 {

--- a/src/System.IO.FileSystem/src/System/IO/FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.cs
@@ -127,11 +127,11 @@ namespace System.IO
             string badArg = null;
 
             if (mode < FileMode.CreateNew || mode > FileMode.Append)
-                badArg = "mode";
+                badArg = nameof(mode);
             else if (access < FileAccess.Read || access > FileAccess.ReadWrite)
-                badArg = "access";
+                badArg = nameof(access);
             else if (tempshare < FileShare.None || tempshare > (FileShare.ReadWrite | FileShare.Delete))
-                badArg = "share";
+                badArg = nameof(share);
 
             if (badArg != null)
                 throw new ArgumentOutOfRangeException(badArg, SR.ArgumentOutOfRange_Enum);

--- a/src/System.IO.Pipes.AccessControl/src/System/IO/PipeAccessRule.cs
+++ b/src/System.IO.Pipes.AccessControl/src/System/IO/PipeAccessRule.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -48,7 +48,7 @@ namespace System.IO.Pipes
         internal static int AccessMaskFromRights(PipeAccessRights rights, AccessControlType controlType)
         {
             if (rights < (PipeAccessRights)0 || rights > (PipeAccessRights.FullControl | PipeAccessRights.AccessSystemSecurity))
-                throw new ArgumentOutOfRangeException("rights", SR.ArgumentOutOfRange_NeedValidPipeAccessRights);
+                throw new ArgumentOutOfRangeException(nameof(rights), SR.ArgumentOutOfRange_NeedValidPipeAccessRights);
 
             if (controlType == AccessControlType.Allow)
             {

--- a/src/System.IO.Pipes.AccessControl/src/System/IO/PipeAuditRule.cs
+++ b/src/System.IO.Pipes.AccessControl/src/System/IO/PipeAuditRule.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -53,7 +53,7 @@ namespace System.IO.Pipes
         {
             if (rights < (PipeAccessRights)0 || rights > (PipeAccessRights.FullControl | PipeAccessRights.AccessSystemSecurity))
             {
-                throw new ArgumentOutOfRangeException("rights", SR.ArgumentOutOfRange_NeedValidPipeAccessRights);
+                throw new ArgumentOutOfRangeException(nameof(rights), SR.ArgumentOutOfRange_NeedValidPipeAccessRights);
             }
 
             return (int)rights;

--- a/src/System.IO.Pipes.AccessControl/src/System/IO/PipeSecurity.cs
+++ b/src/System.IO.Pipes.AccessControl/src/System/IO/PipeSecurity.cs
@@ -23,7 +23,7 @@ namespace System.IO.Pipes
         public void AddAccessRule(PipeAccessRule rule)
         {
             if (rule == null)
-                throw new ArgumentNullException("rule");
+                throw new ArgumentNullException(nameof(rule));
 
             base.AddAccessRule(rule);
         }
@@ -31,7 +31,7 @@ namespace System.IO.Pipes
         public void SetAccessRule(PipeAccessRule rule)
         {
             if (rule == null)
-                throw new ArgumentNullException("rule");
+                throw new ArgumentNullException(nameof(rule));
 
             base.SetAccessRule(rule);
         }
@@ -39,7 +39,7 @@ namespace System.IO.Pipes
         public void ResetAccessRule(PipeAccessRule rule)
         {
             if (rule == null)
-                throw new ArgumentNullException("rule");
+                throw new ArgumentNullException(nameof(rule));
 
             base.ResetAccessRule(rule);
         }
@@ -48,7 +48,7 @@ namespace System.IO.Pipes
         {
             if (rule == null)
             {
-                throw new ArgumentNullException("rule");
+                throw new ArgumentNullException(nameof(rule));
             }
 
             // If the rule to be removed matches what is there currently then 
@@ -89,7 +89,7 @@ namespace System.IO.Pipes
         {
             if (rule == null)
             {
-                throw new ArgumentNullException("rule");
+                throw new ArgumentNullException(nameof(rule));
             }
 
             // If the rule to be removed matches what is there currently then 
@@ -160,11 +160,11 @@ namespace System.IO.Pipes
             // since this is an override
             if (inheritanceFlags != InheritanceFlags.None)
             {
-                throw new ArgumentException(SR.Argument_NonContainerInvalidAnyFlag, "inheritanceFlags");
+                throw new ArgumentException(SR.Argument_NonContainerInvalidAnyFlag, nameof(inheritanceFlags));
             }
             if (propagationFlags != PropagationFlags.None)
             {
-                throw new ArgumentException(SR.Argument_NonContainerInvalidAnyFlag, "propagationFlags");
+                throw new ArgumentException(SR.Argument_NonContainerInvalidAnyFlag, nameof(propagationFlags));
             }
 
             return new PipeAccessRule(
@@ -189,11 +189,11 @@ namespace System.IO.Pipes
             // since this is an override
             if (inheritanceFlags != InheritanceFlags.None)
             {
-                throw new ArgumentException(SR.Argument_NonContainerInvalidAnyFlag, "inheritanceFlags");
+                throw new ArgumentException(SR.Argument_NonContainerInvalidAnyFlag, nameof(inheritanceFlags));
             }
             if (propagationFlags != PropagationFlags.None)
             {
-                throw new ArgumentException(SR.Argument_NonContainerInvalidAnyFlag, "propagationFlags");
+                throw new ArgumentException(SR.Argument_NonContainerInvalidAnyFlag, nameof(propagationFlags));
             }
 
             return new PipeAuditRule(

--- a/src/System.IO.Pipes.AccessControl/src/System/IO/PipesAclExtensions.cs
+++ b/src/System.IO.Pipes.AccessControl/src/System/IO/PipesAclExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -23,7 +23,7 @@ namespace System.IO.Pipes
             // PipeState can not be Closed and the Handle can not be null or closed
             if (pipeSecurity == null)
             {
-                throw new ArgumentNullException("pipeSecurity");
+                throw new ArgumentNullException(nameof(pipeSecurity));
             }
 
             var handle = stream.SafePipeHandle; // A non-null, open handle implies a non-closed PipeState.

--- a/src/System.IO/src/System/IO/TextReader.cs
+++ b/src/System.IO/src/System/IO/TextReader.cs
@@ -189,7 +189,7 @@ namespace System.IO
             }
             if (index < 0 || count < 0)
             {
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index): nameof(count)), SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             if (buffer.Length - index < count)
             {
@@ -223,7 +223,7 @@ namespace System.IO
             }
             if (index < 0 || count < 0)
             {
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index): nameof(count)), SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             if (buffer.Length - index < count)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2178,8 +2178,8 @@ namespace System.Linq.Expressions.Interpreter
 
         private ByRefUpdater CompileArrayIndexAddress(Expression array, Expression index, int argumentIndex)
         {
-            LocalDefinition left = _locals.DefineLocal(Expression.Parameter(array.Type, "array"), _instructions.Count);
-            LocalDefinition right = _locals.DefineLocal(Expression.Parameter(index.Type, "index"), _instructions.Count);
+            LocalDefinition left = _locals.DefineLocal(Expression.Parameter(array.Type, nameof(array)), _instructions.Count);
+            LocalDefinition right = _locals.DefineLocal(Expression.Parameter(index.Type, nameof(index)), _instructions.Count);
             Compile(array);
             _instructions.EmitStoreLocal(left.Index);
             Compile(index);

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
@@ -76,20 +76,20 @@ namespace System.Linq
         IQueryable IQueryProvider.CreateQuery(Expression expression)
         {
             if (expression == null)
-                throw Error.ArgumentNull("expression");
+                throw Error.ArgumentNull(nameof(expression));
             Type iqType = TypeHelper.FindGenericType(typeof(IQueryable<>), expression.Type);
             if (iqType == null)
-                throw Error.ArgumentNotValid("expression");
+                throw Error.ArgumentNotValid(nameof(expression));
             return EnumerableQuery.Create(iqType.GetGenericArguments()[0], expression);
         }
 
         IQueryable<S> IQueryProvider.CreateQuery<S>(Expression expression)
         {
             if (expression == null)
-                throw Error.ArgumentNull("expression");
+                throw Error.ArgumentNull(nameof(expression));
             if (!typeof(IQueryable<S>).IsAssignableFrom(expression.Type))
             {
-                throw Error.ArgumentNotValid("expression");
+                throw Error.ArgumentNotValid(nameof(expression));
             }
             return new EnumerableQuery<S>(expression);
         }
@@ -104,7 +104,7 @@ namespace System.Linq
         object IQueryProvider.Execute(Expression expression)
         {
             if (expression == null)
-                throw Error.ArgumentNull("expression");
+                throw Error.ArgumentNull(nameof(expression));
             Type execType = typeof(EnumerableExecutor<>).MakeGenericType(expression.Type);
             return EnumerableExecutor.Create(expression).ExecuteBoxed();
         }
@@ -113,9 +113,9 @@ namespace System.Linq
         S IQueryProvider.Execute<S>(Expression expression)
         {
             if (expression == null)
-                throw Error.ArgumentNull("expression");
+                throw Error.ArgumentNull(nameof(expression));
             if (!typeof(S).IsAssignableFrom(expression.Type))
-                throw Error.ArgumentNotValid("expression");
+                throw Error.ArgumentNotValid(nameof(expression));
             return new EnumerableExecutor<S>(expression).Execute();
         }
 

--- a/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
@@ -14,28 +14,28 @@ namespace System.Linq
         public static IQueryable<TElement> AsQueryable<TElement>(this IEnumerable<TElement> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source as IQueryable<TElement> ?? new EnumerableQuery<TElement>(source);
         }
 
         public static IQueryable AsQueryable(this IEnumerable source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             IQueryable queryable = source as IQueryable;
             if (queryable != null) return queryable;
             Type enumType = TypeHelper.FindGenericType(typeof(IEnumerable<>), source.GetType());
             if (enumType == null)
-                throw Error.ArgumentNotIEnumerableGeneric("source");
+                throw Error.ArgumentNotIEnumerableGeneric(nameof(source));
             return EnumerableQuery.Create(enumType.GetTypeInfo().GenericTypeArguments[0], source);
         }
 
         public static IQueryable<TSource> Where<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -49,9 +49,9 @@ namespace System.Linq
         public static IQueryable<TSource> Where<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -65,7 +65,7 @@ namespace System.Linq
         public static IQueryable<TResult> OfType<TResult>(this IQueryable source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -78,7 +78,7 @@ namespace System.Linq
         public static IQueryable<TResult> Cast<TResult>(this IQueryable source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -91,9 +91,9 @@ namespace System.Linq
         public static IQueryable<TResult> Select<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -107,9 +107,9 @@ namespace System.Linq
         public static IQueryable<TResult> Select<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, int, TResult>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -123,9 +123,9 @@ namespace System.Linq
         public static IQueryable<TResult> SelectMany<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, IEnumerable<TResult>>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -139,9 +139,9 @@ namespace System.Linq
         public static IQueryable<TResult> SelectMany<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, int, IEnumerable<TResult>>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -155,11 +155,11 @@ namespace System.Linq
         public static IQueryable<TResult> SelectMany<TSource, TCollection, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, int, IEnumerable<TCollection>>> collectionSelector, Expression<Func<TSource, TCollection, TResult>> resultSelector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (collectionSelector == null)
-                throw Error.ArgumentNull("collectionSelector");
+                throw Error.ArgumentNull(nameof(collectionSelector));
             if (resultSelector == null)
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -174,11 +174,11 @@ namespace System.Linq
         public static IQueryable<TResult> SelectMany<TSource, TCollection, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, IEnumerable<TCollection>>> collectionSelector, Expression<Func<TSource, TCollection, TResult>> resultSelector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (collectionSelector == null)
-                throw Error.ArgumentNull("collectionSelector");
+                throw Error.ArgumentNull(nameof(collectionSelector));
             if (resultSelector == null)
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -200,15 +200,15 @@ namespace System.Linq
         public static IQueryable<TResult> Join<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, TInner, TResult>> resultSelector)
         {
             if (outer == null)
-                throw Error.ArgumentNull("outer");
+                throw Error.ArgumentNull(nameof(outer));
             if (inner == null)
-                throw Error.ArgumentNull("inner");
+                throw Error.ArgumentNull(nameof(inner));
             if (outerKeySelector == null)
-                throw Error.ArgumentNull("outerKeySelector");
+                throw Error.ArgumentNull(nameof(outerKeySelector));
             if (innerKeySelector == null)
-                throw Error.ArgumentNull("innerKeySelector");
+                throw Error.ArgumentNull(nameof(innerKeySelector));
             if (resultSelector == null)
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -231,15 +231,15 @@ namespace System.Linq
         public static IQueryable<TResult> Join<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, TInner, TResult>> resultSelector, IEqualityComparer<TKey> comparer)
         {
             if (outer == null)
-                throw Error.ArgumentNull("outer");
+                throw Error.ArgumentNull(nameof(outer));
             if (inner == null)
-                throw Error.ArgumentNull("inner");
+                throw Error.ArgumentNull(nameof(inner));
             if (outerKeySelector == null)
-                throw Error.ArgumentNull("outerKeySelector");
+                throw Error.ArgumentNull(nameof(outerKeySelector));
             if (innerKeySelector == null)
-                throw Error.ArgumentNull("innerKeySelector");
+                throw Error.ArgumentNull(nameof(innerKeySelector));
             if (resultSelector == null)
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -264,15 +264,15 @@ namespace System.Linq
         public static IQueryable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, IEnumerable<TInner>, TResult>> resultSelector)
         {
             if (outer == null)
-                throw Error.ArgumentNull("outer");
+                throw Error.ArgumentNull(nameof(outer));
             if (inner == null)
-                throw Error.ArgumentNull("inner");
+                throw Error.ArgumentNull(nameof(inner));
             if (outerKeySelector == null)
-                throw Error.ArgumentNull("outerKeySelector");
+                throw Error.ArgumentNull(nameof(outerKeySelector));
             if (innerKeySelector == null)
-                throw Error.ArgumentNull("innerKeySelector");
+                throw Error.ArgumentNull(nameof(innerKeySelector));
             if (resultSelector == null)
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -294,15 +294,15 @@ namespace System.Linq
         public static IQueryable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, IEnumerable<TInner>, TResult>> resultSelector, IEqualityComparer<TKey> comparer)
         {
             if (outer == null)
-                throw Error.ArgumentNull("outer");
+                throw Error.ArgumentNull(nameof(outer));
             if (inner == null)
-                throw Error.ArgumentNull("inner");
+                throw Error.ArgumentNull(nameof(inner));
             if (outerKeySelector == null)
-                throw Error.ArgumentNull("outerKeySelector");
+                throw Error.ArgumentNull(nameof(outerKeySelector));
             if (innerKeySelector == null)
-                throw Error.ArgumentNull("innerKeySelector");
+                throw Error.ArgumentNull(nameof(innerKeySelector));
             if (resultSelector == null)
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -326,9 +326,9 @@ namespace System.Linq
         public static IOrderedQueryable<TSource> OrderBy<TSource, TKey>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -342,9 +342,9 @@ namespace System.Linq
         public static IOrderedQueryable<TSource> OrderBy<TSource, TKey>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, IComparer<TKey> comparer)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -359,9 +359,9 @@ namespace System.Linq
         public static IOrderedQueryable<TSource> OrderByDescending<TSource, TKey>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -375,9 +375,9 @@ namespace System.Linq
         public static IOrderedQueryable<TSource> OrderByDescending<TSource, TKey>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, IComparer<TKey> comparer)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -392,9 +392,9 @@ namespace System.Linq
         public static IOrderedQueryable<TSource> ThenBy<TSource, TKey>(this IOrderedQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -408,9 +408,9 @@ namespace System.Linq
         public static IOrderedQueryable<TSource> ThenBy<TSource, TKey>(this IOrderedQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, IComparer<TKey> comparer)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -425,9 +425,9 @@ namespace System.Linq
         public static IOrderedQueryable<TSource> ThenByDescending<TSource, TKey>(this IOrderedQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -441,9 +441,9 @@ namespace System.Linq
         public static IOrderedQueryable<TSource> ThenByDescending<TSource, TKey>(this IOrderedQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, IComparer<TKey> comparer)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -458,7 +458,7 @@ namespace System.Linq
         public static IQueryable<TSource> Take<TSource>(this IQueryable<TSource> source, int count)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -472,9 +472,9 @@ namespace System.Linq
         public static IQueryable<TSource> TakeWhile<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -488,9 +488,9 @@ namespace System.Linq
         public static IQueryable<TSource> TakeWhile<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -504,7 +504,7 @@ namespace System.Linq
         public static IQueryable<TSource> Skip<TSource>(this IQueryable<TSource> source, int count)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -518,9 +518,9 @@ namespace System.Linq
         public static IQueryable<TSource> SkipWhile<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -534,9 +534,9 @@ namespace System.Linq
         public static IQueryable<TSource> SkipWhile<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -550,9 +550,9 @@ namespace System.Linq
         public static IQueryable<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             return source.Provider.CreateQuery<IGrouping<TKey, TSource>>(
                 Expression.Call(
                     null,
@@ -566,11 +566,11 @@ namespace System.Linq
         public static IQueryable<IGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             if (elementSelector == null)
-                throw Error.ArgumentNull("elementSelector");
+                throw Error.ArgumentNull(nameof(elementSelector));
             return source.Provider.CreateQuery<IGrouping<TKey, TElement>>(
                 Expression.Call(
                     null,
@@ -585,9 +585,9 @@ namespace System.Linq
         public static IQueryable<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             return source.Provider.CreateQuery<IGrouping<TKey, TSource>>(
                 Expression.Call(
                     null,
@@ -602,11 +602,11 @@ namespace System.Linq
         public static IQueryable<IGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             if (elementSelector == null)
-                throw Error.ArgumentNull("elementSelector");
+                throw Error.ArgumentNull(nameof(elementSelector));
             return source.Provider.CreateQuery<IGrouping<TKey, TElement>>(
                 Expression.Call(
                     null,
@@ -622,13 +622,13 @@ namespace System.Linq
         public static IQueryable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector, Expression<Func<TKey, IEnumerable<TElement>, TResult>> resultSelector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             if (elementSelector == null)
-                throw Error.ArgumentNull("elementSelector");
+                throw Error.ArgumentNull(nameof(elementSelector));
             if (resultSelector == null)
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -644,11 +644,11 @@ namespace System.Linq
         public static IQueryable<TResult> GroupBy<TSource, TKey, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, Expression<Func<TKey, IEnumerable<TSource>, TResult>> resultSelector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             if (resultSelector == null)
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -663,11 +663,11 @@ namespace System.Linq
         public static IQueryable<TResult> GroupBy<TSource, TKey, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, Expression<Func<TKey, IEnumerable<TSource>, TResult>> resultSelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             if (resultSelector == null)
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -683,13 +683,13 @@ namespace System.Linq
         public static IQueryable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector, Expression<Func<TKey, IEnumerable<TElement>, TResult>> resultSelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (keySelector == null)
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             if (elementSelector == null)
-                throw Error.ArgumentNull("elementSelector");
+                throw Error.ArgumentNull(nameof(elementSelector));
             if (resultSelector == null)
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -706,7 +706,7 @@ namespace System.Linq
         public static IQueryable<TSource> Distinct<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -719,7 +719,7 @@ namespace System.Linq
         public static IQueryable<TSource> Distinct<TSource>(this IQueryable<TSource> source, IEqualityComparer<TSource> comparer)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -733,9 +733,9 @@ namespace System.Linq
         public static IQueryable<TSource> Concat<TSource>(this IQueryable<TSource> source1, IEnumerable<TSource> source2)
         {
             if (source1 == null)
-                throw Error.ArgumentNull("source1");
+                throw Error.ArgumentNull(nameof(source1));
             if (source2 == null)
-                throw Error.ArgumentNull("source2");
+                throw Error.ArgumentNull(nameof(source2));
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -749,11 +749,11 @@ namespace System.Linq
         public static IQueryable<TResult> Zip<TFirst, TSecond, TResult>(this IQueryable<TFirst> source1, IEnumerable<TSecond> source2, Expression<Func<TFirst, TSecond, TResult>> resultSelector)
         {
             if (source1 == null)
-                throw Error.ArgumentNull("source1");
+                throw Error.ArgumentNull(nameof(source1));
             if (source2 == null)
-                throw Error.ArgumentNull("source2");
+                throw Error.ArgumentNull(nameof(source2));
             if (resultSelector == null)
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             return source1.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
@@ -768,9 +768,9 @@ namespace System.Linq
         public static IQueryable<TSource> Union<TSource>(this IQueryable<TSource> source1, IEnumerable<TSource> source2)
         {
             if (source1 == null)
-                throw Error.ArgumentNull("source1");
+                throw Error.ArgumentNull(nameof(source1));
             if (source2 == null)
-                throw Error.ArgumentNull("source2");
+                throw Error.ArgumentNull(nameof(source2));
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -784,9 +784,9 @@ namespace System.Linq
         public static IQueryable<TSource> Union<TSource>(this IQueryable<TSource> source1, IEnumerable<TSource> source2, IEqualityComparer<TSource> comparer)
         {
             if (source1 == null)
-                throw Error.ArgumentNull("source1");
+                throw Error.ArgumentNull(nameof(source1));
             if (source2 == null)
-                throw Error.ArgumentNull("source2");
+                throw Error.ArgumentNull(nameof(source2));
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -805,9 +805,9 @@ namespace System.Linq
         public static IQueryable<TSource> Intersect<TSource>(this IQueryable<TSource> source1, IEnumerable<TSource> source2)
         {
             if (source1 == null)
-                throw Error.ArgumentNull("source1");
+                throw Error.ArgumentNull(nameof(source1));
             if (source2 == null)
-                throw Error.ArgumentNull("source2");
+                throw Error.ArgumentNull(nameof(source2));
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -821,9 +821,9 @@ namespace System.Linq
         public static IQueryable<TSource> Intersect<TSource>(this IQueryable<TSource> source1, IEnumerable<TSource> source2, IEqualityComparer<TSource> comparer)
         {
             if (source1 == null)
-                throw Error.ArgumentNull("source1");
+                throw Error.ArgumentNull(nameof(source1));
             if (source2 == null)
-                throw Error.ArgumentNull("source2");
+                throw Error.ArgumentNull(nameof(source2));
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -842,9 +842,9 @@ namespace System.Linq
         public static IQueryable<TSource> Except<TSource>(this IQueryable<TSource> source1, IEnumerable<TSource> source2)
         {
             if (source1 == null)
-                throw Error.ArgumentNull("source1");
+                throw Error.ArgumentNull(nameof(source1));
             if (source2 == null)
-                throw Error.ArgumentNull("source2");
+                throw Error.ArgumentNull(nameof(source2));
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -858,9 +858,9 @@ namespace System.Linq
         public static IQueryable<TSource> Except<TSource>(this IQueryable<TSource> source1, IEnumerable<TSource> source2, IEqualityComparer<TSource> comparer)
         {
             if (source1 == null)
-                throw Error.ArgumentNull("source1");
+                throw Error.ArgumentNull(nameof(source1));
             if (source2 == null)
-                throw Error.ArgumentNull("source2");
+                throw Error.ArgumentNull(nameof(source2));
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -879,7 +879,7 @@ namespace System.Linq
         public static TSource First<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -892,9 +892,9 @@ namespace System.Linq
         public static TSource First<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -908,7 +908,7 @@ namespace System.Linq
         public static TSource FirstOrDefault<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -921,9 +921,9 @@ namespace System.Linq
         public static TSource FirstOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -937,7 +937,7 @@ namespace System.Linq
         public static TSource Last<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -950,9 +950,9 @@ namespace System.Linq
         public static TSource Last<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -966,7 +966,7 @@ namespace System.Linq
         public static TSource LastOrDefault<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -979,9 +979,9 @@ namespace System.Linq
         public static TSource LastOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -995,7 +995,7 @@ namespace System.Linq
         public static TSource Single<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -1008,9 +1008,9 @@ namespace System.Linq
         public static TSource Single<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -1024,7 +1024,7 @@ namespace System.Linq
         public static TSource SingleOrDefault<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -1037,9 +1037,9 @@ namespace System.Linq
         public static TSource SingleOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -1053,9 +1053,9 @@ namespace System.Linq
         public static TSource ElementAt<TSource>(this IQueryable<TSource> source, int index)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (index < 0)
-                throw Error.ArgumentOutOfRange("index");
+                throw Error.ArgumentOutOfRange(nameof(index));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -1069,7 +1069,7 @@ namespace System.Linq
         public static TSource ElementAtOrDefault<TSource>(this IQueryable<TSource> source, int index)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -1083,7 +1083,7 @@ namespace System.Linq
         public static IQueryable<TSource> DefaultIfEmpty<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -1096,7 +1096,7 @@ namespace System.Linq
         public static IQueryable<TSource> DefaultIfEmpty<TSource>(this IQueryable<TSource> source, TSource defaultValue)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -1110,7 +1110,7 @@ namespace System.Linq
         public static bool Contains<TSource>(this IQueryable<TSource> source, TSource item)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<bool>(
                 Expression.Call(
                     null,
@@ -1124,7 +1124,7 @@ namespace System.Linq
         public static bool Contains<TSource>(this IQueryable<TSource> source, TSource item, IEqualityComparer<TSource> comparer)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<bool>(
                 Expression.Call(
                     null,
@@ -1139,7 +1139,7 @@ namespace System.Linq
         public static IQueryable<TSource> Reverse<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
@@ -1152,9 +1152,9 @@ namespace System.Linq
         public static bool SequenceEqual<TSource>(this IQueryable<TSource> source1, IEnumerable<TSource> source2)
         {
             if (source1 == null)
-                throw Error.ArgumentNull("source1");
+                throw Error.ArgumentNull(nameof(source1));
             if (source2 == null)
-                throw Error.ArgumentNull("source2");
+                throw Error.ArgumentNull(nameof(source2));
             return source1.Provider.Execute<bool>(
                 Expression.Call(
                     null,
@@ -1168,9 +1168,9 @@ namespace System.Linq
         public static bool SequenceEqual<TSource>(this IQueryable<TSource> source1, IEnumerable<TSource> source2, IEqualityComparer<TSource> comparer)
         {
             if (source1 == null)
-                throw Error.ArgumentNull("source1");
+                throw Error.ArgumentNull(nameof(source1));
             if (source2 == null)
-                throw Error.ArgumentNull("source2");
+                throw Error.ArgumentNull(nameof(source2));
             return source1.Provider.Execute<bool>(
                 Expression.Call(
                     null,
@@ -1189,7 +1189,7 @@ namespace System.Linq
         public static bool Any<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<bool>(
                 Expression.Call(
                     null,
@@ -1202,9 +1202,9 @@ namespace System.Linq
         public static bool Any<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.Execute<bool>(
                 Expression.Call(
                     null,
@@ -1218,9 +1218,9 @@ namespace System.Linq
         public static bool All<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.Execute<bool>(
                 Expression.Call(
                     null,
@@ -1234,7 +1234,7 @@ namespace System.Linq
         public static int Count<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<int>(
                 Expression.Call(
                     null,
@@ -1247,9 +1247,9 @@ namespace System.Linq
         public static int Count<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.Execute<int>(
                 Expression.Call(
                     null,
@@ -1263,7 +1263,7 @@ namespace System.Linq
         public static long LongCount<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<long>(
                 Expression.Call(
                     null,
@@ -1276,9 +1276,9 @@ namespace System.Linq
         public static long LongCount<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (predicate == null)
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             return source.Provider.Execute<long>(
                 Expression.Call(
                     null,
@@ -1292,7 +1292,7 @@ namespace System.Linq
         public static TSource Min<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -1305,9 +1305,9 @@ namespace System.Linq
         public static TResult Min<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<TResult>(
                 Expression.Call(
                     null,
@@ -1321,7 +1321,7 @@ namespace System.Linq
         public static TSource Max<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -1334,9 +1334,9 @@ namespace System.Linq
         public static TResult Max<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<TResult>(
                 Expression.Call(
                     null,
@@ -1350,7 +1350,7 @@ namespace System.Linq
         public static int Sum(this IQueryable<int> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<int>(
                 Expression.Call(
                     null,
@@ -1363,7 +1363,7 @@ namespace System.Linq
         public static int? Sum(this IQueryable<int?> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<int?>(
                 Expression.Call(
                     null,
@@ -1376,7 +1376,7 @@ namespace System.Linq
         public static long Sum(this IQueryable<long> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<long>(
                 Expression.Call(
                     null,
@@ -1389,7 +1389,7 @@ namespace System.Linq
         public static long? Sum(this IQueryable<long?> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<long?>(
                 Expression.Call(
                     null,
@@ -1402,7 +1402,7 @@ namespace System.Linq
         public static float Sum(this IQueryable<float> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<float>(
                 Expression.Call(
                     null,
@@ -1415,7 +1415,7 @@ namespace System.Linq
         public static float? Sum(this IQueryable<float?> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<float?>(
                 Expression.Call(
                     null,
@@ -1428,7 +1428,7 @@ namespace System.Linq
         public static double Sum(this IQueryable<double> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
@@ -1441,7 +1441,7 @@ namespace System.Linq
         public static double? Sum(this IQueryable<double?> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
@@ -1454,7 +1454,7 @@ namespace System.Linq
         public static decimal Sum(this IQueryable<decimal> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<decimal>(
                 Expression.Call(
                     null,
@@ -1467,7 +1467,7 @@ namespace System.Linq
         public static decimal? Sum(this IQueryable<decimal?> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<decimal?>(
                 Expression.Call(
                     null,
@@ -1480,9 +1480,9 @@ namespace System.Linq
         public static int Sum<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<int>(
                 Expression.Call(
                     null,
@@ -1496,9 +1496,9 @@ namespace System.Linq
         public static int? Sum<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int?>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<int?>(
                 Expression.Call(
                     null,
@@ -1512,9 +1512,9 @@ namespace System.Linq
         public static long Sum<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<long>(
                 Expression.Call(
                     null,
@@ -1528,9 +1528,9 @@ namespace System.Linq
         public static long? Sum<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long?>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<long?>(
                 Expression.Call(
                     null,
@@ -1544,9 +1544,9 @@ namespace System.Linq
         public static float Sum<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<float>(
                 Expression.Call(
                     null,
@@ -1560,9 +1560,9 @@ namespace System.Linq
         public static float? Sum<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float?>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<float?>(
                 Expression.Call(
                     null,
@@ -1576,9 +1576,9 @@ namespace System.Linq
         public static double Sum<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
@@ -1592,9 +1592,9 @@ namespace System.Linq
         public static double? Sum<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double?>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
@@ -1608,9 +1608,9 @@ namespace System.Linq
         public static decimal Sum<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<decimal>(
                 Expression.Call(
                     null,
@@ -1624,9 +1624,9 @@ namespace System.Linq
         public static decimal? Sum<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal?>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<decimal?>(
                 Expression.Call(
                     null,
@@ -1640,7 +1640,7 @@ namespace System.Linq
         public static double Average(this IQueryable<int> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
@@ -1653,7 +1653,7 @@ namespace System.Linq
         public static double? Average(this IQueryable<int?> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
@@ -1666,7 +1666,7 @@ namespace System.Linq
         public static double Average(this IQueryable<long> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
@@ -1679,7 +1679,7 @@ namespace System.Linq
         public static double? Average(this IQueryable<long?> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
@@ -1692,7 +1692,7 @@ namespace System.Linq
         public static float Average(this IQueryable<float> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<float>(
                 Expression.Call(
                     null,
@@ -1705,7 +1705,7 @@ namespace System.Linq
         public static float? Average(this IQueryable<float?> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<float?>(
                 Expression.Call(
                     null,
@@ -1718,7 +1718,7 @@ namespace System.Linq
         public static double Average(this IQueryable<double> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
@@ -1731,7 +1731,7 @@ namespace System.Linq
         public static double? Average(this IQueryable<double?> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
@@ -1744,7 +1744,7 @@ namespace System.Linq
         public static decimal Average(this IQueryable<decimal> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<decimal>(
                 Expression.Call(
                     null,
@@ -1757,7 +1757,7 @@ namespace System.Linq
         public static decimal? Average(this IQueryable<decimal?> source)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             return source.Provider.Execute<decimal?>(
                 Expression.Call(
                     null,
@@ -1770,9 +1770,9 @@ namespace System.Linq
         public static double Average<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
@@ -1786,9 +1786,9 @@ namespace System.Linq
         public static double? Average<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int?>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
@@ -1802,9 +1802,9 @@ namespace System.Linq
         public static float Average<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<float>(
                 Expression.Call(
                     null,
@@ -1818,9 +1818,9 @@ namespace System.Linq
         public static float? Average<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float?>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<float?>(
                 Expression.Call(
                     null,
@@ -1834,9 +1834,9 @@ namespace System.Linq
         public static double Average<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
@@ -1850,9 +1850,9 @@ namespace System.Linq
         public static double? Average<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long?>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
@@ -1866,9 +1866,9 @@ namespace System.Linq
         public static double Average<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
@@ -1882,9 +1882,9 @@ namespace System.Linq
         public static double? Average<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double?>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
@@ -1898,9 +1898,9 @@ namespace System.Linq
         public static decimal Average<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<decimal>(
                 Expression.Call(
                     null,
@@ -1914,9 +1914,9 @@ namespace System.Linq
         public static decimal? Average<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal?>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<decimal?>(
                 Expression.Call(
                     null,
@@ -1930,9 +1930,9 @@ namespace System.Linq
         public static TSource Aggregate<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, TSource, TSource>> func)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (func == null)
-                throw Error.ArgumentNull("func");
+                throw Error.ArgumentNull(nameof(func));
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
@@ -1946,9 +1946,9 @@ namespace System.Linq
         public static TAccumulate Aggregate<TSource, TAccumulate>(this IQueryable<TSource> source, TAccumulate seed, Expression<Func<TAccumulate, TSource, TAccumulate>> func)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (func == null)
-                throw Error.ArgumentNull("func");
+                throw Error.ArgumentNull(nameof(func));
             return source.Provider.Execute<TAccumulate>(
                 Expression.Call(
                     null,
@@ -1963,11 +1963,11 @@ namespace System.Linq
         public static TResult Aggregate<TSource, TAccumulate, TResult>(this IQueryable<TSource> source, TAccumulate seed, Expression<Func<TAccumulate, TSource, TAccumulate>> func, Expression<Func<TAccumulate, TResult>> selector)
         {
             if (source == null)
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             if (func == null)
-                throw Error.ArgumentNull("func");
+                throw Error.ArgumentNull(nameof(func));
             if (selector == null)
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             return source.Provider.Execute<TResult>(
                 Expression.Call(
                     null,

--- a/src/System.Net.Http/src/System/Net/Http/Headers/AuthenticationHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/AuthenticationHeaderValue.cs
@@ -37,7 +37,7 @@ namespace System.Net.Http.Headers
 
         public AuthenticationHeaderValue(string scheme, string parameter)
         {
-            HeaderUtilities.CheckValidToken(scheme, "scheme");
+            HeaderUtilities.CheckValidToken(scheme, nameof(scheme));
             _scheme = scheme;
             _parameter = parameter;
         }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
@@ -640,7 +640,7 @@ namespace System.Net.Http.Headers
 
         private static void CheckIsValidToken(string item)
         {
-            HeaderUtilities.CheckValidToken(item, "item");
+            HeaderUtilities.CheckValidToken(item, nameof(item));
         }
 
         object ICloneable.Clone()

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
@@ -20,7 +20,7 @@ namespace System.Net.Http.Headers
             get { return _unit; }
             set
             {
-                HeaderUtilities.CheckValidToken(value, "value");
+                HeaderUtilities.CheckValidToken(value, nameof(value));
                 _unit = value;
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
@@ -69,7 +69,7 @@ namespace System.Net.Http.Headers
             get { return _mediaType; }
             set
             {
-                CheckMediaTypeFormat(value, "value");
+                CheckMediaTypeFormat(value, nameof(value));
                 _mediaType = value;
             }
         }
@@ -96,7 +96,7 @@ namespace System.Net.Http.Headers
 
         public MediaTypeHeaderValue(string mediaType)
         {
-            CheckMediaTypeFormat(mediaType, "mediaType");
+            CheckMediaTypeFormat(mediaType, nameof(mediaType));
             _mediaType = mediaType;
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
@@ -340,7 +340,7 @@ namespace System.Net.Http.Headers
 
         private static void CheckNameValueFormat(string name, string value)
         {
-            HeaderUtilities.CheckValidToken(name, "name");
+            HeaderUtilities.CheckValidToken(name, nameof(name));
             CheckValueFormat(value);
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ProductHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ProductHeaderValue.cs
@@ -29,11 +29,11 @@ namespace System.Net.Http.Headers
 
         public ProductHeaderValue(string name, string version)
         {
-            HeaderUtilities.CheckValidToken(name, "name");
+            HeaderUtilities.CheckValidToken(name, nameof(name));
 
             if (!string.IsNullOrEmpty(version))
             {
-                HeaderUtilities.CheckValidToken(version, "version");
+                HeaderUtilities.CheckValidToken(version, nameof(version));
                 _version = version;
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ProductInfoHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ProductInfoHeaderValue.cs
@@ -38,7 +38,7 @@ namespace System.Net.Http.Headers
 
         public ProductInfoHeaderValue(string comment)
         {
-            HeaderUtilities.CheckValidComment(comment, "comment");
+            HeaderUtilities.CheckValidComment(comment, nameof(comment));
             _comment = comment;
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/RangeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/RangeHeaderValue.cs
@@ -18,7 +18,7 @@ namespace System.Net.Http.Headers
             get { return _unit; }
             set
             {
-                HeaderUtilities.CheckValidToken(value, "value");
+                HeaderUtilities.CheckValidToken(value, nameof(value));
                 _unit = value;
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/StringWithQualityHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/StringWithQualityHeaderValue.cs
@@ -24,14 +24,14 @@ namespace System.Net.Http.Headers
 
         public StringWithQualityHeaderValue(string value)
         {
-            HeaderUtilities.CheckValidToken(value, "value");
+            HeaderUtilities.CheckValidToken(value, nameof(value));
 
             _value = value;
         }
 
         public StringWithQualityHeaderValue(string value, double quality)
         {
-            HeaderUtilities.CheckValidToken(value, "value");
+            HeaderUtilities.CheckValidToken(value, nameof(value));
 
             if ((quality < 0) || (quality > 1))
             {

--- a/src/System.Net.Http/src/System/Net/Http/Headers/TransferCodingHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/TransferCodingHeaderValue.cs
@@ -51,7 +51,7 @@ namespace System.Net.Http.Headers
 
         public TransferCodingHeaderValue(string value)
         {
-            HeaderUtilities.CheckValidToken(value, "value");
+            HeaderUtilities.CheckValidToken(value, nameof(value));
             _value = value;
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ViaHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ViaHeaderValue.cs
@@ -46,18 +46,18 @@ namespace System.Net.Http.Headers
 
         public ViaHeaderValue(string protocolVersion, string receivedBy, string protocolName, string comment)
         {
-            HeaderUtilities.CheckValidToken(protocolVersion, "protocolVersion");
+            HeaderUtilities.CheckValidToken(protocolVersion, nameof(protocolVersion));
             CheckReceivedBy(receivedBy);
 
             if (!string.IsNullOrEmpty(protocolName))
             {
-                HeaderUtilities.CheckValidToken(protocolName, "protocolName");
+                HeaderUtilities.CheckValidToken(protocolName, nameof(protocolName));
                 _protocolName = protocolName;
             }
 
             if (!string.IsNullOrEmpty(comment))
             {
-                HeaderUtilities.CheckValidComment(comment, "comment");
+                HeaderUtilities.CheckValidComment(comment, nameof(comment));
                 _comment = comment;
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
@@ -39,7 +39,7 @@ namespace System.Net.Http.Headers
         {
             CheckCode(code);
             CheckAgent(agent);
-            HeaderUtilities.CheckValidQuotedString(text, "text");
+            HeaderUtilities.CheckValidQuotedString(text, nameof(text));
 
             _code = code;
             _agent = agent;
@@ -50,7 +50,7 @@ namespace System.Net.Http.Headers
         {
             CheckCode(code);
             CheckAgent(agent);
-            HeaderUtilities.CheckValidQuotedString(text, "text");
+            HeaderUtilities.CheckValidQuotedString(text, nameof(text));
 
             _code = code;
             _agent = agent;

--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -52,7 +52,7 @@ namespace System.Net.Http
             get { return _baseAddress; }
             set
             {
-                CheckBaseAddress(value, "value");
+                CheckBaseAddress(value, nameof(value));
                 CheckDisposedOrStarted();
 
                 if (NetEventSource.IsEnabled) NetEventSource.UriBaseAddress(this, value);

--- a/src/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
@@ -168,7 +168,7 @@ namespace System.Net.Mail
             {
                 if (7 < (uint)value && value != DeliveryNotificationOptions.Never)
                 {
-                    throw new ArgumentOutOfRangeException("value");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
                 _deliveryStatusNotification = value;
             }

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -222,7 +222,7 @@ namespace System.Net.Mail
 
                 if (value <= 0)
                 {
-                    throw new ArgumentOutOfRangeException("value");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
                 if (value != DefaultPort)
@@ -287,7 +287,7 @@ namespace System.Net.Mail
 
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException("value");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
                 _transport.Timeout = value;

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -83,7 +83,7 @@ namespace System.Net.Mail
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException("value");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
                 _timeout = value;

--- a/src/System.Net.Primitives/src/System/Net/DnsEndPoint.cs
+++ b/src/System.Net.Primitives/src/System/Net/DnsEndPoint.cs
@@ -23,7 +23,7 @@ namespace System.Net
 
             if (String.IsNullOrEmpty(host))
             {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, "host"));
+                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(host)));
             }
 
             if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)

--- a/src/System.Net.Requests/src/System/Net/FileWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/FileWebRequest.cs
@@ -118,7 +118,7 @@ namespace System.Net
             {
                 if (value < 0 && value != System.Threading.Timeout.Infinite)
                 {
-                    throw new ArgumentOutOfRangeException("value", SR.net_io_timeout_use_ge_zero);
+                    throw new ArgumentOutOfRangeException(nameof(value), SR.net_io_timeout_use_ge_zero);
                 }
                 _timeout = value;
             }

--- a/src/System.Net.Requests/src/System/Net/FtpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/FtpWebRequest.cs
@@ -106,7 +106,7 @@ namespace System.Net
                 if (method == methodInfo.Method)
                     return methodInfo;
             // We don't support generic methods
-            throw new ArgumentException(SR.net_ftp_unsupported_method, "method");
+            throw new ArgumentException(SR.net_ftp_unsupported_method, nameof(method));
         }
 
         private static readonly FtpMethodInfo[] s_knownMethodInfo =
@@ -276,7 +276,7 @@ namespace System.Net
             {
                 if (String.IsNullOrEmpty(value))
                 {
-                    throw new ArgumentException(SR.net_ftp_invalid_method_name, "value");
+                    throw new ArgumentException(SR.net_ftp_invalid_method_name, nameof(value));
                 }
                 if (InUse)
                 {
@@ -288,7 +288,7 @@ namespace System.Net
                 }
                 catch (ArgumentException)
                 {
-                    throw new ArgumentException(SR.net_ftp_unsupported_method, "value");
+                    throw new ArgumentException(SR.net_ftp_unsupported_method, nameof(value));
                 }
             }
         }
@@ -314,7 +314,7 @@ namespace System.Net
 
                 if (String.IsNullOrEmpty(value))
                 {
-                    throw new ArgumentException(SR.net_ftp_invalid_renameto, "value");
+                    throw new ArgumentException(SR.net_ftp_invalid_renameto, nameof(value));
                 }
 
                 _renameTo = value;
@@ -338,11 +338,11 @@ namespace System.Net
                 }
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
                 if (value == CredentialCache.DefaultNetworkCredentials)
                 {
-                    throw new ArgumentException(SR.net_ftp_no_defaultcreds, "value");
+                    throw new ArgumentException(SR.net_ftp_no_defaultcreds, nameof(value));
                 }
                 _authInfo = value;
             }
@@ -376,7 +376,7 @@ namespace System.Net
                 }
                 if (value < 0 && value != System.Threading.Timeout.Infinite)
                 {
-                    throw new ArgumentOutOfRangeException("value", SR.net_io_timeout_use_ge_zero);
+                    throw new ArgumentOutOfRangeException(nameof(value), SR.net_io_timeout_use_ge_zero);
                 }
                 if (_timeout != value)
                 {
@@ -414,7 +414,7 @@ namespace System.Net
                 }
                 if (value <= 0 && value != System.Threading.Timeout.Infinite)
                 {
-                    throw new ArgumentOutOfRangeException("value", SR.net_io_timeout_use_gt_zero);
+                    throw new ArgumentOutOfRangeException(nameof(value), SR.net_io_timeout_use_gt_zero);
                 }
                 _readWriteTimeout = value;
             }
@@ -437,7 +437,7 @@ namespace System.Net
                 }
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException("value");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
                 _contentOffset = value;
             }
@@ -516,7 +516,7 @@ namespace System.Net
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, uri);
 
             if ((object)uri.Scheme != (object)Uri.UriSchemeFtp)
-                throw new ArgumentOutOfRangeException("uri");
+                throw new ArgumentOutOfRangeException(nameof(uri));
 
             _timerCallback = new TimerThread.Callback(TimerCallback);
             _syncObject = new object();
@@ -731,12 +731,12 @@ namespace System.Net
                 // parameter validation
                 if (asyncResult == null)
                 {
-                    throw new ArgumentNullException("asyncResult");
+                    throw new ArgumentNullException(nameof(asyncResult));
                 }
                 LazyAsyncResult castedAsyncResult = asyncResult as LazyAsyncResult;
                 if (castedAsyncResult == null)
                 {
-                    throw new ArgumentException(SR.net_io_invalidasyncresult, "asyncResult");
+                    throw new ArgumentException(SR.net_io_invalidasyncresult, nameof(asyncResult));
                 }
                 if (castedAsyncResult.EndCalled)
                 {
@@ -876,14 +876,14 @@ namespace System.Net
             {
                 if (asyncResult == null)
                 {
-                    throw new ArgumentNullException("asyncResult");
+                    throw new ArgumentNullException(nameof(asyncResult));
                 }
 
                 LazyAsyncResult castedAsyncResult = asyncResult as LazyAsyncResult;
 
                 if (castedAsyncResult == null)
                 {
-                    throw new ArgumentException(SR.net_io_invalidasyncresult, "asyncResult");
+                    throw new ArgumentException(SR.net_io_invalidasyncresult, nameof(asyncResult));
                 }
 
                 if (castedAsyncResult.EndCalled)
@@ -1659,7 +1659,7 @@ namespace System.Net
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
                 _clientCertificates = value;
             }

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1318,7 +1318,7 @@ namespace System.Net
 
             if (rangeSpecifier == null)
             {
-                throw new ArgumentNullException("rangeSpecifier");
+                throw new ArgumentNullException(nameof(rangeSpecifier));
             }
             if ((from < 0) || (to < 0))
             {
@@ -1326,11 +1326,11 @@ namespace System.Net
             }
             if (from > to)
             {
-                throw new ArgumentOutOfRangeException("from", SR.net_fromto);
+                throw new ArgumentOutOfRangeException(nameof(from), SR.net_fromto);
             }
             if (!HttpValidationHelpers.IsValidToken(rangeSpecifier))
             {
-                throw new ArgumentException(SR.net_nottoken, "rangeSpecifier");
+                throw new ArgumentException(SR.net_nottoken, nameof(rangeSpecifier));
             }
             if (!AddRange(rangeSpecifier, from.ToString(NumberFormatInfo.InvariantInfo), to.ToString(NumberFormatInfo.InvariantInfo)))
             {
@@ -1347,11 +1347,11 @@ namespace System.Net
         {
             if (rangeSpecifier == null)
             {
-                throw new ArgumentNullException("rangeSpecifier");
+                throw new ArgumentNullException(nameof(rangeSpecifier));
             }
             if (!HttpValidationHelpers.IsValidToken(rangeSpecifier))
             {
-                throw new ArgumentException(SR.net_nottoken, "rangeSpecifier");
+                throw new ArgumentException(SR.net_nottoken, nameof(rangeSpecifier));
             }
             if (!AddRange(rangeSpecifier, range.ToString(NumberFormatInfo.InvariantInfo), (range >= 0) ? "" : null))
             {

--- a/src/System.Net.Requests/src/System/Net/TimerThread.cs
+++ b/src/System.Net.Requests/src/System/Net/TimerThread.cs
@@ -186,7 +186,7 @@ namespace System.Net
 
             if (durationMilliseconds < 0)
             {
-                throw new ArgumentOutOfRangeException("durationMilliseconds");
+                throw new ArgumentOutOfRangeException(nameof(durationMilliseconds));
             }
 
             TimerQueue queue;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1168,7 +1168,7 @@ namespace System.Net.Sockets
 
             if (buffers.Count == 0)
             {
-                throw new ArgumentException(SR.Format(SR.net_sockets_zerolist, "buffers"), nameof(buffers));
+                throw new ArgumentException(SR.Format(SR.net_sockets_zerolist, nameof(buffers)), nameof(buffers));
             }
 
             ValidateBlockingMode();
@@ -1514,7 +1514,7 @@ namespace System.Net.Sockets
 
             if (buffers.Count == 0)
             {
-                throw new ArgumentException(SR.Format(SR.net_sockets_zerolist, "buffers"), nameof(buffers));
+                throw new ArgumentException(SR.Format(SR.net_sockets_zerolist, nameof(buffers)), nameof(buffers));
             }
 
 
@@ -2095,15 +2095,15 @@ namespace System.Net.Sockets
             const int MaxSelect = 65536;
             if (checkRead != null && checkRead.Count > MaxSelect)
             {
-                throw new ArgumentOutOfRangeException(nameof(checkRead), SR.Format(SR.net_sockets_toolarge_select, "checkRead", MaxSelect.ToString(NumberFormatInfo.CurrentInfo)));
+                throw new ArgumentOutOfRangeException(nameof(checkRead), SR.Format(SR.net_sockets_toolarge_select, nameof(checkRead), MaxSelect.ToString(NumberFormatInfo.CurrentInfo)));
             }
             if (checkWrite != null && checkWrite.Count > MaxSelect)
             {
-                throw new ArgumentOutOfRangeException(nameof(checkWrite), SR.Format(SR.net_sockets_toolarge_select, "checkWrite", MaxSelect.ToString(NumberFormatInfo.CurrentInfo)));
+                throw new ArgumentOutOfRangeException(nameof(checkWrite), SR.Format(SR.net_sockets_toolarge_select, nameof(checkWrite), MaxSelect.ToString(NumberFormatInfo.CurrentInfo)));
             }
             if (checkError != null && checkError.Count > MaxSelect)
             {
-                throw new ArgumentOutOfRangeException(nameof(checkError), SR.Format(SR.net_sockets_toolarge_select, "checkError", MaxSelect.ToString(NumberFormatInfo.CurrentInfo)));
+                throw new ArgumentOutOfRangeException(nameof(checkError), SR.Format(SR.net_sockets_toolarge_select, nameof(checkError), MaxSelect.ToString(NumberFormatInfo.CurrentInfo)));
             }
 
             SocketError errorCode = SocketPal.Select(checkRead, checkWrite, checkError, microSeconds);
@@ -2718,7 +2718,7 @@ namespace System.Net.Sockets
 
             if (buffers.Count == 0)
             {
-                throw new ArgumentException(SR.Format(SR.net_sockets_zerolist, "buffers"), nameof(buffers));
+                throw new ArgumentException(SR.Format(SR.net_sockets_zerolist, nameof(buffers)), nameof(buffers));
             }
 
             // We need to flow the context here.  But we don't need to lock the context - we don't use it until the callback.
@@ -3196,7 +3196,7 @@ namespace System.Net.Sockets
 
             if (buffers.Count == 0)
             {
-                throw new ArgumentException(SR.Format(SR.net_sockets_zerolist, "buffers"), nameof(buffers));
+                throw new ArgumentException(SR.Format(SR.net_sockets_zerolist, nameof(buffers)), nameof(buffers));
             }
 
             // We need to flow the context here.  But we don't need to lock the context - we don't use it until the callback.
@@ -3874,7 +3874,7 @@ namespace System.Net.Sockets
             }
 
             SafeCloseSocket acceptHandle;
-            asyncResult.AcceptSocket = GetOrCreateAcceptSocket(acceptSocket, false, "acceptSocket", out acceptHandle);
+            asyncResult.AcceptSocket = GetOrCreateAcceptSocket(acceptSocket, false, nameof(acceptSocket), out acceptHandle);
 
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"AcceptSocket:{acceptSocket}");
 
@@ -4789,7 +4789,7 @@ namespace System.Net.Sockets
         {
             if (remoteEP is DnsEndPoint)
             {
-                throw new ArgumentException(SR.Format(SR.net_sockets_invalid_dnsendpoint, "remoteEP"), nameof(remoteEP));
+                throw new ArgumentException(SR.Format(SR.net_sockets_invalid_dnsendpoint, nameof(remoteEP)), nameof(remoteEP));
             }
 
             return IPEndPointExtensions.Serialize(remoteEP);

--- a/src/System.Net.WebHeaderCollection/src/System/Net/WebHeaderCollection.cs
+++ b/src/System.Net.WebHeaderCollection/src/System/Net/WebHeaderCollection.cs
@@ -180,7 +180,7 @@ namespace System.Net
             {
                 if (value != null && value.Length > ushort.MaxValue)
                 {
-                    throw new ArgumentOutOfRangeException("value", value, string.Format(CultureInfo.InvariantCulture, SR.net_headers_toolong, ushort.MaxValue));
+                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(CultureInfo.InvariantCulture, SR.net_headers_toolong, ushort.MaxValue));
                 }
             }
             this.Set(header.GetName(), value);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -120,7 +120,7 @@ namespace System.Runtime.Serialization
             DataContractResolver dataContractResolver,
             bool serializeReadOnlyTypes)
         {
-            CheckNull(type, "type");
+            CheckNull(type, nameof(type));
             _rootType = type;
 
             if (knownTypes != null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
@@ -613,7 +613,7 @@ namespace System.Runtime.Serialization.Json
 
         public override object ReadObject(Stream stream)
         {
-            CheckNull(stream, "stream");
+            CheckNull(stream, nameof(stream));
             return ReadObject(JsonReaderWriterFactory.CreateJsonReader(stream, XmlDictionaryReaderQuotas.Max));
         }
 
@@ -652,7 +652,7 @@ namespace System.Runtime.Serialization.Json
 
         public override void WriteObject(Stream stream, object graph)
         {
-            CheckNull(stream, "stream");
+            CheckNull(stream, nameof(stream));
             XmlDictionaryWriter jsonWriter = JsonReaderWriterFactory.CreateJsonWriter(stream, Encoding.UTF8, false); //  ownsStream 
             WriteObject(jsonWriter, graph);
             jsonWriter.Flush();
@@ -910,7 +910,7 @@ namespace System.Runtime.Serialization.Json
             DateTimeFormat dateTimeFormat,
             bool useSimpleDictionaryFormat)
         {
-            CheckNull(type, "type");
+            CheckNull(type, nameof(type));
             _rootType = type;
 
             if (knownTypes != null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializer.cs
@@ -22,7 +22,7 @@ namespace System.Runtime.Serialization
 
         public virtual void WriteObject(Stream stream, object graph)
         {
-            CheckNull(stream, "stream");
+            CheckNull(stream, nameof(stream));
             XmlDictionaryWriter writer = XmlDictionaryWriter.CreateTextWriter(stream, Encoding.UTF8, false /*ownsStream*/);
             WriteObject(writer, graph);
             writer.Flush();
@@ -30,25 +30,25 @@ namespace System.Runtime.Serialization
 
         public virtual void WriteObject(XmlWriter writer, object graph)
         {
-            CheckNull(writer, "writer");
+            CheckNull(writer, nameof(writer));
             WriteObject(XmlDictionaryWriter.CreateDictionaryWriter(writer), graph);
         }
 
         public virtual void WriteStartObject(XmlWriter writer, object graph)
         {
-            CheckNull(writer, "writer");
+            CheckNull(writer, nameof(writer));
             WriteStartObject(XmlDictionaryWriter.CreateDictionaryWriter(writer), graph);
         }
 
         public virtual void WriteObjectContent(XmlWriter writer, object graph)
         {
-            CheckNull(writer, "writer");
+            CheckNull(writer, nameof(writer));
             WriteObjectContent(XmlDictionaryWriter.CreateDictionaryWriter(writer), graph);
         }
 
         public virtual void WriteEndObject(XmlWriter writer)
         {
-            CheckNull(writer, "writer");
+            CheckNull(writer, nameof(writer));
             WriteEndObject(XmlDictionaryWriter.CreateDictionaryWriter(writer));
         }
 
@@ -66,7 +66,7 @@ namespace System.Runtime.Serialization
         {
             try
             {
-                CheckNull(writer, "writer");
+                CheckNull(writer, nameof(writer));
                 {
                     InternalWriteObject(writer, graph, dataContractResolver);
                 }
@@ -121,7 +121,7 @@ namespace System.Runtime.Serialization
         {
             try
             {
-                CheckNull(writer, "writer");
+                CheckNull(writer, nameof(writer));
                 InternalWriteStartObject(writer, graph);
             }
             catch (XmlException ex)
@@ -138,7 +138,7 @@ namespace System.Runtime.Serialization
         {
             try
             {
-                CheckNull(writer, "writer");
+                CheckNull(writer, nameof(writer));
                 {
                     if (writer.WriteState != WriteState.Element)
                         throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.XmlWriterMustBeInElement, writer.WriteState)));
@@ -159,7 +159,7 @@ namespace System.Runtime.Serialization
         {
             try
             {
-                CheckNull(writer, "writer");
+                CheckNull(writer, nameof(writer));
                 InternalWriteEndObject(writer);
             }
             catch (XmlException ex)
@@ -220,13 +220,13 @@ namespace System.Runtime.Serialization
 
         public virtual object ReadObject(Stream stream)
         {
-            CheckNull(stream, "stream");
+            CheckNull(stream, nameof(stream));
             return ReadObject(XmlDictionaryReader.CreateTextReader(stream, XmlDictionaryReaderQuotas.Max));
         }
 
         public virtual object ReadObject(XmlReader reader)
         {
-            CheckNull(reader, "reader");
+            CheckNull(reader, nameof(reader));
             return ReadObject(XmlDictionaryReader.CreateDictionaryReader(reader));
         }
 
@@ -237,7 +237,7 @@ namespace System.Runtime.Serialization
 
         public virtual object ReadObject(XmlReader reader, bool verifyObjectName)
         {
-            CheckNull(reader, "reader");
+            CheckNull(reader, nameof(reader));
             return ReadObject(XmlDictionaryReader.CreateDictionaryReader(reader), verifyObjectName);
         }
 
@@ -245,7 +245,7 @@ namespace System.Runtime.Serialization
 
         public virtual bool IsStartObject(XmlReader reader)
         {
-            CheckNull(reader, "reader");
+            CheckNull(reader, nameof(reader));
             return IsStartObject(XmlDictionaryReader.CreateDictionaryReader(reader));
         }
 
@@ -276,7 +276,7 @@ namespace System.Runtime.Serialization
         {
             try
             {
-                CheckNull(reader, "reader");
+                CheckNull(reader, nameof(reader));
                 return InternalReadObject(reader, verifyObjectName, dataContractResolver);
             }
             catch (XmlException ex)
@@ -293,7 +293,7 @@ namespace System.Runtime.Serialization
         {
             try
             {
-                CheckNull(reader, "reader");
+                CheckNull(reader, nameof(reader));
                 return InternalIsStartObject(reader);
             }
             catch (XmlException ex)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlReaderDelegator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlReaderDelegator.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.Serialization
 
         public XmlReaderDelegator(XmlReader reader)
         {
-            XmlObjectSerializer.CheckNull(reader, "reader");
+            XmlObjectSerializer.CheckNull(reader, nameof(reader));
             this.reader = reader;
             this.dictionaryReader = reader as XmlDictionaryReader;
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlWriterDelegator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlWriterDelegator.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.Serialization
 
         public XmlWriterDelegator(XmlWriter writer)
         {
-            XmlObjectSerializer.CheckNull(writer, "writer");
+            XmlObjectSerializer.CheckNull(writer, nameof(writer));
             this.writer = writer;
             this.dictionaryWriter = writer as XmlDictionaryWriter;
         }

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReaderSession.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReaderSession.cs
@@ -25,7 +25,7 @@ namespace System.Xml
             if (id < 0)
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException(nameof(id), SR.Format(SR.XmlInvalidID)));
             if (value == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(value));
             XmlDictionaryString xmlString;
             if (TryLookup(id, out xmlString))
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.XmlIDDefined)));
@@ -74,7 +74,7 @@ namespace System.Xml
         public bool TryLookup(string value, out XmlDictionaryString result)
         {
             if (value == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(value));
 
             if (_strings != null)
             {

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriterSession.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriterSession.cs
@@ -30,7 +30,7 @@ namespace System.Xml
         {
             IntArray keys;
             if (value == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(value));
 
             if (_maps.TryGetValue(value.Dictionary, out keys))
             {

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
@@ -23,7 +23,7 @@ namespace System.Xml
         public static XmlDictionaryReader CreateDictionaryReader(XmlReader reader)
         {
             if (reader == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(reader));
 
             XmlDictionaryReader dictionaryReader = reader as XmlDictionaryReader;
 
@@ -38,7 +38,7 @@ namespace System.Xml
         public static XmlDictionaryReader CreateBinaryReader(byte[] buffer, XmlDictionaryReaderQuotas quotas)
         {
             if (buffer == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("buffer");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(buffer));
             return CreateBinaryReader(buffer, 0, buffer.Length, quotas);
         }
 
@@ -97,7 +97,7 @@ namespace System.Xml
         public static XmlDictionaryReader CreateTextReader(byte[] buffer, XmlDictionaryReaderQuotas quotas)
         {
             if (buffer == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("buffer");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(buffer));
             return CreateTextReader(buffer, 0, buffer.Length, quotas);
         }
 
@@ -133,7 +133,7 @@ namespace System.Xml
         public static XmlDictionaryReader CreateMtomReader(Stream stream, Encoding encoding, XmlDictionaryReaderQuotas quotas)
         {
             if (encoding == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("encoding");
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(encoding));
 
             return CreateMtomReader(stream, new Encoding[1] { encoding }, quotas);
         }
@@ -157,7 +157,7 @@ namespace System.Xml
         public static XmlDictionaryReader CreateMtomReader(byte[] buffer, int offset, int count, Encoding encoding, XmlDictionaryReaderQuotas quotas)
         {
             if (encoding == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("encoding");
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(encoding));
 
             return CreateMtomReader(buffer, offset, count, new Encoding[1] { encoding }, quotas);
         }
@@ -236,7 +236,7 @@ namespace System.Xml
         public virtual bool IsLocalName(XmlDictionaryString localName)
         {
             if (localName == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("localName");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(localName));
 
             return IsLocalName(localName.Value);
         }
@@ -244,14 +244,14 @@ namespace System.Xml
         public virtual bool IsNamespaceUri(string namespaceUri)
         {
             if (namespaceUri == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("namespaceUri");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(namespaceUri));
             return this.NamespaceURI == namespaceUri;
         }
 
         public virtual bool IsNamespaceUri(XmlDictionaryString namespaceUri)
         {
             if (namespaceUri == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("namespaceUri");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(namespaceUri));
             return IsNamespaceUri(namespaceUri.Value);
         }
 
@@ -301,10 +301,10 @@ namespace System.Xml
         public virtual int IndexOfLocalName(string[] localNames, string namespaceUri)
         {
             if (localNames == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("localNames");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(localNames));
 
             if (namespaceUri == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("namespaceUri");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(namespaceUri));
 
             if (this.NamespaceURI == namespaceUri)
             {
@@ -327,10 +327,10 @@ namespace System.Xml
         public virtual int IndexOfLocalName(XmlDictionaryString[] localNames, XmlDictionaryString namespaceUri)
         {
             if (localNames == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("localNames");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(localNames));
 
             if (namespaceUri == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("namespaceUri");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(namespaceUri));
 
             if (this.NamespaceURI == namespaceUri.Value)
             {
@@ -620,7 +620,7 @@ namespace System.Xml
         public virtual string ReadContentAsString(string[] strings, out int index)
         {
             if (strings == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("strings");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(strings));
             string s = ReadContentAsString();
             index = -1;
             for (int i = 0; i < strings.Length; i++)
@@ -640,7 +640,7 @@ namespace System.Xml
         public virtual string ReadContentAsString(XmlDictionaryString[] strings, out int index)
         {
             if (strings == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("strings");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(strings));
             string s = ReadContentAsString();
             index = -1;
             for (int i = 0; i < strings.Length; i++)

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryString.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryString.cs
@@ -106,7 +106,7 @@ namespace System.Xml
             public bool TryLookup(string value, out XmlDictionaryString result)
             {
                 if (value == null)
-                    throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+                    throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(value));
                 if (value.Length == 0)
                 {
                     result = _empty;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
@@ -72,7 +72,7 @@ namespace System.Xml
         public static XmlDictionaryWriter CreateDictionaryWriter(XmlWriter writer)
         {
             if (writer == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(writer));
 
             XmlDictionaryWriter dictionaryWriter = writer as XmlDictionaryWriter;
 
@@ -112,7 +112,7 @@ namespace System.Xml
         public virtual void WriteXmlnsAttribute(string prefix, string namespaceUri)
         {
             if (namespaceUri == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("namespaceUri");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(namespaceUri));
             if (prefix == null)
             {
                 if (LookupPrefix(namespaceUri) != null)
@@ -181,7 +181,7 @@ namespace System.Xml
         public virtual void WriteValue(UniqueId value)
         {
             if (value == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(value));
 
             WriteString(value.ToString());
         }
@@ -849,7 +849,7 @@ namespace System.Xml
             public override void WriteXmlnsAttribute(string prefix, string namespaceUri)
             {
                 if (namespaceUri == null)
-                    throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("namespaceUri");
+                    throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(namespaceUri));
                 if (prefix == null)
                 {
                     if (LookupPrefix(namespaceUri) != null)

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextReader.cs
@@ -575,7 +575,7 @@ namespace System.Xml
         public void SetInput(Stream stream, Encoding encoding, XmlDictionaryReaderQuotas quotas, OnXmlDictionaryReaderClose onClose)
         {
             if (stream == null)
-                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("stream");
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(stream));
             MoveToInitial(quotas, onClose);
             stream = new EncodingStreamWrapper(stream, encoding);
             BufferReader.SetBuffer(stream, null, null);

--- a/src/System.Private.Uri/src/System/UriScheme.cs
+++ b/src/System.Private.Uri/src/System/UriScheme.cs
@@ -145,19 +145,19 @@ namespace System
         public static void Register(UriParser uriParser, string schemeName, int defaultPort)
         {
             if (uriParser == null)
-                throw new ArgumentNullException("uriParser");
+                throw new ArgumentNullException(nameof(uriParser));
  
             if (schemeName == null)
-                throw new ArgumentNullException("schemeName");
+                throw new ArgumentNullException(nameof(schemeName));
  
             if (schemeName.Length == 1)
-                throw new ArgumentOutOfRangeException("schemeName");
+                throw new ArgumentOutOfRangeException(nameof(schemeName));
  
             if (!Uri.CheckSchemeName(schemeName))
-                throw new ArgumentOutOfRangeException("schemeName");
+                throw new ArgumentOutOfRangeException(nameof(schemeName));
  
             if ((defaultPort >= 0xFFFF || defaultPort < 0) && defaultPort != -1)
-                throw new ArgumentOutOfRangeException("defaultPort");
+                throw new ArgumentOutOfRangeException(nameof(defaultPort));
  
             schemeName = schemeName.ToLower();
             FetchSyntax(uriParser, schemeName, defaultPort);

--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
@@ -190,7 +190,7 @@ namespace System.Xml.Linq
         /// <param name="info">The <see cref="SerializationInfo"/> to populate with data</param>
         /// <param name="context">The destination for this serialization</param>
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) {
-            if (info == null) throw new ArgumentNullException("info");
+            if (info == null) throw new ArgumentNullException(nameof(info));
             info.AddValue("name", ToString());
             info.SetType(typeof(NameSerializer));
         }
@@ -202,7 +202,7 @@ namespace System.Xml.Linq
         string _expandedName;
 
         private NameSerializer(SerializationInfo info, StreamingContext context) {
-            if (info == null) throw new ArgumentNullException("info");
+            if (info == null) throw new ArgumentNullException(nameof(info));
             _expandedName = info.GetString("name");
         }
 

--- a/src/System.Private.Xml.Linq/src/System/Xml/Schema/XNodeValidator.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Schema/XNodeValidator.cs
@@ -436,7 +436,7 @@ namespace System.Xml.Schema
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "Reviewed by the design group.")]
         public static IXmlSchemaInfo GetSchemaInfo(this XElement source)
         {
-            if (source == null) throw new ArgumentNullException("source");
+            if (source == null) throw new ArgumentNullException(nameof(source));
             return source.Annotation<IXmlSchemaInfo>();
         }
 
@@ -447,7 +447,7 @@ namespace System.Xml.Schema
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "Reviewed by the design group.")]
         public static IXmlSchemaInfo GetSchemaInfo(this XAttribute source)
         {
-            if (source == null) throw new ArgumentNullException("source");
+            if (source == null) throw new ArgumentNullException(nameof(source));
             return source.Annotation<IXmlSchemaInfo>();
         }
 
@@ -478,8 +478,8 @@ namespace System.Xml.Schema
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "Reviewed by the design group.")]
         public static void Validate(this XDocument source, XmlSchemaSet schemas, ValidationEventHandler validationEventHandler, bool addSchemaInfo)
         {
-            if (source == null) throw new ArgumentNullException("source");
-            if (schemas == null) throw new ArgumentNullException("schemas");
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (schemas == null) throw new ArgumentNullException(nameof(schemas));
             new XNodeValidator(schemas, validationEventHandler).Validate(source, null, addSchemaInfo);
         }
 
@@ -516,9 +516,9 @@ namespace System.Xml.Schema
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "Reviewed by the design group.")]
         public static void Validate(this XElement source, XmlSchemaObject partialValidationType, XmlSchemaSet schemas, ValidationEventHandler validationEventHandler, bool addSchemaInfo)
         {
-            if (source == null) throw new ArgumentNullException("source");
-            if (partialValidationType == null) throw new ArgumentNullException("partialValidationType");
-            if (schemas == null) throw new ArgumentNullException("schemas");
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (partialValidationType == null) throw new ArgumentNullException(nameof(partialValidationType));
+            if (schemas == null) throw new ArgumentNullException(nameof(schemas));
             new XNodeValidator(schemas, validationEventHandler).Validate(source, partialValidationType, addSchemaInfo);
         }
 
@@ -555,9 +555,9 @@ namespace System.Xml.Schema
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "Reviewed by the design group.")]
         public static void Validate(this XAttribute source, XmlSchemaObject partialValidationType, XmlSchemaSet schemas, ValidationEventHandler validationEventHandler, bool addSchemaInfo)
         {
-            if (source == null) throw new ArgumentNullException("source");
-            if (partialValidationType == null) throw new ArgumentNullException("partialValidationType");
-            if (schemas == null) throw new ArgumentNullException("schemas");
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (partialValidationType == null) throw new ArgumentNullException(nameof(partialValidationType));
+            if (schemas == null) throw new ArgumentNullException(nameof(schemas));
             new XNodeValidator(schemas, validationEventHandler).Validate(source, partialValidationType, addSchemaInfo);
         }
     }

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlReader.cs
@@ -1000,7 +1000,7 @@ namespace System.Xml
         {
             if (name == null || name.Length == 0)
             {
-                throw XmlConvert.CreateInvalidNameArgumentException(name, "name");
+                throw XmlConvert.CreateInvalidNameArgumentException(name, nameof(name));
             }
             // atomize name
             name = NameTable.Add(name);
@@ -1021,7 +1021,7 @@ namespace System.Xml
         {
             if (localName == null || localName.Length == 0)
             {
-                throw XmlConvert.CreateInvalidNameArgumentException(localName, "localName");
+                throw XmlConvert.CreateInvalidNameArgumentException(localName, nameof(localName));
             }
             if (namespaceURI == null)
             {
@@ -1048,7 +1048,7 @@ namespace System.Xml
         {
             if (name == null || name.Length == 0)
             {
-                throw XmlConvert.CreateInvalidNameArgumentException(name, "name");
+                throw XmlConvert.CreateInvalidNameArgumentException(name, nameof(name));
             }
             // save the element or root depth
             int parentDepth = Depth;
@@ -1090,7 +1090,7 @@ namespace System.Xml
         {
             if (localName == null || localName.Length == 0)
             {
-                throw XmlConvert.CreateInvalidNameArgumentException(localName, "localName");
+                throw XmlConvert.CreateInvalidNameArgumentException(localName, nameof(localName));
             }
             if (namespaceURI == null)
             {
@@ -1137,7 +1137,7 @@ namespace System.Xml
         {
             if (name == null || name.Length == 0)
             {
-                throw XmlConvert.CreateInvalidNameArgumentException(name, "name");
+                throw XmlConvert.CreateInvalidNameArgumentException(name, nameof(name));
             }
 
             // atomize name
@@ -1165,7 +1165,7 @@ namespace System.Xml
         {
             if (localName == null || localName.Length == 0)
             {
-                throw XmlConvert.CreateInvalidNameArgumentException(localName, "localName");
+                throw XmlConvert.CreateInvalidNameArgumentException(localName, nameof(localName));
             }
             if (namespaceURI == null)
             {
@@ -1541,7 +1541,7 @@ namespace System.Xml
         {
             if (localName == null || localName.Length == 0)
             {
-                throw XmlConvert.CreateInvalidNameArgumentException(localName, "localName");
+                throw XmlConvert.CreateInvalidNameArgumentException(localName, nameof(localName));
             }
             if (namespaceURI == null)
             {
@@ -1884,7 +1884,7 @@ namespace System.Xml
             if (byteCount >= 2 && (bytes[0] == 0xdf && bytes[1] == 0xff))
             {
                 if (inputContext != null)
-                    throw new ArgumentException(SR.XmlBinary_NoParserContext, "inputContext");
+                    throw new ArgumentException(SR.XmlBinary_NoParserContext, nameof(inputContext));
                 reader = new XmlSqlBinaryReader(input, bytes, byteCount, string.Empty, settings.CloseInput, settings);
             }
             else

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -563,7 +563,7 @@ namespace System.Xml
             }
             if (url.Length == 0)
             {
-                throw new ArgumentException(SR.Xml_EmptyUrl, "url");
+                throw new ArgumentException(SR.Xml_EmptyUrl, nameof(url));
             }
             _namespaceManager = new XmlNamespaceManager(nt);
 
@@ -8245,19 +8245,19 @@ namespace System.Xml
         {
             if (array == null)
             {
-                throw new ArgumentNullException((_incReadDecoder is IncrementalReadCharsDecoder) ? "buffer" : "array");
+                throw new ArgumentNullException((_incReadDecoder is IncrementalReadCharsDecoder) ? "buffer" : nameof(array));
             }
             if (count < 0)
             {
-                throw new ArgumentOutOfRangeException((_incReadDecoder is IncrementalReadCharsDecoder) ? "count" : "len");
+                throw new ArgumentOutOfRangeException((_incReadDecoder is IncrementalReadCharsDecoder) ? nameof(count): "len");
             }
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException((_incReadDecoder is IncrementalReadCharsDecoder) ? "index" : "offset");
+                throw new ArgumentOutOfRangeException((_incReadDecoder is IncrementalReadCharsDecoder) ? nameof(index): "offset");
             }
             if (array.Length - index < count)
             {
-                throw new ArgumentException((_incReadDecoder is IncrementalReadCharsDecoder) ? "count" : "len");
+                throw new ArgumentException((_incReadDecoder is IncrementalReadCharsDecoder) ? nameof(count): "len");
             }
 
             if (count == 0)

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlValidatingReaderImpl.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlValidatingReaderImpl.cs
@@ -137,7 +137,7 @@ namespace System.Xml
             }
             if (_coreReaderImpl == null)
             {
-                throw new ArgumentException(SR.Arg_ExpectingXmlTextReader, "reader");
+                throw new ArgumentException(SR.Arg_ExpectingXmlTextReader, nameof(reader));
             }
             _coreReaderImpl.EntityHandling = EntityHandling.ExpandEntities;
             _coreReaderImpl.XmlValidatingReaderCompatibilityMode = true;
@@ -215,7 +215,7 @@ namespace System.Xml
             }
             if (_coreReaderImpl == null)
             {
-                throw new ArgumentException(SR.Arg_ExpectingXmlTextReader, "reader");
+                throw new ArgumentException(SR.Arg_ExpectingXmlTextReader, nameof(reader));
             }
             _coreReaderImpl.XmlValidatingReaderCompatibilityMode = true;
             _coreReaderNSResolver = reader as IXmlNamespaceResolver;

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriter.cs
@@ -403,21 +403,21 @@ namespace System.Xml
                     {
                         if ((i = _xmlCharType.IsPublicId(pubid)) >= 0)
                         {
-                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(pubid, i)), "pubid");
+                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(pubid, i)), nameof(pubid));
                         }
                     }
                     if (sysid != null)
                     {
                         if ((i = _xmlCharType.IsOnlyCharData(sysid)) >= 0)
                         {
-                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(sysid, i)), "sysid");
+                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(sysid, i)), nameof(sysid));
                         }
                     }
                     if (subset != null)
                     {
                         if ((i = _xmlCharType.IsOnlyCharData(subset)) >= 0)
                         {
-                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(subset, i)), "subset");
+                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(subset, i)), nameof(subset));
                         }
                     }
                 }

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
@@ -95,21 +95,21 @@ namespace System.Xml
                     {
                         if ((i = _xmlCharType.IsPublicId(pubid)) >= 0)
                         {
-                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(pubid, i)), "pubid");
+                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(pubid, i)), nameof(pubid));
                         }
                     }
                     if (sysid != null)
                     {
                         if ((i = _xmlCharType.IsOnlyCharData(sysid)) >= 0)
                         {
-                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(sysid, i)), "sysid");
+                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(sysid, i)), nameof(sysid));
                         }
                     }
                     if (subset != null)
                     {
                         if ((i = _xmlCharType.IsOnlyCharData(subset)) >= 0)
                         {
-                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(subset, i)), "subset");
+                            throw new ArgumentException(SR.Format(SR.Xml_InvalidCharacter, XmlException.BuildCharExceptionArgs(subset, i)), nameof(subset));
                         }
                     }
                 }

--- a/src/System.Private.Xml/src/System/Xml/Dom/XmlDocument.cs
+++ b/src/System.Private.Xml/src/System/Xml/Dom/XmlDocument.cs
@@ -1430,7 +1430,7 @@ namespace System.Xml
             XmlDocument parentDocument = nodeToValidate.Document;
             if (parentDocument != this)
             {
-                throw new ArgumentException(SR.Format(SR.XmlDocument_NodeNotFromDocument, "nodeToValidate"));
+                throw new ArgumentException(SR.Format(SR.XmlDocument_NodeNotFromDocument, nameof(nodeToValidate)));
             }
             if (nodeToValidate == this)
             {

--- a/src/System.Private.Xml/src/System/Xml/Dom/XmlLoader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Dom/XmlLoader.cs
@@ -986,13 +986,13 @@ namespace System.Xml
             {
                 tempreader.Read();
                 //get version info.
-                if (tempreader.MoveToAttribute("version"))
+                if (tempreader.MoveToAttribute(nameof(version)))
                     version = tempreader.Value;
                 //get encoding info
-                if (tempreader.MoveToAttribute("encoding"))
+                if (tempreader.MoveToAttribute(nameof(encoding)))
                     encoding = tempreader.Value;
                 //get standalone info
-                if (tempreader.MoveToAttribute("standalone"))
+                if (tempreader.MoveToAttribute(nameof(standalone)))
                     standalone = tempreader.Value;
             }
             finally

--- a/src/System.Private.Xml/src/System/Xml/Schema/DtdParser.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/DtdParser.cs
@@ -288,7 +288,7 @@ namespace System.Xml
 
             if (docTypeName == null || docTypeName.Length == 0)
             {
-                throw XmlConvert.CreateInvalidNameArgumentException(docTypeName, "docTypeName");
+                throw XmlConvert.CreateInvalidNameArgumentException(docTypeName, nameof(docTypeName));
             }
 
             // check doctype name

--- a/src/System.Private.Xml/src/System/Xml/Schema/XmlSchemaSet.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/XmlSchemaSet.cs
@@ -718,7 +718,7 @@ namespace System.Xml.Schema
             }
             if (!_schemas.ContainsKey(schema.SchemaId))
             {
-                throw new ArgumentException(SR.Sch_SchemaDoesNotExist, "schema");
+                throw new ArgumentException(SR.Sch_SchemaDoesNotExist, nameof(schema));
             }
             XmlSchema originalSchema = schema;
             lock (InternalSyncObject)

--- a/src/System.Private.Xml/src/System/Xml/Schema/XsdBuilder.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/XsdBuilder.cs
@@ -2416,7 +2416,7 @@ namespace System.Xml.Schema
                 case SchemaNames.Token.XsdGroup:
                     if (_group.Particle != null)
                     {
-                        SendValidationEvent(SR.Sch_DupGroupParticle, "particle");
+                        SendValidationEvent(SR.Sch_DupGroupParticle, nameof(particle));
                     }
                     _group.Particle = (XmlSchemaGroupBase)particle;
                     break;

--- a/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
@@ -156,7 +156,7 @@ namespace System.Xml.Serialization
         internal static void CheckValidIdentifier(string ident)
         {
             if (!CodeGenerator.IsValidLanguageIndependentIdentifier(ident))
-                throw new ArgumentException(SR.Format(SR.XmlInvalidIdentifier, ident), "ident");
+                throw new ArgumentException(SR.Format(SR.XmlInvalidIdentifier, ident), nameof(ident));
         }
 
         internal static string GetCSharpName(string name)

--- a/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifiers.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifiers.cs
@@ -24,7 +24,7 @@ namespace System.Xml.Serialization
         {
             string s = obj as string;
             if (s == null)
-                throw new ArgumentException(null, "obj");
+                throw new ArgumentException(null, nameof(obj));
 
             return CultureInfo.CurrentCulture.TextInfo.ToUpper(s).GetHashCode();
         }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -27,7 +27,7 @@ namespace System.Xml.Serialization
 
             if (!xmlMapping.IsWriteable || !xmlMapping.GenerateSerializer)
             {
-                throw new ArgumentException(SR.Format(SR.XmlInternalError, "xmlMapping"));
+                throw new ArgumentException(SR.Format(SR.XmlInternalError, nameof(xmlMapping)));
             }
 
             if (xmlMapping is XmlTypeMapping || xmlMapping is XmlMembersMapping)
@@ -36,7 +36,7 @@ namespace System.Xml.Serialization
             }
             else
             {
-                throw new ArgumentException(SR.Format(SR.XmlInternalError, "xmlMapping"));
+                throw new ArgumentException(SR.Format(SR.XmlInternalError, nameof(xmlMapping)));
             }
         }
 

--- a/src/System.Private.Xml/src/System/Xml/Serialization/SoapSchemaExporter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/SoapSchemaExporter.cs
@@ -196,7 +196,7 @@ namespace System.Xml.Serialization
             else if (mapping is MembersMapping)
                 return ExportMembersMapping((MembersMapping)mapping, ns);
             else
-                throw new ArgumentException(SR.XmlInternalError, "mapping");
+                throw new ArgumentException(SR.XmlInternalError, nameof(mapping));
         }
 
         private XmlQualifiedName ExportNonXsdPrimitiveMapping(PrimitiveMapping mapping, string ns)

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSchemaExporter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSchemaExporter.cs
@@ -398,7 +398,7 @@ namespace System.Xml.Serialization
             else if (mapping is NullableMapping)
                 ExportMapping(((NullableMapping)mapping).BaseMapping, ns, isAny);
             else
-                throw new ArgumentException(SR.XmlInternalError, "mapping");
+                throw new ArgumentException(SR.XmlInternalError, nameof(mapping));
         }
 
         private void ExportElementMapping(XmlSchemaElement element, Mapping mapping, string ns, bool isAny)
@@ -430,7 +430,7 @@ namespace System.Xml.Serialization
                 ExportElementMapping(element, ((NullableMapping)mapping).BaseMapping, ns, isAny);
             }
             else
-                throw new ArgumentException(SR.XmlInternalError, "mapping");
+                throw new ArgumentException(SR.XmlInternalError, nameof(mapping));
         }
 
         private XmlQualifiedName ExportNonXsdPrimitiveMapping(PrimitiveMapping mapping, string ns)
@@ -572,7 +572,7 @@ namespace System.Xml.Serialization
                         }
                     }
                 default:
-                    throw new ArgumentException(SR.XmlInternalError, "mapping");
+                    throw new ArgumentException(SR.XmlInternalError, nameof(mapping));
             }
         }
 

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSchemaImporter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSchemaImporter.cs
@@ -578,7 +578,7 @@ namespace System.Xml.Serialization
             else if (desiredMappingType == typeof(MembersMapping))
                 return ImportMembersType(type, typeNs, identifier);
             else
-                throw new ArgumentException(SR.XmlInternalError, "desiredMappingType");
+                throw new ArgumentException(SR.XmlInternalError, nameof(desiredMappingType));
         }
 
         private MembersMapping ImportMembersType(XmlSchemaType type, string typeNs, string identifier)

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationGeneratedCode.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationGeneratedCode.cs
@@ -390,7 +390,7 @@ namespace System.Xml.Serialization
             _writer.Write(writerType);
             _writer.WriteLine("(); } }");
 
-            GeneratePublicMethods("readMethods", "ReadMethods", readMethods, xmlMappings);
+            GeneratePublicMethods(nameof(readMethods), "ReadMethods", readMethods, xmlMappings);
             GeneratePublicMethods("writeMethods", "WriteMethods", writerMethods, xmlMappings);
             GenerateTypedSerializers(serializers);
             GenerateSupportedTypes(types);

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationILGen.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationILGen.cs
@@ -529,7 +529,7 @@ namespace System.Xml.Serialization
             ilg.New(ctor);
             ilg.EndMethod();
 
-            FieldBuilder readMethodsField = GeneratePublicMethods("readMethods", "ReadMethods", readMethods, xmlMappings, serializerContractTypeBuilder);
+            FieldBuilder readMethodsField = GeneratePublicMethods(nameof(readMethods), "ReadMethods", readMethods, xmlMappings, serializerContractTypeBuilder);
             FieldBuilder writeMethodsField = GeneratePublicMethods("writeMethods", "WriteMethods", writerMethods, xmlMappings, serializerContractTypeBuilder);
             FieldBuilder typedSerializersField = GenerateTypedSerializers(serializers, serializerContractTypeBuilder);
             GenerateSupportedTypes(types, serializerContractTypeBuilder);

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -1016,7 +1016,7 @@ namespace System.Xml.Serialization
 
             if (value.Length == 0)
             {
-                throw new ArgumentException(SR.Format(SR.XmlEmptyArrayType, CurrentTag()), "value");
+                throw new ArgumentException(SR.Format(SR.XmlEmptyArrayType, CurrentTag()), nameof(value));
             }
 
             char[] chars = value.ToCharArray();
@@ -1030,7 +1030,7 @@ namespace System.Xml.Serialization
             // Must end with ]
             if (chars[pos] != ']')
             {
-                throw new ArgumentException(SR.XmlInvalidArraySyntax, "value");
+                throw new ArgumentException(SR.XmlInvalidArraySyntax, nameof(value));
             }
             pos--;
 
@@ -1038,12 +1038,12 @@ namespace System.Xml.Serialization
             while (pos != -1 && chars[pos] != '[')
             {
                 if (chars[pos] == ',')
-                    throw new ArgumentException(SR.Format(SR.XmlInvalidArrayDimentions, CurrentTag()), "value");
+                    throw new ArgumentException(SR.Format(SR.XmlInvalidArrayDimentions, CurrentTag()), nameof(value));
                 pos--;
             }
             if (pos == -1)
             {
-                throw new ArgumentException(SR.XmlMismatchedArrayBrackets, "value");
+                throw new ArgumentException(SR.XmlMismatchedArrayBrackets, nameof(value));
             }
 
             int len = charsLength - pos - 2;
@@ -1060,7 +1060,7 @@ namespace System.Xml.Serialization
                     {
                         throw;
                     }
-                    throw new ArgumentException(SR.Format(SR.XmlInvalidArrayLength, lengthString), "value");
+                    throw new ArgumentException(SR.Format(SR.XmlInvalidArrayLength, lengthString), nameof(value));
                 }
             }
             else
@@ -1075,11 +1075,11 @@ namespace System.Xml.Serialization
             {
                 pos--;
                 if (pos < 0)
-                    throw new ArgumentException(SR.XmlMismatchedArrayBrackets, "value");
+                    throw new ArgumentException(SR.XmlMismatchedArrayBrackets, nameof(value));
                 if (chars[pos] == ',')
-                    throw new ArgumentException(SR.Format(SR.XmlInvalidArrayDimentions, CurrentTag()), "value");
+                    throw new ArgumentException(SR.Format(SR.XmlInvalidArrayDimentions, CurrentTag()), nameof(value));
                 else if (chars[pos] != '[')
-                    throw new ArgumentException(SR.XmlInvalidArraySyntax, "value");
+                    throw new ArgumentException(SR.XmlInvalidArraySyntax, nameof(value));
                 pos--;
                 soapArrayInfo.jaggedDimensions++;
             }
@@ -2448,13 +2448,13 @@ namespace System.Xml.Serialization
             if (!xmlMapping.IsReadable)
                 return null;
             if (!xmlMapping.GenerateSerializer)
-                throw new ArgumentException(SR.XmlInternalError, "xmlMapping");
+                throw new ArgumentException(SR.XmlInternalError, nameof(xmlMapping));
             if (xmlMapping is XmlTypeMapping)
                 return GenerateTypeElement((XmlTypeMapping)xmlMapping);
             else if (xmlMapping is XmlMembersMapping)
                 return GenerateMembersElement((XmlMembersMapping)xmlMapping);
             else
-                throw new ArgumentException(SR.XmlInternalError, "xmlMapping");
+                throw new ArgumentException(SR.XmlInternalError, nameof(xmlMapping));
         }
 
         private void WriteIsStartTag(string name, string ns)
@@ -3740,7 +3740,7 @@ namespace System.Xml.Serialization
             TypeDesc td = c.TypeDesc;
             bool useReflection = td.UseReflection;
             string fullTypeName = td.CSharpName;
-            WriteLocalDecl(fullTypeName, "c", "collection", useReflection);
+            WriteLocalDecl(fullTypeName, nameof(c), "collection", useReflection);
 
             WriteCreateCollection(td, "collectionItems");
 

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
@@ -506,7 +506,7 @@ namespace System.Xml.Serialization
                     {
                         if (alias.Length > 0)
                             throw new InvalidOperationException(SR.Format(SR.XmlInvalidXmlns, alias));
-                        WriteAttribute("xmlns", alias, null, aliasNs);
+                        WriteAttribute(nameof(xmlns), alias, null, aliasNs);
                     }
                     else
                     {
@@ -515,7 +515,7 @@ namespace System.Xml.Serialization
                             // write the default namespace declaration only if we have not written it already, over wise we just ignore one provided by the user
                             if (prefix == null && alias.Length == 0)
                                 break;
-                            WriteAttribute("xmlns", alias, null, aliasNs);
+                            WriteAttribute(nameof(xmlns), alias, null, aliasNs);
                         }
                     }
                 }
@@ -1405,7 +1405,7 @@ namespace System.Xml.Serialization
 
                     if (oldPrefix == null || oldPrefix != prefix)
                     {
-                        WriteAttribute("xmlns", prefix, null, ns);
+                        WriteAttribute(nameof(xmlns), prefix, null, ns);
                     }
                 }
             }
@@ -1507,13 +1507,13 @@ namespace System.Xml.Serialization
             if (!xmlMapping.IsWriteable)
                 return null;
             if (!xmlMapping.GenerateSerializer)
-                throw new ArgumentException(SR.XmlInternalError, "xmlMapping");
+                throw new ArgumentException(SR.XmlInternalError, nameof(xmlMapping));
             if (xmlMapping is XmlTypeMapping)
                 return GenerateTypeElement((XmlTypeMapping)xmlMapping);
             else if (xmlMapping is XmlMembersMapping)
                 return GenerateMembersElement((XmlMembersMapping)xmlMapping);
             else
-                throw new ArgumentException(SR.XmlInternalError, "xmlMapping");
+                throw new ArgumentException(SR.XmlInternalError, nameof(xmlMapping));
         }
 
         private void GenerateInitCallbacksMethod()
@@ -3774,7 +3774,7 @@ namespace System.Xml.Serialization
             }
             else
             {
-                typeVariable = GenerateVariableName("type", typeDesc.CSharpName);
+                typeVariable = GenerateVariableName(nameof(type), typeDesc.CSharpName);
 
                 Type parameterType = Nullable.GetUnderlyingType(type);
                 if (parameterType != null)

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -871,7 +871,7 @@ namespace System.Xml.Serialization
                     assembly = type.GetTypeInfo().Assembly;
                 else if (type.GetTypeInfo().Assembly != assembly)
                 {
-                    throw new ArgumentException(SR.Format(SR.XmlPregenOrphanType, type.FullName/*, assembly.Location*/), "types");
+                    throw new ArgumentException(SR.Format(SR.XmlPregenOrphanType, type.FullName/*, assembly.Location*/), nameof(types));
                 }
             }
             return TempAssembly.GenerateAssembly(mappings, types, null, null, XmlSerializerCompilerParameters.Create(parameters, /* needTempDirAccess = */ true), assembly, new Hashtable());

--- a/src/System.Private.Xml/src/System/Xml/ValidateNames.cs
+++ b/src/System.Private.Xml/src/System/Xml/ValidateNames.cs
@@ -649,7 +649,7 @@ namespace System.Xml
             }
             else if (0 == colonPos || (name.Length - 1) == colonPos)
             {
-                throw new ArgumentException(SR.Format(SR.Xml_BadNameChar, XmlException.BuildCharExceptionArgs(':', '\0')), "name");
+                throw new ArgumentException(SR.Format(SR.Xml_BadNameChar, XmlException.BuildCharExceptionArgs(':', '\0')), nameof(name));
             }
             else
             {

--- a/src/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -619,7 +619,7 @@ namespace System.Xml
         }
 #endif
 
-        // Valid XML character – as defined in XML 1.0 spec (fifth edition) production [2] Char
+        // Valid XML character â€“ as defined in XML 1.0 spec (fifth edition) production [2] Char
         public static unsafe bool IsXmlChar(char ch)
         {
             return s_xmlCharType.IsCharData(ch);
@@ -630,13 +630,13 @@ namespace System.Xml
             return XmlCharType.IsHighSurrogate(highChar) && XmlCharType.IsLowSurrogate(lowChar);
         }
 
-        // Valid PUBLIC ID character – as defined in XML 1.0 spec (fifth edition) production [13] PublidChar
+        // Valid PUBLIC ID character â€“ as defined in XML 1.0 spec (fifth edition) production [13] PublidChar
         public static bool IsPublicIdChar(char ch)
         {
             return s_xmlCharType.IsPubidChar(ch);
         }
 
-        // Valid Xml white space – as defined in XML 1.0 spec (fifth edition) production [3] S
+        // Valid Xml white space â€“ as defined in XML 1.0 spec (fifth edition) production [3] S
         public static unsafe bool IsWhitespaceChar(char ch)
         {
             return s_xmlCharType.IsWhiteSpace(ch);
@@ -854,7 +854,7 @@ namespace System.Xml
                     break;
 
                 default:
-                    throw new ArgumentException(SR.Format(SR.Sch_InvalidDateTimeOption, dateTimeOption, "dateTimeOption"));
+                    throw new ArgumentException(SR.Format(SR.Sch_InvalidDateTimeOption, dateTimeOption, nameof(dateTimeOption)));
             }
             XsdDateTime xsdDateTime = new XsdDateTime(value, XsdDateTimeFlags.DateTime);
             return xsdDateTime.ToString();
@@ -1409,7 +1409,7 @@ namespace System.Xml
                     break;
 
                 default:
-                    throw new ArgumentException(SR.Format(SR.Sch_InvalidDateTimeOption, dateTimeOption, "dateTimeOption"));
+                    throw new ArgumentException(SR.Format(SR.Sch_InvalidDateTimeOption, dateTimeOption, nameof(dateTimeOption)));
             }
             return dt;
         }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/ListBase.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/ListBase.cs
@@ -134,7 +134,7 @@ namespace System.Xml.Xsl
             set
             {
                 if (!IsCompatibleType(value.GetType()))
-                    throw new ArgumentException(SR.Arg_IncompatibleParamType, "value");
+                    throw new ArgumentException(SR.Arg_IncompatibleParamType, nameof(value));
 
                 this[index] = (T)value;
             }
@@ -143,7 +143,7 @@ namespace System.Xml.Xsl
         int System.Collections.IList.Add(object value)
         {
             if (!IsCompatibleType(value.GetType()))
-                throw new ArgumentException(SR.Arg_IncompatibleParamType, "value");
+                throw new ArgumentException(SR.Arg_IncompatibleParamType, nameof(value));
 
             Add((T)value);
             return Count - 1;
@@ -173,7 +173,7 @@ namespace System.Xml.Xsl
         void System.Collections.IList.Insert(int index, object value)
         {
             if (!IsCompatibleType(value.GetType()))
-                throw new ArgumentException(SR.Arg_IncompatibleParamType, "value");
+                throw new ArgumentException(SR.Arg_IncompatibleParamType, nameof(value));
 
             Insert(index, (T)value);
         }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltLibrary.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltLibrary.cs
@@ -249,11 +249,11 @@ namespace System.Xml.Xsl.Runtime
                     {
                         if (errorHelper != null)
                         {
-                            errorHelper.ReportError(/*[XT_032]*/SR.Xslt_InvalidAttrValue, "lang", lang);
+                            errorHelper.ReportError(/*[XT_032]*/SR.Xslt_InvalidAttrValue, nameof(lang), lang);
                         }
                         else
                         {
-                            throw new XslTransformException(SR.Xslt_InvalidAttrValue, "lang", lang);
+                            throw new XslTransformException(SR.Xslt_InvalidAttrValue, nameof(lang), lang);
                         }
                     }
                 }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathQilFactory.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathQilFactory.cs
@@ -423,7 +423,7 @@ namespace System.Xml.Xsl.XPath
         {
             CheckString(lang);
             CheckNodeNotRtf(context);
-            return XsltInvokeEarlyBound(QName("lang"),
+            return XsltInvokeEarlyBound(QName(nameof(lang)),
                 XsltMethods.Lang, T.BooleanX, new QilNode[] { lang, context }
             );
         }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XsltLoader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XsltLoader.cs
@@ -3061,7 +3061,7 @@ namespace System.Xml.Xsl.Xslt
                     case "html": method = XmlOutputMethod.Html; break;
                     case "text": method = XmlOutputMethod.Text; break;
                     default:
-                        ReportError(/*[XT1570]*/SR.Xslt_InvalidAttrValue, "method", attValue);
+                        ReportError(/*[XT1570]*/SR.Xslt_InvalidAttrValue, nameof(method), attValue);
                         return null;
                 }
             }

--- a/src/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
@@ -272,7 +272,7 @@ namespace System.Xml.Xsl
             {
                 if (new Version(Version).CompareTo(new Version(generatedCodeAttr.Version)) < 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.Xslt_IncompatibleCompiledStylesheetVersion, generatedCodeAttr.Version, Version), "compiledStylesheet");
+                    throw new ArgumentException(SR.Format(SR.Xslt_IncompatibleCompiledStylesheetVersion, generatedCodeAttr.Version, Version), nameof(compiledStylesheet));
                 }
 
                 FieldInfo fldData = compiledStylesheet.GetField(XmlQueryStaticData.DataFieldName, BindingFlags.Static | BindingFlags.NonPublic);
@@ -298,7 +298,7 @@ namespace System.Xml.Xsl
 
             // Throw an exception if the command was not loaded
             if (_command == null)
-                throw new ArgumentException(SR.Format(SR.Xslt_NotCompiledStylesheet, compiledStylesheet.FullName), "compiledStylesheet");
+                throw new ArgumentException(SR.Format(SR.Xslt_NotCompiledStylesheet, compiledStylesheet.FullName), nameof(compiledStylesheet));
         }
 
         public void Load(MethodInfo executeMethod, byte[] queryData, Type[] earlyBoundTypes)

--- a/src/System.Private.Xml/src/System/Xml/Xslt/XsltArgumentList.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xslt/XsltArgumentList.cs
@@ -35,9 +35,9 @@ namespace System.Xml.Xsl
 
         public void AddParam(string name, string namespaceUri, object parameter)
         {
-            CheckArgumentNull(name, "name");
-            CheckArgumentNull(namespaceUri, "namespaceUri");
-            CheckArgumentNull(parameter, "parameter");
+            CheckArgumentNull(name, nameof(name));
+            CheckArgumentNull(namespaceUri, nameof(namespaceUri));
+            CheckArgumentNull(parameter, nameof(parameter));
 
             XmlQualifiedName qname = new XmlQualifiedName(name, namespaceUri);
             qname.Verify();
@@ -46,8 +46,8 @@ namespace System.Xml.Xsl
 
         public void AddExtensionObject(string namespaceUri, object extension)
         {
-            CheckArgumentNull(namespaceUri, "namespaceUri");
-            CheckArgumentNull(extension, "extension");
+            CheckArgumentNull(namespaceUri, nameof(namespaceUri));
+            CheckArgumentNull(extension, nameof(extension));
             _extensions.Add(namespaceUri, extension);
         }
 

--- a/src/System.Runtime.Extensions/src/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.cs
@@ -190,7 +190,7 @@ namespace System.IO
         public static string Combine(string path1, string path2)
         {
             if (path1 == null || path2 == null)
-                throw new ArgumentNullException((path1 == null) ? "path1" : "path2");
+                throw new ArgumentNullException((path1 == null) ? nameof(path1): nameof(path2));
             Contract.EndContractBlock();
 
             PathInternal.CheckInvalidPathChars(path1);
@@ -202,7 +202,7 @@ namespace System.IO
         public static string Combine(string path1, string path2, string path3)
         {
             if (path1 == null || path2 == null || path3 == null)
-                throw new ArgumentNullException((path1 == null) ? "path1" : (path2 == null) ? "path2" : "path3");
+                throw new ArgumentNullException((path1 == null) ? nameof(path1): (path2 == null) ? nameof(path2): nameof(path3));
             Contract.EndContractBlock();
 
             PathInternal.CheckInvalidPathChars(path1);
@@ -215,7 +215,7 @@ namespace System.IO
         public static string Combine(string path1, string path2, string path3, string path4)
         {
             if (path1 == null || path2 == null || path3 == null || path4 == null)
-                throw new ArgumentNullException((path1 == null) ? "path1" : (path2 == null) ? "path2" : (path3 == null) ? "path3" : "path4");
+                throw new ArgumentNullException((path1 == null) ? nameof(path1): (path2 == null) ? nameof(path2): (path3 == null) ? nameof(path3): nameof(path4));
             Contract.EndContractBlock();
 
             PathInternal.CheckInvalidPathChars(path1);

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -307,7 +307,7 @@ namespace System.Numerics
             // Check for undefined flags
             if ((style & InvalidNumberStyles) != 0)
             {
-                e = new ArgumentException(SR.Format(SR.Argument_InvalidNumberStyles, "style"));
+                e = new ArgumentException(SR.Format(SR.Argument_InvalidNumberStyles, nameof(style)));
                 return false;
             }
             if ((style & NumberStyles.AllowHexSpecifier) != 0)

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/UnmanagedMemoryStreamInternal.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/UnmanagedMemoryStreamInternal.cs
@@ -103,7 +103,7 @@ namespace System.IO
             if (pointer == null)
                 throw new ArgumentNullException(nameof(pointer));
             if (length < 0 || capacity < 0)
-                throw new ArgumentOutOfRangeException((length < 0) ? "length" : "capacity", SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((length < 0) ? nameof(length): nameof(capacity), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (length > capacity)
                 throw new ArgumentOutOfRangeException(nameof(length), SR.ArgumentOutOfRange_LengthGreaterThanCapacity);
             Contract.EndContractBlock();
@@ -199,7 +199,7 @@ namespace System.IO
                 {
                     // On 32 bit machines, ensure we don't wrap around.
                     if (value > (long)Int32.MaxValue || _mem + value < _mem)
-                        throw new ArgumentOutOfRangeException("value", SR.ArgumentOutOfRange_StreamLength);
+                        throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_StreamLength);
                 }
 #endif
                 Interlocked.Exchange(ref _position, value);

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -197,7 +197,7 @@ namespace Internal.NativeCrypto
             string containerName = null;
             if (null == cspParameters)
             {
-                throw new ArgumentException(SR.Format(SR.CspParameter_invalid, "cspParameters"));
+                throw new ArgumentException(SR.Format(SR.CspParameter_invalid, nameof(cspParameters)));
             }
 
             //look for provider type in the cspParameters

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CspParameters.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CspParameters.cs
@@ -42,7 +42,7 @@ namespace System.Security.Cryptography
                 int flags = (int)value;
                 if ((flags & ~allFlags) != 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.Arg_EnumIllegalVal, "value"));
+                    throw new ArgumentException(SR.Format(SR.Arg_EnumIllegalVal, nameof(value)));
                 }
                 _flags = flags;
             }

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
@@ -44,11 +44,11 @@ namespace System.Security.Cryptography
             switch (_transformMode)
             {
                 case CryptoStreamMode.Read:
-                    if (!(_stream.CanRead)) throw new ArgumentException(SR.Format(SR.Argument_StreamNotReadable, "stream"));
+                    if (!(_stream.CanRead)) throw new ArgumentException(SR.Format(SR.Argument_StreamNotReadable, nameof(stream)));
                     _canRead = true;
                     break;
                 case CryptoStreamMode.Write:
-                    if (!(_stream.CanWrite)) throw new ArgumentException(SR.Format(SR.Argument_StreamNotWritable, "stream"));
+                    if (!(_stream.CanWrite)) throw new ArgumentException(SR.Format(SR.Argument_StreamNotWritable, nameof(stream)));
                     _canWrite = true;
                     break;
                 default:

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -287,7 +287,7 @@ namespace Internal.Cryptography.Pal
 
                 if (!StringComparer.Ordinal.Equals(storeName, fileName))
                 {
-                    throw new CryptographicException(SR.Format(SR.Security_InvalidValue, "storeName"));
+                    throw new CryptographicException(SR.Format(SR.Security_InvalidValue, nameof(storeName)));
                 }
             }
             catch (IOException e)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.CspParametersStub.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.CspParametersStub.cs
@@ -41,7 +41,7 @@ namespace Internal.Cryptography.Pal
                     int flags = (int)value;
                     if ((flags & ~allFlags) != 0)
                     {
-                        throw new ArgumentException(SR.Format(SR.Arg_EnumIllegalVal, "value"));
+                        throw new ArgumentException(SR.Format(SR.Arg_EnumIllegalVal, nameof(value)));
                     }
                     _flags = flags;
                 }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
@@ -33,7 +33,7 @@ namespace System.Security.Cryptography.X509Certificates
             set
             {
                 if (value < X509RevocationMode.NoCheck || value > X509RevocationMode.Offline)
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, "value"));
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, nameof(value)));
                 _revocationMode = value;
             }
         }
@@ -47,7 +47,7 @@ namespace System.Security.Cryptography.X509Certificates
             set
             {
                 if (value < X509RevocationFlag.EndCertificateOnly || value > X509RevocationFlag.ExcludeRoot)
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, "value"));
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, nameof(value)));
                 _revocationFlag = value;
             }
         }
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.X509Certificates
             set
             {
                 if (value < X509VerificationFlags.NoFlag || value > X509VerificationFlags.AllFlags)
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, "value"));
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, nameof(value)));
                 _verificationFlags = value;
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography.X509Certificates
         public X509Store(StoreName storeName, StoreLocation storeLocation)
         {
             if (storeLocation != StoreLocation.CurrentUser && storeLocation != StoreLocation.LocalMachine)
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, "storeLocation"));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, nameof(storeLocation)));
 
             switch (storeName)
             {
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.X509Certificates
                     Name = "TrustedPublisher";
                     break;
                 default:
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, "storeName"));
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, nameof(storeName)));
             }
 
             Location = storeLocation;
@@ -62,7 +62,7 @@ namespace System.Security.Cryptography.X509Certificates
         public X509Store(string storeName, StoreLocation storeLocation)
         {
             if (storeLocation != StoreLocation.CurrentUser && storeLocation != StoreLocation.LocalMachine)
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, "storeLocation"));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Arg_EnumIllegalVal, nameof(storeLocation)));
 
             Location = storeLocation;
             Name = storeName;

--- a/src/System.Security.SecureString/src/System/Security/SecureString.Unix.cs
+++ b/src/System.Security.SecureString/src/System/Security/SecureString.Unix.cs
@@ -201,7 +201,7 @@ namespace System.Security
             // Make sure the requested capacity doesn't exceed SecureString's defined limit
             if (capacity > MaxLength)
             {
-                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_Capacity);
+                throw new ArgumentOutOfRangeException(nameof(capacity), SR.ArgumentOutOfRange_Capacity);
             }
 
             // If we already have enough space allocated, we're done

--- a/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
+++ b/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
@@ -53,7 +53,7 @@ namespace System.ServiceProcess
                 throw new ArgumentException(SR.Format(SR.BadMachineName, machineName));
 
             if (string.IsNullOrEmpty(name))
-                throw new ArgumentException(SR.Format(SR.InvalidParameter, "name", name));
+                throw new ArgumentException(SR.Format(SR.InvalidParameter, nameof(name), name));
 
             _machineName = machineName;
             _eitherName = name;
@@ -839,7 +839,7 @@ namespace System.ServiceProcess
         public void WaitForStatus(ServiceControllerStatus desiredStatus, TimeSpan timeout)
         {
             if (!Enum.IsDefined(typeof(ServiceControllerStatus), desiredStatus))
-                throw new ArgumentException(SR.Format(SR.InvalidEnumArgument, "desiredStatus", (int)desiredStatus, typeof(ServiceControllerStatus)));
+                throw new ArgumentException(SR.Format(SR.InvalidEnumArgument, nameof(desiredStatus), (int)desiredStatus, typeof(ServiceControllerStatus)));
 
             DateTime start = DateTime.UtcNow;
             Refresh();

--- a/src/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
@@ -137,7 +137,7 @@ namespace System.Text
                 throw new ArgumentNullException(nameof(bytes), SR.ArgumentNull_Array);
 
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index): nameof(count)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (bytes.Length - index < count)
                 throw new ArgumentOutOfRangeException(nameof(bytes), SR.ArgumentOutOfRange_IndexCountBuffer);
@@ -184,10 +184,10 @@ namespace System.Text
         {
             // Validate Parameters
             if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars", SR.ArgumentNull_Array);
+                throw new ArgumentNullException(bytes == null ? nameof(bytes): nameof(chars), SR.ArgumentNull_Array);
 
             if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex < 0 ? "byteIndex" : "byteCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((byteIndex < 0 ? nameof(byteIndex): nameof(byteCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (bytes.Length - byteIndex < byteCount)
                 throw new ArgumentOutOfRangeException(nameof(bytes), SR.ArgumentOutOfRange_IndexCountBuffer);
@@ -219,10 +219,10 @@ namespace System.Text
         {
             // Validate parameters
             if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"), SR.ArgumentNull_Array);
+                throw new ArgumentNullException((chars == null ? nameof(chars): nameof(bytes)), SR.ArgumentNull_Array);
 
             if (byteCount < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((byteCount < 0 ? "byteCount" : "charCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((byteCount < 0 ? nameof(byteCount): nameof(charCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
             Contract.EndContractBlock();
 
             // Remember our flush
@@ -242,13 +242,13 @@ namespace System.Text
         {
             // Validate parameters
             if (bytes == null || chars == null)
-                throw new ArgumentNullException((bytes == null ? "bytes" : "chars"), SR.ArgumentNull_Array);
+                throw new ArgumentNullException((bytes == null ? nameof(bytes): nameof(chars)), SR.ArgumentNull_Array);
 
             if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex < 0 ? "byteIndex" : "byteCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((byteIndex < 0 ? nameof(byteIndex): nameof(byteCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex < 0 ? "charIndex" : "charCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((charIndex < 0 ? nameof(charIndex): nameof(charCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (bytes.Length - byteIndex < byteCount)
                 throw new ArgumentOutOfRangeException(nameof(bytes), SR.ArgumentOutOfRange_IndexCountBuffer);
@@ -284,10 +284,10 @@ namespace System.Text
         {
             // Validate input parameters
             if (chars == null || bytes == null)
-                throw new ArgumentNullException(chars == null ? "chars" : "bytes", SR.ArgumentNull_Array);
+                throw new ArgumentNullException(chars == null ? nameof(chars): nameof(bytes), SR.ArgumentNull_Array);
 
             if (byteCount < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((byteCount < 0 ? "byteCount" : "charCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((byteCount < 0 ? nameof(byteCount): nameof(charCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
             Contract.EndContractBlock();
 
             // We don't want to throw

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
@@ -147,7 +147,7 @@ namespace System.Text
                 throw new ArgumentNullException(nameof(chars), SR.ArgumentNull_Array);
 
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index): nameof(count)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (chars.Length - index < count)
                 throw new ArgumentOutOfRangeException(nameof(chars), SR.ArgumentOutOfRange_IndexCountBuffer);
@@ -188,10 +188,10 @@ namespace System.Text
         {
             // Validate parameters
             if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"), SR.ArgumentNull_Array);
+                throw new ArgumentNullException((chars == null ? nameof(chars): nameof(bytes)), SR.ArgumentNull_Array);
 
             if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex < 0 ? "charIndex" : "charCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((charIndex < 0 ? nameof(charIndex): nameof(charCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (chars.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(chars), SR.ArgumentOutOfRange_IndexCountBuffer);
@@ -221,10 +221,10 @@ namespace System.Text
         {
             // Validate parameters
             if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"), SR.ArgumentNull_Array);
+                throw new ArgumentNullException((chars == null ? nameof(chars): nameof(bytes)), SR.ArgumentNull_Array);
 
             if (byteCount < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((byteCount < 0 ? "byteCount" : "charCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((byteCount < 0 ? nameof(byteCount): nameof(charCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
             Contract.EndContractBlock();
 
             m_mustFlush = flush;
@@ -241,13 +241,13 @@ namespace System.Text
         {
             // Validate parameters
             if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"), SR.ArgumentNull_Array);
+                throw new ArgumentNullException((chars == null ? nameof(chars): nameof(bytes)), SR.ArgumentNull_Array);
 
             if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex < 0 ? "charIndex" : "charCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((charIndex < 0 ? nameof(charIndex): nameof(charCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex < 0 ? "byteIndex" : "byteCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((byteIndex < 0 ? nameof(byteIndex): nameof(byteCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (chars.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(chars), SR.ArgumentOutOfRange_IndexCountBuffer);
@@ -283,10 +283,10 @@ namespace System.Text
         {
             // Validate input parameters
             if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars", SR.ArgumentNull_Array);
+                throw new ArgumentNullException(bytes == null ? nameof(bytes): nameof(chars), SR.ArgumentNull_Array);
 
             if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount < 0 ? "charCount" : "byteCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((charCount < 0 ? nameof(charCount): nameof(byteCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
             Contract.EndContractBlock();
 
             // We don't want to throw

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
@@ -55,7 +55,7 @@ namespace System.Text
                 throw new ArgumentNullException(nameof(chars), SR.ArgumentNull_Array);
 
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index): nameof(count)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (chars.Length - index < count)
                 throw new ArgumentOutOfRangeException(nameof(chars), SR.ArgumentOutOfRange_IndexCountBuffer);
@@ -111,10 +111,10 @@ namespace System.Text
                                               byte[] bytes, int byteIndex)
         {
             if (s == null || bytes == null)
-                throw new ArgumentNullException((s == null ? "s" : "bytes"), SR.ArgumentNull_Array);
+                throw new ArgumentNullException((s == null ? nameof(s): nameof(bytes)), SR.ArgumentNull_Array);
 
             if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex < 0 ? "charIndex" : "charCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((charIndex < 0 ? nameof(charIndex): nameof(charCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (s.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(s), SR.ArgumentOutOfRange_IndexCount);
@@ -153,10 +153,10 @@ namespace System.Text
         {
             // Validate parameters
             if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"), SR.ArgumentNull_Array);
+                throw new ArgumentNullException((chars == null ? nameof(chars): nameof(bytes)), SR.ArgumentNull_Array);
 
             if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex < 0 ? "charIndex" : "charCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((charIndex < 0 ? nameof(charIndex): nameof(charCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (chars.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(chars), SR.ArgumentOutOfRange_IndexCountBuffer);
@@ -190,10 +190,10 @@ namespace System.Text
         {
             // Validate Parameters
             if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars", SR.ArgumentNull_Array);
+                throw new ArgumentNullException(bytes == null ? nameof(bytes): nameof(chars), SR.ArgumentNull_Array);
 
             if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount < 0 ? "charCount" : "byteCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((charCount < 0 ? nameof(charCount): nameof(byteCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
             Contract.EndContractBlock();
 
             return GetBytes(chars, charCount, bytes, byteCount, null);
@@ -213,7 +213,7 @@ namespace System.Text
                 throw new ArgumentNullException(nameof(bytes), SR.ArgumentNull_Array);
 
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index): nameof(count)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (bytes.Length - index < count)
                 throw new ArgumentOutOfRangeException(nameof(bytes), SR.ArgumentOutOfRange_IndexCountBuffer);
@@ -253,10 +253,10 @@ namespace System.Text
         {
             // Validate Parameters
             if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars", SR.ArgumentNull_Array);
+                throw new ArgumentNullException(bytes == null ? nameof(bytes): nameof(chars), SR.ArgumentNull_Array);
 
             if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex < 0 ? "byteIndex" : "byteCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((byteIndex < 0 ? nameof(byteIndex): nameof(byteCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (bytes.Length - byteIndex < byteCount)
                 throw new ArgumentOutOfRangeException(nameof(bytes), SR.ArgumentOutOfRange_IndexCountBuffer);
@@ -290,10 +290,10 @@ namespace System.Text
         {
             // Validate Parameters
             if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars", SR.ArgumentNull_Array);
+                throw new ArgumentNullException(bytes == null ? nameof(bytes): nameof(chars), SR.ArgumentNull_Array);
 
             if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount < 0 ? "charCount" : "byteCount"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((charCount < 0 ? nameof(charCount): nameof(byteCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
             Contract.EndContractBlock();
 
             return GetChars(bytes, byteCount, chars, charCount, null);
@@ -313,7 +313,7 @@ namespace System.Text
                 throw new ArgumentNullException(nameof(bytes), SR.ArgumentNull_Array);
 
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index): nameof(count)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
             if (bytes.Length - index < count)
                 throw new ArgumentOutOfRangeException(nameof(bytes), SR.ArgumentOutOfRange_IndexCountBuffer);


### PR DESCRIPTION
We previously made a pass through corefx to use nameof with argument exceptions.  Since then, a lot more code has come into the repo, and not all argument exceptions were converted at the time. We also previously missed a bunch of places where helpers were used to throw the exceptions.  This does another pass through corefx to catch most of the remaining occurrences.