### PR TITLE
Add full support build for test runs on Fedora 24

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -105,7 +105,7 @@
     </StaticDependency>
    
     <StaticDependency Include="Microsoft.xunit.netcore.extensions;Microsoft.DotNet.BuildTools.TestSuite">
-      <Version>1.0.0-prerelease-00925-01</Version>
+      <Version>1.0.1-prerelease-01001-04</Version>
     </StaticDependency>
 
     <PerformancePackDependency Include="Microsoft.DotNet.xunit.performance" />

--- a/netci.groovy
+++ b/netci.groovy
@@ -18,6 +18,7 @@ def osGroupMap = ['Ubuntu14.04':'Linux',
                   'Ubuntu16.10':'Linux',
                   'Debian8.4':'Linux',
                   'Fedora23':'Linux',
+                  'Fedora24':'Linux',
                   'OSX':'OSX',
                   'Windows_NT':'Windows_NT',
                   'CentOS7.1': 'Linux',
@@ -32,6 +33,7 @@ def targetNugetRuntimeMap = ['OSX' : 'osx.10.10-x64',
                              'Ubuntu16.04' : 'ubuntu.16.04-x64',
                              'Ubuntu16.10' : 'ubuntu.16.10-x64',
                              'Fedora23' : 'fedora.23-x64',
+                             'Fedora24' : 'fedora.24-x64',
                              'Debian8.4' : 'debian.8-x64',
                              'CentOS7.1' : 'centos.7-x64',
                              'OpenSUSE13.2' : 'opensuse.13.2-x64',
@@ -51,6 +53,7 @@ def osShortName = ['Windows 10': 'win10',
                    'OpenSUSE13.2' : 'opensuse13.2',
                    'OpenSUSE42.1' : 'opensuse42.1',
                    'Fedora23' : 'fedora23',
+                   'Fedora24' : 'fedora24',
                    'RHEL7.2' : 'rhel7.2']
 
 // **************************
@@ -213,7 +216,7 @@ def osShortName = ['Windows 10': 'win10',
 // Define outerloop testing for OSes that can build and run.  Run locally on each machine.
 // **************************
 [true, false].each { isPR ->
-    ['Windows 10', 'Windows 7', 'Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'Ubuntu16.10', 'CentOS7.1', 'OpenSUSE13.2', 'OpenSUSE42.1', 'RHEL7.2', 'Fedora23', 'Debian8.4', 'OSX'].each { osName ->
+    ['Windows 10', 'Windows 7', 'Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'Ubuntu16.10', 'CentOS7.1', 'OpenSUSE13.2', 'OpenSUSE42.1', 'RHEL7.2', 'Fedora23', 'Fedora24', 'Debian8.4', 'OSX'].each { osName ->
         ['Debug', 'Release'].each { configurationGroup ->
 
             def newJobName = "outerloop_${osShortName[osName]}_${configurationGroup.toLowerCase()}"
@@ -348,7 +351,7 @@ def osShortName = ['Windows 10': 'win10',
 // **************************
 [true, false].each { isPR ->
     ['Debug', 'Release'].each { configurationGroup ->
-        ['Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'Ubuntu16.10', 'Debian8.4', 'CentOS7.1', 'OpenSUSE13.2', 'OpenSUSE42.1', 'Fedora23', 'RHEL7.2', 'OSX'].each { osName ->
+        ['Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'Ubuntu16.10', 'Debian8.4', 'CentOS7.1', 'OpenSUSE13.2', 'OpenSUSE42.1', 'Fedora23', 'Fedora24', 'RHEL7.2', 'OSX'].each { osName ->
             def osGroup = osGroupMap[osName]
             def newJobName = "${osName.toLowerCase()}_${configurationGroup.toLowerCase()}"
 

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -5,9 +5,9 @@
     "ReportGenerator": "2.4.3",
     "Microsoft.NETCore.TestHost": "1.2.0-beta-24628-03",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24628-03",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04",
     "xunit.console.netcore": "1.0.3-prerelease-00921-01",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
     "perf": {
       "target": "project",
       "include": "compile,runtime"
@@ -416,6 +416,7 @@
         "ubuntu.16.04-x64",
         "ubuntu.16.10-x64",
         "fedora.23-x64",
+        "fedora.24-x64",
         "linux-x64",
         "opensuse.13.2-x64",
         "opensuse.42.1-x64"

--- a/src/System.Console/tests/ManualTests/project.json
+++ b/src/System.Console/tests/ManualTests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -9,8 +9,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -24,8 +24,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.Http/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/unix/project.json
@@ -24,8 +24,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Net.Http/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/win/project.json
@@ -25,8 +25,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Net.Http/tests/UnitTests/project.json
+++ b/src/System.Net.Http/tests/UnitTests/project.json
@@ -21,8 +21,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Net.Mail/tests/Functional/project.json
+++ b/src/System.Net.Mail/tests/Functional/project.json
@@ -27,8 +27,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Net.Mail/tests/Unit/project.json
+++ b/src/System.Net.Mail/tests/Unit/project.json
@@ -25,8 +25,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Net.NameResolution/tests/PalTests/project.json
+++ b/src/System.Net.NameResolution/tests/PalTests/project.json
@@ -32,8 +32,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NameResolution/tests/UnitTests/project.json
+++ b/src/System.Net.NameResolution/tests/UnitTests/project.json
@@ -16,8 +16,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Net.NetworkInformation/tests/UnitTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/UnitTests/project.json
@@ -10,8 +10,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Net.Primitives/tests/PalTests/project.json
+++ b/src/System.Net.Primitives/tests/PalTests/project.json
@@ -23,8 +23,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.3": {},

--- a/src/System.Net.Primitives/tests/PerformanceTests/project.json
+++ b/src/System.Net.Primitives/tests/PerformanceTests/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {

--- a/src/System.Net.Primitives/tests/UnitTests/project.json
+++ b/src/System.Net.Primitives/tests/UnitTests/project.json
@@ -24,8 +24,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.7": {},

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -25,8 +25,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -21,8 +21,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Net.Security/tests/UnitTests/project.json
+++ b/src/System.Net.Security/tests/UnitTests/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.Private.Xml.Linq/tests/Schema/project.json
+++ b/src/System.Private.Xml.Linq/tests/Schema/project.json
@@ -8,8 +8,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.7": {},

--- a/src/System.Private.Xml.Linq/tests/XDocument.Common/project.json
+++ b/src/System.Private.Xml.Linq/tests/XDocument.Common/project.json
@@ -17,8 +17,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/project.json
+++ b/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/project.json
@@ -14,8 +14,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.Xml/tests/XmlReaderLib/project.json
+++ b/src/System.Private.Xml/tests/XmlReaderLib/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Reflection.Metadata/tests/project.json
+++ b/src/System.Reflection.Metadata/tests/project.json
@@ -26,8 +26,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Reflection/tests/CoreCLR/project.json
+++ b/src/System.Reflection/tests/CoreCLR/project.json
@@ -15,8 +15,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/src/System.Runtime.Loader/tests/DefaultContext/project.json
+++ b/src/System.Runtime.Loader/tests/DefaultContext/project.json
@@ -19,8 +19,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Runtime.Loader/tests/RefEmitLoadContext/project.json
+++ b/src/System.Runtime.Loader/tests/RefEmitLoadContext/project.json
@@ -20,8 +20,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Runtime.Loader/tests/project.json
+++ b/src/System.Runtime.Loader/tests/project.json
@@ -18,8 +18,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01"
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04"
   },
   "frameworks": {
     "netstandard1.6": {}

--- a/src/System.Runtime.Serialization.Json/tests/Performance/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/Performance/project.json
@@ -27,8 +27,8 @@
       "exclude": "compile"
     },
     "Newtonsoft.Json": "8.0.4-beta1",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Json/tests/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/project.json
@@ -27,8 +27,8 @@
       "exclude": "compile"
     },
     "Newtonsoft.Json": "8.0.4-beta1",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -27,8 +27,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040"
   },
   "frameworks": {


### PR DESCRIPTION
Now that we've updated buildtools, we can enable full test runs on Fedora 24. This change updates a few test projects in order to support Fedora 24, and also adds CI runs for them.