### PR TITLE
Fix RID for runtime.native.System.IO.Compression

### DIFF
--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -9,7 +9,7 @@
     <!-- When updating ExternalExpectedPrerelease with a version that 
          below should be updated to $(PackageVersion)-$(ExternalExpectedPrerelease) -->
     <RuntimeDependency Include="runtime.win10-x64-aot.runtime.native.System.IO.Compression">
-      <TargetRuntime>win10-amd64-aot</TargetRuntime>
+      <TargetRuntime>win10-x64-aot</TargetRuntime>
       <Version>$(RuntimeWin10RuntimeNativeSystemIOCompressionVersion)</Version>
       <SkipVersionCheck>true</SkipVersionCheck>
     </RuntimeDependency>


### PR DESCRIPTION
This package was incorrectly using the win10-amd64-aot to associate the
runtime.win10-x64-aot.runtime.native.System.IO.Compression package.

Fix this to use win10-x64-aot.

/cc @ianhays 