### PR TITLE
Remove duplicate string resources in 5 projects

### DIFF
--- a/src/System.CodeDom/src/Resources/Strings.resx
+++ b/src/System.CodeDom/src/Resources/Strings.resx
@@ -169,9 +169,6 @@
   <data name="InvalidLanguageIdentifier" xml:space="preserve">
     <value>The identifier:"{0}" on the property:"{1}" of type:"{2}" is not a valid language-independent identifier name. Check to see if CodeGenerator.IsValidLanguageIndependentIdentifier allows the identifier name.</value>
   </data>
-  <data name="CodeDomProvider_NotDefined" xml:space="preserve">
-    <value>There is no CodeDom provider defined for the language.</value>
-  </data>
   <data name="toStringUnknown" xml:space="preserve">
     <value>{unknown}</value>
   </data>

--- a/src/System.Net.Requests/src/Resources/Strings.resx
+++ b/src/System.Net.Requests/src/Resources/Strings.resx
@@ -240,9 +240,6 @@
   <data name="net_PropertyNotSupportedException" xml:space="preserve">
     <value>This property is not supported by this class.</value>
   </data>
-  <data name="net_securityprotocolnotsupported" xml:space="preserve">
-    <value>This operation cannot be performed on a completed asynchronous result object.</value>
-  </data>
   <data name="net_InvalidStatusCode" xml:space="preserve">
     <value>The server returned a status code outside the valid range of 100-599.</value>
   </data>

--- a/src/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/System.Private.Xml/src/Resources/Strings.resx
@@ -3156,15 +3156,6 @@
   <data name="Xml_SystemPathResolverCannotOpenUri" xml:space="preserve">
     <value />
   </data>
-  <data name="Xml_UserException" xml:space="preserve">
-    <value>{0}</value>
-  </data>
-  <data name="Xml_ErrorFilePosition" xml:space="preserve">
-    <value>An error occurred at {0}({1},{2}).</value>
-  </data>
-  <data name="Xml_InvalidOperation" xml:space="preserve">
-    <value>Operation is not valid due to the current state of the object.</value>
-  </data>
   <data name="Xml_EndOfInnerExceptionStack" xml:space="preserve">
     <value>--- End of inner exception stack trace ---</value>
   </data>
@@ -3596,9 +3587,6 @@
   </data>
   <data name="Xslt_InvalidQName" xml:space="preserve">
     <value>'{0}' is an invalid QName.</value>
-  </data>
-  <data name="Xslt_NoStylesheetLoaded" xml:space="preserve">
-    <value>No stylesheet was loaded.</value>
   </data>
   <data name="Xslt_TemplateNoAttrib" xml:space="preserve">
     <value>The 'xsl:template' instruction must have the 'match' and/or 'name' attribute present.</value>

--- a/src/System.Runtime.Extensions/src/Resources/Strings.resx
+++ b/src/System.Runtime.Extensions/src/Resources/Strings.resx
@@ -294,9 +294,6 @@
   <data name="Arg_DllInitFailure" xml:space="preserve">
     <value>One machine may not have remote administration enabled, or both machines may not be running the remote registry service.</value>
   </data>
-  <data name="Arg_EnumIllegalVal" xml:space="preserve">
-    <value>Illegal enum value: {0}.</value>
-  </data>
   <data name="Arg_RegSubKeyValueAbsent" xml:space="preserve">
     <value>No value exists with that name.</value>
   </data>
@@ -323,9 +320,6 @@
   </data>
   <data name="UnauthorizedAccess_RegistryNoWrite" xml:space="preserve">
     <value>Cannot write to the registry key.</value>
-  </data>
-  <data name="UnknownError_Num" xml:space="preserve">
-    <value>Unknown error '{0}'.</value>
   </data>
   <data name="PersistedFiles_NoHomeDirectory" xml:space="preserve">
     <value>The home directory of the current user could not be determined.</value>

--- a/src/System.Runtime.Serialization.Formatters/src/Resources/Strings.resx
+++ b/src/System.Runtime.Serialization.Formatters/src/Resources/Strings.resx
@@ -195,12 +195,6 @@
   <data name="Serialization_ConstructorNotFound" xml:space="preserve">
     <value>The constructor to deserialize an object of type '{0}' was not found.</value>
   </data>
-  <data name="Serialization_ObjectNotSupplied" xml:space="preserve">
-    <value>The object with ID {0} was referenced in a fixup but does not exist.</value>
-  </data>
-  <data name="Serialization_TypeLoadFailure" xml:space="preserve">
-    <value>Unable to load type {0} required for deserialization.</value>
-  </data>
   <data name="Serialization_IncorrectNumberOfFixups" xml:space="preserve">
     <value>The ObjectManager found an invalid number of fixups. This usually indicates a problem in the Formatter.</value>
   </data>
@@ -257,9 +251,6 @@
   </data>
   <data name="Serialization_AssemblyId" xml:space="preserve">
     <value>No assembly ID for object type '{0}'.</value>
-  </data>
-  <data name="Serialization_ObjectTypeEnum" xml:space="preserve">
-    <value>Invalid ObjectTypeEnum {0}.</value>
   </data>
   <data name="Serialization_ArrayType" xml:space="preserve">
     <value>Invalid array type '{0}'.</value>


### PR DESCRIPTION
These string resources are duplicates and produce build warnings.