### PR TITLE
Add serialization constructors to Transaction, DependentTransaction, …

### DIFF
--- a/src/System.Transactions/src/System/Transactions/CommittableTransaction.cs
+++ b/src/System.Transactions/src/System/Transactions/CommittableTransaction.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// System.Runtime.Serialization needs to be removed when we implement distributed transaction capabilities
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Transactions.Diagnostics;
 
@@ -40,6 +42,12 @@ namespace System.Transactions
             {
                 TransactionCreatedTraceRecord.Trace(SR.TraceSourceLtm, TransactionTraceId);
             }
+        }
+
+        // This serializtion constructor needs to be removed when we implement distributed transaction capabilities
+        // Issue 13137
+        CommittableTransaction(SerializationInfo serializationInfo, StreamingContext context) : base(serializationInfo, context)
+        {
         }
 
         public IAsyncResult BeginCommit(AsyncCallback asyncCallback, object asyncState)

--- a/src/System.Transactions/src/System/Transactions/DependentTransaction.cs
+++ b/src/System.Transactions/src/System/Transactions/DependentTransaction.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// System.Runtime.Serialization needs to be removed when we implement distributed transaction capabilities
+using System.Runtime.Serialization;
 using System.Transactions.Diagnostics;
 
 namespace System.Transactions
@@ -28,6 +30,12 @@ namespace System.Transactions
                     _internalTransaction.State.CreateAbortingClone(_internalTransaction);
                 }
             }
+        }
+
+        // This serializtion constructor needs to be removed when we implement distributed transaction capabilities
+        // Issue 13137
+        DependentTransaction(SerializationInfo serializationInfo, StreamingContext context) : base(serializationInfo, context)
+        {
         }
 
         public void Complete()

--- a/src/System.Transactions/src/System/Transactions/SubordinateTransaction.cs
+++ b/src/System.Transactions/src/System/Transactions/SubordinateTransaction.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// System.Runtime.Serialization needs to be removed when we implement distributed transaction capabilities
+using System.Runtime.Serialization;
+
 namespace System.Transactions
 {
     [Serializable]
@@ -12,5 +15,12 @@ namespace System.Transactions
         public SubordinateTransaction(IsolationLevel isoLevel, ISimpleTransactionSuperior superior) : base(isoLevel, superior)
         {
         }
+
+        // This serializtion constructor needs to be removed when we implement distributed transaction capabilities
+        // Issue 13137
+        SubordinateTransaction(SerializationInfo serializationInfo, StreamingContext context) : base(serializationInfo, context)
+        {
+        }
+
     }
 }

--- a/src/System.Transactions/src/System/Transactions/Transaction.cs
+++ b/src/System.Transactions/src/System/Transactions/Transaction.cs
@@ -306,6 +306,18 @@ namespace System.Transactions
             _cloneId = 1;
         }
 
+        // This serializtion constructor needs to be removed when we implement distributed transaction capabilities
+        // Issue 13137
+        protected Transaction(SerializationInfo serializationInfo, StreamingContext context)
+        {
+            if (serializationInfo == null)
+            {
+                throw new ArgumentNullException(nameof(serializationInfo));
+            }
+
+            throw DistributedTransaction.NotSupported();
+        }
+
         #region System.Object Overrides
 
         // Don't use the identifier for the hash code.


### PR DESCRIPTION
…CommittableTransaction, and SubordinateTransaction.

They all throw a PlatformNotSupportedException because serialization of transactions cannot be supported until
distributed transactions are supported.
These constructors will be removed when support for distributed transactions is added.