### PR TITLE
Disable socket tests for clean CI

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -916,6 +916,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(13213)]
         [Fact]
         public void AcceptAsyncV6BoundToAnyV4_CantConnect()
         {


### PR DESCRIPTION
Disable AcceptAsyncV6BoundToAnyV4_CantConnect test, ref: #13213.