### PR TITLE
Reduce allocations in SslStream reading/writing by ~30%

### DIFF
--- a/src/System.Net.Security/src/System/Net/BufferAsyncResult.cs
+++ b/src/System.Net.Security/src/System/Net/BufferAsyncResult.cs
@@ -13,20 +13,13 @@ namespace System.Net
         public byte[] Buffer;
         public int Offset;
         public int Count;
-        public bool IsWrite;
 
         public BufferAsyncResult(object asyncObject, byte[] buffer, int offset, int count, object asyncState, AsyncCallback asyncCallback)
-            : this(asyncObject, buffer, offset, count, false, asyncState, asyncCallback)
-        {
-        }
-
-        public BufferAsyncResult(object asyncObject, byte[] buffer, int offset, int count, bool isWrite, object asyncState, AsyncCallback asyncCallback)
             : base(asyncObject, asyncState, asyncCallback)
         {
             Buffer = buffer;
             Offset = offset;
             Count = count;
-            IsWrite = isWrite;
         }
     }
 }

--- a/src/System.Net.Security/src/System/Net/BufferAsyncResult.cs
+++ b/src/System.Net.Security/src/System/Net/BufferAsyncResult.cs
@@ -2,24 +2,64 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System.Net
 {
     //
     // Preserve the original request buffer & sizes for user IO requests.
     // This is returned as an IAsyncResult to the application.
     //
-    internal class BufferAsyncResult : LazyAsyncResult
+    internal sealed class BufferAsyncResult : LazyAsyncResult
     {
-        public byte[] Buffer;
-        public int Offset;
-        public int Count;
+        /// <summary>Stored into LazyAsyncResult.Result to indicate a completed result.</summary>
+        public static readonly object ResultSentinal = nameof(BufferAsyncResult) + "." + nameof(ResultSentinal);
+        /// <summary>Stores the input count or the output result of the operation.</summary>
+        private int _countOrResult;
+#if DEBUG
+        /// <summary>true if <see cref="_countOrResult"/> backs <see cref="Int32Result"/>, false if <see cref="Count"/>.</summary>
+        private bool _countOrResultIsResult;
+#endif
 
         public BufferAsyncResult(object asyncObject, byte[] buffer, int offset, int count, object asyncState, AsyncCallback asyncCallback)
             : base(asyncObject, asyncState, asyncCallback)
         {
             Buffer = buffer;
             Offset = offset;
-            Count = count;
+            _countOrResult = count;
+        }
+
+        public byte[] Buffer { get; }
+        public int Offset { get; }
+        public int Count
+        {
+            get
+            {
+#if DEBUG
+                Debug.Assert(!_countOrResultIsResult, "Trying to get count after it's already the result");
+#endif
+                return _countOrResult;
+            }
+        }
+
+        public int Int32Result // Int32Result to differentiate from the base's "object Result"
+        {
+            get
+            {
+#if DEBUG
+                Debug.Assert(_countOrResultIsResult, "Still represents the count, not the result");
+                Debug.Assert(ReferenceEquals(Result, ResultSentinal), "Expected the base object Result to be the sentinel");
+#endif
+                return _countOrResult;
+            }
+            set
+            {
+#if DEBUG
+                Debug.Assert(!_countOrResultIsResult, "Should only be set when result hasn't yet been set");
+                _countOrResultIsResult = true;
+#endif
+                _countOrResult = value;
+            }
         }
     }
 }

--- a/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
+++ b/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
@@ -151,7 +151,7 @@ namespace System.Net
                     throw;
                 }
 
-                request.CompleteWithError(e);
+                request.CompleteUserWithError(e);
             }
         }
     }

--- a/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
+++ b/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Threading;
 
 namespace System.Net
@@ -31,7 +30,6 @@ namespace System.Net
         private const int StatusCompleted = 1;
         private const int StatusCheckedOnSyncCompletion = 2;
 
-
         public LazyAsyncResult UserAsyncResult;
         public int Result;
         public object AsyncState;
@@ -51,6 +49,30 @@ namespace System.Net
                 NetEventSource.Fail(this, "userAsyncResult is already completed.");
             }
             UserAsyncResult = userAsyncResult;
+        }
+
+        public void Reset(LazyAsyncResult userAsyncResult)
+        {
+            if (userAsyncResult == null)
+            {
+                NetEventSource.Fail(this, "userAsyncResult == null");
+            }
+            if (userAsyncResult.InternalPeekCompleted)
+            {
+                NetEventSource.Fail(this, "userAsyncResult is already completed.");
+            }
+            UserAsyncResult = userAsyncResult;
+
+            _callback = null;
+            _completionStatus = 0;
+            Result = 0;
+            AsyncState = null;
+            Buffer = null;
+            Offset = 0;
+            Count = 0;
+#if DEBUG
+            _DebugAsyncChain = 0;
+#endif
         }
 
         public void SetNextRequest(byte[] buffer, int offset, int count, AsyncProtocolCallback callback)

