### PR TITLE
Port missing System.Security.Cryptography.X509Certificates members

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -115,6 +115,8 @@ namespace System.Security.Cryptography.X509Certificates
         public System.IntPtr Handle { get { throw null; } }
         public string Issuer { get { throw null; } }
         public string Subject { get { throw null; } }
+        public static System.Security.Cryptography.X509Certificates.X509Certificate CreateFromCertFile(string filename) { throw null; }
+        public static System.Security.Cryptography.X509Certificates.X509Certificate CreateFromSignedFile(string filename) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public override bool Equals(object obj) { throw null; }
@@ -122,6 +124,7 @@ namespace System.Security.Cryptography.X509Certificates
         public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType) { throw null; }
         public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, System.Security.SecureString password) { throw null; }
         public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, string password) { throw null; }
+        protected static string FormatDate(System.DateTime date) { throw null; }
         public virtual byte[] GetCertHash() { throw null; }
         public virtual string GetCertHashString() { throw null; }
         public virtual string GetEffectiveDateString() { throw null; }
@@ -135,14 +138,21 @@ namespace System.Security.Cryptography.X509Certificates
         public virtual string GetKeyAlgorithmParametersString() { throw null; }
         [System.ObsoleteAttribute("This method has been deprecated.  Please use the Subject property instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
         public virtual string GetName() { throw null; }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual byte[] GetPublicKey() { throw null; }
         public virtual string GetPublicKeyString() { throw null; }
         public virtual byte[] GetRawCertData() { throw null; }
         public virtual string GetRawCertDataString() { throw null; }
         public virtual byte[] GetSerialNumber() { throw null; }
         public virtual string GetSerialNumberString() { throw null; }
+        public virtual void Import(byte[] rawData) { }
+        public virtual void Import(byte[] rawData, System.Security.SecureString password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public virtual void Import(byte[] rawData, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public virtual void Import(string fileName) { }
+        public virtual void Import(string fileName, System.Security.SecureString password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public virtual void Import(string fileName, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public virtual void Reset() { }
         void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
         public virtual string ToString(bool fVerbose) { throw null; }
     }
@@ -169,8 +179,8 @@ namespace System.Security.Cryptography.X509Certificates
         public System.Security.Cryptography.X509Certificates.X500DistinguishedName IssuerName { get { throw null; } }
         public System.DateTime NotAfter { get { throw null; } }
         public System.DateTime NotBefore { get { throw null; } }
-        public System.Security.Cryptography.X509Certificates.PublicKey PublicKey { get { throw null; } }
         public System.Security.Cryptography.AsymmetricAlgorithm PrivateKey { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.PublicKey PublicKey { get { throw null; } }
         public byte[] RawData { get { throw null; } }
         public string SerialNumber { get { throw null; } }
         public System.Security.Cryptography.Oid SignatureAlgorithm { get { throw null; } }
@@ -180,8 +190,16 @@ namespace System.Security.Cryptography.X509Certificates
         public static System.Security.Cryptography.X509Certificates.X509ContentType GetCertContentType(byte[] rawData) { throw null; }
         public static System.Security.Cryptography.X509Certificates.X509ContentType GetCertContentType(string fileName) { throw null; }
         public string GetNameInfo(System.Security.Cryptography.X509Certificates.X509NameType nameType, bool forIssuer) { throw null; }
+        public override void Import(byte[] rawData) { }
+        public override void Import(byte[] rawData, System.Security.SecureString password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public override void Import(byte[] rawData, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public override void Import(string fileName) { }
+        public override void Import(string fileName, System.Security.SecureString password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public override void Import(string fileName, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public override void Reset() { }
         public override string ToString() { throw null; }
         public override string ToString(bool verbose) { throw null; }
+        public bool Verify() { throw null; }
     }
     public partial class X509Certificate2Collection : System.Security.Cryptography.X509Certificates.X509CertificateCollection
     {
@@ -262,6 +280,9 @@ namespace System.Security.Cryptography.X509Certificates
     public partial class X509Chain : System.IDisposable
     {
         public X509Chain() { }
+        public X509Chain(bool useMachineContext) { }
+        public X509Chain(System.IntPtr chainContext) { }
+        public System.IntPtr ChainContext { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509ChainElementCollection ChainElements { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509ChainPolicy ChainPolicy { get { throw null; } set { } }
         public System.Security.Cryptography.X509Certificates.X509ChainStatus[] ChainStatus { get { throw null; } }
@@ -269,6 +290,7 @@ namespace System.Security.Cryptography.X509Certificates
         public bool Build(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+        public void Reset() { }
     }
     public partial class X509ChainElement
     {
@@ -281,9 +303,9 @@ namespace System.Security.Cryptography.X509Certificates
     {
         internal X509ChainElementCollection() { }
         public int Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509ChainElement this[int index] { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
         public void CopyTo(System.Security.Cryptography.X509Certificates.X509ChainElement[] array, int index) { }
         public System.Security.Cryptography.X509Certificates.X509ChainElementEnumerator GetEnumerator() { throw null; }
         void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
@@ -378,10 +400,10 @@ namespace System.Security.Cryptography.X509Certificates
     {
         public X509ExtensionCollection() { }
         public int Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509Extension this[int index] { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509Extension this[string oid] { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
         public int Add(System.Security.Cryptography.X509Certificates.X509Extension extension) { throw null; }
         public void CopyTo(System.Security.Cryptography.X509Certificates.X509Extension[] array, int index) { }
         public System.Security.Cryptography.X509Certificates.X509ExtensionEnumerator GetEnumerator() { throw null; }
@@ -480,15 +502,23 @@ namespace System.Security.Cryptography.X509Certificates
     public sealed partial class X509Store : System.IDisposable
     {
         public X509Store() { }
+        public X509Store(System.IntPtr storeHandle) { }
+        public X509Store(System.Security.Cryptography.X509Certificates.StoreLocation storeLocation) { }
+        public X509Store(System.Security.Cryptography.X509Certificates.StoreName storeName) { }
         public X509Store(System.Security.Cryptography.X509Certificates.StoreName storeName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation) { }
+        public X509Store(string storeName) { }
         public X509Store(string storeName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation) { }
         public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.StoreLocation Location { get { throw null; } }
         public string Name { get { throw null; } }
+        public System.IntPtr StoreHandle { get { throw null; } }
         public void Add(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void AddRange(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public void Close() { }
         public void Dispose() { }
         public void Open(System.Security.Cryptography.X509Certificates.OpenFlags flags) { }
         public void Remove(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void RemoveRange(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
     }
     public sealed partial class X509SubjectKeyIdentifierExtension : System.Security.Cryptography.X509Certificates.X509Extension
     {

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/IStorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/IStorePal.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Internal.Cryptography.Pal
@@ -12,5 +13,6 @@ namespace Internal.Cryptography.Pal
         void CloneTo(X509Certificate2Collection collection);
         void Add(ICertificatePal cert);
         void Remove(ICertificatePal cert);
+        SafeHandle SafeHandle { get; }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -13,6 +13,11 @@ namespace Internal.Cryptography.Pal
 {
     internal sealed partial class ChainPal
     {
+        public static IChainPal FromHandle(IntPtr chainContext)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public static bool ReleaseSafeX509ChainHandle(IntPtr handle)
         {
             return true;

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CollectionBackedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CollectionBackedStoreProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Internal.Cryptography.Pal
@@ -46,6 +47,11 @@ namespace Internal.Cryptography.Pal
         public void Remove(ICertificatePal cert)
         {
             throw new InvalidOperationException();
+        }
+
+        SafeHandle IStorePal.SafeHandle
+        {
+            get { return null; }
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -217,6 +218,11 @@ namespace Internal.Cryptography.Pal
                     }
                 } while (currentFilename != null);
             }
+        }
+
+        SafeHandle IStorePal.SafeHandle
+        {
+            get { return null; }
         }
 
         private static string FindExistingFilename(X509Certificate2 cert, string storePath, out bool hadCandidates)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
 
 namespace Internal.Cryptography.Pal
 {
@@ -17,6 +18,11 @@ namespace Internal.Cryptography.Pal
         private static CollectionBackedStoreProvider s_machineRootStore;
         private static CollectionBackedStoreProvider s_machineIntermediateStore;
         private static readonly object s_machineLoadLock = new object();
+
+        public static IStorePal FromHandle(IntPtr storeHandle)
+        {
+            throw new PlatformNotSupportedException();
+        }
 
         public static ILoaderPal FromBlob(byte[] rawData, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
         {

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/ChainPal.cs
@@ -2,21 +2,34 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Cryptography.Pal.Native;
+using Microsoft.Win32.SafeHandles;
 using System;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
-using Internal.Cryptography.Pal.Native;
-
-using Microsoft.Win32.SafeHandles;
-
 namespace Internal.Cryptography.Pal
 {
     internal sealed partial class ChainPal : IDisposable, IChainPal
     {
+        private SafeX509ChainHandle _chain;
+
+        public static IChainPal FromHandle(IntPtr chainContext)
+        {
+            if (chainContext == IntPtr.Zero)
+                throw new ArgumentNullException(nameof(chainContext));
+
+            SafeX509ChainHandle certChainHandle = Interop.crypt32.CertDuplicateCertificateChain(chainContext);
+            if (certChainHandle == null || certChainHandle.IsInvalid)
+                throw new CryptographicException(SR.Cryptography_InvalidContextHandle, nameof(chainContext));
+
+            var pal = new ChainPal(certChainHandle);
+            return pal;
+        }
+
         /// <summary>
-        /// Does not throw on api error. Returns default(bool?) and sets "exception" instead. 
+        /// Does not throw on api error. Returns default(bool?) and sets "exception" instead.
         /// </summary>
         public bool? Verify(X509VerificationFlags flags, out Exception exception)
         {
@@ -105,7 +118,5 @@ namespace Internal.Cryptography.Pal
             if (chain != null)
                 chain.Dispose();
         }
-
-        private SafeX509ChainHandle _chain;
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
@@ -92,6 +92,12 @@ internal static partial class Interop
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern SafeCertContextHandle CertDuplicateCertificateContext(IntPtr pCertContext);
 
+        [DllImport(Libraries.Crypt32, SetLastError = true)]
+        public static extern SafeX509ChainHandle CertDuplicateCertificateChain(IntPtr pChainContext);
+
+        [DllImport(Libraries.Crypt32, SetLastError = true)]
+        internal static extern SafeCertStoreHandle CertDuplicateStore(IntPtr hCertStore);
+
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertDuplicateCertificateContext")]
         public static extern SafeCertContextHandleWithKeyContainerDeletion CertDuplicateCertificateContextWithKeyContainerDeletion(IntPtr pCertContext);
 

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -7,6 +7,7 @@ using Internal.Cryptography.Pal;
 using System;
 using System.IO;
 using System.Runtime.Serialization;
+using System.Security;
 using System.Text;
 
 namespace System.Security.Cryptography.X509Certificates
@@ -14,6 +15,29 @@ namespace System.Security.Cryptography.X509Certificates
     [Serializable]
     public class X509Certificate2 : X509Certificate
     {
+        private volatile byte[] _lazyRawData;
+        private volatile Oid _lazySignatureAlgorithm;
+        private volatile int _lazyVersion;
+        private volatile X500DistinguishedName _lazySubjectName;
+        private volatile X500DistinguishedName _lazyIssuerName;
+        private volatile PublicKey _lazyPublicKey;
+        private volatile AsymmetricAlgorithm _lazyPrivateKey;
+        private volatile X509ExtensionCollection _lazyExtensions;
+
+        public override void Reset()
+        {
+            _lazyRawData = null;
+            _lazySignatureAlgorithm = null;
+            _lazyVersion = 0;
+            _lazySubjectName = null;
+            _lazyIssuerName = null;
+            _lazyPublicKey = null;
+            _lazyPrivateKey = null;
+            _lazyExtensions = null;
+
+            base.Reset();
+        }
+
         public X509Certificate2()
             : base()
         {
@@ -167,6 +191,8 @@ namespace System.Security.Cryptography.X509Certificates
         {
             get
             {
+                ThrowIfInvalid();
+
                 if (_lazyPrivateKey == null)
                 {
                     _lazyPrivateKey = Pal.GetPrivateKey();
@@ -185,9 +211,9 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 ThrowIfInvalid();
 
-                X500DistinguishedName issuerName = _lazyIssuer;
+                X500DistinguishedName issuerName = _lazyIssuerName;
                 if (issuerName == null)
-                    issuerName = _lazyIssuer = Pal.IssuerName;
+                    issuerName = _lazyIssuerName = Pal.IssuerName;
                 return issuerName;
             }
         }
@@ -530,6 +556,54 @@ namespace System.Security.Cryptography.X509Certificates
             return sb.ToString();
         }
 
+        public override void Import(byte[] rawData)
+        {
+            base.Import(rawData);
+        }
+
+        public override void Import(byte[] rawData, string password, X509KeyStorageFlags keyStorageFlags)
+        {
+            base.Import(rawData, password, keyStorageFlags);
+        }
+
+        public override void Import(byte[] rawData, SecureString password, X509KeyStorageFlags keyStorageFlags)
+        {
+            base.Import(rawData, password, keyStorageFlags);
+        }
+
+        public override void Import(string fileName)
+        {
+            base.Import(fileName);
+        }
+
+        public override void Import(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
+        {
+            base.Import(fileName, password, keyStorageFlags);
+        }
+
+        public override void Import(string fileName, SecureString password, X509KeyStorageFlags keyStorageFlags)
+        {
+            base.Import(fileName, password, keyStorageFlags);
+        }
+
+        public bool Verify()
+        {
+            ThrowIfInvalid();
+
+            using (var chain = new X509Chain())
+            {
+                // Use the default vales of chain.ChainPolicy including:
+                //  RevocationMode = X509RevocationMode.Online
+                //  RevocationFlag = X509RevocationFlag.ExcludeRoot
+                //  VerificationFlags = X509VerificationFlags.NoFlag
+                //  VerificationTime = DateTime.Now
+                //  UrlRetrievalTimeout = new TimeSpan(0, 0, 0)
+
+                bool verified = chain.Build(this, throwOnException: false);
+                return verified;
+            }
+        }
+
         private static X509Extension CreateCustomExtensionIfAny(Oid oid)
         {
             string oidValue = oid.Value;
@@ -556,14 +630,5 @@ namespace System.Security.Cryptography.X509Certificates
                     return null;
             }
         }
-
-        private volatile byte[] _lazyRawData;
-        private volatile Oid _lazySignatureAlgorithm;
-        private volatile int _lazyVersion;
-        private volatile X500DistinguishedName _lazySubjectName;
-        private volatile X500DistinguishedName _lazyIssuer;
-        private volatile PublicKey _lazyPublicKey;
-        private volatile AsymmetricAlgorithm _lazyPrivateKey;
-        private volatile X509ExtensionCollection _lazyExtensions;
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
@@ -2,25 +2,33 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.IO;
-using System.Text;
-using System.Diagnostics;
-using System.Globalization;
-using System.Runtime.InteropServices;
-
 using SafeX509ChainHandle = Microsoft.Win32.SafeHandles.SafeX509ChainHandle;
-
-using Internal.Cryptography;
 using Internal.Cryptography.Pal;
+using System.Diagnostics;
 
 namespace System.Security.Cryptography.X509Certificates
 {
     public class X509Chain : IDisposable
     {
-        public X509Chain()
+        private X509ChainPolicy _chainPolicy;
+        private volatile X509ChainStatus[] _lazyChainStatus;
+        private X509ChainElementCollection _chainElements;
+        private IChainPal _pal;
+        private bool _useMachineContext;
+        private readonly object _syncRoot = new object();
+
+        public X509Chain() { }
+
+        public X509Chain(bool useMachineContext)
         {
-            Reset();
+            _useMachineContext = useMachineContext;
+        }
+
+        public X509Chain(IntPtr chainContext)
+        {
+            _pal = ChainPal.FromHandle(chainContext);
+            Debug.Assert(_pal != null);
+            _chainElements = new X509ChainElementCollection(_pal.ChainElements);
         }
 
         public X509ChainElementCollection ChainElements
@@ -61,6 +69,22 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
+        public IntPtr ChainContext
+        {
+            get
+            {
+                SafeX509ChainHandle handle = SafeHandle;
+                if (handle == null)
+                {
+                    // This case will only exist for Unix
+                    return IntPtr.Zero;
+                }
+
+                // For desktop compat, we may return an invalid handle here (IntPtr.Zero)
+                return handle.DangerousGetHandle();
+            }
+        }
+
         public SafeX509ChainHandle SafeHandle
         {
             get
@@ -74,6 +98,11 @@ namespace System.Security.Cryptography.X509Certificates
 
         public bool Build(X509Certificate2 certificate)
         {
+            return Build(certificate, true);
+        }
+
+        internal bool Build(X509Certificate2 certificate, bool throwOnException)
+        {
             lock (_syncRoot)
             {
                 if (certificate == null)
@@ -83,7 +112,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 X509ChainPolicy chainPolicy = ChainPolicy;
                 _pal = ChainPal.BuildChain(
-                    false,
+                    _useMachineContext,
                     certificate.Pal,
                     chainPolicy.ExtraStore,
                     chainPolicy.ApplicationPolicy,
@@ -101,7 +130,17 @@ namespace System.Security.Cryptography.X509Certificates
                 Exception verificationException;
                 bool? verified = _pal.Verify(chainPolicy.VerificationFlags, out verificationException);
                 if (!verified.HasValue)
-                    throw verificationException;
+                {
+                    if (throwOnException)
+                    {
+                        throw verificationException;
+                    }
+                    else
+                    {
+                        verified = false;
+                    }
+                }
+
                 return verified.Value;
             }
         }
@@ -120,21 +159,17 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        private void Reset()
+        public void Reset()
         {
+            // _chainPolicy is not reset for desktop compat
             _lazyChainStatus = null;
             _chainElements = null;
+            _useMachineContext = false;
 
             IChainPal pal = _pal;
             _pal = null;
             if (pal != null)
                 pal.Dispose();
         }
-
-        private X509ChainPolicy _chainPolicy;
-        private volatile X509ChainStatus[] _lazyChainStatus;
-        private X509ChainElementCollection _chainElements;
-        private IChainPal _pal;
-        private readonly object _syncRoot = new object();
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainElementCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainElementCollection.cs
@@ -27,12 +27,12 @@ namespace System.Security.Cryptography.X509Certificates
             get { return _elements.Length; }
         }
 
-        bool System.Collections.ICollection.IsSynchronized
+        public bool IsSynchronized
         {
             get { return false; }
         }
 
-        object System.Collections.ICollection.SyncRoot
+        public object SyncRoot
         {
             get { return this; }
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ExtensionCollection.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ExtensionCollection.cs
@@ -26,12 +26,12 @@ namespace System.Security.Cryptography.X509Certificates
             get { return _list.Count; }
         }
 
-        bool System.Collections.ICollection.IsSynchronized
+        public bool IsSynchronized
         {
             get { return false; }
         }
 
-        object System.Collections.ICollection.SyncRoot
+        public object SyncRoot
         {
             get { return this; }
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
@@ -2,22 +2,33 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.IO;
-using System.Text;
+using Internal.Cryptography.Pal;
 using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.InteropServices;
-
-using Internal.Cryptography;
-using Internal.Cryptography.Pal;
 
 namespace System.Security.Cryptography.X509Certificates
 {
     public sealed class X509Store : IDisposable
     {
+        private IStorePal _storePal;
+
         public X509Store()
             : this(StoreName.My, StoreLocation.CurrentUser)
+        {
+        }
+
+        public X509Store(string storeName)
+            : this(storeName, StoreLocation.CurrentUser)
+        {
+        }
+
+        public X509Store(StoreName storeName)
+            : this(storeName, StoreLocation.CurrentUser)
+        {
+        }
+
+        public X509Store(StoreLocation storeLocation)
+            : this(StoreName.My, storeLocation)
         {
         }
 
@@ -68,6 +79,27 @@ namespace System.Security.Cryptography.X509Certificates
             Name = storeName;
         }
 
+        public X509Store(IntPtr storeHandle)
+        {
+            _storePal = StorePal.FromHandle(storeHandle);
+            Debug.Assert(_storePal != null);
+        }
+
+        public IntPtr StoreHandle
+        {
+            get
+            {
+                if (_storePal == null)
+                    throw new CryptographicException(SR.Cryptography_X509_StoreNotOpen);
+
+                // The Pal layer may return null (Unix) or throw exception (Windows)
+                if (_storePal.SafeHandle == null)
+                    return IntPtr.Zero;
+
+                return _storePal.SafeHandle.DangerousGetHandle();
+            }
+        }
+
         public StoreLocation Location { get; private set; }
 
         public string Name { get; private set; }
@@ -103,6 +135,32 @@ namespace System.Security.Cryptography.X509Certificates
             _storePal.Add(certificate.Pal);
         }
 
+        public void AddRange(X509Certificate2Collection certificates)
+        {
+            if (certificates == null)
+                throw new ArgumentNullException(nameof(certificates));
+
+            int i = 0;
+            try
+            {
+                foreach (X509Certificate2 certificate in certificates)
+                {
+                    Add(certificate);
+                    i++;
+                }
+            }
+            catch
+            {
+                // For desktop compat, we keep the exception semantics even though they are not ideal
+                // because an exception may cause certs to be removed even if they weren't there before.
+                for (int j = 0; j < i; j++)
+                {
+                    Remove(certificates[j]);
+                }
+                throw;
+            }
+        }
+
         public void Remove(X509Certificate2 certificate)
         {
             if (certificate == null)
@@ -114,12 +172,39 @@ namespace System.Security.Cryptography.X509Certificates
             _storePal.Remove(certificate.Pal);
         }
 
+        public void RemoveRange(X509Certificate2Collection certificates)
+        {
+            if (certificates == null)
+                throw new ArgumentNullException(nameof(certificates));
+
+            int i = 0;
+            try
+            {
+                foreach (X509Certificate2 certificate in certificates)
+                {
+                    Remove(certificate);
+                    i++;
+                }
+            }
+            catch
+            {
+                // For desktop compat, we keep the exception semantics even though they are not ideal
+                // because an exception above may cause certs to be added even if they weren't there before
+                // and an exception here may cause certs not to be re-added.
+                for (int j = 0; j < i; j++)
+                {
+                    Add(certificates[j]);
+                }
+                throw;
+            }
+        }
+
         public void Dispose()
         {
             Close();
         }
 
-        private void Close()
+        public void Close()
         {
             IStorePal storePal = _storePal;
             _storePal = null;
@@ -128,8 +213,6 @@ namespace System.Security.Cryptography.X509Certificates
                 storePal.Dispose();
             }
         }
-
-        private IStorePal _storePal;
     }
 }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -79,6 +79,28 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+#if netstandard17
+        [Fact]
+        public static void TestVerify()
+        {
+            using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
+            {
+                // Fails because expired (NotAfter = 10/16/2016)
+                Assert.False(microsoftDotCom.Verify());
+            }
+
+            using (var microsoftDotComIssuer = new X509Certificate2(TestData.MicrosoftDotComIssuerBytes))
+            {
+                Assert.True(microsoftDotComIssuer.Verify()); // NotAfter=10/31/2023
+            }
+
+            using (var microsoftDotComRoot = new X509Certificate2(TestData.MicrosoftDotComRootBytes))
+            {
+                Assert.True(microsoftDotComRoot.Verify()); // NotAfter=7/17/2036
+            }
+        }
+#endif
+
         [Fact]
         public static void X509CertEmptyToString()
         {
@@ -185,6 +207,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 // causing ObjectDisposedExceptions.
                 h = c.Handle;
                 Assert.Equal(IntPtr.Zero, h);
+
+                // State held on X509Certificate
                 Assert.ThrowsAny<CryptographicException>(() => c.GetCertHash());
                 Assert.ThrowsAny<CryptographicException>(() => c.GetKeyAlgorithm());
                 Assert.ThrowsAny<CryptographicException>(() => c.GetKeyAlgorithmParameters());
@@ -193,6 +217,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.ThrowsAny<CryptographicException>(() => c.GetSerialNumber());
                 Assert.ThrowsAny<CryptographicException>(() => c.Issuer);
                 Assert.ThrowsAny<CryptographicException>(() => c.Subject);
+                Assert.ThrowsAny<CryptographicException>(() => c.NotBefore);
+                Assert.ThrowsAny<CryptographicException>(() => c.NotAfter);
+
+                // State held on X509Certificate2
+                Assert.ThrowsAny<CryptographicException>(() => c.RawData);
+                Assert.ThrowsAny<CryptographicException>(() => c.SignatureAlgorithm);
+                Assert.ThrowsAny<CryptographicException>(() => c.Version);
+                Assert.ThrowsAny<CryptographicException>(() => c.SubjectName);
+                Assert.ThrowsAny<CryptographicException>(() => c.IssuerName);
+                Assert.ThrowsAny<CryptographicException>(() => c.PublicKey);
+                Assert.ThrowsAny<CryptographicException>(() => c.Extensions);
+#if netstandard17
+                Assert.ThrowsAny<CryptographicException>(() => c.PrivateKey);
+#endif
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainHolder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainHolder.cs
@@ -10,7 +10,21 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     /// </summary>
     internal sealed class ChainHolder : IDisposable
     {
-        public X509Chain Chain { get; } = new X509Chain();
+        private X509Chain _chain;
+
+        public ChainHolder()
+        {
+            _chain = new X509Chain();
+        }
+
+#if netstandard17
+        public ChainHolder(IntPtr chainContext)
+        {
+            _chain = new X509Chain(chainContext);
+        }
+#endif
+
+        public X509Chain Chain => _chain;
 
         public void Dispose()
         {

--- a/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
@@ -312,12 +312,26 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void TestNullConstructorArguments()
         {
-            Assert.Throws<ArgumentException>(() => new X509Certificate2((byte[])null, (String)null));
-            Assert.Throws<ArgumentException>(() => new X509Certificate2(new byte[0], (String)null));
-            Assert.Throws<ArgumentException>(() => new X509Certificate2((byte[])null, (String)null, X509KeyStorageFlags.DefaultKeySet));
-            Assert.Throws<ArgumentException>(() => new X509Certificate2(new byte[0], (String)null, X509KeyStorageFlags.DefaultKeySet));
+            Assert.Throws<ArgumentNullException>(() => new X509Certificate2((string)null));
+            Assert.Throws<ArgumentException>(() => new X509Certificate2(IntPtr.Zero));
+            Assert.Throws<ArgumentException>(() => new X509Certificate2((byte[])null, (string)null));
+            Assert.Throws<ArgumentException>(() => new X509Certificate2(Array.Empty<byte>(), (string)null));
+            Assert.Throws<ArgumentException>(() => new X509Certificate2((byte[])null, (string)null, X509KeyStorageFlags.DefaultKeySet));
+            Assert.Throws<ArgumentException>(() => new X509Certificate2(Array.Empty<byte>(), (string)null, X509KeyStorageFlags.DefaultKeySet));
+
+            // A null string password does not throw
+            using (new X509Certificate2(TestData.MsCertificate, (string)null)) { }
+            using (new X509Certificate2(TestData.MsCertificate, (string)null, X509KeyStorageFlags.DefaultKeySet)) { }
+
 #if netstandard17
-            Assert.Throws<ArgumentNullException>(() => new X509Certificate2((X509Certificate2)null));
+            Assert.Throws<ArgumentNullException>(() => X509Certificate.CreateFromCertFile(null));
+            Assert.Throws<ArgumentNullException>(() => X509Certificate.CreateFromSignedFile(null));
+            Assert.Throws<ArgumentNullException>("cert", () => new X509Certificate2((X509Certificate2)null));
+            Assert.Throws<ArgumentException>("handle", () => new X509Certificate2(IntPtr.Zero));
+
+            // A null SecureString password does not throw
+            using (new X509Certificate2(TestData.MsCertificate, (SecureString)null)) { }
+            using (new X509Certificate2(TestData.MsCertificate, (SecureString)null, X509KeyStorageFlags.DefaultKeySet)) { }
 #endif
 
             // For compat reasons, the (byte[]) constructor (and only that constructor) treats a null or 0-length array as the same
@@ -332,7 +346,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
 
             {
-                using (X509Certificate2 c = new X509Certificate2(new byte[0]))
+                using (X509Certificate2 c = new X509Certificate2(Array.Empty<byte>()))
                 {
                     IntPtr h = c.Handle;
                     Assert.Equal(IntPtr.Zero, h);

--- a/src/System.Security.Cryptography.X509Certificates/tests/ImportTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ImportTests.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security;
+using Xunit;
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{
+    public static class ImportTests
+    {
+        [Fact]
+        public static void TestImportNotSupported_X509Certificate()
+        {
+            using (var c = new X509Certificate())
+            {
+                VerifyImportNotSupported(c);
+            }
+        }
+
+        [Fact]
+        public static void TestImportNotSupported_X509Certificate2()
+        {
+            using (var c = new X509Certificate2())
+            {
+                VerifyImportNotSupported(c);
+            }
+        }
+
+        private static void VerifyImportNotSupported(X509Certificate c)
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => c.Import(Array.Empty<byte>()));
+            Assert.Throws<PlatformNotSupportedException>(() => c.Import(string.Empty));
+            Assert.Throws<PlatformNotSupportedException>(() => c.Import(Array.Empty<byte>(), string.Empty, X509KeyStorageFlags.DefaultKeySet));
+            Assert.Throws<PlatformNotSupportedException>(() => c.Import(Array.Empty<byte>(), new SecureString(), X509KeyStorageFlags.DefaultKeySet));
+            Assert.Throws<PlatformNotSupportedException>(() => c.Import(string.Empty, string.Empty, X509KeyStorageFlags.DefaultKeySet));
+            Assert.Throws<PlatformNotSupportedException>(() => c.Import(string.Empty, new SecureString(), X509KeyStorageFlags.DefaultKeySet));
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -149,7 +149,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     issuer);
 #if netstandard17
 #pragma warning disable 0618
-                    Assert.Equal(c.Issuer, c.GetIssuerName());
+                Assert.Equal(c.Issuer, c.GetIssuerName());
 #pragma warning restore 0618
 #endif
 
@@ -159,7 +159,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     subject);
 #if netstandard17
 #pragma warning disable 0618
-                    Assert.Equal(subject, c.GetName());
+                Assert.Equal(subject, c.GetName());
 #pragma warning restore 0618
 #endif
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -241,7 +241,7 @@ Wry5FNNo
             }
         }
 
-#if netcoreapp11
+#if netstandard17
         [Fact]
         public static void TestPrivateKey()
         {

--- a/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
@@ -63,7 +63,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal("1.2.840.10040.4.1", pk.Oid.Value);
         }
 
-#if netcoreapp11
+#if netstandard17
         [Fact]
         public static void TestPublicKey_Key_RSA()
         {
@@ -279,7 +279,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-#if netcoreapp11
+#if netstandard17
         [Fact]
         public static void TestPublicKey_Key_ECDsa()
         {

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -54,7 +54,10 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs" Condition="'$(TargetGroup)'=='' OR '$(TargetGroup)'=='netcoreapp1.1'">
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='' OR '$(TargetGroup)'=='netcoreapp1.1'">
+    <Compile Include="ImportTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -18,6 +18,84 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+#if netstandard17
+        [Fact]
+        public static void Constructor_DefaultStoreName()
+        {
+            using (X509Store store = new X509Store(StoreLocation.CurrentUser))
+            {
+                Assert.Equal("My", store.Name);
+            }
+        }
+
+        [Fact]
+        public static void Constructor_DefaultStoreLocation()
+        {
+            using (X509Store store = new X509Store(StoreName.My))
+            {
+                Assert.Equal(StoreLocation.CurrentUser, store.Location);
+            }
+
+            using (X509Store store = new X509Store("My"))
+            {
+                Assert.Equal(StoreLocation.CurrentUser, store.Location);
+            }
+        }
+
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [Fact]
+        public static void Constructor_StoreHandle()
+        {
+            using (X509Store store1 = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                store1.Open(OpenFlags.ReadOnly);
+                int certCount1;
+
+                using (var coll = new ImportedCollection(store1.Certificates))
+                {
+                    certCount1 = coll.Collection.Count;
+                    Assert.True(certCount1 >= 0);
+                }
+
+                using (X509Store store2 = new X509Store(store1.StoreHandle))
+                {
+                    using (var coll = new ImportedCollection(store2.Certificates))
+                    {
+                        int certCount2 = coll.Collection.Count;
+                        Assert.Equal(certCount1, certCount2);
+                    }
+                }
+            }
+        }
+
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [Fact]
+        public static void Constructor_StoreHandle_Unix()
+        {
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                store.Open(OpenFlags.ReadOnly);
+                Assert.Equal(IntPtr.Zero, store.StoreHandle);
+            }
+
+            Assert.Throws<PlatformNotSupportedException>(() => new X509Chain(IntPtr.Zero));
+        }
+
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [Fact]
+        public static void TestDispose()
+        {
+            X509Store store;
+            using (store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                store.Open(OpenFlags.ReadOnly);
+                Assert.NotEqual(IntPtr.Zero, store.StoreHandle);
+            }
+
+            Assert.Throws<CryptographicException>(() => store.StoreHandle);
+        }
+#endif
+
         [Fact]
         public static void ReadMyCertificates()
         {
@@ -123,6 +201,26 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 }
             }
         }
+
+        /* Placeholder information for these tests until they can be written to run reliably.
+         * Currently such tests would create physical files (Unix) and\or certificates (Windows)
+         * which can collide with other running tests that use the same cert, or from a
+         * test suite running more than once at the same time on the same machine.
+         * Ideally, we use a GUID-named store to aoiv collitions with proper cleanup on Unix and Windows
+         * and\or have lower testing hooks or use Microsoft Fakes Framework to redirect
+         * and encapsulate the actual storage logic so it can be tested, along with mock exceptions
+         * to verify exception handling.
+         * See issue https://github.com/dotnet/corefx/issues/12833
+         * and https://github.com/dotnet/corefx/issues/12223
+
+        [Fact]
+        public static void TestAddAndRemove() {}
+
+#if netstandard17
+        [Fact]
+        public static void TestAddRangeAndRemoveRange() {}
+#endif
+        */
 
         [Fact]
         public static void EnumerateClosedIsEmpty()


### PR DESCRIPTION
Address issue https://github.com/dotnet/corefx/issues/12295

Note that tests need to be added for X509Store.AddRange and .RemoveRange but if implemented like the rest of the tests they would run unreliably as they create physical artifacts on the machine. There are comments in the tests for this, and I will create a new issue to address this in addition to addressing related testing issues with the pre-existing Add and Remove methods (see https://github.com/dotnet/corefx/issues/12833)

The X509Certificate.Import methods throw PNSE as the implementation is flaky in netfx. This has been previously discussed as acceptable for ns2.0.

@bartonjs please review. There are some review notes embedded.