### PR TITLE
Fix some race conditions in TypeConverter lib

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -67,6 +67,7 @@
     <Compile Include="System\ComponentModel\ICustomTypeDescriptor.cs" />
     <Compile Include="System\ComponentModel\IExtenderProvider.cs" />
     <Compile Include="System\ComponentModel\IListSource.cs" />
+    <Compile Include="System\ComponentModel\InterlockedBitVector32.cs" />
     <Compile Include="System\ComponentModel\InvalidAsynchronousStateException.cs" />
     <Compile Include="System\InvariantComparer.cs" />
     <Compile Include="System\ComponentModel\ITypedList.cs" />

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/InterlockedBitVector32.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/InterlockedBitVector32.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Threading;
+
+namespace System.ComponentModel
+{
+    /// <summary>
+    /// Provides a subset of the <see cref="BitVector32"/> surface area, using volatile operations for reads and interlocked operations for writes. 
+    /// </summary>
+    internal struct InterlockedBitVector32
+    {
+        private int _data;
+
+        public InterlockedBitVector32(int data)
+        {
+            _data = data;
+        }
+
+        public bool this[int bit]
+        {
+            get { return (Volatile.Read(ref _data) & bit) == bit; }
+            set
+            {
+                while (true)
+                {
+                    int oldValue = _data;
+                    int newValue = value ? oldValue | bit : oldValue &= ~bit;
+                    if (Interlocked.CompareExchange(ref _data, newValue, oldValue) == oldValue)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>Sets or unsets the specified bit, without using interlocked operations.</summary>
+        public void DangerousSet(int bit, bool value)
+        {
+            _data = value ? _data | bit : _data & ~bit;
+        }
+
+        public int Data => _data;
+
+        public static int CreateMask() => CreateMask(0);
+
+        public static int CreateMask(int previous)
+        {
+            Debug.Assert(previous != unchecked((int)0x80000000));
+            return previous == 0 ? 1 : previous << 1;
+        }
+
+        public override bool Equals(object o) => o is InterlockedBitVector32 ? _data == ((InterlockedBitVector32)o)._data : false;
+
+        public override int GetHashCode() => base.GetHashCode();
+    }
+}


### PR DESCRIPTION
There are a whole bunch of potential race conditions in the TypeConverter library.  This does not attempt to fix all of them, just address the symptoms of the ones that have been causing some failed tests.

In particular, the static TypeDescriptor.GetProperties will return a cached collection of instances, which means that instances end up being shared between threads.  Each ReflectPropertyDescriptor instance has properties that check whether a bit flag contains a bit indicating that the value has been lazily created, and if it doesn't, sets the bit, then creates and stores the value.  This leads to a variety of race conditions, including two threads racing to access the same value and one of them getting back the uninitialized value (this can also happen if an exception occurs in one thread before updating the value, leaving the flag set but the value uninitialized), and including two threads racing to access different fields but cloberring each other's updates to the state flags.

This PR addresses those two issues specifically (there are very likely others), by a) setting the bit only after the fields have been set, and b) using compare/exchange operations to update the set bits. The desktop code has the same issues, and I'm just making enough changes to avoid the test failures we've been seeing that arise due to this.

cc: @AlexGhiondea, @chlowell, @twsouthwick, @safern 
Fixes https://github.com/dotnet/corefx/issues/12753
Fixes https://github.com/dotnet/corefx/issues/13215