--- a/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
+++ b/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Threading;
 
 namespace System.Net
@@ -88,13 +89,7 @@ namespace System.Net
             _callback = callback;
         }
 
-        internal object AsyncObject
-        {
-            get
-            {
-                return UserAsyncResult.AsyncObject;
-            }
-        }
+        internal object AsyncObject => UserAsyncResult.AsyncObject;
 
         //
         // Notify protocol so a next stage could be started.
@@ -137,24 +132,18 @@ namespace System.Net
         //
         // Important: This will abandon _Callback and directly notify UserAsyncResult.
         //
-        internal void CompleteWithError(Exception e)
+        internal void CompleteUserWithError(Exception e) => UserAsyncResult.InvokeCallback(e);
+
+        internal void CompleteUser() => UserAsyncResult.InvokeCallback();
+
+        internal void CompleteUser(int userResult)
         {
-            UserAsyncResult.InvokeCallback(e);
+            Debug.Assert(UserAsyncResult is BufferAsyncResult, "CompleteUser(int) may only be used with a BufferAsyncResult");
+            var bar = (BufferAsyncResult)UserAsyncResult;
+            bar.Int32Result = userResult;
+            bar.InvokeCallback(BufferAsyncResult.ResultSentinal);
         }
 
-        internal void CompleteUser()
-        {
-            UserAsyncResult.InvokeCallback();
-        }
-
-        internal void CompleteUser(object userResult)
-        {
-            UserAsyncResult.InvokeCallback(userResult);
-        }
-
-        internal bool IsUserCompleted
-        {
-            get { return UserAsyncResult.InternalPeekCompleted; }
-        }
+        internal bool IsUserCompleted => UserAsyncResult.InternalPeekCompleted;
     }
 }

--- a/src/System.Net.Security/src/System/Net/Security/InternalNegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/InternalNegotiateStream.cs
@@ -216,10 +216,7 @@ namespace System.Net.Security
                         Buffer.BlockCopy(InternalBuffer, InternalOffset, buffer, offset, copyBytes);
                         DecrementInternalBufferCount(copyBytes);
                     }
-                    if (asyncRequest != null)
-                    {
-                        asyncRequest.CompleteUser((object)copyBytes);
-                    }
+                    asyncRequest?.CompleteUser(copyBytes);
                     return copyBytes;
                 }
 
@@ -283,10 +280,7 @@ namespace System.Net.Security
             if (readBytes == 0)
             {
                 //EOF
-                if (asyncRequest != null)
-                {
-                    asyncRequest.CompleteUser((object)0);
-                }
+                asyncRequest?.CompleteUser(0);
                 return 0;
             }
 
@@ -368,10 +362,7 @@ namespace System.Net.Security
             // This will adjust both the remaining internal buffer count and the offset.
             DecrementInternalBufferCount(readBytes);
 
-            if (asyncRequest != null)
-            {
-                asyncRequest.CompleteUser((object)readBytes);
-            }
+            asyncRequest?.CompleteUser(readBytes);
 
             return readBytes;
         }
@@ -410,7 +401,7 @@ namespace System.Net.Security
                     throw;
                 }
 
-                asyncRequest.CompleteWithError(e);
+                asyncRequest.CompleteUserWithError(e);
             }
         }
 
@@ -444,7 +435,7 @@ namespace System.Net.Security
                     throw;
                 }
 
-                asyncRequest.CompleteWithError(e);
+                asyncRequest.CompleteUserWithError(e);
             }
         }
     }

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -625,7 +625,7 @@ namespace System.Net.Security
                     throw new IOException(SR.net_io_read, (Exception)bufferResult.Result);
                 }
 
-                return (int)bufferResult.Result;
+                return bufferResult.Int32Result;
 #if DEBUG
             }
 #endif

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -645,7 +645,7 @@ namespace System.Net.Security
                     return InnerStream.BeginWrite(buffer, offset, count, asyncCallback, asyncState);
                 }
 
-                BufferAsyncResult bufferResult = new BufferAsyncResult(this, buffer, offset, count, true, asyncState, asyncCallback);
+                BufferAsyncResult bufferResult = new BufferAsyncResult(this, buffer, offset, count, asyncState, asyncCallback);
                 AsyncProtocolRequest asyncRequest = new AsyncProtocolRequest(bufferResult);
 
                 ProcessWrite(buffer, offset, count, asyncRequest);

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -1441,7 +1441,7 @@ namespace System.Net.Security
                 {
                     if (e != null)
                     {
-                        asyncRequest.CompleteWithError(e);
+                        asyncRequest.CompleteUserWithError(e);
                     }
                     else
                     {
@@ -1725,7 +1725,7 @@ namespace System.Net.Security
             }
             catch (Exception e)
             {
-                request.CompleteWithError(e);
+                request.CompleteUserWithError(e);
             }
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -169,7 +169,7 @@ namespace System.Net.Security
                 throw new IOException(SR.net_io_read, (Exception)bufferResult.Result);
             }
 
