### PR TITLE
Disable tests for clean CI

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
@@ -23,7 +23,8 @@ namespace System.Net.Http.Functional.Tests
         {
             _output = output;
         }
-        
+
+        [ActiveIssue(11623)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -90,6 +90,7 @@ namespace System.Net.Security.Tests
             });
         }
 
+        [ActiveIssue(8744)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]


### PR DESCRIPTION
ServerAsyncAuthenticate_AllClientVsIndividualServerSupportedProtocols_Success

HttpClient_ClientUsesAuxRecord_Ok

Ref: #8744, #11623