### PR TITLE
Bring remaining System.Runtime members to netstandard2.0

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -428,7 +428,9 @@ namespace System
         public BadImageFormatException(string message, string fileName, System.Exception inner) { }
         protected BadImageFormatException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public string FileName { get { throw null; } }
+        public string FusionLog { get { throw null; } }
         public override string Message { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1063,6 +1065,14 @@ namespace System
         public static bool TryParse(string s, out double result) { throw null; }
         public static bool TryParse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider, out double result) { throw null; }
     }
+    public partial class DuplicateWaitObjectException : System.ArgumentException, System.Runtime.Serialization.ISerializable
+    {
+        public DuplicateWaitObjectException() { }
+        public DuplicateWaitObjectException(string parameterName) { }
+        public DuplicateWaitObjectException(string parameterName, string message) { }
+        public DuplicateWaitObjectException(string message, System.Exception inner) { }
+        protected DuplicateWaitObjectException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
     public abstract partial class Enum : System.ValueType, System.IComparable, System.IConvertible, System.IFormattable
     {
         protected Enum() { }
@@ -1603,14 +1613,19 @@ namespace System
     {
         public MissingFieldException() { }
         public MissingFieldException(string message) { }
+        public MissingFieldException(string className, string fieldName) { }
         public MissingFieldException(string message, System.Exception inner) { }
         protected MissingFieldException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public override string Message { get { throw null; } }
     }
     public partial class MissingMemberException : System.MemberAccessException, System.Runtime.Serialization.ISerializable
     {
+        protected string ClassName;
+        protected string MemberName;
+        protected byte[] Signature;
         public MissingMemberException() { }
         public MissingMemberException(string message) { }
+        public MissingMemberException(string className, string memberName) { }
         public MissingMemberException(string message, System.Exception inner) { }
         protected MissingMemberException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public override string Message { get { throw null; } }
@@ -1620,6 +1635,7 @@ namespace System
     {
         public MissingMethodException() { }
         public MissingMethodException(string message) { }
+        public MissingMethodException(string className, string methodName) { }
         public MissingMethodException(string message, System.Exception inner) { }
         protected MissingMethodException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public override string Message { get { throw null; } }
@@ -2633,6 +2649,13 @@ namespace System
         public override string Message { get { throw null; } }
         public string TypeName { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class TypeUnloadedException : System.SystemException, System.Runtime.Serialization.ISerializable
+    {
+        public TypeUnloadedException() { }
+        public TypeUnloadedException(string message) { }
+        public TypeUnloadedException(string message, System.Exception inner) { }
+        protected TypeUnloadedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
     [System.CLSCompliantAttribute(false)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -5646,6 +5669,12 @@ namespace System.Reflection
 }
 namespace System.Runtime
 {
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited = false)]
+    public sealed partial class AssemblyTargetedPatchBandAttribute : System.Attribute
+    {
+        public AssemblyTargetedPatchBandAttribute(string targetedPatchBand) { }
+        public string TargetedPatchBand { get { throw null; } }
+    }
     public enum GCLargeObjectHeapCompactionMode
     {
         CompactOnce = 2,
@@ -5671,7 +5700,12 @@ namespace System.Runtime
         public void Dispose() { }
         ~MemoryFailPoint() { }
     }
-
+    [System.AttributeUsageAttribute((System.AttributeTargets)(64), AllowMultiple = false, Inherited = false)]
+    public sealed partial class TargetedPatchingOptOutAttribute : System.Attribute
+    {
+        public TargetedPatchingOptOutAttribute(string reason) { }
+        public string Reason { get { throw null; } }
+    }
 }
 namespace System.Runtime.CompilerServices
 {

--- a/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
@@ -624,3 +624,6 @@ CannotRemoveBaseTypeOrInterface : Type 'System.Threading.Tasks.Task' does not im
 MembersMustExist : Member 'System.Threading.Tasks.Task.Dispose()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Threading.Tasks.Task.Dispose(System.Boolean)' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Threading.Tasks.Task<TResult>' does not implement interface 'System.IDisposable' in the implementation but it does in the contract.
+MembersMustExist : Member 'System.BadImageFormatException.FusionLog.get()' does not exist in the implementation but it does exist in the contract. 
+TypesMustExist : Type 'System.DuplicateWaitObjectException' does not exist in the implementation but it does exist in the contract. 
+TypesMustExist : Type 'System.TypeUnloadedException' does not exist in the implementation but it does exist in the contract. 

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -36,6 +36,7 @@
     <Compile Include="System\Runtime\CompilerServices\Attributes.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == '' OR '$(TargetGroup)' == 'netstandard1.7' OR '$(TargetGroup)' == 'uap101aot'">
+    <Compile Include="System\Runtime\NgenServicingAttributes.cs" />
     <Compile Include="System\IO\HandleInheritability.cs" />
     <Compile Include="System\Runtime\ConstrainedExecution\PrePrepareMethodAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\SpecialNameAttribute.cs" />

--- a/src/System.Runtime/src/System/Runtime/NgenServicingAttributes.cs
+++ b/src/System.Runtime/src/System/Runtime/NgenServicingAttributes.cs
@@ -17,12 +17,6 @@ namespace System.Runtime
         }
     }
 
-    //============================================================================================================
-    // Sacrifices cheap servicing of a method body in order to allow unrestricted inlining.  Certain types of
-    // trivial methods (e.g. simple property getters) are automatically attributed by ILCA.EXE during the build.
-    // For other performance critical methods, it should be added manually.
-    //============================================================================================================
-
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
     public sealed class TargetedPatchingOptOutAttribute : Attribute
     {
@@ -32,7 +26,5 @@ namespace System.Runtime
         {
             Reason = reason;
         }
-
-        private TargetedPatchingOptOutAttribute() { }
     }
 }

--- a/src/System.Runtime/src/System/Runtime/NgenServicingAttributes.cs
+++ b/src/System.Runtime/src/System/Runtime/NgenServicingAttributes.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Runtime
+{
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class AssemblyTargetedPatchBandAttribute : Attribute
+    {
+        private String m_targetedPatchBand;
+
+        public AssemblyTargetedPatchBandAttribute(String targetedPatchBand)
+        {
+            m_targetedPatchBand = targetedPatchBand;
+        }
+
+        public String TargetedPatchBand
+        {
+            get { return m_targetedPatchBand; }
+        }
+    }
+
+    //============================================================================================================
+    // Sacrifices cheap servicing of a method body in order to allow unrestricted inlining.  Certain types of
+    // trivial methods (e.g. simple property getters) are automatically attributed by ILCA.EXE during the build.
+    // For other performance critical methods, it should be added manually.
+    //============================================================================================================
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    public sealed class TargetedPatchingOptOutAttribute : Attribute
+    {
+        private String m_reason;
+
+        public TargetedPatchingOptOutAttribute(String reason)
+        {
+            m_reason = reason;
+        }
+
+        public String Reason
+        {
+            get { return m_reason; }
+        }
+
+        private TargetedPatchingOptOutAttribute() { }
+    }
+}

--- a/src/System.Runtime/src/System/Runtime/NgenServicingAttributes.cs
+++ b/src/System.Runtime/src/System/Runtime/NgenServicingAttributes.cs
@@ -9,16 +9,11 @@ namespace System.Runtime
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
     public sealed class AssemblyTargetedPatchBandAttribute : Attribute
     {
-        private String m_targetedPatchBand;
+        public string TargetedPatchBand { get; }
 
-        public AssemblyTargetedPatchBandAttribute(String targetedPatchBand)
+        public AssemblyTargetedPatchBandAttribute(string targetedPatchBand)
         {
-            m_targetedPatchBand = targetedPatchBand;
-        }
-
-        public String TargetedPatchBand
-        {
-            get { return m_targetedPatchBand; }
+            TargetedPatchBand = targetedPatchBand;
         }
     }
 
@@ -31,16 +26,11 @@ namespace System.Runtime
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
     public sealed class TargetedPatchingOptOutAttribute : Attribute
     {
-        private String m_reason;
+        public string Reason { get; }
 
-        public TargetedPatchingOptOutAttribute(String reason)
+        public TargetedPatchingOptOutAttribute(string reason)
         {
-            m_reason = reason;
-        }
-
-        public String Reason
-        {
-            get { return m_reason; }
+            Reason = reason;
         }
 
         private TargetedPatchingOptOutAttribute() { }

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -129,8 +129,10 @@
     <Compile Include="EnumTests.netstandard1.7.cs" />
     <Compile Include="GetTypeCodeTests.cs" />
     <Compile Include="System\AccessViolationExceptionTests.cs" />
+    <Compile Include="System\BadImageFormatExceptionTests.cs" />
     <Compile Include="System\CharTests.netstandard1.7.cs" />
     <Compile Include="System\DateTimeOffsetTests.netstandard1.7.cs" />
+    <Compile Include="System\DuplicateWaitObjectExceptionTests.cs" />
     <Compile Include="System\ExternalExceptionTests.cs" />
     <Compile Include="System\ApplicationExceptionTests.cs" />
     <Compile Include="System\EntryPointNotFoundExceptionTests.cs" />
@@ -138,12 +140,14 @@
     <Compile Include="System\ExecutionEngineExceptionTests.cs" />
     <Compile Include="System\GuidTests.netstandard1.7.cs" />
     <Compile Include="System\MarshalByRefObjectTests.cs" />
+    <Compile Include="System\MissingMemberExceptionTests.cs" />
     <Compile Include="System\NotFiniteNumberExceptionTests.cs" />
-    <Compile Include="System\Security\SecurityAttributeTests.cs" /> 
+    <Compile Include="System\Security\SecurityAttributeTests.cs" />
     <Compile Include="System\StackOverflowExceptionTests.cs" />
     <Compile Include="System\SystemExceptionTests.cs" />
     <Compile Include="System\StringTests.netstandard1.7.cs" />
     <Compile Include="System\TimeSpanTests.netstandard1.7.cs" />
+    <Compile Include="System\TypeUnloadedExceptionTests.cs" />
     <Compile Include="TimeZoneInfoTests.netstandard1.7.cs" />
     <Compile Include="TimeZoneNotFoundExceptionTests.netstandard1.7.cs" />
     <Compile Include="VersionTests.netstandard1.7.cs" />
@@ -184,6 +188,7 @@
       <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
     <Compile Include="System\Runtime\CompilerServices\RuntimeHelpersTests.netstandard1.7.cs" />
+    <Compile Include="System\Runtime\NgenServicingAttributesTests.cs" />
     <Compile Include="System\Attributes.netstandard1.7.cs" />
     <Compile Include="System\HandleTests.netstandard1.7.cs" />
     <Compile Include="System\AppContext\AppContext.Switch.cs" />
@@ -194,11 +199,11 @@
     <Compile Include="System\GCTests.netstandard1.7.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
       <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
-   </Compile>
-   <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
-   <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>

--- a/src/System.Runtime/tests/System/BadImageFormatExceptionTests.cs
+++ b/src/System.Runtime/tests/System/BadImageFormatExceptionTests.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using ExceptionUtility = System.IO.Tests.ExceptionUtility;
+
+namespace System.Tests
+{
+    public static class BadImageFormatExceptionTests
+    {
+        private const int COR_E_BADIMAGEFORMAT = unchecked((int)0x8007000B);
+
+        [Fact]
+        public static void Ctor_Empty()
+        {
+            var exception = new BadImageFormatException();
+            ExceptionUtility.ValidateExceptionProperties(exception, hResult: COR_E_BADIMAGEFORMAT, validateMessage: false);
+            Assert.Null(exception.FileName);
+        }
+
+        [Fact]
+        public static void Ctor_String()
+        {
+            string message = "this is not the file you're looking for";
+            var exception = new BadImageFormatException(message);
+            ExceptionUtility.ValidateExceptionProperties(exception, hResult: COR_E_BADIMAGEFORMAT, message: message);
+            Assert.Null(exception.FileName);
+        }
+
+        [Fact]
+        public static void Ctor_String_Exception()
+        {
+            string message = "this is not the file you're looking for";
+            var innerException = new Exception("Inner exception");
+            var exception = new BadImageFormatException(message, innerException);
+            ExceptionUtility.ValidateExceptionProperties(exception, hResult: COR_E_BADIMAGEFORMAT, innerException: innerException, message: message);
+            Assert.Equal(null, exception.FileName);
+        }
+
+        [Fact]
+        public static void Ctor_String_String()
+        {
+            string message = "this is not the file you're looking for";
+            string fileName = "file.txt";
+            var exception = new BadImageFormatException(message, fileName);
+            ExceptionUtility.ValidateExceptionProperties(exception, hResult: COR_E_BADIMAGEFORMAT, message: message);
+            Assert.Equal(fileName, exception.FileName);
+        }
+
+        [Fact]
+        public static void Ctor_String_String_Exception()
+        {
+            string message = "this is not the file you're looking for";
+            string fileName = "file.txt";
+            var innerException = new Exception("Inner exception");
+            var exception = new BadImageFormatException(message, fileName, innerException);
+            ExceptionUtility.ValidateExceptionProperties(exception, hResult: COR_E_BADIMAGEFORMAT, innerException: innerException, message: message);
+            Assert.Equal(fileName, exception.FileName);
+        }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            string message = "this is not the file you're looking for";
+            string fileName = "file.txt";
+            var innerException = new Exception("Inner exception");
+            var exception = new BadImageFormatException(message, fileName, innerException);
+
+            var toString = exception.ToString();
+            Assert.Contains(": " + message, toString);
+            Assert.Contains(": '" + fileName + "'", toString);
+            Assert.Contains("---> " + innerException.ToString(), toString);
+
+            // set the stack trace
+            try { throw exception; }
+            catch
+            {
+                Assert.False(string.IsNullOrEmpty(exception.StackTrace));
+                Assert.Contains(exception.StackTrace, exception.ToString());
+            }
+        }
+
+        [Fact]
+        public static void FusionLogTest()
+        {
+            string message = "this is not the file you're looking for";
+            string fileName = "file.txt";
+            var innerException = new Exception("Inner exception");
+            var exception = new BadImageFormatException(message, fileName, innerException);
+
+            Assert.Null(exception.FusionLog);
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/DuplicateWaitObjectExceptionTests.cs
+++ b/src/System.Runtime/tests/System/DuplicateWaitObjectExceptionTests.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.Missing
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace System.Tests
+{
+    public static class DuplicateWaitObjectExceptionTests
+    {
+        private const int COR_E_DUPLICATEWAITOBJECT = unchecked((int)0x80131529);
+
+        [Fact]
+        public static void Ctor_Empty()
+        {
+            var exception = new DuplicateWaitObjectException();
+            Assert.NotEmpty(exception.Message);
+            Assert.Equal(COR_E_DUPLICATEWAITOBJECT, exception.HResult);
+        }
+
+        [Fact]
+        public static void Ctor_String()
+        {
+            string parameterName = "THISISAPARAMETERNAME";
+            var exception = new DuplicateWaitObjectException(parameterName);
+            Assert.True(exception.Message.Contains(parameterName));
+            Assert.Equal(COR_E_DUPLICATEWAITOBJECT, exception.HResult);
+        }
+
+        [Fact]
+        public static void Ctor_String_Exception()
+        {
+            string message = "CreatedDuplicateWaitObjectException";
+            var innerException = new Exception("Created inner exception");
+            var exception = new DuplicateWaitObjectException(message, innerException);
+            Assert.Equal(message, exception.Message);
+            Assert.Equal(COR_E_DUPLICATEWAITOBJECT, exception.HResult);
+            Assert.Same(innerException, exception.InnerException);
+            Assert.Equal(innerException.HResult, exception.InnerException.HResult);
+        }
+
+        [Fact]
+        public static void Ctor_String_String()
+        {
+            string parameterName = "THISISAPARAMETERNAME";
+            string message = "CreatedDuplicateWaitObjectException";
+            var exception = new DuplicateWaitObjectException(parameterName, message);
+            Assert.True(exception.Message.Contains(parameterName));
+            Assert.True(exception.Message.Contains(message));
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/MissingMemberExceptionTests.cs
+++ b/src/System.Runtime/tests/System/MissingMemberExceptionTests.cs
@@ -7,49 +7,47 @@ using Xunit;
 
 namespace System.Tests
 {
-    public static class MissingFieldExceptionTests
+    public static class MissingMemberExceptionTests
     {
-        private const int COR_E_MISSINGFIELD = unchecked((int)0x80131511);
+        private const int COR_E_MISSINGMEMBER = unchecked((int)0x80131512);
 
         [Fact]
         public static void Ctor_Empty()
         {
-            var exception = new MissingFieldException();
+            var exception = new MissingMemberException();
             Assert.NotEmpty(exception.Message);
-            Assert.Equal(COR_E_MISSINGFIELD, exception.HResult);
+            Assert.Equal(COR_E_MISSINGMEMBER, exception.HResult);
         }
 
         [Fact]
         public static void Ctor_String()
         {
-            string message = "Created MissingFieldException";
-            var exception = new MissingFieldException(message);
+            string message = "Created MissingMemberException";
+            var exception = new MissingMemberException(message);
             Assert.Equal(message, exception.Message);
-            Assert.Equal(COR_E_MISSINGFIELD, exception.HResult);
+            Assert.Equal(COR_E_MISSINGMEMBER, exception.HResult);
         }
 
         [Fact]
         public static void Ctor_String_Exception()
         {
-            string message = "Created MissingFieldException";
+            string message = "Created MissingMemberException";
             var innerException = new Exception("Created inner exception");
-            var exception = new MissingFieldException(message, innerException);
+            var exception = new MissingMemberException(message, innerException);
             Assert.Equal(message, exception.Message);
-            Assert.Equal(COR_E_MISSINGFIELD, exception.HResult);
+            Assert.Equal(COR_E_MISSINGMEMBER, exception.HResult);
             Assert.Same(innerException, exception.InnerException);
             Assert.Equal(innerException.HResult, exception.InnerException.HResult);
         }
 
-#if netstandard17
         [Fact]
         public static void Ctor_String_String()
         {
             string className = "class";
             string memberName = "member";
-            var exception = new MissingFieldException(className, memberName);
+            var exception = new MissingMemberException(className, memberName);
             Assert.True(exception.Message.Contains(className));
             Assert.True(exception.Message.Contains(memberName));
         }
-#endif
     }
 }

--- a/src/System.Runtime/tests/System/MissingMethodExceptionTests.cs
+++ b/src/System.Runtime/tests/System/MissingMethodExceptionTests.cs
@@ -39,5 +39,16 @@ namespace System.Tests
             Assert.Same(innerException, exception.InnerException);
             Assert.Equal(innerException.HResult, exception.InnerException.HResult);
         }
+#if netstandard17
+        [Fact]
+        public static void Ctor_String_String()
+        {
+            string className = "class";
+            string memberName = "member";
+            var exception = new MissingMethodException(className, memberName);
+            Assert.True(exception.Message.Contains(className));
+            Assert.True(exception.Message.Contains(memberName));
+        }
+#endif
     }
 }

--- a/src/System.Runtime/tests/System/Runtime/NgenServicingAttributesTests.cs
+++ b/src/System.Runtime/tests/System/Runtime/NgenServicingAttributesTests.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.Tests
+{
+    public static class NgenServicingAttributesTests
+    {
+        [Fact]
+        public static void AssemblyTargetedPatchBandAttributeTest()
+        {
+            string targetedPatchBand = "testStr";
+            var attr = new AssemblyTargetedPatchBandAttribute(targetedPatchBand);
+            Assert.Equal(targetedPatchBand, attr.TargetedPatchBand);
+        }
+
+        [Fact]
+        public static void TargetedPatchingOptOutAttributeTest()
+        {
+            string reason = "testStr";
+            var attr = new TargetedPatchingOptOutAttribute(reason);
+            Assert.Equal(reason, attr.Reason);
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/TypeUnloadedExceptionTests.cs
+++ b/src/System.Runtime/tests/System/TypeUnloadedExceptionTests.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace System.Tests
+{
+    public static class TypeUnloadedExceptionTests
+    {
+        private const int COR_E_TYPEUNLOADED = unchecked((int)0x80131013);
+
+        [Fact]
+        public static void Ctor_Empty()
+        {
+            var exception = new TypeUnloadedException();
+            Assert.NotEmpty(exception.Message);
+            Assert.Equal(COR_E_TYPEUNLOADED, exception.HResult);
+        }
+
+        [Fact]
+        public static void Ctor_String()
+        {
+            string message = "Created TypeUnloadedException ";
+            var exception = new TypeUnloadedException(message);
+            Assert.Equal(message, exception.Message);
+            Assert.Equal(COR_E_TYPEUNLOADED, exception.HResult);
+        }
+
+        [Fact]
+        public static void Ctor_String_Exception()
+        {
+            string message = "Created TypeUnloadedException ";
+            var innerException = new Exception("Created inner exception");
+            var exception = new TypeUnloadedException(message, innerException);
+            Assert.Equal(message, exception.Message);
+            Assert.Equal(COR_E_TYPEUNLOADED, exception.HResult);
+            Assert.Same(innerException, exception.InnerException);
+            Assert.Equal(innerException.HResult, exception.InnerException.HResult);
+        }
+    }
+}

--- a/src/System.Security.Permissions/System.Security.Permissions.sln
+++ b/src/System.Security.Permissions/System.Security.Permissions.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Permissions", "src\System.Security.Permissions.csproj", "{07390899-C8F6-4E83-A3A9-6867B8CB46A0}"
 EndProject
@@ -18,35 +17,35 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		net46_Debug|Any CPU = net46_Debug|Any CPU
 		net46_Release|Any CPU = net46_Release|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Debug|Any CPU.ActiveCfg = net463_Release|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Debug|Any CPU.Build.0 = net463_Release|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Release|Any CPU.Build.0 = Release|Any CPU
 		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
 		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Release|Any CPU.Build.0 = Release|Any CPU
 		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
 		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.net46_Release|Any CPU.Build.0 = Release|Any CPU
+		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.net46_Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.net46_Release|Any CPU.Build.0 = Debug|Any CPU
+		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{F82A69C2-3687-4A50-9C80-BC7005F40ADC}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds src, ref, and tests for the remaining members of System.Runtime.

resolves https://github.com/dotnet/corefx/issues/12812, resolves https://github.com/dotnet/corefx/issues/12398

@joperezr @AlexGhiondea @alexperovich @stephentoub 