-            return (int)bufferResult.Result;
+            return bufferResult.Int32Result;
         }
 
         internal IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
@@ -495,7 +495,7 @@ namespace System.Net.Security
         //
         // Combined sync/async read method. For sync request asyncRequest==null.
         //
-        private int ProcessRead(byte[] buffer, int offset, int count, LazyAsyncResult asyncResult)
+        private int ProcessRead(byte[] buffer, int offset, int count, BufferAsyncResult asyncResult)
         {
             ValidateParameters(buffer, offset, count);
 
@@ -522,9 +522,7 @@ namespace System.Net.Security
                         SkipBytes(copyBytes);
                     }
                     
-                    if (asyncRequest != null) {
-                        asyncRequest.CompleteUser((object) copyBytes);
-                    }
+                    asyncRequest?.CompleteUser(copyBytes);
                     
                     return copyBytes;
                 }
@@ -580,10 +578,7 @@ namespace System.Net.Security
 
                 if (copyBytes != -1)
                 {
-                    if (asyncRequest != null)
-                    {
-                        asyncRequest.CompleteUser((object)copyBytes);
-                    }
+                    asyncRequest?.CompleteUser(copyBytes);
 
                     return copyBytes;
                 }
@@ -633,10 +628,7 @@ namespace System.Net.Security
             {
                 //EOF : Reset the buffer as we did not read anything into it.
                 SkipBytes(InternalBufferCount);
-                if (asyncRequest != null)
-                {
-                    asyncRequest.CompleteUser((object)0);
-                }
+                asyncRequest?.CompleteUser(0);
                 
                 return 0;
             }
@@ -728,10 +720,7 @@ namespace System.Net.Security
             SkipBytes(readBytes);
 
             _sslState.FinishRead(null);
-            if (asyncRequest != null)
-            {
-                asyncRequest.CompleteUser((object)readBytes);
-            }
+            asyncRequest?.CompleteUser(readBytes);
 
             return readBytes;
         }
@@ -752,10 +741,7 @@ namespace System.Net.Security
             if (message.CloseConnection)
             {
                 _sslState.FinishRead(null);
-                if (asyncRequest != null)
-                {
-                    asyncRequest.CompleteUser((object)0);
-                }
+                asyncRequest?.CompleteUser(0);
 
                 return 0;
             }
@@ -801,7 +787,7 @@ namespace System.Net.Security
                 }
 
                 sslStream._sslState.FinishWrite();
-                asyncRequest.CompleteWithError(e);
+                asyncRequest.CompleteUserWithError(e);
             }
         }
 
@@ -823,7 +809,7 @@ namespace System.Net.Security
                 }
 
                 ((SslStreamInternal)request.AsyncObject)._sslState.FinishRead(null);
-                request.CompleteWithError(e);
+                request.CompleteUserWithError(e);
             }
         }
 
@@ -845,7 +831,7 @@ namespace System.Net.Security
                 }
 
                 ((SslStreamInternal)asyncRequest.AsyncObject)._sslState.FinishWrite();
-                asyncRequest.CompleteWithError(e);
+                asyncRequest.CompleteUserWithError(e);
             }
         }
 
@@ -869,7 +855,7 @@ namespace System.Net.Security
                     throw;
                 }
 
-                asyncRequest.CompleteWithError(e);
+                asyncRequest.CompleteUserWithError(e);
             }
         }
 
@@ -893,7 +879,7 @@ namespace System.Net.Security
                     throw;
                 }
 
-                asyncRequest.CompleteWithError(e);
+                asyncRequest.CompleteUserWithError(e);
             }
         }
     }


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/12935 reduced allocations in SslStream reading/writing by ~70%.  This PR reduces it further by another ~30% from where it was after that PR.

Before (10K reads / 10K writes):
![image](https://cloud.githubusercontent.com/assets/2642209/19942733/1ecfce22-a10b-11e6-890e-8038c20a8aaa.png)

After (10K reads / 10K writes):
![image](https://cloud.githubusercontent.com/assets/2642209/19942743/2ddb8640-a10b-11e6-9e16-5ab07e747b54.png)

Main changes:
- Every read/write operation was allocating a new AsyncProtocolRequest.  Without changing any of the plumbing through SslStream, we can take advantage of the fact that SslStream allows only a single read and a single write operation at a time, which means we can store and reuse an AsyncProtocolRequest instance for reading and one for writing, reusing the instances for all read/write operations on the stream.
- Every read operation was boxing an Int32 result.  This changes the BufferAsyncResult instance used for reads to reuse one of its existing fields to store that result, rather than storing it in the base LazyAsyncResult's object field.
- Also took the opportunity to remove an unused field from BufferAsyncResult, though it doesn't change the size on 64-bit given the other fields on the base class.

cc: @geoffkizer, @ericeil, @davidsh, @cipop, @benaadams, @davidfowl 
Contributes to https://github.com/dotnet/corefx/issues/11826