### PR TITLE
Add XmlSortKey implementation in System.Private.Xml

### DIFF
--- a/src/System.Private.Xml/src/System.Private.Xml.builds
+++ b/src/System.Private.Xml/src/System.Private.Xml.builds
@@ -3,6 +3,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Private.Xml.csproj" />
+    <Project Include="System.Private.Xml.csproj">
+      <OSGroup>Unix</OSGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/System.Private.Xml/src/System.Private.Xml.csproj
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+	<Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{C427CE0D-0740-41F3-9C3A-552BEA3DDB0D}</ProjectGuid>
@@ -728,6 +731,12 @@
     <Compile Include="$(CommonPath)\System\LocalAppContext.cs" />
     <Compile Include="System\Xml\Core\LocalAppContextSwitches.cs" />
     <Compile Include="Misc\ThisAssembly.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)'=='true'">
+    <Compile Include="System\Xml\Xsl\Runtime\XmlCollation.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)'=='true'">
+    <Compile Include="System\Xml\Xsl\Runtime\XmlCollation.Unix.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Unix.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Unix.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace System.Xml.Xsl.Runtime
+{
+    public sealed partial class XmlCollation
+    {
+        /// <summary>
+        /// Create a sort key that can be compared quickly with other keys.
+        /// </summary>
+        internal XmlSortKey CreateSortKey(string s)
+        {
+            SortKey sortKey;
+            byte[] bytesKey;
+
+            sortKey = Culture.CompareInfo.GetSortKey(s, _compops);
+
+            // Create an XmlStringSortKey using the SortKey if possible
+#if DEBUG
+            // In debug-only code, test other code path more frequently
+            if (!UpperFirst && DescendingOrder)
+                return new XmlStringSortKey(sortKey, DescendingOrder);
+#else
+            if (!UpperFirst)
+                return new XmlStringSortKey(sortKey, DescendingOrder);
+#endif
+
+            // Get byte buffer from SortKey and modify it
+            bytesKey = sortKey.KeyData;
+
+            // TODO: Add Linux implementation for modifying SortKey; issue #13236
+
+            return new XmlStringSortKey(bytesKey, DescendingOrder);
+        }
+    }
+}

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Windows.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Windows.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace System.Xml.Xsl.Runtime
+{
+    public sealed partial class XmlCollation
+    {
+        /// <summary>
+        /// Create a sort key that can be compared quickly with other keys.
+        /// </summary>
+        internal XmlSortKey CreateSortKey(string s)
+        {
+            SortKey sortKey;
+            byte[] bytesKey;
+            int idx;
+
+            sortKey = Culture.CompareInfo.GetSortKey(s, _compops);
+
+            // Create an XmlStringSortKey using the SortKey if possible
+#if DEBUG
+            // In debug-only code, test other code path more frequently
+            if (!UpperFirst && DescendingOrder)
+                return new XmlStringSortKey(sortKey, DescendingOrder);
+#else
+            if (!UpperFirst)
+                return new XmlStringSortKey(sortKey, DescendingOrder);
+#endif
+
+            // Get byte buffer from SortKey and modify it
+            bytesKey = sortKey.KeyData;
+            if (UpperFirst && bytesKey.Length != 0)
+            {
+                // By default lower-case is always sorted first for any locale (verified by empirical testing).
+                // In order to place upper-case first, invert the case weights in the generated sort key.
+                // Skip to case weight section (3rd weight section)
+                idx = 0;
+                while (bytesKey[idx] != 1)
+                    idx++;
+
+                do
+                {
+                    idx++;
+                }
+                while (bytesKey[idx] != 1);
+
+                // Invert all case weights (including terminating 0x1)
+                do
+                {
+                    idx++;
+                    bytesKey[idx] ^= 0xff;
+                }
+                while (bytesKey[idx] != 0xfe);
+            }
+
+            return new XmlStringSortKey(bytesKey, DescendingOrder);
+        }
+    }
+}

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.cs
@@ -13,7 +13,7 @@ namespace System.Xml.Xsl.Runtime
 {
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public sealed class XmlCollation
+    public sealed partial class XmlCollation
     {
         // lgid support for sort
         private const string deDE = "de-DE";

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlSortKeyAccumulator.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlSortKeyAccumulator.cs
@@ -41,8 +41,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public void AddStringSortKey(XmlCollation collation, string value)
         {
-            //BinCompat TODO
-            throw new NotImplementedException();
+            AppendSortKey(collation.CreateSortKey(value));
         }
 
         public void AddDecimalSortKey(XmlCollation collation, decimal value)

--- a/src/System.Private.Xml/tests/Xslt/TestFiles/TestData/XsltApiV2/baseline/sort.txt
+++ b/src/System.Private.Xml/tests/Xslt/TestFiles/TestData/XsltApiV2/baseline/sort.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<out>
+  <title>XML Primer</title>
+  <title>XSLT Basics</title>
+  <title>Advanced XSLT</title>
+</out>

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
@@ -36,8 +36,7 @@
     <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="$(CommonTestPath)\System\Xml\xmlDiff\XmlDiff.csproj" />
     <ProjectReference Include="..\xslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj" />
-    <ProjectReference Include="..\..\..\..\System.Xml.ReaderWriter\pkg\System.Xml.ReaderWriter.pkgproj" />
-    <ProjectReference Include="..\..\..\..\System.Xml.XPath\pkg\System.Xml.XPath.pkgproj" />
+    <ProjectReference Include="..\..\..\..\System.Private.Xml\pkg\System.Private.Xml.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
@@ -359,10 +359,6 @@ namespace System.Xml.Tests
                                 _output.WriteLine("Loading style sheet as XmlTextReader " + _strXslFile);
                                 xslt.Load(trTemp, XsltSettings.TrustedXslt, xr);
                             }
-                            catch (Exception ex)
-                            {
-                                throw (ex);
-                            }
                             finally
                             {
                                 if (trTemp != null)
@@ -378,10 +374,6 @@ namespace System.Xml.Tests
                             {
                                 _output.WriteLine("Loading style sheet as XmlNodeReader " + _strXslFile);
                                 xslt.Load(nrTemp);
-                            }
-                            catch (Exception ex)
-                            {
-                                throw (ex);
                             }
                             finally
                             {
@@ -402,10 +394,6 @@ namespace System.Xml.Tests
                             {
                                 _output.WriteLine("Loading style sheet as XmlValidatingReader " + _strXslFile);
                                 xslt.Load(xvr, XsltSettings.TrustedXslt, xr);
-                            }
-                            catch (Exception ex)
-                            {
-                                throw (ex);
                             }
                             finally
                             {
@@ -458,10 +446,6 @@ namespace System.Xml.Tests
                                 _output.WriteLine("Loading style sheet as XmlTextReader " + _strXslFile);
                                 xslt.Load(trTemp, XsltSettings.TrustedXslt, xr);
                             }
-                            catch (Exception ex)
-                            {
-                                throw (ex);
-                            }
                             finally
                             {
                                 if (trTemp != null)
@@ -477,10 +461,6 @@ namespace System.Xml.Tests
                             {
                                 _output.WriteLine("Loading style sheet as XmlNodeReader " + _strXslFile);
                                 xslt.Load(nrTemp, XsltSettings.TrustedXslt, xr);
-                            }
-                            catch (Exception ex)
-                            {
-                                throw (ex);
                             }
                             finally
                             {
@@ -500,10 +480,6 @@ namespace System.Xml.Tests
                             {
                                 _output.WriteLine("Loading style sheet as XmlValidatingReader " + _strXslFile);
                                 xslt.Load(vrTemp, XsltSettings.TrustedXslt, xr);
-                            }
-                            catch (Exception ex)
-                            {
-                                throw (ex);
                             }
                             finally
                             {
@@ -741,10 +717,6 @@ namespace System.Xml.Tests
                         strmTemp = new FileStream(_strOutFile, FileMode.Create, FileAccess.ReadWrite);
                         xslt.Transform(xd, null, strmTemp);
                     }
-                    catch (Exception ex)
-                    {
-                        throw (ex);
-                    }
                     finally
                     {
                         if (strmTemp != null)
@@ -762,10 +734,6 @@ namespace System.Xml.Tests
                         xw.WriteStartDocument();
                         xslt.Transform(xd, null, xw);
                     }
-                    catch (Exception ex)
-                    {
-                        throw (ex);
-                    }
                     finally
                     {
                         if (xw != null)
@@ -779,10 +747,6 @@ namespace System.Xml.Tests
                     {
                         tw = new StreamWriter(new FileStream(_strOutFile, FileMode.Create, FileAccess.Write), Encoding.UTF8);
                         xslt.Transform(xd, null, tw);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw (ex);
                     }
                     finally
                     {
@@ -822,10 +786,6 @@ namespace System.Xml.Tests
                         strmTemp = new FileStream(_strOutFile, FileMode.Create, FileAccess.ReadWrite);
                         xslt.Transform(xd, m_xsltArg, strmTemp);
                     }
-                    catch (Exception ex)
-                    {
-                        throw (ex);
-                    }
                     finally
                     {
                         if (strmTemp != null)
@@ -841,10 +801,6 @@ namespace System.Xml.Tests
                         xw.WriteStartDocument();
                         xslt.Transform(xd, m_xsltArg, xw);
                     }
-                    catch (Exception ex)
-                    {
-                        throw (ex);
-                    }
                     finally
                     {
                         if (xw != null)
@@ -858,10 +814,6 @@ namespace System.Xml.Tests
                     {
                         tw = new StreamWriter(new FileStream(_strOutFile, FileMode.Create, FileAccess.Write), Encoding.UTF8);
                         xslt.Transform(xd, m_xsltArg, tw);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw (ex);
                     }
                     finally
                     {
@@ -904,10 +856,6 @@ namespace System.Xml.Tests
                         strmTemp = new FileStream(_strOutFile, FileMode.Create, FileAccess.ReadWrite);
                         xslt.Transform(xd, null, strmTemp);
                     }
-                    catch (Exception ex)
-                    {
-                        throw (ex);
-                    }
                     finally
                     {
                         if (strmTemp != null)
@@ -923,10 +871,6 @@ namespace System.Xml.Tests
                         xw.WriteStartDocument();
                         xslt.Transform(xd, null, xw);
                     }
-                    catch (Exception ex)
-                    {
-                        throw (ex);
-                    }
                     finally
                     {
                         if (xw != null)
@@ -940,10 +884,6 @@ namespace System.Xml.Tests
                     {
                         tw = new StreamWriter(new FileStream(_strOutFile, FileMode.Create, FileAccess.Write), Encoding.UTF8);
                         xslt.Transform(xd, null, tw);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw (ex);
                     }
                     finally
                     {

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentList.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentList.cs
@@ -2456,11 +2456,11 @@ namespace System.Xml.Tests
             Assert.True(false);
         }
 
-        [ActiveIssue(9997)]
         //[Variation(id = 36, Desc = "Calling extension object from select in xsl:sort", Params = new object[] { "sort.xsl", "sort.txt" })]
+        [PlatformSpecific(TestPlatforms.Windows)] // Non Windows is not supported yet
         [InlineData("sort.xsl", "sort.txt")]
         [Theory]
-        public void AddExtObject33_ActiveIssue9877(object param0, object param1)
+        public void AddExtObject33_ActiveIssue9997(object param0, object param1)
         {
             AddExtObject33(param0, param1);
         }


### PR DESCRIPTION
Related issue: https://github.com/dotnet/corefx/issues/9997
Adds `XmlSortKey` to System.Private.Xml and re-enables a related test on Windows (as SortKey is not available in other platforms yet)

cc: @danmosemsft @tarekgh @weshaggard 