### PR TITLE
Fix ProcessThread exception thrown on Unix

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Linux.cs
@@ -84,7 +84,7 @@ namespace System.Diagnostics
             Interop.procfs.ParsedStat stat;
             if (!Interop.procfs.TryReadStatFile(pid: _processId, tid: Id, result: out stat, reusableReader: new ReusableTextReader(Encoding.UTF8)))
             {
-                throw new Win32Exception(SR.ProcessInformationUnavailable);
+                throw new InvalidOperationException(SR.Format(SR.ThreadExited, Id));
             }
             return stat;
         }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.OSX.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.InteropServices;
-
 namespace System.Diagnostics
 {
     public partial class ProcessThread
@@ -15,39 +13,20 @@ namespace System.Diagnostics
         /// </summary>
         private ThreadPriorityLevel PriorityLevelCore
         {
-            get
-            {
-                throw new PlatformNotSupportedException();
-            }
-            set
-            {
-                throw new PlatformNotSupportedException();
-            }
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
         }
 
         /// <summary>
         /// Returns the amount of time the thread has spent running code inside the operating
         /// system core.
         /// </summary>
-        public TimeSpan PrivilegedProcessorTime
-        {
-            get
-            {
-                Interop.libproc.proc_threadinfo? info = Interop.libproc.GetThreadInfoById(_processId, (ulong)_threadInfo._threadId);
-                if (info.HasValue)
-                    return new TimeSpan((long)info.Value.pth_system_time);
-                else
-                    throw new System.ComponentModel.Win32Exception();
-            }
-        }
+        public TimeSpan PrivilegedProcessorTime => new TimeSpan((long)GetThreadInfo().pth_system_time);
 
         /// <summary>Returns the time the associated thread was started.</summary>
         public DateTime StartTime
         {
-            get
-            {
-                throw new PlatformNotSupportedException();
-            }
+            get { throw new PlatformNotSupportedException(); }
         }
 
         /// <summary>
@@ -59,11 +38,8 @@ namespace System.Diagnostics
         {
             get
             {
-                Interop.libproc.proc_threadinfo? info = Interop.libproc.GetThreadInfoById(_processId, (ulong)_threadInfo._threadId);
-                if (info.HasValue)
-                    return new TimeSpan((long)(info.Value.pth_user_time + info.Value.pth_system_time));
-                else
-                    throw new System.ComponentModel.Win32Exception();
+                Interop.libproc.proc_threadinfo info = GetThreadInfo();
+                return new TimeSpan((long)(info.pth_user_time + info.pth_system_time));
             }
         }
 
@@ -71,21 +47,20 @@ namespace System.Diagnostics
         /// Returns the amount of time the associated thread has spent running code
         /// inside the application (not the operating system core).
         /// </summary>
-        public TimeSpan UserProcessorTime
-        {
-            get
-            {
-                Interop.libproc.proc_threadinfo? info = Interop.libproc.GetThreadInfoById(_processId, (ulong)_threadInfo._threadId);
-                if (info.HasValue)
-                    return new TimeSpan((long)info.Value.pth_user_time);
-                else
-                    throw new System.ComponentModel.Win32Exception();
-            }
-        }
+        public TimeSpan UserProcessorTime => new TimeSpan((long)GetThreadInfo().pth_user_time);
 
         // -----------------------------
         // ---- PAL layer ends here ----
         // -----------------------------
 
+        private Interop.libproc.proc_threadinfo GetThreadInfo()
+        {
+            Interop.libproc.proc_threadinfo? info = Interop.libproc.GetThreadInfoById(_processId, _threadInfo._threadId);
+            if (!info.HasValue)
+            {
+                throw new InvalidOperationException(SR.Format(SR.ThreadExited, Id));
+            }
+            return info.GetValueOrDefault();
+        }
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -31,9 +31,10 @@ namespace System.Diagnostics.Tests
                     Assert.True(thread.TotalProcessorTime.TotalSeconds >= 0);
                 }
             }
-            catch (Win32Exception)
+            catch (Exception e) when (e is Win32Exception || e is InvalidOperationException)
             {
-                // Win32Exception is thrown when getting threadinfo fails. 
+                // Win32Exception is thrown when getting threadinfo fails, or
+                // InvalidOperationException if it fails because the thread already exited.
             }
         }
 


### PR DESCRIPTION
When a thread goes away and then code tries to access its information, an InvalidOperationException is thrown on Windows.  This fixes the Unix implementations to match.

Fixes https://github.com/dotnet/corefx/issues/13210
cc: @Priya91 