### PR TITLE
Implement System.Security.PrincipalPermission and SecurityElement

### DIFF
--- a/src/System.Security.Permissions/dir.props
+++ b/src/System.Security.Permissions/dir.props
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>

--- a/src/System.Security.Permissions/src/Resources/Strings.resx
+++ b/src/System.Security.Permissions/src/Resources/Strings.resx
@@ -1,0 +1,165 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Argument_ImproperType" xml:space="preserve">
+    <value>Improper types in collection.</value>
+  </data>
+  <data name="Arg_EmptyCollection" xml:space="preserve">
+    <value>Collection must not be empty.</value>
+  </data>
+  <data name="Argument_InvalidPermissionState" xml:space="preserve">
+    <value>Invalid permission state.</value>
+  </data>
+  <data name="Argument_NotAPermissionElement" xml:space="preserve">
+    <value>'elem' was not a permission element.</value>
+  </data>
+  <data name="Argument_InvalidXMLBadVersion" xml:space="preserve">
+    <value>Invalid Xml - can only parse elements of version one.</value>
+  </data>
+  <data name="Argument_WrongType" xml:space="preserve">
+    <value>Operation on type '{0}' attempted with target of incorrect type.</value>
+  </data>
+  <data name="Security_PrincipalPermission" xml:space="preserve">
+    <value>Request for principal permission failed.</value>
+  </data>
+  <data name="IdentityReference_InvalidNumberOfSubauthorities" xml:space="preserve">
+    <value>The number of sub-authorities must not exceed {0}.</value>
+  </data>
+  <data name="IdentityReference_InvalidSidRevision" xml:space="preserve">
+    <value>SIDs with revision other than '1' are not supported.</value>
+  </data>
+  <data name="Argument_InvalidElementTag" xml:space="preserve">
+    <value>Invalid element tag '{0}'.</value>
+  </data>
+  <data name="Argument_InvalidElementText" xml:space="preserve">
+    <value>Invalid element text '{0}'.</value>
+  </data>
+  <data name="Argument_InvalidElementName" xml:space="preserve">
+    <value>Invalid element name '{0}'.</value>
+  </data>
+  <data name="Argument_InvalidElementValue" xml:space="preserve">
+    <value>Invalid element value '{0}'.</value>
+  </data>
+  <data name="ArgumentNull_Child" xml:space="preserve">
+    <value>Cannot have a null child.</value>
+  </data>
+  <data name="Argument_AttributeNamesMustBeUnique" xml:space="preserve">
+    <value>Attribute names must be unique.</value>
+  </data>
+</root>

--- a/src/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{07390899-C8F6-4E83-A3A9-6867B8CB46A0}</ProjectGuid>
     <RootNamespace>System.Security.Permissions</RootNamespace>
     <AssemblyName>System.Security.Permissions</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.7</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
@@ -14,8 +13,8 @@
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
     <Compile Include="System\Net\NetworkInformation\NetworkInformationAccess.cs" />
     <Compile Include="System\Net\NetworkInformation\NetworkInformationPermission.cs" />

--- a/src/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -31,6 +31,7 @@
     <Compile Include="System\Security\Permissions\UrlIdentityPermission.cs" />
     <Compile Include="System\Security\Permissions\UrlIdentityPermissionAttribute.cs" />
     <Compile Include="System\Security\Permissions\ZoneIdentityPermission.cs" />
+    <Compile Include="System\Security\Permissions\IDRole.cs" />
     <Compile Include="System\Security\Permissions\PrincipalPermission.cs" />
     <Compile Include="System\Security\Permissions\PrincipalPermissionAttribute.cs" />
     <Compile Include="System\Security\Permissions\PublisherIdentityPermission.cs" />

--- a/src/System.Security.Permissions/src/System/Security/Permissions/IDRole.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/IDRole.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Permissions
+{
+    [Serializable]
+    internal sealed class IDRole
+    {
+        internal bool Authenticated { get; }
+        internal string ID { get; }
+        internal string Role { get; }
+
+        internal IDRole(bool authenticated, string id, string role)
+        {
+            Authenticated = authenticated;
+            ID = id;
+            Role = role;
+        }
+
+        internal IDRole(SecurityElement e)
+        {
+            string elAuth = e.Attribute("Authenticated");
+            Authenticated = elAuth == null ? false : string.Equals(elAuth, "true", StringComparison.OrdinalIgnoreCase);
+            ID = e.Attribute("ID");
+            Role = e.Attribute("Role");
+        }
+
+        internal SecurityElement ToXml()
+        {
+            SecurityElement root = new SecurityElement("Identity");
+
+            if (Authenticated)
+            {
+                root.AddAttribute("Authenticated", "true");
+            }
+            if (ID != null)
+            {
+                root.AddAttribute("ID", SecurityElement.Escape(ID));
+            }
+            if (Role != null)
+            {
+                root.AddAttribute("Role", SecurityElement.Escape(Role));
+            }
+
+            return root;
+        }
+
+        public override int GetHashCode()
+        {
+            return ((Authenticated ? 0 : 101) +
+                        (ID == null ? 0 : ID.GetHashCode()) +
+                        (Role == null ? 0 : Role.GetHashCode()));
+        }
+    }
+}

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
@@ -1,26 +1,584 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
+﻿// ==++==
+// 
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+// 
+// ==--==
+//  PrincipalPermission.cs
+// 
+// <OWNER>Microsoft</OWNER>
+//
+ 
 namespace System.Security.Permissions
 {
-    //TODO #9641: Implement PrincipalPermission with real behavior
+    using System;
+    using SecurityElement = System.Security.SecurityElement;
+    using System.Security.Util;
+    using System.IO;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Security.Principal;
+    using System.Text;
+    using System.Threading;    
+    using System.Globalization;
+    using System.Reflection;
+    using System.Diagnostics.Contracts;
+    
     [Serializable]
-    public sealed partial class PrincipalPermission : IPermission, ISecurityEncodable, IUnrestrictedPermission
+    internal class IDRole
     {
-        public PrincipalPermission(PermissionState state) { }
-        public PrincipalPermission(string name, string role) { }
-        public PrincipalPermission(string name, string role, bool isAuthenticated) { }
-        public IPermission Copy() { return default(IPermission); }
-        public void Demand() { throw new SecurityException(); }
-        public override bool Equals(object o) => base.Equals(o);
-        public void FromXml(SecurityElement elem) { }
-        public override int GetHashCode() => base.GetHashCode();
-        public IPermission Intersect(IPermission target) { return default(IPermission); }
-        public bool IsSubsetOf(IPermission target) { return false; }
-        public bool IsUnrestricted() { return false; }
-        public override string ToString() => base.ToString();
-        public SecurityElement ToXml() { return default(SecurityElement); }
-        public IPermission Union(IPermission other) { return default(IPermission); }
+        internal bool m_authenticated;
+        internal String m_id;
+        internal String m_role;
+ 
+#if !FEATURE_PAL
+        // cache the translation from name to Sid for the case of WindowsPrincipal.
+        [NonSerialized]
+        private SecurityIdentifier m_sid = null;
+        internal SecurityIdentifier Sid {
+            [System.Security.SecurityCritical]  // auto-generated
+            get {
+                if (String.IsNullOrEmpty(m_role))
+                    return null;
+ 
+                if (m_sid == null) {
+                    NTAccount ntAccount = new NTAccount(m_role);
+                    IdentityReferenceCollection source = new IdentityReferenceCollection(1);
+                    source.Add(ntAccount);
+                    IdentityReferenceCollection target = NTAccount.Translate(source, typeof(SecurityIdentifier), false);
+                    m_sid = target[0] as SecurityIdentifier;
+                }
+ 
+                return m_sid;
+            }
+        }
+#endif // !FEATURE_PAL
+ 
+#if FEATURE_CAS_POLICY
+        internal SecurityElement ToXml()
+        {
+            SecurityElement root = new SecurityElement( "Identity" );
+            
+            if (m_authenticated)
+                root.AddAttribute( "Authenticated", "true" );
+                
+            if (m_id != null)
+            {
+                root.AddAttribute( "ID", SecurityElement.Escape( m_id ) );
+            }
+               
+            if (m_role != null)
+            {
+                root.AddAttribute( "Role", SecurityElement.Escape( m_role ) );
+            }
+                            
+            return root;
+        }
+        
+        internal void FromXml( SecurityElement e )
+        {
+            String elAuth = e.Attribute( "Authenticated" );
+            if (elAuth != null)
+            {
+                m_authenticated = String.Compare( elAuth, "true", StringComparison.OrdinalIgnoreCase) == 0;
+            }
+            else
+            {
+                m_authenticated = false;
+            }
+           
+            String elID = e.Attribute( "ID" );
+            if (elID != null)
+            {
+                m_id = elID;
+            }
+            else
+            {
+                m_id = null;
+            }
+            
+            String elRole = e.Attribute( "Role" );
+            if (elRole != null)
+            {
+                m_role = elRole;
+            }
+            else
+            {
+                m_role = null;
+            }
+        }
+#endif // FEATURE_CAS_POLICY
+ 
+        public override int GetHashCode()
+        {
+            return ((m_authenticated ? 0 : 101) +
+                        (m_id == null ? 0 : m_id.GetHashCode()) +
+                        (m_role == null? 0 : m_role.GetHashCode()));
+        }    
+ 
     }
+    
+[System.Runtime.InteropServices.ComVisible(true)]
+    [Serializable]
+    sealed public class PrincipalPermission : IPermission, IUnrestrictedPermission, ISecurityEncodable, IBuiltInPermission
+    {
+        private IDRole[] m_array;
+        
+        public PrincipalPermission( PermissionState state )
+        {
+            if (state == PermissionState.Unrestricted)
+            {
+                m_array = new IDRole[1];
+                m_array[0] = new IDRole();
+                m_array[0].m_authenticated = true;
+                m_array[0].m_id = null;
+                m_array[0].m_role = null;
+            }
+            else if (state == PermissionState.None)
+            {
+                m_array = new IDRole[1];
+                m_array[0] = new IDRole();
+                m_array[0].m_authenticated = false;
+                m_array[0].m_id = "";
+                m_array[0].m_role = "";
+            }
+            else
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidPermissionState"));
+        }
+        
+        public PrincipalPermission( String name, String role )
+        {
+            m_array = new IDRole[1];
+            m_array[0] = new IDRole();
+            m_array[0].m_authenticated = true;
+            m_array[0].m_id = name;
+            m_array[0].m_role = role;
+        }
+    
+        public PrincipalPermission( String name, String role, bool isAuthenticated )
+        {
+            m_array = new IDRole[1];
+            m_array[0] = new IDRole();
+            m_array[0].m_authenticated = isAuthenticated;
+            m_array[0].m_id = name;
+            m_array[0].m_role = role;
+        }        
+    
+        private PrincipalPermission( IDRole[] array )
+        {
+            m_array = array;
+        }
+    
+        private bool IsEmpty()
+        {
+            for (int i = 0; i < m_array.Length; ++i)
+            {
+                if ((m_array[i].m_id == null || !m_array[i].m_id.Equals( "" )) ||
+                    (m_array[i].m_role == null || !m_array[i].m_role.Equals( "" )) ||
+                    m_array[i].m_authenticated)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+        
+        private bool VerifyType(IPermission perm)
+        {
+            // if perm is null, then obviously not of the same type
+            if ((perm == null) || (perm.GetType() != this.GetType())) {
+                return(false);
+            } else {
+                return(true);
+            }
+        }
+         
+        
+        public bool IsUnrestricted()
+        {
+            for (int i = 0; i < m_array.Length; ++i)
+            {
+                if (m_array[i].m_id != null || m_array[i].m_role != null || !m_array[i].m_authenticated)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+ 
+        
+        //------------------------------------------------------
+        //
+        // IPERMISSION IMPLEMENTATION
+        //
+        //------------------------------------------------------
+        
+        public bool IsSubsetOf(IPermission target)
+        {
+            if (target == null)
+            {
+                return this.IsEmpty();
+            }
+        
+            try
+            {
+                PrincipalPermission operand = (PrincipalPermission)target;
+            
+                if (operand.IsUnrestricted())
+                    return true;
+                else if (this.IsUnrestricted())
+                    return false;
+                else
+                {
+                    for (int i = 0; i < this.m_array.Length; ++i)
+                    {
+                        bool foundMatch = false;
+                
+                        for (int j = 0; j < operand.m_array.Length; ++j)
+                        {
+                            if (operand.m_array[j].m_authenticated == this.m_array[i].m_authenticated &&
+                                (operand.m_array[j].m_id == null ||
+                                 (this.m_array[i].m_id != null && this.m_array[i].m_id.Equals( operand.m_array[j].m_id ))) &&
+                                (operand.m_array[j].m_role == null ||
+                                 (this.m_array[i].m_role != null && this.m_array[i].m_role.Equals( operand.m_array[j].m_role ))))
+                            {
+                                foundMatch = true;
+                                break;
+                            }
+                        }
+                    
+                        if (!foundMatch)
+                            return false;
+                    }
+                                            
+                    return true;
+                }
+            }
+            catch (InvalidCastException)
+            {
+                throw new 
+                    ArgumentException(
+                                    Environment.GetResourceString("Argument_WrongType", this.GetType().FullName)
+                                     );
+            }                
+ 
+            
+        }
+        
+        public IPermission Intersect(IPermission target)
+        {
+            if (target == null)
+            {
+                return null;
+            }
+            else if (!VerifyType(target))
+            {
+                throw new 
+                    ArgumentException(
+                                    Environment.GetResourceString("Argument_WrongType", this.GetType().FullName)
+                                     );
+            }
+            else if (this.IsUnrestricted())
+            {
+                return target.Copy();
+            }
+    
+            PrincipalPermission operand = (PrincipalPermission)target;
+    
+            if (operand.IsUnrestricted())
+            {
+                return this.Copy();
+            }
+            
+            List<IDRole> idroles = null;
+            
+            for (int i = 0; i < this.m_array.Length; ++i)
+            {
+                for (int j = 0; j < operand.m_array.Length; ++j)
+                {
+                    if (operand.m_array[j].m_authenticated == this.m_array[i].m_authenticated)
+                    {
+                        if (operand.m_array[j].m_id == null ||
+                            this.m_array[i].m_id == null ||
+                            this.m_array[i].m_id.Equals( operand.m_array[j].m_id ))
+                        {
+                            if (idroles == null)
+                            {
+                                idroles = new List<IDRole>();
+                            }
+                    
+                            IDRole idrole = new IDRole();
+                            
+                            idrole.m_id = operand.m_array[j].m_id == null ? this.m_array[i].m_id : operand.m_array[j].m_id;
+                            
+                            if (operand.m_array[j].m_role == null ||
+                                this.m_array[i].m_role == null ||
+                                this.m_array[i].m_role.Equals( operand.m_array[j].m_role))
+                            {
+                                idrole.m_role = operand.m_array[j].m_role == null ? this.m_array[i].m_role : operand.m_array[j].m_role;
+                            }
+                            else
+                            {
+                                idrole.m_role = "";
+                            }
+                            
+                            idrole.m_authenticated = operand.m_array[j].m_authenticated;
+                            
+                            idroles.Add( idrole );
+                        }
+                        else if (operand.m_array[j].m_role == null ||
+                                 this.m_array[i].m_role == null ||
+                                 this.m_array[i].m_role.Equals( operand.m_array[j].m_role))
+                        {
+                            if (idroles == null)
+                            {
+                                idroles = new List<IDRole>();
+                            }
+ 
+                            IDRole idrole = new IDRole();
+                            
+                            idrole.m_id = "";
+                            idrole.m_role = operand.m_array[j].m_role == null ? this.m_array[i].m_role : operand.m_array[j].m_role;
+                            idrole.m_authenticated = operand.m_array[j].m_authenticated;
+                            
+                            idroles.Add( idrole );
+                        }
+                    }
+                }
+            }
+            
+            if (idroles == null)
+            {
+                return null;
+            }
+            else
+            {
+                IDRole[] idrolesArray = new IDRole[idroles.Count];
+                
+                IEnumerator idrolesEnumerator = idroles.GetEnumerator();
+                int index = 0;
+                
+                while (idrolesEnumerator.MoveNext())
+                {
+                    idrolesArray[index++] = (IDRole)idrolesEnumerator.Current;
+                }
+                                                                
+                return new PrincipalPermission( idrolesArray );
+            }
+        }                                                    
+        
+        public IPermission Union(IPermission other)
+        {
+            if (other == null)
+            {
+                return this.Copy();
+            }
+            else if (!VerifyType(other))
+            {
+                throw new 
+                    ArgumentException(
+                                    Environment.GetResourceString("Argument_WrongType", this.GetType().FullName)
+                                     );
+            }
+    
+            PrincipalPermission operand = (PrincipalPermission)other;
+           
+            if (this.IsUnrestricted() || operand.IsUnrestricted())
+            {
+                return new PrincipalPermission( PermissionState.Unrestricted );
+            }
+    
+            // Now we have to do a real union
+            
+            int combinedLength = this.m_array.Length + operand.m_array.Length;
+            IDRole[] idrolesArray = new IDRole[combinedLength];
+            
+            int i, j;
+            for (i = 0; i < this.m_array.Length; ++i)
+            {
+                idrolesArray[i] = this.m_array[i];
+            }
+            
+            for (j = 0; j < operand.m_array.Length; ++j)
+            {
+                idrolesArray[i+j] = operand.m_array[j];
+            }
+            
+            return new PrincipalPermission( idrolesArray );
+ 
+        }    
+ 
+        [System.Runtime.InteropServices.ComVisible(false)]
+        public override bool Equals(Object obj)
+        {
+            IPermission perm = obj as IPermission;
+            if(obj != null && perm == null)
+                return false;
+            if(!this.IsSubsetOf(perm))
+                return false;
+            if(perm != null && !perm.IsSubsetOf(this))
+                return false;
+            return true;
+        }
+ 
+        [System.Runtime.InteropServices.ComVisible(false)]
+        public override int GetHashCode()
+        {
+            int hash = 0;
+            int i;
+            for(i = 0; i < m_array.Length; i++)
+                hash += m_array[i].GetHashCode();
+            return hash;
+        }    
+ 
+        public IPermission Copy()
+        {
+            return new PrincipalPermission( m_array );  
+        }
+ 
+        [System.Security.SecurityCritical]  // auto-generated
+        private void ThrowSecurityException()
+        {
+            System.Reflection.AssemblyName name = null;
+            System.Security.Policy.Evidence evid = null;
+            PermissionSet.s_fullTrust.Assert();                    
+            try
+            {
+                System.Reflection.Assembly asm = Reflection.Assembly.GetCallingAssembly();
+                name = asm.GetName();
+#if FEATURE_CAS_POLICY
+                if(asm != Assembly.GetExecutingAssembly()) // this condition is to avoid having to marshal mscorlib's evidence (which is always in teh default domain) to the current domain
+                    evid = asm.Evidence;
+#endif // FEATURE_CAS_POLICY
+            }
+            catch
+            {
+            }
+            PermissionSet.RevertAssert();
+            throw new SecurityException(Environment.GetResourceString("Security_PrincipalPermission"), name, null, null, null, SecurityAction.Demand, this, this, evid);
+        }
+ 
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public void Demand()
+        {
+            IPrincipal principal = null;
+#if FEATURE_IMPERSONATION
+            new SecurityPermission(SecurityPermissionFlag.ControlPrincipal).Assert();
+            principal = Thread.CurrentPrincipal;
+#endif // FEATURE_IMPERSONATION
+ 
+            if (principal == null)
+                ThrowSecurityException();
+ 
+            if (m_array == null)
+                return;
+ 
+            // A demand passes when the grant satisfies all entries.
+ 
+            int count = this.m_array.Length;
+            bool foundMatch = false;
+            for (int i = 0; i < count; ++i)
+            {
+                // If the demand is authenticated, we need to check the identity and role
+ 
+                if (m_array[i].m_authenticated)
+                {
+                    IIdentity identity = principal.Identity;
+ 
+                    if ((identity.IsAuthenticated &&
+                         (m_array[i].m_id == null || String.Compare( identity.Name, m_array[i].m_id, StringComparison.OrdinalIgnoreCase) == 0)))
+                    {
+                        if (m_array[i].m_role == null) {
+                            foundMatch = true;
+                        }
+                        else {
+#if !FEATURE_PAL && FEATURE_IMPERSONATION 
+                            WindowsPrincipal wp = principal as WindowsPrincipal;
+                            if (wp != null && m_array[i].Sid != null)
+                                foundMatch = wp.IsInRole(m_array[i].Sid);
+                            else
+#endif // !FEATURE_PAL && FEATURE_IMPERSONATION 
+                                foundMatch = principal.IsInRole(m_array[i].m_role);
+                        }
+ 
+                        if (foundMatch)
+                            break;
+                    }
+                }
+                else
+                {
+                    foundMatch = true;
+                    break;
+                }
+            }
+ 
+            if (!foundMatch)
+                ThrowSecurityException();
+        }
+        
+#if FEATURE_CAS_POLICY
+        public SecurityElement ToXml()
+        {
+            SecurityElement root = new SecurityElement( "IPermission" );
+            
+            XMLUtil.AddClassAttribute( root, this.GetType(), "System.Security.Permissions.PrincipalPermission" );
+            // If you hit this assert then most likely you are trying to change the name of this class. 
+            // This is ok as long as you change the hard coded string above and change the assert below.
+            Contract.Assert( this.GetType().FullName.Equals( "System.Security.Permissions.PrincipalPermission" ), "Class name changed!" );
+ 
+            root.AddAttribute( "version", "1" );
+            
+            int count = m_array.Length;
+            for (int i = 0; i < count; ++i)
+            {
+                root.AddChild( m_array[i].ToXml() );
+            }
+            
+            return root;
+        }
+ 
+        public void FromXml(SecurityElement elem)
+        {
+            CodeAccessPermission.ValidateElement( elem, this );
+ 
+            if (elem.InternalChildren != null && elem.InternalChildren.Count != 0)
+            { 
+                int numChildren = elem.InternalChildren.Count;
+                int count = 0;
+                
+                m_array = new IDRole[numChildren];
+            
+                IEnumerator enumerator = elem.Children.GetEnumerator();
+            
+                while (enumerator.MoveNext())  
+                {
+                    IDRole idrole = new IDRole();
+                    
+                    idrole.FromXml( (SecurityElement)enumerator.Current );
+                    
+                    m_array[count++] = idrole;
+                }
+            }
+            else
+                m_array = new IDRole[0];
+        }
+                 
+        public override String ToString()
+        {
+            return ToXml().ToString();
+        }    
+#endif // FEATURE_CAS_POLICY
+ 
+        /// <internalonly/>
+        int IBuiltInPermission.GetTokenIndex()
+        {
+            return PrincipalPermission.GetTokenIndex();
+        }
+ 
+        internal static int GetTokenIndex()
+        {
+            return BuiltInPermissionIndex.PrincipalPermissionIndex;
+        }
+ 
+    }
+ 
 }

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
@@ -1,92 +1,61 @@
-﻿// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
-//  PrincipalPermission.cs
-// 
-// <OWNER>Microsoft</OWNER>
-//
- 
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Security.Principal;
+using System.Threading;
+
 namespace System.Security.Permissions
 {
-    using System;
-    using SecurityElement = System.Security.SecurityElement;
-    using System.Security.Util;
-    using System.IO;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Security.Principal;
-    using System.Text;
-    using System.Threading;    
-    using System.Globalization;
-    using System.Reflection;
-    using System.Diagnostics.Contracts;
-    
     [Serializable]
-    internal class IDRole
+    internal partial class IDRole
     {
         internal bool m_authenticated;
-        internal String m_id;
-        internal String m_role;
- 
-#if !FEATURE_PAL
-        // cache the translation from name to Sid for the case of WindowsPrincipal.
-        [NonSerialized]
-        private SecurityIdentifier m_sid = null;
-        internal SecurityIdentifier Sid {
-            [System.Security.SecurityCritical]  // auto-generated
-            get {
-                if (String.IsNullOrEmpty(m_role))
-                    return null;
- 
-                if (m_sid == null) {
-                    NTAccount ntAccount = new NTAccount(m_role);
-                    IdentityReferenceCollection source = new IdentityReferenceCollection(1);
-                    source.Add(ntAccount);
-                    IdentityReferenceCollection target = NTAccount.Translate(source, typeof(SecurityIdentifier), false);
-                    m_sid = target[0] as SecurityIdentifier;
-                }
- 
-                return m_sid;
-            }
+        internal string m_id;
+        internal string m_role;
+
+        public override int GetHashCode()
+        {
+            return ((m_authenticated ? 0 : 101) +
+                        (m_id == null ? 0 : m_id.GetHashCode()) +
+                        (m_role == null ? 0 : m_role.GetHashCode()));
         }
-#endif // !FEATURE_PAL
- 
-#if FEATURE_CAS_POLICY
+
         internal SecurityElement ToXml()
         {
-            SecurityElement root = new SecurityElement( "Identity" );
-            
+            SecurityElement root = new SecurityElement("Identity");
+
             if (m_authenticated)
-                root.AddAttribute( "Authenticated", "true" );
-                
+                root.AddAttribute("Authenticated", "true");
+
             if (m_id != null)
             {
-                root.AddAttribute( "ID", SecurityElement.Escape( m_id ) );
+                root.AddAttribute("ID", SecurityElement.Escape(m_id));
             }
-               
+
             if (m_role != null)
             {
-                root.AddAttribute( "Role", SecurityElement.Escape( m_role ) );
+                root.AddAttribute("Role", SecurityElement.Escape(m_role));
             }
-                            
+
             return root;
         }
-        
-        internal void FromXml( SecurityElement e )
+
+        internal void FromXml(SecurityElement e)
         {
-            String elAuth = e.Attribute( "Authenticated" );
+            string elAuth = e.Attribute("Authenticated");
             if (elAuth != null)
             {
-                m_authenticated = String.Compare( elAuth, "true", StringComparison.OrdinalIgnoreCase) == 0;
+                m_authenticated = string.Compare(elAuth, "true", StringComparison.OrdinalIgnoreCase) == 0;
             }
             else
             {
                 m_authenticated = false;
             }
-           
-            String elID = e.Attribute( "ID" );
+
+            string elID = e.Attribute("ID");
             if (elID != null)
             {
                 m_id = elID;
@@ -95,8 +64,8 @@ namespace System.Security.Permissions
             {
                 m_id = null;
             }
-            
-            String elRole = e.Attribute( "Role" );
+
+            string elRole = e.Attribute("Role");
             if (elRole != null)
             {
                 m_role = elRole;
@@ -106,24 +75,14 @@ namespace System.Security.Permissions
                 m_role = null;
             }
         }
-#endif // FEATURE_CAS_POLICY
- 
-        public override int GetHashCode()
-        {
-            return ((m_authenticated ? 0 : 101) +
-                        (m_id == null ? 0 : m_id.GetHashCode()) +
-                        (m_role == null? 0 : m_role.GetHashCode()));
-        }    
- 
     }
-    
-[System.Runtime.InteropServices.ComVisible(true)]
+
     [Serializable]
-    sealed public class PrincipalPermission : IPermission, IUnrestrictedPermission, ISecurityEncodable, IBuiltInPermission
+    public sealed partial class PrincipalPermission : IPermission, ISecurityEncodable, IUnrestrictedPermission
     {
         private IDRole[] m_array;
-        
-        public PrincipalPermission( PermissionState state )
+
+        public PrincipalPermission(PermissionState state)
         {
             if (state == PermissionState.Unrestricted)
             {
@@ -142,38 +101,33 @@ namespace System.Security.Permissions
                 m_array[0].m_role = "";
             }
             else
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidPermissionState"));
+            {
+                throw new ArgumentException(SR.Argument_InvalidPermissionState);
+            }
         }
-        
-        public PrincipalPermission( String name, String role )
-        {
-            m_array = new IDRole[1];
-            m_array[0] = new IDRole();
-            m_array[0].m_authenticated = true;
-            m_array[0].m_id = name;
-            m_array[0].m_role = role;
-        }
-    
-        public PrincipalPermission( String name, String role, bool isAuthenticated )
+
+        public PrincipalPermission(string name, string role) : this(name, role, isAuthenticated: true) { }
+
+        public PrincipalPermission(string name, string role, bool isAuthenticated)
         {
             m_array = new IDRole[1];
             m_array[0] = new IDRole();
             m_array[0].m_authenticated = isAuthenticated;
             m_array[0].m_id = name;
             m_array[0].m_role = role;
-        }        
-    
-        private PrincipalPermission( IDRole[] array )
+        }
+
+        private PrincipalPermission(IDRole[] array)
         {
             m_array = array;
         }
-    
+
         private bool IsEmpty()
         {
             for (int i = 0; i < m_array.Length; ++i)
             {
-                if ((m_array[i].m_id == null || !m_array[i].m_id.Equals( "" )) ||
-                    (m_array[i].m_role == null || !m_array[i].m_role.Equals( "" )) ||
+                if ((m_array[i].m_id == null || m_array[i].m_id.Length != 0) ||
+                    (m_array[i].m_role == null || m_array[i].m_role.Length != 0) ||
                     m_array[i].m_authenticated)
                 {
                     return false;
@@ -181,18 +135,13 @@ namespace System.Security.Permissions
             }
             return true;
         }
-        
+
         private bool VerifyType(IPermission perm)
         {
             // if perm is null, then obviously not of the same type
-            if ((perm == null) || (perm.GetType() != this.GetType())) {
-                return(false);
-            } else {
-                return(true);
-            }
+            return (perm != null) && (perm.GetType() == GetType());
         }
-         
-        
+
         public bool IsUnrestricted()
         {
             for (int i = 0; i < m_array.Length; ++i)
@@ -204,66 +153,54 @@ namespace System.Security.Permissions
             }
             return true;
         }
- 
-        
-        //------------------------------------------------------
-        //
-        // IPERMISSION IMPLEMENTATION
-        //
-        //------------------------------------------------------
-        
+
         public bool IsSubsetOf(IPermission target)
         {
             if (target == null)
             {
-                return this.IsEmpty();
+                return IsEmpty();
             }
-        
+
             try
             {
                 PrincipalPermission operand = (PrincipalPermission)target;
-            
+
                 if (operand.IsUnrestricted())
                     return true;
-                else if (this.IsUnrestricted())
+                else if (IsUnrestricted())
                     return false;
                 else
                 {
-                    for (int i = 0; i < this.m_array.Length; ++i)
+                    for (int i = 0; i < m_array.Length; ++i)
                     {
                         bool foundMatch = false;
-                
+
                         for (int j = 0; j < operand.m_array.Length; ++j)
                         {
-                            if (operand.m_array[j].m_authenticated == this.m_array[i].m_authenticated &&
+                            if (operand.m_array[j].m_authenticated == m_array[i].m_authenticated &&
                                 (operand.m_array[j].m_id == null ||
-                                 (this.m_array[i].m_id != null && this.m_array[i].m_id.Equals( operand.m_array[j].m_id ))) &&
+                                 (m_array[i].m_id != null && m_array[i].m_id.Equals(operand.m_array[j].m_id))) &&
                                 (operand.m_array[j].m_role == null ||
-                                 (this.m_array[i].m_role != null && this.m_array[i].m_role.Equals( operand.m_array[j].m_role ))))
+                                 (m_array[i].m_role != null && m_array[i].m_role.Equals(operand.m_array[j].m_role))))
                             {
                                 foundMatch = true;
                                 break;
                             }
                         }
-                    
+
                         if (!foundMatch)
                             return false;
                     }
-                                            
+
                     return true;
                 }
             }
             catch (InvalidCastException)
             {
-                throw new 
-                    ArgumentException(
-                                    Environment.GetResourceString("Argument_WrongType", this.GetType().FullName)
-                                     );
-            }                
- 
-            
+                throw new ArgumentException(SR.Argument_WrongType, GetType().FullName);
+            }
         }
-        
+
         public IPermission Intersect(IPermission target)
         {
             if (target == null)
@@ -272,80 +209,77 @@ namespace System.Security.Permissions
             }
             else if (!VerifyType(target))
             {
-                throw new 
-                    ArgumentException(
-                                    Environment.GetResourceString("Argument_WrongType", this.GetType().FullName)
-                                     );
+                throw new ArgumentException(SR.Argument_WrongType, GetType().FullName);
             }
-            else if (this.IsUnrestricted())
+            else if (IsUnrestricted())
             {
                 return target.Copy();
             }
-    
+
             PrincipalPermission operand = (PrincipalPermission)target;
-    
+
             if (operand.IsUnrestricted())
             {
-                return this.Copy();
+                return Copy();
             }
-            
+
             List<IDRole> idroles = null;
-            
-            for (int i = 0; i < this.m_array.Length; ++i)
+
+            for (int i = 0; i < m_array.Length; ++i)
             {
                 for (int j = 0; j < operand.m_array.Length; ++j)
                 {
-                    if (operand.m_array[j].m_authenticated == this.m_array[i].m_authenticated)
+                    if (operand.m_array[j].m_authenticated == m_array[i].m_authenticated)
                     {
                         if (operand.m_array[j].m_id == null ||
-                            this.m_array[i].m_id == null ||
-                            this.m_array[i].m_id.Equals( operand.m_array[j].m_id ))
+                            m_array[i].m_id == null ||
+                            m_array[i].m_id.Equals(operand.m_array[j].m_id))
                         {
                             if (idroles == null)
                             {
                                 idroles = new List<IDRole>();
                             }
-                    
+
                             IDRole idrole = new IDRole();
-                            
-                            idrole.m_id = operand.m_array[j].m_id == null ? this.m_array[i].m_id : operand.m_array[j].m_id;
-                            
+
+                            idrole.m_id = operand.m_array[j].m_id == null ? m_array[i].m_id : operand.m_array[j].m_id;
+
                             if (operand.m_array[j].m_role == null ||
-                                this.m_array[i].m_role == null ||
-                                this.m_array[i].m_role.Equals( operand.m_array[j].m_role))
+                                m_array[i].m_role == null ||
+                                m_array[i].m_role.Equals(operand.m_array[j].m_role))
                             {
-                                idrole.m_role = operand.m_array[j].m_role == null ? this.m_array[i].m_role : operand.m_array[j].m_role;
+                                idrole.m_role = operand.m_array[j].m_role == null ? m_array[i].m_role : operand.m_array[j].m_role;
                             }
                             else
                             {
                                 idrole.m_role = "";
                             }
-                            
+
                             idrole.m_authenticated = operand.m_array[j].m_authenticated;
-                            
-                            idroles.Add( idrole );
+
+                            idroles.Add(idrole);
                         }
                         else if (operand.m_array[j].m_role == null ||
-                                 this.m_array[i].m_role == null ||
-                                 this.m_array[i].m_role.Equals( operand.m_array[j].m_role))
+                                 m_array[i].m_role == null ||
+                                 m_array[i].m_role.Equals(operand.m_array[j].m_role))
                         {
                             if (idroles == null)
                             {
                                 idroles = new List<IDRole>();
                             }
- 
+
                             IDRole idrole = new IDRole();
-                            
+
                             idrole.m_id = "";
-                            idrole.m_role = operand.m_array[j].m_role == null ? this.m_array[i].m_role : operand.m_array[j].m_role;
+                            idrole.m_role = operand.m_array[j].m_role == null ? m_array[i].m_role : operand.m_array[j].m_role;
                             idrole.m_authenticated = operand.m_array[j].m_authenticated;
-                            
-                            idroles.Add( idrole );
+
+                            idroles.Add(idrole);
                         }
                     }
                 }
             }
-            
+
             if (idroles == null)
             {
                 return null;
@@ -353,153 +287,113 @@ namespace System.Security.Permissions
             else
             {
                 IDRole[] idrolesArray = new IDRole[idroles.Count];
-                
+
                 IEnumerator idrolesEnumerator = idroles.GetEnumerator();
                 int index = 0;
-                
+
                 while (idrolesEnumerator.MoveNext())
                 {
                     idrolesArray[index++] = (IDRole)idrolesEnumerator.Current;
                 }
-                                                                
-                return new PrincipalPermission( idrolesArray );
+
+                return new PrincipalPermission(idrolesArray);
             }
-        }                                                    
-        
+        }
+
         public IPermission Union(IPermission other)
         {
             if (other == null)
             {
-                return this.Copy();
+                return Copy();
             }
             else if (!VerifyType(other))
             {
-                throw new 
-                    ArgumentException(
-                                    Environment.GetResourceString("Argument_WrongType", this.GetType().FullName)
-                                     );
+                throw new ArgumentException(SR.Argument_WrongType, GetType().FullName);
             }
-    
+
             PrincipalPermission operand = (PrincipalPermission)other;
-           
-            if (this.IsUnrestricted() || operand.IsUnrestricted())
+
+            if (IsUnrestricted() || operand.IsUnrestricted())
             {
-                return new PrincipalPermission( PermissionState.Unrestricted );
+                return new PrincipalPermission(PermissionState.Unrestricted);
             }
-    
+
             // Now we have to do a real union
-            
-            int combinedLength = this.m_array.Length + operand.m_array.Length;
+            int combinedLength = m_array.Length + operand.m_array.Length;
             IDRole[] idrolesArray = new IDRole[combinedLength];
-            
+
             int i, j;
-            for (i = 0; i < this.m_array.Length; ++i)
+            for (i = 0; i < m_array.Length; ++i)
             {
-                idrolesArray[i] = this.m_array[i];
+                idrolesArray[i] = m_array[i];
             }
-            
+
             for (j = 0; j < operand.m_array.Length; ++j)
             {
-                idrolesArray[i+j] = operand.m_array[j];
+                idrolesArray[i + j] = operand.m_array[j];
             }
-            
-            return new PrincipalPermission( idrolesArray );
- 
-        }    
- 
-        [System.Runtime.InteropServices.ComVisible(false)]
-        public override bool Equals(Object obj)
+
+            return new PrincipalPermission(idrolesArray);
+
+        }
+
+        public override bool Equals(object obj)
         {
             IPermission perm = obj as IPermission;
-            if(obj != null && perm == null)
+            if (obj != null && perm == null)
                 return false;
-            if(!this.IsSubsetOf(perm))
+            if (!IsSubsetOf(perm))
                 return false;
-            if(perm != null && !perm.IsSubsetOf(this))
+            if (perm != null && !perm.IsSubsetOf(this))
                 return false;
             return true;
         }
- 
-        [System.Runtime.InteropServices.ComVisible(false)]
+
         public override int GetHashCode()
         {
             int hash = 0;
             int i;
-            for(i = 0; i < m_array.Length; i++)
+            for (i = 0; i < m_array.Length; i++)
                 hash += m_array[i].GetHashCode();
             return hash;
-        }    
- 
+        }
+
         public IPermission Copy()
         {
-            return new PrincipalPermission( m_array );  
+            return new PrincipalPermission(m_array);
         }
- 
-        [System.Security.SecurityCritical]  // auto-generated
-        private void ThrowSecurityException()
-        {
-            System.Reflection.AssemblyName name = null;
-            System.Security.Policy.Evidence evid = null;
-            PermissionSet.s_fullTrust.Assert();                    
-            try
-            {
-                System.Reflection.Assembly asm = Reflection.Assembly.GetCallingAssembly();
-                name = asm.GetName();
-#if FEATURE_CAS_POLICY
-                if(asm != Assembly.GetExecutingAssembly()) // this condition is to avoid having to marshal mscorlib's evidence (which is always in teh default domain) to the current domain
-                    evid = asm.Evidence;
-#endif // FEATURE_CAS_POLICY
-            }
-            catch
-            {
-            }
-            PermissionSet.RevertAssert();
-            throw new SecurityException(Environment.GetResourceString("Security_PrincipalPermission"), name, null, null, null, SecurityAction.Demand, this, this, evid);
-        }
- 
-        [System.Security.SecuritySafeCritical]  // auto-generated
+
         public void Demand()
         {
-            IPrincipal principal = null;
-#if FEATURE_IMPERSONATION
             new SecurityPermission(SecurityPermissionFlag.ControlPrincipal).Assert();
-            principal = Thread.CurrentPrincipal;
-#endif // FEATURE_IMPERSONATION
- 
+            IPrincipal principal = Thread.CurrentPrincipal;
             if (principal == null)
-                ThrowSecurityException();
- 
+                throw new SecurityException(SR.Security_PrincipalPermission);
             if (m_array == null)
                 return;
- 
+
             // A demand passes when the grant satisfies all entries.
- 
-            int count = this.m_array.Length;
+            int count = m_array.Length;
             bool foundMatch = false;
             for (int i = 0; i < count; ++i)
             {
                 // If the demand is authenticated, we need to check the identity and role
- 
                 if (m_array[i].m_authenticated)
                 {
                     IIdentity identity = principal.Identity;
- 
+
                     if ((identity.IsAuthenticated &&
-                         (m_array[i].m_id == null || String.Compare( identity.Name, m_array[i].m_id, StringComparison.OrdinalIgnoreCase) == 0)))
+                         (m_array[i].m_id == null || string.Compare(identity.Name, m_array[i].m_id, StringComparison.OrdinalIgnoreCase) == 0)))
                     {
-                        if (m_array[i].m_role == null) {
+                        if (m_array[i].m_role == null)
+                        {
                             foundMatch = true;
                         }
-                        else {
-#if !FEATURE_PAL && FEATURE_IMPERSONATION 
-                            WindowsPrincipal wp = principal as WindowsPrincipal;
-                            if (wp != null && m_array[i].Sid != null)
-                                foundMatch = wp.IsInRole(m_array[i].Sid);
-                            else
-#endif // !FEATURE_PAL && FEATURE_IMPERSONATION 
-                                foundMatch = principal.IsInRole(m_array[i].m_role);
+                        else
+                        {
+                            foundMatch = principal.IsInRole(m_array[i].m_role);
                         }
- 
+
                         if (foundMatch)
                             break;
                     }
@@ -510,75 +404,69 @@ namespace System.Security.Permissions
                     break;
                 }
             }
- 
+
             if (!foundMatch)
-                ThrowSecurityException();
+                throw new SecurityException(SR.Security_PrincipalPermission);
         }
-        
-#if FEATURE_CAS_POLICY
+
         public SecurityElement ToXml()
         {
-            SecurityElement root = new SecurityElement( "IPermission" );
-            
-            XMLUtil.AddClassAttribute( root, this.GetType(), "System.Security.Permissions.PrincipalPermission" );
-            // If you hit this assert then most likely you are trying to change the name of this class. 
-            // This is ok as long as you change the hard coded string above and change the assert below.
-            Contract.Assert( this.GetType().FullName.Equals( "System.Security.Permissions.PrincipalPermission" ), "Class name changed!" );
- 
-            root.AddAttribute( "version", "1" );
-            
-            int count = m_array.Length;
-            for (int i = 0; i < count; ++i)
+            SecurityElement root = new SecurityElement("IPermission");
+
+            string typename = "System.Security.Permissions.PrincipalPermission";
+            root.AddAttribute("class", typename + ", " + GetType().Module.Assembly.FullName.Replace('\"', '\''));
+            root.AddAttribute("version", "1");
+
+            if (m_array != null)
             {
-                root.AddChild( m_array[i].ToXml() );
+                int count = m_array.Length;
+                for (int i = 0; i < count; ++i)
+                {
+                    root.AddChild(m_array[i].ToXml());
+                }
             }
-            
+
             return root;
         }
- 
+
         public void FromXml(SecurityElement elem)
         {
-            CodeAccessPermission.ValidateElement( elem, this );
- 
+            if (elem == null)
+                throw new ArgumentNullException(nameof(elem));
+
+            if (elem.Tag == null || !elem.Tag.Equals("Permission") && !elem.Tag.Equals("IPermission"))
+                throw new ArgumentException(SR.Argument_NotAPermissionElement);
+
+            string version = elem.Attribute("version");
+
+            if (version == null || (version != null && !version.Equals("1")))
+                throw new ArgumentException(SR.Argument_InvalidXMLBadVersion);
+
             if (elem.InternalChildren != null && elem.InternalChildren.Count != 0)
-            { 
+            {
                 int numChildren = elem.InternalChildren.Count;
                 int count = 0;
-                
+
                 m_array = new IDRole[numChildren];
-            
+
                 IEnumerator enumerator = elem.Children.GetEnumerator();
-            
-                while (enumerator.MoveNext())  
+
+                while (enumerator.MoveNext())
                 {
                     IDRole idrole = new IDRole();
-                    
-                    idrole.FromXml( (SecurityElement)enumerator.Current );
-                    
+
+                    idrole.FromXml((SecurityElement)enumerator.Current);
+
                     m_array[count++] = idrole;
                 }
             }
             else
                 m_array = new IDRole[0];
         }
-                 
-        public override String ToString()
+
+        public override string ToString()
         {
             return ToXml().ToString();
-        }    
-#endif // FEATURE_CAS_POLICY
- 
-        /// <internalonly/>
-        int IBuiltInPermission.GetTokenIndex()
-        {
-            return PrincipalPermission.GetTokenIndex();
         }
- 
-        internal static int GetTokenIndex()
-        {
-            return BuiltInPermissionIndex.PrincipalPermissionIndex;
-        }
- 
     }
- 
 }

--- a/src/System.Security.Permissions/src/System/Security/SecurityElement.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityElement.cs
@@ -1,165 +1,116 @@
-﻿// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
-// <OWNER>Microsoft</OWNER>
-// 
- 
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.s
+
+using System.Collections;
+using System.Text;
+using System.Globalization;
+using System.IO;
+using System.Diagnostics;
+
 namespace System.Security
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Security.Util;
-    using System.Text;
-    using System.Globalization;
-    using System.IO;
-    using System.Security.Permissions;
-    using System.Diagnostics.Contracts;
- 
     internal enum SecurityElementType
     {
         Regular = 0,
         Format = 1,
         Comment = 2
     }
- 
-    
+
     internal interface ISecurityElementFactory
     {
         SecurityElement CreateSecurityElement();
- 
-        Object Copy();
- 
-        String GetTag();
- 
-        String Attribute( String attributeName );
+
+        object Copy();
+
+        string GetTag();
+
+        string Attribute(string attributeName);
     }
- 
+
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
     sealed public class SecurityElement : ISecurityElementFactory
     {
-        internal String  m_strTag;
-        internal String  m_strText;
+        internal string m_strTag;
+        internal string m_strText;
         private ArrayList m_lChildren;
         internal ArrayList m_lAttributes;
-        internal SecurityElementType m_type = SecurityElementType.Regular;
-        
+
+        internal readonly SecurityElementType m_type = SecurityElementType.Regular;
+        private const int c_AttributesTypical = 4 * 2;  // 4 attributes, times 2 strings per attribute
+        private const int c_ChildrenTypical = 1;
+
         private static readonly char[] s_tagIllegalCharacters = new char[] { ' ', '<', '>' };
         private static readonly char[] s_textIllegalCharacters = new char[] { '<', '>' };
         private static readonly char[] s_valueIllegalCharacters = new char[] { '<', '>', '\"' };
-        private const String s_strIndent = "   ";
-        
-        private const int c_AttributesTypical = 4 * 2;  // 4 attributes, times 2 strings per attribute
-        private const int c_ChildrenTypical = 1;  
- 
-        private static readonly String[] s_escapeStringPairs = new String[]
-            {
-                // these must be all once character escape sequences or a new escaping algorithm is needed
-                "<", "&lt;",
-                ">", "&gt;",
-                "\"", "&quot;",
-                "\'", "&apos;",
-                "&", "&amp;"
-            };
- 
+        private const string s_strIndent = "   ";
+
+        private static readonly string[] s_escapeStringPairs = new string[]
+        {
+            // these must be all once character escape sequences or a new escaping algorithm is needed
+            "<", "&lt;",
+            ">", "&gt;",
+            "\"", "&quot;",
+            "\'", "&apos;",
+            "&", "&amp;"
+        };
+
         private static readonly char[] s_escapeChars = new char[] { '<', '>', '\"', '\'', '&' };
-        
+
         //-------------------------- Constructors ---------------------------
-        
+
         internal SecurityElement()
         {
         }
- 
-////// ISecurityElementFactory implementation
- 
-        SecurityElement ISecurityElementFactory.CreateSecurityElement()
-        {
-            return this;
-        }
- 
-        String ISecurityElementFactory.GetTag()
-        {
-            return ((SecurityElement)this).Tag;
-        }
- 
-        Object ISecurityElementFactory.Copy()
-        {
-            return ((SecurityElement)this).Copy();
-        }
- 
-        String ISecurityElementFactory.Attribute( String attributeName )
-        {
-            return ((SecurityElement)this).Attribute( attributeName );
-        }
- 
-//////////////
- 
-#if FEATURE_CAS_POLICY
-        public static SecurityElement FromString( String xml )
-        {
-            if (xml == null)
-                throw new ArgumentNullException( "xml" );
-            Contract.EndContractBlock();
- 
-            return new Parser( xml ).GetTopElement();
-        }
-#endif // FEATURE_CAS_POLICY
-    
-        public SecurityElement( String tag )
+
+        public SecurityElement(string tag)
         {
             if (tag == null)
-                throw new ArgumentNullException( "tag" );
-        
-            if (!IsValidTag( tag ))
-                throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementTag" ), tag ) );
-            Contract.EndContractBlock();
-        
+                throw new ArgumentNullException(nameof(tag));
+
+            if (!IsValidTag(tag))
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, tag));
+
             m_strTag = tag;
             m_strText = null;
         }
- 
-        public SecurityElement( String tag, String text )
+
+        public SecurityElement(string tag, string text)
         {
             if (tag == null)
-                throw new ArgumentNullException( "tag" );
-        
-            if (!IsValidTag( tag ))
-                throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementTag" ), tag ) );
- 
-            if (text != null && !IsValidText( text ))
-                throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementText" ), text ) );
-            Contract.EndContractBlock();
-        
+                throw new ArgumentNullException(nameof(tag));
+
+            if (!IsValidTag(tag))
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, tag));
+
+            if (text != null && !IsValidText(text))
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementText, text));
+
             m_strTag = tag;
             m_strText = text;
         }
-    
+
         //-------------------------- Properties -----------------------------
- 
-        public String Tag
+
+        public string Tag
         {
-            [Pure]
             get
             {
                 return m_strTag;
             }
-            
+
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException( "Tag" );
-        
-                if (!IsValidTag( value ))
-                    throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementTag" ), value ) );
-                Contract.EndContractBlock();
-            
+                    throw new ArgumentNullException(nameof(Tag));
+
+                if (!IsValidTag(value))
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, value));
+
                 m_strTag = value;
             }
         }
- 
+
         public Hashtable Attributes
         {
             get
@@ -170,20 +121,20 @@ namespace System.Security
                 }
                 else
                 {
-                    Hashtable hashtable = new Hashtable( m_lAttributes.Count/2 );
-                                        
+                    Hashtable hashtable = new Hashtable(m_lAttributes.Count / 2);
+
                     int iMax = m_lAttributes.Count;
-                    Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
-                          
+                    Debug.Assert(iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly");
+
                     for (int i = 0; i < iMax; i += 2)
                     {
-                        hashtable.Add( m_lAttributes[i], m_lAttributes[i+1]);
+                        hashtable.Add(m_lAttributes[i], m_lAttributes[i + 1]);
                     }
-                                        
+
                     return hashtable;
                 }
             }
-            
+
             set
             {
                 if (value == null || value.Count == 0)
@@ -193,36 +144,35 @@ namespace System.Security
                 else
                 {
                     ArrayList list = new ArrayList(value.Count);
-                    
-                    System.Collections.IDictionaryEnumerator enumerator = (System.Collections.IDictionaryEnumerator)value.GetEnumerator();
-                    
+                    IDictionaryEnumerator enumerator = value.GetEnumerator();
+
                     while (enumerator.MoveNext())
                     {
-                        String attrName = (String)enumerator.Key;
-                        String attrValue = (String)enumerator.Value;
-                    
-                        if (!IsValidAttributeName( attrName ))
-                            throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementName" ), (String)enumerator.Current ) );
-                        
-                        if (!IsValidAttributeValue( attrValue ))
-                            throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementValue" ), (String)enumerator.Value ) );
-                    
+                        string attrName = (string)enumerator.Key;
+                        string attrValue = (string)enumerator.Value;
+
+                        if (!IsValidAttributeName(attrName))
+                            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementName, (string)enumerator.Current));
+
+                        if (!IsValidAttributeValue(attrValue))
+                            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementValue, (string)enumerator.Value));
+
                         list.Add(attrName);
                         list.Add(attrValue);
                     }
-                    
+
                     m_lAttributes = list;
                 }
             }
         }
- 
-        public String Text
+
+        public string Text
         {
             get
             {
-                return Unescape( m_strText );
+                return Unescape(m_strText);
             }
-            
+
             set
             {
                 if (value == null)
@@ -231,14 +181,14 @@ namespace System.Security
                 }
                 else
                 {
-                    if (!IsValidText( value ))
-                        throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementTag" ), value ) );
-                        
+                    if (!IsValidText(value))
+                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, value));
+
                     m_strText = value;
                 }
             }
         }
- 
+
         public ArrayList Children
         {
             get
@@ -246,29 +196,29 @@ namespace System.Security
                 ConvertSecurityElementFactories();
                 return m_lChildren;
             }
-            
+
             set
             {
                 if (value != null)
                 {
                     IEnumerator enumerator = value.GetEnumerator();
-                    
+
                     while (enumerator.MoveNext())
                     {
                         if (enumerator.Current == null)
-                            throw new ArgumentException( Environment.GetResourceString( "ArgumentNull_Child" ) );
+                            throw new ArgumentException(SR.ArgumentNull_Child);
                     }
                 }
-            
+
                 m_lChildren = value;
             }
         }
- 
+
         internal void ConvertSecurityElementFactories()
         {
             if (m_lChildren == null)
                 return;
- 
+
             for (int i = 0; i < m_lChildren.Count; ++i)
             {
                 ISecurityElementFactory iseFactory = m_lChildren[i] as ISecurityElementFactory;
@@ -276,7 +226,7 @@ namespace System.Security
                     m_lChildren[i] = iseFactory.CreateSecurityElement();
             }
         }
- 
+
         internal ArrayList InternalChildren
         {
             get
@@ -285,86 +235,83 @@ namespace System.Security
                 // If you want to get a consistent SecurityElement view, call get_Children.
                 return m_lChildren;
             }
-        }  
-   
+        }
+
         //-------------------------- Public Methods -----------------------------
-        
-        internal void AddAttributeSafe( String name, String value )
+
+        internal void AddAttributeSafe(string name, string value)
         {
             if (m_lAttributes == null)
             {
-                m_lAttributes = new ArrayList( c_AttributesTypical  );
+                m_lAttributes = new ArrayList(c_AttributesTypical);
             }
             else
             {
                 int iMax = m_lAttributes.Count;
-                Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
-                          
+                Debug.Assert(iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly");
+
                 for (int i = 0; i < iMax; i += 2)
                 {
-                    String strAttrName = (String)m_lAttributes[i];
-                    
-                    if (String.Equals(strAttrName, name))
-                        throw new ArgumentException( Environment.GetResourceString( "Argument_AttributeNamesMustBeUnique" ) );
+                    string strAttrName = (string)m_lAttributes[i];
+
+                    if (string.Equals(strAttrName, name))
+                        throw new ArgumentException(SR.Argument_AttributeNamesMustBeUnique);
                 }
             }
-        
+
             m_lAttributes.Add(name);
             m_lAttributes.Add(value);
-        }        
-        
-        public void AddAttribute( String name, String value )
-        {   
+        }
+
+        public void AddAttribute(string name, string value)
+        {
             if (name == null)
-                throw new ArgumentNullException( "name" );
-                
+                throw new ArgumentNullException(nameof(name));
+
             if (value == null)
-                throw new ArgumentNullException( "value" );
-        
-            if (!IsValidAttributeName( name ))
-                throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementName" ), name ) );
-                
-            if (!IsValidAttributeValue( value ))
-                throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementValue" ), value ) );
-            Contract.EndContractBlock();
-        
-            AddAttributeSafe( name, value );
+                throw new ArgumentNullException(nameof(value));
+
+            if (!IsValidAttributeName(name))
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementName, name));
+
+            if (!IsValidAttributeValue(value))
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementValue, value));
+
+            AddAttributeSafe(name, value);
         }
- 
-        public void AddChild( SecurityElement child )
-        {   
-            if (child == null)
-                throw new ArgumentNullException( "child" );
-            Contract.EndContractBlock();
-        
-            if (m_lChildren == null)
-                m_lChildren = new ArrayList( c_ChildrenTypical  );
-                
-            m_lChildren.Add( child );
-        }
- 
-        internal void AddChild( ISecurityElementFactory child )
+
+        public void AddChild(SecurityElement child)
         {
             if (child == null)
-                throw new ArgumentNullException( "child" );
-            Contract.EndContractBlock();
-        
+                throw new ArgumentNullException(nameof(child));
+
             if (m_lChildren == null)
-                m_lChildren = new ArrayList( c_ChildrenTypical  );
-             
-            m_lChildren.Add( child );
-        }            
- 
-        internal void AddChildNoDuplicates( ISecurityElementFactory child )
-        {   
+                m_lChildren = new ArrayList(c_ChildrenTypical);
+
+            m_lChildren.Add(child);
+        }
+
+        internal void AddChild(ISecurityElementFactory child)
+        {
             if (child == null)
-                throw new ArgumentNullException( "child" );
-            Contract.EndContractBlock();
-        
+                throw new ArgumentNullException(nameof(child));
+            
+
+            if (m_lChildren == null)
+                m_lChildren = new ArrayList(c_ChildrenTypical);
+
+            m_lChildren.Add(child);
+        }
+
+        internal void AddChildNoDuplicates(ISecurityElementFactory child)
+        {
+            if (child == null)
+                throw new ArgumentNullException(nameof(child));
+
             if (m_lChildren == null)
             {
-                m_lChildren = new ArrayList( c_ChildrenTypical  );
-                m_lChildren.Add( child );
+                m_lChildren = new ArrayList(c_ChildrenTypical);
+                m_lChildren.Add(child);
             }
             else
             {
@@ -373,235 +320,159 @@ namespace System.Security
                     if (m_lChildren[i] == child)
                         return;
                 }
-                m_lChildren.Add( child );
+                m_lChildren.Add(child);
             }
         }
- 
-        public bool Equal( SecurityElement other )
+
+        public bool Equal(SecurityElement other)
         {
             if (other == null)
                 return false;
-        
+
             // Check if the tags are the same
-            if (!String.Equals(m_strTag, other.m_strTag))
+            if (!string.Equals(m_strTag, other.m_strTag))
                 return false;
- 
+
             // Check if the text is the same
-            if (!String.Equals(m_strText, other.m_strText))
+            if (!string.Equals(m_strText, other.m_strText))
                 return false;
- 
+
             // Check if the attributes are the same and appear in the same
             // order.
-            
-            // Maybe we can get away by only checking the number of attributes
             if (m_lAttributes == null || other.m_lAttributes == null)
             {
                 if (m_lAttributes != other.m_lAttributes)
                     return false;
             }
-            else 
-            {                
+            else
+            {
                 int iMax = m_lAttributes.Count;
-                Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
- 
+                Debug.Assert(iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly");
+
+                // Maybe we can get away by only checking the number of attributes
                 if (iMax != other.m_lAttributes.Count)
                     return false;
-                          
+
                 for (int i = 0; i < iMax; i++)
                 {
-                    String lhs = (String)m_lAttributes[i];
-                    String rhs = (String)other.m_lAttributes[i];
-                    
-                    if (!String.Equals(lhs, rhs))
+                    string lhs = (string)m_lAttributes[i];
+                    string rhs = (string)other.m_lAttributes[i];
+
+                    if (!string.Equals(lhs, rhs))
                         return false;
                 }
             }
- 
+
             // Finally we must check the child and make sure they are
             // equal and in the same order
-            
-            // Maybe we can get away by only checking the number of children
-            if (m_lChildren == null || other.m_lChildren == null) 
+            if (m_lChildren == null || other.m_lChildren == null)
             {
                 if (m_lChildren != other.m_lChildren)
                     return false;
-            } 
-            else 
+            }
+            else
             {
+                // Maybe we can get away by only checking the number of children
                 if (m_lChildren.Count != other.m_lChildren.Count)
                     return false;
- 
-                this.ConvertSecurityElementFactories();
+
+                ConvertSecurityElementFactories();
                 other.ConvertSecurityElementFactories();
- 
-                // Okay, we'll need to go through each one of them
+
                 IEnumerator lhs = m_lChildren.GetEnumerator();
                 IEnumerator rhs = other.m_lChildren.GetEnumerator();
- 
+
                 SecurityElement e1, e2;
                 while (lhs.MoveNext())
                 {
                     rhs.MoveNext();
                     e1 = (SecurityElement)lhs.Current;
-                    e2 = (SecurityElement)rhs.Current;       
-                    if (e1 == null || !e1.Equal(e2))                
+                    e2 = (SecurityElement)rhs.Current;
+                    if (e1 == null || !e1.Equal(e2))
                         return false;
                 }
             }
             return true;
         }
- 
-        [System.Runtime.InteropServices.ComVisible(false)]
+
         public SecurityElement Copy()
         {
-            SecurityElement element = new SecurityElement( this.m_strTag, this.m_strText );
-            element.m_lChildren = this.m_lChildren == null ? null : new ArrayList( this.m_lChildren );
-            element.m_lAttributes = this.m_lAttributes == null ? null : new ArrayList(this.m_lAttributes);
- 
+            SecurityElement element = new SecurityElement(m_strTag, m_strText);
+            element.m_lChildren = m_lChildren == null ? null : new ArrayList(m_lChildren);
+            element.m_lAttributes = m_lAttributes == null ? null : new ArrayList(m_lAttributes);
+
             return element;
         }
- 
-        [Pure]
-        public static bool IsValidTag( String tag )
+
+        public static bool IsValidTag(string tag)
         {
             if (tag == null)
                 return false;
-                
-            return tag.IndexOfAny( s_tagIllegalCharacters ) == -1;
+
+            return tag.IndexOfAny(s_tagIllegalCharacters) == -1;
         }
- 
-        [Pure]
-        public static bool IsValidText( String text )
+
+        public static bool IsValidText(string text)
         {
             if (text == null)
                 return false;
-                
-            return text.IndexOfAny( s_textIllegalCharacters ) == -1;
+
+            return text.IndexOfAny(s_textIllegalCharacters) == -1;
         }
- 
-        [Pure]
-        public static bool IsValidAttributeName( String name )
+
+        public static bool IsValidAttributeName(string name)
         {
-            return IsValidTag( name );
+            return IsValidTag(name);
         }
-        
-        [Pure]
-        public static bool IsValidAttributeValue( String value )
+
+        public static bool IsValidAttributeValue(string value)
         {
             if (value == null)
                 return false;
-                
-            return value.IndexOfAny( s_valueIllegalCharacters ) == -1;
+
+            return value.IndexOfAny(s_valueIllegalCharacters) == -1;
         }
- 
-        private static String GetEscapeSequence( char c )
+
+        private static string GetEscapeSequence(char c)
         {
             int iMax = s_escapeStringPairs.Length;
-            Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
-                          
+            Debug.Assert(iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly");
+
             for (int i = 0; i < iMax; i += 2)
             {
-                String strEscSeq = s_escapeStringPairs[i];
-                String strEscValue = s_escapeStringPairs[i+1];
- 
+                string strEscSeq = s_escapeStringPairs[i];
+                string strEscValue = s_escapeStringPairs[i + 1];
+
                 if (strEscSeq[0] == c)
                     return strEscValue;
             }
- 
-            Contract.Assert( false, "Unable to find escape sequence for this character" );
+
+            Debug.Assert(false, "Unable to find escape sequence for this character");
             return c.ToString();
         }
- 
-        public static String Escape( String str )
+
+        public static string Escape(string str)
         {
             if (str == null)
                 return null;
- 
+
             StringBuilder sb = null;
- 
+
             int strLen = str.Length;
             int index; // Pointer into the string that indicates the location of the current '&' character
             int newIndex = 0; // Pointer into the string that indicates the start index of the "remaining" string (that still needs to be processed).
- 
- 
+
             do
             {
-                index = str.IndexOfAny( s_escapeChars, newIndex );
- 
+                index = str.IndexOfAny(s_escapeChars, newIndex);
+
                 if (index == -1)
                 {
                     if (sb == null)
                         return str;
                     else
                     {
-                        sb.Append( str, newIndex, strLen - newIndex );
-                        return sb.ToString();
-                    }
-                }
-                else
-                {
-                    if (sb == null)
-                        sb = new StringBuilder();                    
- 
-                    sb.Append( str, newIndex, index - newIndex );
-                    sb.Append( GetEscapeSequence( str[index] ) );
- 
-                    newIndex = ( index + 1 );
-                }
-            }
-            while (true);
-            
-            // no normal exit is possible
-        }
- 
-        private static String GetUnescapeSequence( String str, int index, out int newIndex )
-        {
-            int maxCompareLength = str.Length - index;
- 
-            int iMax = s_escapeStringPairs.Length;
-            Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
-                          
-            for (int i = 0; i < iMax; i += 2)
-            {
-                String strEscSeq = s_escapeStringPairs[i];
-                String strEscValue = s_escapeStringPairs[i+1];
-                
-                int length = strEscValue.Length;
- 
-                if (length <= maxCompareLength && String.Compare( strEscValue, 0, str, index, length, StringComparison.Ordinal) == 0)
-                {
-                    newIndex = index + strEscValue.Length;
-                    return strEscSeq;
-                }
-            }
- 
-            newIndex = index + 1;
-            return str[index].ToString();
-        }
-            
- 
-        private static String Unescape( String str )
-        {
-            if (str == null)
-                return null;
- 
-            StringBuilder sb = null;
- 
-            int strLen = str.Length;
-            int index; // Pointer into the string that indicates the location of the current '&' character
-            int newIndex = 0; // Pointer into the string that indicates the start index of the "remainging" string (that still needs to be processed).
- 
-            do
-            {
-                index = str.IndexOf( '&', newIndex );
- 
-                if (index == -1)
-                {
-                    if (sb == null)
-                        return str;
-                    else
-                    {
-                        sb.Append( str, newIndex, strLen - newIndex );
+                        sb.Append(str, newIndex, strLen - newIndex);
                         return sb.ToString();
                     }
                 }
@@ -609,323 +480,349 @@ namespace System.Security
                 {
                     if (sb == null)
                         sb = new StringBuilder();
- 
-                    sb.Append(str,  newIndex, index - newIndex);
-                    sb.Append( GetUnescapeSequence( str, index, out newIndex ) ); // updates the newIndex too
- 
+
+                    sb.Append(str, newIndex, index - newIndex);
+                    sb.Append(GetEscapeSequence(str[index]));
+
+                    newIndex = (index + 1);
                 }
             }
             while (true);
- 
-            // C# reports a warning if I leave this in, but I still kinda want to just in case.
-            // Contract.Assert( false, "If you got here, the execution engine or compiler is really confused" );
-            // return str;
+
+            // no normal exit is possible
         }
- 
-        private delegate void ToStringHelperFunc( Object obj, String str );
- 
-        private static void ToStringHelperStringBuilder( Object obj, String str )
+
+        private static string GetUnescapeSequence(string str, int index, out int newIndex)
         {
-            ((StringBuilder)obj).Append( str );
+            int maxCompareLength = str.Length - index;
+
+            int iMax = s_escapeStringPairs.Length;
+            Debug.Assert(iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly");
+
+            for (int i = 0; i < iMax; i += 2)
+            {
+                string strEscSeq = s_escapeStringPairs[i];
+                string strEscValue = s_escapeStringPairs[i + 1];
+
+                int length = strEscValue.Length;
+
+                if (length <= maxCompareLength && string.Compare(strEscValue, 0, str, index, length, StringComparison.Ordinal) == 0)
+                {
+                    newIndex = index + strEscValue.Length;
+                    return strEscSeq;
+                }
+            }
+
+            newIndex = index + 1;
+            return str[index].ToString();
         }
-        
-        private static void ToStringHelperStreamWriter( Object obj, String str )
+
+        private static string Unescape(string str)
         {
-            ((StreamWriter)obj).Write( str );
+            if (str == null)
+                return null;
+
+            StringBuilder sb = null;
+
+            int strLen = str.Length;
+            int index; // Pointer into the string that indicates the location of the current '&' character
+            int newIndex = 0; // Pointer into the string that indicates the start index of the "remainging" string (that still needs to be processed).
+
+            do
+            {
+                index = str.IndexOf('&', newIndex);
+
+                if (index == -1)
+                {
+                    if (sb == null)
+                        return str;
+                    else
+                    {
+                        sb.Append(str, newIndex, strLen - newIndex);
+                        return sb.ToString();
+                    }
+                }
+                else
+                {
+                    if (sb == null)
+                        sb = new StringBuilder();
+
+                    sb.Append(str, newIndex, index - newIndex);
+                    sb.Append(GetUnescapeSequence(str, index, out newIndex)); // updates the newIndex too
+
+                }
+            }
+            while (true);
         }
- 
-        public override String ToString ()
+
+        private delegate void ToStringHelperFunc(object obj, string str);
+
+        private static void ToStringHelperStringBuilder(object obj, string str)
+        {
+            ((StringBuilder)obj).Append(str);
+        }
+
+        private static void ToStringHelperStreamWriter(object obj, string str)
+        {
+            ((StreamWriter)obj).Write(str);
+        }
+
+        public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
- 
-            ToString( "", sb, new ToStringHelperFunc( ToStringHelperStringBuilder ) );
- 
+
+            ToString("", sb, new ToStringHelperFunc(ToStringHelperStringBuilder));
+
             return sb.ToString();
         }
- 
-        internal void ToWriter( StreamWriter writer )
+
+        internal void ToWriter(StreamWriter writer)
         {
-            ToString( "", writer, new ToStringHelperFunc( ToStringHelperStreamWriter ) );
+            ToString("", writer, new ToStringHelperFunc(ToStringHelperStreamWriter));
         }
-        
-        private void ToString( String indent, Object obj, ToStringHelperFunc func )
+
+        private void ToString(string indent, object obj, ToStringHelperFunc func)
         {
-            // First add the indent
-            
-            // func( obj, indent );                       
-            
-            // Add in the opening bracket and the tag.
-            
-            func( obj, "<" );
- 
+            func(obj, "<");
+
             switch (m_type)
             {
                 case SecurityElementType.Format:
-                    func( obj, "?" );
+                    func(obj, "?");
                     break;
- 
+
                 case SecurityElementType.Comment:
-                    func( obj, "!" );
+                    func(obj, "!");
                     break;
- 
+
                 default:
                     break;
             }
- 
-            func( obj, m_strTag );
-            
+
+            func(obj, m_strTag);
+
             // If there are any attributes, plop those in.
-            
             if (m_lAttributes != null && m_lAttributes.Count > 0)
             {
-                func( obj, " " );
- 
+                func(obj, " ");
+
                 int iMax = m_lAttributes.Count;
-                Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
-                          
+                Debug.Assert(iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly");
+
                 for (int i = 0; i < iMax; i += 2)
                 {
-                    String strAttrName = (String)m_lAttributes[i];
-                    String strAttrValue = (String)m_lAttributes[i+1];
-                    
-                    func( obj, strAttrName );
-                    func( obj, "=\"" );
-                    func( obj, strAttrValue );
-                    func( obj, "\"" );
- 
+                    string strAttrName = (string)m_lAttributes[i];
+                    string strAttrValue = (string)m_lAttributes[i + 1];
+
+                    func(obj, strAttrName);
+                    func(obj, "=\"");
+                    func(obj, strAttrValue);
+                    func(obj, "\"");
+
                     if (i != m_lAttributes.Count - 2)
                     {
                         if (m_type == SecurityElementType.Regular)
                         {
-                            func( obj, Environment.NewLine );
+                            func(obj, Environment.NewLine);
                         }
                         else
                         {
-                            func( obj, " " );
+                            func(obj, " ");
                         }
                     }
                 }
             }
-         
+
             if (m_strText == null && (m_lChildren == null || m_lChildren.Count == 0))
             {
                 // If we are a single tag with no children, just add the end of tag text.
-    
                 switch (m_type)
                 {
                     case SecurityElementType.Comment:
-                        func( obj, ">" );
+                        func(obj, ">");
                         break;
- 
+
                     case SecurityElementType.Format:
-                        func( obj, " ?>" );
+                        func(obj, " ?>");
                         break;
- 
+
                     default:
-                        func( obj, "/>" );
+                        func(obj, "/>");
                         break;
                 }
-                func( obj, Environment.NewLine );
+                func(obj, Environment.NewLine);
             }
             else
             {
                 // Close the current tag.
-            
-                func( obj, ">" );
-                
+                func(obj, ">");
+
                 // Output the text
-                
-                func( obj, m_strText );
-                
+                func(obj, m_strText);
+
                 // Output any children.
-                
                 if (m_lChildren != null)
                 {
-                    this.ConvertSecurityElementFactories();
- 
-                    func( obj, Environment.NewLine );
-                
-                    // String childIndent = indent + s_strIndent;
-                
-                    for (int i = 0; i < m_lChildren.Count; ++i)                    
+                    ConvertSecurityElementFactories();
+
+                    func(obj, Environment.NewLine);
+
+                    for (int i = 0; i < m_lChildren.Count; ++i)
                     {
-                        ((SecurityElement)m_lChildren[i]).ToString( "", obj, func );
+                        ((SecurityElement)m_lChildren[i]).ToString(string.Empty, obj, func);
                     }
- 
-                    // In the case where we have children, the close tag will not be on the same line as the
-                    // opening tag, so we need to indent.
- 
-                    // func( obj, indent );
                 }
-                
+
                 // Output the closing tag
-                
-                func( obj, "</" );
-                func( obj, m_strTag );
-                func( obj, ">" );
-                func( obj, Environment.NewLine );
+                func(obj, "</");
+                func(obj, m_strTag);
+                func(obj, ">");
+                func(obj, Environment.NewLine);
             }
         }
-                
-                
- 
-        public String Attribute( String name )
+
+        public string Attribute(string name)
         {
             if (name == null)
-                throw new ArgumentNullException( "name" );
-            Contract.EndContractBlock();
-                
+                throw new ArgumentNullException(nameof(name));
+
             // Note: we don't check for validity here because an
             // if an invalid name is passed we simply won't find it.
-        
             if (m_lAttributes == null)
                 return null;
-                            
+
             // Go through all the attribute and see if we know about
             // the one we are asked for
- 
             int iMax = m_lAttributes.Count;
-            Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
-                          
+            Debug.Assert(iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly");
+
             for (int i = 0; i < iMax; i += 2)
             {
-                String strAttrName = (String)m_lAttributes[i];
-                
-                if (String.Equals(strAttrName, name))
+                string strAttrName = (string)m_lAttributes[i];
+
+                if (string.Equals(strAttrName, name))
                 {
-                    String strAttrValue = (String)m_lAttributes[i+1];
-                    
+                    string strAttrValue = (string)m_lAttributes[i + 1];
+
                     return Unescape(strAttrValue);
                 }
             }
- 
+
             // In the case where we didn't find it, we are expected to
             // return null
             return null;
         }
- 
-        public SecurityElement SearchForChildByTag( String tag )
+
+        public SecurityElement SearchForChildByTag(string tag)
         {
             // Go through all the children and see if we can
             // find the one are are asked for (matching tags)
- 
             if (tag == null)
-                throw new ArgumentNullException( "tag" );
-            Contract.EndContractBlock();
-                
+                throw new ArgumentNullException(nameof(tag));
+
             // Note: we don't check for a valid tag here because
             // an invalid tag simply won't be found.    
-                
             if (m_lChildren == null)
                 return null;
- 
+
             IEnumerator enumerator = m_lChildren.GetEnumerator();
- 
+
             while (enumerator.MoveNext())
             {
                 SecurityElement current = (SecurityElement)enumerator.Current;
-            
-                if (current != null && String.Equals(current.Tag, tag))
+
+                if (current != null && string.Equals(current.Tag, tag))
                     return current;
             }
             return null;
         }
- 
-#if FEATURE_CAS_POLICY
-        internal IPermission ToPermission(bool ignoreTypeLoadFailures)
-        {
-            IPermission ip = XMLUtil.CreatePermission( this, PermissionState.None, ignoreTypeLoadFailures );
-            if (ip == null)
-                return null;
-            ip.FromXml(this);
- 
-            // Get the permission token here to ensure that the token
-            // type is updated appropriately now that we've loaded the type.
-            PermissionToken token = PermissionToken.GetToken( ip );
-            Contract.Assert((token.m_type & PermissionTokenType.DontKnow) == 0, "Token type not properly assigned");
- 
-            return ip;            
-        }
- 
-        [System.Security.SecurityCritical]  // auto-generated
-        internal Object ToSecurityObject()
-        {
-            switch (m_strTag)
-            {
-                case "PermissionSet":
-                    PermissionSet pset = new PermissionSet(PermissionState.None);
-                    pset.FromXml(this);
-                    return pset;
- 
-                default:
-                    return ToPermission(false);
-            }
-        }
-#endif // FEATURE_CAS_POLICY
- 
-        internal String SearchForTextOfLocalName(String strLocalName) 
+
+        internal string SearchForTextOfLocalName(string strLocalName)
         {
             // Search on each child in order and each
             // child's child, depth-first
-            
             if (strLocalName == null)
-                throw new ArgumentNullException( "strLocalName" );
-            Contract.EndContractBlock();
-                
+                throw new ArgumentNullException(nameof(strLocalName));
+
             // Note: we don't check for a valid tag here because
             // an invalid tag simply won't be found.    
-            
-            // First we check this.
-            
-            if (m_strTag == null) return null;            
-            if (m_strTag.Equals( strLocalName ) || m_strTag.EndsWith( ":" + strLocalName, StringComparison.Ordinal ))
-                return Unescape( m_strText );               
+            if (m_strTag == null)
+                return null;
+            if (m_strTag.Equals(strLocalName) || m_strTag.EndsWith(":" + strLocalName, StringComparison.Ordinal))
+                return Unescape(m_strText);
             if (m_lChildren == null)
                 return null;
- 
+
             IEnumerator enumerator = m_lChildren.GetEnumerator();
- 
+
             while (enumerator.MoveNext())
             {
-                String current = ((SecurityElement)enumerator.Current).SearchForTextOfLocalName( strLocalName );
-            
-                if (current != null)
-                    return current;
-            }
-            return null;            
-        }
- 
-        public String SearchForTextOfTag( String tag )
-        {
-            // Search on each child in order and each
-            // child's child, depth-first
-            
-            if (tag == null)
-                throw new ArgumentNullException( "tag" );
-            Contract.EndContractBlock();
-                
-            // Note: we don't check for a valid tag here because
-            // an invalid tag simply won't be found.    
-            
-            // First we check this.
-            
-            if (String.Equals(m_strTag, tag))
-                return Unescape( m_strText );              
-            if (m_lChildren == null)
-                return null;
- 
-            IEnumerator enumerator = m_lChildren.GetEnumerator();
- 
-            this.ConvertSecurityElementFactories();
- 
-            while (enumerator.MoveNext())
-            {
-                String current = ((SecurityElement)enumerator.Current).SearchForTextOfTag( tag );
-            
+                string current = ((SecurityElement)enumerator.Current).SearchForTextOfLocalName(strLocalName);
+
                 if (current != null)
                     return current;
             }
             return null;
-        } 
-    }                        
+        }
+
+        public string SearchForTextOfTag(string tag)
+        {
+            // Search on each child in order and each
+            // child's child, depth-first
+            if (tag == null)
+                throw new ArgumentNullException(nameof(tag));
+
+            // Note: we don't check for a valid tag here because
+            // an invalid tag simply won't be found.    
+            if (string.Equals(m_strTag, tag))
+                return Unescape(m_strText);
+            if (m_lChildren == null)
+                return null;
+
+            IEnumerator enumerator = m_lChildren.GetEnumerator();
+
+            ConvertSecurityElementFactories();
+
+            while (enumerator.MoveNext())
+            {
+                string current = ((SecurityElement)enumerator.Current).SearchForTextOfTag(tag);
+
+                if (current != null)
+                    return current;
+            }
+            return null;
+        }
+
+        public static SecurityElement FromString(string xml)
+        {
+            if (xml == null)
+                throw new ArgumentNullException(nameof(xml));
+
+            return default(SecurityElement);
+        }
+
+        //--------------- ISecurityElementFactory implementation -----------------
+
+        SecurityElement ISecurityElementFactory.CreateSecurityElement()
+        {
+            return this;
+        }
+
+        string ISecurityElementFactory.GetTag()
+        {
+            return ((SecurityElement)this).Tag;
+        }
+
+        object ISecurityElementFactory.Copy()
+        {
+            return ((SecurityElement)this).Copy();
+        }
+
+        string ISecurityElementFactory.Attribute(string attributeName)
+        {
+            return ((SecurityElement)this).Attribute(attributeName);
+        }
+
+
+    }
 }

--- a/src/System.Security.Permissions/src/System/Security/SecurityElement.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityElement.cs
@@ -1,31 +1,931 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.s
-
+﻿// ==++==
+// 
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+// 
+// ==--==
+// <OWNER>Microsoft</OWNER>
+// 
+ 
 namespace System.Security
 {
-    [Serializable]
-    public sealed partial class SecurityElement
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Security.Util;
+    using System.Text;
+    using System.Globalization;
+    using System.IO;
+    using System.Security.Permissions;
+    using System.Diagnostics.Contracts;
+ 
+    internal enum SecurityElementType
     {
-        public SecurityElement(string tag) { }
-        public SecurityElement(string tag, string text) { }
-        public System.Collections.Hashtable Attributes { get; set; }
-        public System.Collections.ArrayList Children { get; set; }
-        public string Tag { get; set; }
-        public string Text { get; set; }
-        public void AddAttribute(string name, string value) { }
-        public void AddChild(SecurityElement child) { }
-        public string Attribute(string name) { return default(string); }
-        public SecurityElement Copy() { return this; }
-        public bool Equal(SecurityElement other) { return false; }
-        public static string Escape(string str) { return default(string); }
-        public static SecurityElement FromString(string xml) { return default(SecurityElement); }
-        public static bool IsValidAttributeName(string name) { return false; }
-        public static bool IsValidAttributeValue(string value) { return false; }
-        public static bool IsValidTag(string tag) { return false; }
-        public static bool IsValidText(string text) { return false; }
-        public SecurityElement SearchForChildByTag(string tag) { return default(SecurityElement); }
-        public string SearchForTextOfTag(string tag) { return default(string); }
-        public override string ToString() => base.ToString();
+        Regular = 0,
+        Format = 1,
+        Comment = 2
     }
+ 
+    
+    internal interface ISecurityElementFactory
+    {
+        SecurityElement CreateSecurityElement();
+ 
+        Object Copy();
+ 
+        String GetTag();
+ 
+        String Attribute( String attributeName );
+    }
+ 
+    [Serializable]
+[System.Runtime.InteropServices.ComVisible(true)]
+    sealed public class SecurityElement : ISecurityElementFactory
+    {
+        internal String  m_strTag;
+        internal String  m_strText;
+        private ArrayList m_lChildren;
+        internal ArrayList m_lAttributes;
+        internal SecurityElementType m_type = SecurityElementType.Regular;
+        
+        private static readonly char[] s_tagIllegalCharacters = new char[] { ' ', '<', '>' };
+        private static readonly char[] s_textIllegalCharacters = new char[] { '<', '>' };
+        private static readonly char[] s_valueIllegalCharacters = new char[] { '<', '>', '\"' };
+        private const String s_strIndent = "   ";
+        
+        private const int c_AttributesTypical = 4 * 2;  // 4 attributes, times 2 strings per attribute
+        private const int c_ChildrenTypical = 1;  
+ 
+        private static readonly String[] s_escapeStringPairs = new String[]
+            {
+                // these must be all once character escape sequences or a new escaping algorithm is needed
+                "<", "&lt;",
+                ">", "&gt;",
+                "\"", "&quot;",
+                "\'", "&apos;",
+                "&", "&amp;"
+            };
+ 
+        private static readonly char[] s_escapeChars = new char[] { '<', '>', '\"', '\'', '&' };
+        
+        //-------------------------- Constructors ---------------------------
+        
+        internal SecurityElement()
+        {
+        }
+ 
+////// ISecurityElementFactory implementation
+ 
+        SecurityElement ISecurityElementFactory.CreateSecurityElement()
+        {
+            return this;
+        }
+ 
+        String ISecurityElementFactory.GetTag()
+        {
+            return ((SecurityElement)this).Tag;
+        }
+ 
+        Object ISecurityElementFactory.Copy()
+        {
+            return ((SecurityElement)this).Copy();
+        }
+ 
+        String ISecurityElementFactory.Attribute( String attributeName )
+        {
+            return ((SecurityElement)this).Attribute( attributeName );
+        }
+ 
+//////////////
+ 
+#if FEATURE_CAS_POLICY
+        public static SecurityElement FromString( String xml )
+        {
+            if (xml == null)
+                throw new ArgumentNullException( "xml" );
+            Contract.EndContractBlock();
+ 
+            return new Parser( xml ).GetTopElement();
+        }
+#endif // FEATURE_CAS_POLICY
+    
+        public SecurityElement( String tag )
+        {
+            if (tag == null)
+                throw new ArgumentNullException( "tag" );
+        
+            if (!IsValidTag( tag ))
+                throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementTag" ), tag ) );
+            Contract.EndContractBlock();
+        
+            m_strTag = tag;
+            m_strText = null;
+        }
+ 
+        public SecurityElement( String tag, String text )
+        {
+            if (tag == null)
+                throw new ArgumentNullException( "tag" );
+        
+            if (!IsValidTag( tag ))
+                throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementTag" ), tag ) );
+ 
+            if (text != null && !IsValidText( text ))
+                throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementText" ), text ) );
+            Contract.EndContractBlock();
+        
+            m_strTag = tag;
+            m_strText = text;
+        }
+    
+        //-------------------------- Properties -----------------------------
+ 
+        public String Tag
+        {
+            [Pure]
+            get
+            {
+                return m_strTag;
+            }
+            
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException( "Tag" );
+        
+                if (!IsValidTag( value ))
+                    throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementTag" ), value ) );
+                Contract.EndContractBlock();
+            
+                m_strTag = value;
+            }
+        }
+ 
+        public Hashtable Attributes
+        {
+            get
+            {
+                if (m_lAttributes == null || m_lAttributes.Count == 0)
+                {
+                    return null;
+                }
+                else
+                {
+                    Hashtable hashtable = new Hashtable( m_lAttributes.Count/2 );
+                                        
+                    int iMax = m_lAttributes.Count;
+                    Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
+                          
+                    for (int i = 0; i < iMax; i += 2)
+                    {
+                        hashtable.Add( m_lAttributes[i], m_lAttributes[i+1]);
+                    }
+                                        
+                    return hashtable;
+                }
+            }
+            
+            set
+            {
+                if (value == null || value.Count == 0)
+                {
+                    m_lAttributes = null;
+                }
+                else
+                {
+                    ArrayList list = new ArrayList(value.Count);
+                    
+                    System.Collections.IDictionaryEnumerator enumerator = (System.Collections.IDictionaryEnumerator)value.GetEnumerator();
+                    
+                    while (enumerator.MoveNext())
+                    {
+                        String attrName = (String)enumerator.Key;
+                        String attrValue = (String)enumerator.Value;
+                    
+                        if (!IsValidAttributeName( attrName ))
+                            throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementName" ), (String)enumerator.Current ) );
+                        
+                        if (!IsValidAttributeValue( attrValue ))
+                            throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementValue" ), (String)enumerator.Value ) );
+                    
+                        list.Add(attrName);
+                        list.Add(attrValue);
+                    }
+                    
+                    m_lAttributes = list;
+                }
+            }
+        }
+ 
+        public String Text
+        {
+            get
+            {
+                return Unescape( m_strText );
+            }
+            
+            set
+            {
+                if (value == null)
+                {
+                    m_strText = null;
+                }
+                else
+                {
+                    if (!IsValidText( value ))
+                        throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementTag" ), value ) );
+                        
+                    m_strText = value;
+                }
+            }
+        }
+ 
+        public ArrayList Children
+        {
+            get
+            {
+                ConvertSecurityElementFactories();
+                return m_lChildren;
+            }
+            
+            set
+            {
+                if (value != null)
+                {
+                    IEnumerator enumerator = value.GetEnumerator();
+                    
+                    while (enumerator.MoveNext())
+                    {
+                        if (enumerator.Current == null)
+                            throw new ArgumentException( Environment.GetResourceString( "ArgumentNull_Child" ) );
+                    }
+                }
+            
+                m_lChildren = value;
+            }
+        }
+ 
+        internal void ConvertSecurityElementFactories()
+        {
+            if (m_lChildren == null)
+                return;
+ 
+            for (int i = 0; i < m_lChildren.Count; ++i)
+            {
+                ISecurityElementFactory iseFactory = m_lChildren[i] as ISecurityElementFactory;
+                if (iseFactory != null && !(m_lChildren[i] is SecurityElement))
+                    m_lChildren[i] = iseFactory.CreateSecurityElement();
+            }
+        }
+ 
+        internal ArrayList InternalChildren
+        {
+            get
+            {
+                // Beware!  This array list can contain SecurityElements and other ISecurityElementFactories.
+                // If you want to get a consistent SecurityElement view, call get_Children.
+                return m_lChildren;
+            }
+        }  
+   
+        //-------------------------- Public Methods -----------------------------
+        
+        internal void AddAttributeSafe( String name, String value )
+        {
+            if (m_lAttributes == null)
+            {
+                m_lAttributes = new ArrayList( c_AttributesTypical  );
+            }
+            else
+            {
+                int iMax = m_lAttributes.Count;
+                Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
+                          
+                for (int i = 0; i < iMax; i += 2)
+                {
+                    String strAttrName = (String)m_lAttributes[i];
+                    
+                    if (String.Equals(strAttrName, name))
+                        throw new ArgumentException( Environment.GetResourceString( "Argument_AttributeNamesMustBeUnique" ) );
+                }
+            }
+        
+            m_lAttributes.Add(name);
+            m_lAttributes.Add(value);
+        }        
+        
+        public void AddAttribute( String name, String value )
+        {   
+            if (name == null)
+                throw new ArgumentNullException( "name" );
+                
+            if (value == null)
+                throw new ArgumentNullException( "value" );
+        
+            if (!IsValidAttributeName( name ))
+                throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementName" ), name ) );
+                
+            if (!IsValidAttributeValue( value ))
+                throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, Environment.GetResourceString( "Argument_InvalidElementValue" ), value ) );
+            Contract.EndContractBlock();
+        
+            AddAttributeSafe( name, value );
+        }
+ 
+        public void AddChild( SecurityElement child )
+        {   
+            if (child == null)
+                throw new ArgumentNullException( "child" );
+            Contract.EndContractBlock();
+        
+            if (m_lChildren == null)
+                m_lChildren = new ArrayList( c_ChildrenTypical  );
+                
+            m_lChildren.Add( child );
+        }
+ 
+        internal void AddChild( ISecurityElementFactory child )
+        {
+            if (child == null)
+                throw new ArgumentNullException( "child" );
+            Contract.EndContractBlock();
+        
+            if (m_lChildren == null)
+                m_lChildren = new ArrayList( c_ChildrenTypical  );
+             
+            m_lChildren.Add( child );
+        }            
+ 
+        internal void AddChildNoDuplicates( ISecurityElementFactory child )
+        {   
+            if (child == null)
+                throw new ArgumentNullException( "child" );
+            Contract.EndContractBlock();
+        
+            if (m_lChildren == null)
+            {
+                m_lChildren = new ArrayList( c_ChildrenTypical  );
+                m_lChildren.Add( child );
+            }
+            else
+            {
+                for (int i = 0; i < m_lChildren.Count; ++i)
+                {
+                    if (m_lChildren[i] == child)
+                        return;
+                }
+                m_lChildren.Add( child );
+            }
+        }
+ 
+        public bool Equal( SecurityElement other )
+        {
+            if (other == null)
+                return false;
+        
+            // Check if the tags are the same
+            if (!String.Equals(m_strTag, other.m_strTag))
+                return false;
+ 
+            // Check if the text is the same
+            if (!String.Equals(m_strText, other.m_strText))
+                return false;
+ 
+            // Check if the attributes are the same and appear in the same
+            // order.
+            
+            // Maybe we can get away by only checking the number of attributes
+            if (m_lAttributes == null || other.m_lAttributes == null)
+            {
+                if (m_lAttributes != other.m_lAttributes)
+                    return false;
+            }
+            else 
+            {                
+                int iMax = m_lAttributes.Count;
+                Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
+ 
+                if (iMax != other.m_lAttributes.Count)
+                    return false;
+                          
+                for (int i = 0; i < iMax; i++)
+                {
+                    String lhs = (String)m_lAttributes[i];
+                    String rhs = (String)other.m_lAttributes[i];
+                    
+                    if (!String.Equals(lhs, rhs))
+                        return false;
+                }
+            }
+ 
+            // Finally we must check the child and make sure they are
+            // equal and in the same order
+            
+            // Maybe we can get away by only checking the number of children
+            if (m_lChildren == null || other.m_lChildren == null) 
+            {
+                if (m_lChildren != other.m_lChildren)
+                    return false;
+            } 
+            else 
+            {
+                if (m_lChildren.Count != other.m_lChildren.Count)
+                    return false;
+ 
+                this.ConvertSecurityElementFactories();
+                other.ConvertSecurityElementFactories();
+ 
+                // Okay, we'll need to go through each one of them
+                IEnumerator lhs = m_lChildren.GetEnumerator();
+                IEnumerator rhs = other.m_lChildren.GetEnumerator();
+ 
+                SecurityElement e1, e2;
+                while (lhs.MoveNext())
+                {
+                    rhs.MoveNext();
+                    e1 = (SecurityElement)lhs.Current;
+                    e2 = (SecurityElement)rhs.Current;       
+                    if (e1 == null || !e1.Equal(e2))                
+                        return false;
+                }
+            }
+            return true;
+        }
+ 
+        [System.Runtime.InteropServices.ComVisible(false)]
+        public SecurityElement Copy()
+        {
+            SecurityElement element = new SecurityElement( this.m_strTag, this.m_strText );
+            element.m_lChildren = this.m_lChildren == null ? null : new ArrayList( this.m_lChildren );
+            element.m_lAttributes = this.m_lAttributes == null ? null : new ArrayList(this.m_lAttributes);
+ 
+            return element;
+        }
+ 
+        [Pure]
+        public static bool IsValidTag( String tag )
+        {
+            if (tag == null)
+                return false;
+                
+            return tag.IndexOfAny( s_tagIllegalCharacters ) == -1;
+        }
+ 
+        [Pure]
+        public static bool IsValidText( String text )
+        {
+            if (text == null)
+                return false;
+                
+            return text.IndexOfAny( s_textIllegalCharacters ) == -1;
+        }
+ 
+        [Pure]
+        public static bool IsValidAttributeName( String name )
+        {
+            return IsValidTag( name );
+        }
+        
+        [Pure]
+        public static bool IsValidAttributeValue( String value )
+        {
+            if (value == null)
+                return false;
+                
+            return value.IndexOfAny( s_valueIllegalCharacters ) == -1;
+        }
+ 
+        private static String GetEscapeSequence( char c )
+        {
+            int iMax = s_escapeStringPairs.Length;
+            Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
+                          
+            for (int i = 0; i < iMax; i += 2)
+            {
+                String strEscSeq = s_escapeStringPairs[i];
+                String strEscValue = s_escapeStringPairs[i+1];
+ 
+                if (strEscSeq[0] == c)
+                    return strEscValue;
+            }
+ 
+            Contract.Assert( false, "Unable to find escape sequence for this character" );
+            return c.ToString();
+        }
+ 
+        public static String Escape( String str )
+        {
+            if (str == null)
+                return null;
+ 
+            StringBuilder sb = null;
+ 
+            int strLen = str.Length;
+            int index; // Pointer into the string that indicates the location of the current '&' character
+            int newIndex = 0; // Pointer into the string that indicates the start index of the "remaining" string (that still needs to be processed).
+ 
+ 
+            do
+            {
+                index = str.IndexOfAny( s_escapeChars, newIndex );
+ 
+                if (index == -1)
+                {
+                    if (sb == null)
+                        return str;
+                    else
+                    {
+                        sb.Append( str, newIndex, strLen - newIndex );
+                        return sb.ToString();
+                    }
+                }
+                else
+                {
+                    if (sb == null)
+                        sb = new StringBuilder();                    
+ 
+                    sb.Append( str, newIndex, index - newIndex );
+                    sb.Append( GetEscapeSequence( str[index] ) );
+ 
+                    newIndex = ( index + 1 );
+                }
+            }
+            while (true);
+            
+            // no normal exit is possible
+        }
+ 
+        private static String GetUnescapeSequence( String str, int index, out int newIndex )
+        {
+            int maxCompareLength = str.Length - index;
+ 
+            int iMax = s_escapeStringPairs.Length;
+            Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
+                          
+            for (int i = 0; i < iMax; i += 2)
+            {
+                String strEscSeq = s_escapeStringPairs[i];
+                String strEscValue = s_escapeStringPairs[i+1];
+                
+                int length = strEscValue.Length;
+ 
+                if (length <= maxCompareLength && String.Compare( strEscValue, 0, str, index, length, StringComparison.Ordinal) == 0)
+                {
+                    newIndex = index + strEscValue.Length;
+                    return strEscSeq;
+                }
+            }
+ 
+            newIndex = index + 1;
+            return str[index].ToString();
+        }
+            
+ 
+        private static String Unescape( String str )
+        {
+            if (str == null)
+                return null;
+ 
+            StringBuilder sb = null;
+ 
+            int strLen = str.Length;
+            int index; // Pointer into the string that indicates the location of the current '&' character
+            int newIndex = 0; // Pointer into the string that indicates the start index of the "remainging" string (that still needs to be processed).
+ 
+            do
+            {
+                index = str.IndexOf( '&', newIndex );
+ 
+                if (index == -1)
+                {
+                    if (sb == null)
+                        return str;
+                    else
+                    {
+                        sb.Append( str, newIndex, strLen - newIndex );
+                        return sb.ToString();
+                    }
+                }
+                else
+                {
+                    if (sb == null)
+                        sb = new StringBuilder();
+ 
+                    sb.Append(str,  newIndex, index - newIndex);
+                    sb.Append( GetUnescapeSequence( str, index, out newIndex ) ); // updates the newIndex too
+ 
+                }
+            }
+            while (true);
+ 
+            // C# reports a warning if I leave this in, but I still kinda want to just in case.
+            // Contract.Assert( false, "If you got here, the execution engine or compiler is really confused" );
+            // return str;
+        }
+ 
+        private delegate void ToStringHelperFunc( Object obj, String str );
+ 
+        private static void ToStringHelperStringBuilder( Object obj, String str )
+        {
+            ((StringBuilder)obj).Append( str );
+        }
+        
+        private static void ToStringHelperStreamWriter( Object obj, String str )
+        {
+            ((StreamWriter)obj).Write( str );
+        }
+ 
+        public override String ToString ()
+        {
+            StringBuilder sb = new StringBuilder();
+ 
+            ToString( "", sb, new ToStringHelperFunc( ToStringHelperStringBuilder ) );
+ 
+            return sb.ToString();
+        }
+ 
+        internal void ToWriter( StreamWriter writer )
+        {
+            ToString( "", writer, new ToStringHelperFunc( ToStringHelperStreamWriter ) );
+        }
+        
+        private void ToString( String indent, Object obj, ToStringHelperFunc func )
+        {
+            // First add the indent
+            
+            // func( obj, indent );                       
+            
+            // Add in the opening bracket and the tag.
+            
+            func( obj, "<" );
+ 
+            switch (m_type)
+            {
+                case SecurityElementType.Format:
+                    func( obj, "?" );
+                    break;
+ 
+                case SecurityElementType.Comment:
+                    func( obj, "!" );
+                    break;
+ 
+                default:
+                    break;
+            }
+ 
+            func( obj, m_strTag );
+            
+            // If there are any attributes, plop those in.
+            
+            if (m_lAttributes != null && m_lAttributes.Count > 0)
+            {
+                func( obj, " " );
+ 
+                int iMax = m_lAttributes.Count;
+                Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
+                          
+                for (int i = 0; i < iMax; i += 2)
+                {
+                    String strAttrName = (String)m_lAttributes[i];
+                    String strAttrValue = (String)m_lAttributes[i+1];
+                    
+                    func( obj, strAttrName );
+                    func( obj, "=\"" );
+                    func( obj, strAttrValue );
+                    func( obj, "\"" );
+ 
+                    if (i != m_lAttributes.Count - 2)
+                    {
+                        if (m_type == SecurityElementType.Regular)
+                        {
+                            func( obj, Environment.NewLine );
+                        }
+                        else
+                        {
+                            func( obj, " " );
+                        }
+                    }
+                }
+            }
+         
+            if (m_strText == null && (m_lChildren == null || m_lChildren.Count == 0))
+            {
+                // If we are a single tag with no children, just add the end of tag text.
+    
+                switch (m_type)
+                {
+                    case SecurityElementType.Comment:
+                        func( obj, ">" );
+                        break;
+ 
+                    case SecurityElementType.Format:
+                        func( obj, " ?>" );
+                        break;
+ 
+                    default:
+                        func( obj, "/>" );
+                        break;
+                }
+                func( obj, Environment.NewLine );
+            }
+            else
+            {
+                // Close the current tag.
+            
+                func( obj, ">" );
+                
+                // Output the text
+                
+                func( obj, m_strText );
+                
+                // Output any children.
+                
+                if (m_lChildren != null)
+                {
+                    this.ConvertSecurityElementFactories();
+ 
+                    func( obj, Environment.NewLine );
+                
+                    // String childIndent = indent + s_strIndent;
+                
+                    for (int i = 0; i < m_lChildren.Count; ++i)                    
+                    {
+                        ((SecurityElement)m_lChildren[i]).ToString( "", obj, func );
+                    }
+ 
+                    // In the case where we have children, the close tag will not be on the same line as the
+                    // opening tag, so we need to indent.
+ 
+                    // func( obj, indent );
+                }
+                
+                // Output the closing tag
+                
+                func( obj, "</" );
+                func( obj, m_strTag );
+                func( obj, ">" );
+                func( obj, Environment.NewLine );
+            }
+        }
+                
+                
+ 
+        public String Attribute( String name )
+        {
+            if (name == null)
+                throw new ArgumentNullException( "name" );
+            Contract.EndContractBlock();
+                
+            // Note: we don't check for validity here because an
+            // if an invalid name is passed we simply won't find it.
+        
+            if (m_lAttributes == null)
+                return null;
+                            
+            // Go through all the attribute and see if we know about
+            // the one we are asked for
+ 
+            int iMax = m_lAttributes.Count;
+            Contract.Assert( iMax % 2 == 0, "Odd number of strings means the attr/value pairs were not added correctly" );
+                          
+            for (int i = 0; i < iMax; i += 2)
+            {
+                String strAttrName = (String)m_lAttributes[i];
+                
+                if (String.Equals(strAttrName, name))
+                {
+                    String strAttrValue = (String)m_lAttributes[i+1];
+                    
+                    return Unescape(strAttrValue);
+                }
+            }
+ 
+            // In the case where we didn't find it, we are expected to
+            // return null
+            return null;
+        }
+ 
+        public SecurityElement SearchForChildByTag( String tag )
+        {
+            // Go through all the children and see if we can
+            // find the one are are asked for (matching tags)
+ 
+            if (tag == null)
+                throw new ArgumentNullException( "tag" );
+            Contract.EndContractBlock();
+                
+            // Note: we don't check for a valid tag here because
+            // an invalid tag simply won't be found.    
+                
+            if (m_lChildren == null)
+                return null;
+ 
+            IEnumerator enumerator = m_lChildren.GetEnumerator();
+ 
+            while (enumerator.MoveNext())
+            {
+                SecurityElement current = (SecurityElement)enumerator.Current;
+            
+                if (current != null && String.Equals(current.Tag, tag))
+                    return current;
+            }
+            return null;
+        }
+ 
+#if FEATURE_CAS_POLICY
+        internal IPermission ToPermission(bool ignoreTypeLoadFailures)
+        {
+            IPermission ip = XMLUtil.CreatePermission( this, PermissionState.None, ignoreTypeLoadFailures );
+            if (ip == null)
+                return null;
+            ip.FromXml(this);
+ 
+            // Get the permission token here to ensure that the token
+            // type is updated appropriately now that we've loaded the type.
+            PermissionToken token = PermissionToken.GetToken( ip );
+            Contract.Assert((token.m_type & PermissionTokenType.DontKnow) == 0, "Token type not properly assigned");
+ 
+            return ip;            
+        }
+ 
+        [System.Security.SecurityCritical]  // auto-generated
+        internal Object ToSecurityObject()
+        {
+            switch (m_strTag)
+            {
+                case "PermissionSet":
+                    PermissionSet pset = new PermissionSet(PermissionState.None);
+                    pset.FromXml(this);
+                    return pset;
+ 
+                default:
+                    return ToPermission(false);
+            }
+        }
+#endif // FEATURE_CAS_POLICY
+ 
+        internal String SearchForTextOfLocalName(String strLocalName) 
+        {
+            // Search on each child in order and each
+            // child's child, depth-first
+            
+            if (strLocalName == null)
+                throw new ArgumentNullException( "strLocalName" );
+            Contract.EndContractBlock();
+                
+            // Note: we don't check for a valid tag here because
+            // an invalid tag simply won't be found.    
+            
+            // First we check this.
+            
+            if (m_strTag == null) return null;            
+            if (m_strTag.Equals( strLocalName ) || m_strTag.EndsWith( ":" + strLocalName, StringComparison.Ordinal ))
+                return Unescape( m_strText );               
+            if (m_lChildren == null)
+                return null;
+ 
+            IEnumerator enumerator = m_lChildren.GetEnumerator();
+ 
+            while (enumerator.MoveNext())
+            {
+                String current = ((SecurityElement)enumerator.Current).SearchForTextOfLocalName( strLocalName );
+            
+                if (current != null)
+                    return current;
+            }
+            return null;            
+        }
+ 
+        public String SearchForTextOfTag( String tag )
+        {
+            // Search on each child in order and each
+            // child's child, depth-first
+            
+            if (tag == null)
+                throw new ArgumentNullException( "tag" );
+            Contract.EndContractBlock();
+                
+            // Note: we don't check for a valid tag here because
+            // an invalid tag simply won't be found.    
+            
+            // First we check this.
+            
+            if (String.Equals(m_strTag, tag))
+                return Unescape( m_strText );              
+            if (m_lChildren == null)
+                return null;
+ 
+            IEnumerator enumerator = m_lChildren.GetEnumerator();
+ 
+            this.ConvertSecurityElementFactories();
+ 
+            while (enumerator.MoveNext())
+            {
+                String current = ((SecurityElement)enumerator.Current).SearchForTextOfTag( tag );
+            
+                if (current != null)
+                    return current;
+            }
+            return null;
+        } 
+    }                        
 }

--- a/src/System.Security.Permissions/src/project.json
+++ b/src/System.Security.Permissions/src/project.json
@@ -3,15 +3,20 @@
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
+        "Microsoft.Win32.Primitives": "4.4.0-beta-24705-01",
+        "System.Collections": "4.4.0-beta-24705-01",
         "System.Collections.NonGeneric": "4.4.0-beta-24705-01",
+        "System.Diagnostics.Debug": "4.4.0-beta-24705-01",
         "System.Reflection": "4.4.0-beta-24705-01",
+        "System.Resources.ResourceManager": "4.4.0-beta-24705-01",
         "System.Runtime.Extensions": "4.4.0-beta-24705-01",
         "System.Runtime": "4.4.0-beta-24705-01",
         "System.Security.AccessControl": "4.4.0-beta-24705-01",
         "System.Security.Cryptography.Primitives": "4.4.0-beta-24705-01",
         "System.Security.Cryptography.X509Certificates": "4.4.0-beta-24705-01",
         "System.Security.Principal": "4.4.0-beta-24705-01",
-        "System.Threading": "4.4.0-beta-24705-01"
+        "System.Threading": "4.4.0-beta-24705-01",
+        "System.Threading.Thread": "4.4.0-beta-24705-01"
       }
     },
     "net463": {

--- a/src/System.Security.Permissions/tests/PermissionTests.cs
+++ b/src/System.Security.Permissions/tests/PermissionTests.cs
@@ -107,9 +107,7 @@ namespace System.Security.Permissions.Tests
             testbool = pp.IsUnrestricted();
             string teststring = pp.ToString();
             ip2 = pp.Union(ip);
-            SecurityElement se = new SecurityElement("");
-            pp.FromXml(se);
-            se = pp.ToXml();
+            pp.ToXml();
         }
 
         [Fact]

--- a/src/System.Security.Permissions/tests/PrincipalPermissionTests.cs
+++ b/src/System.Security.Permissions/tests/PrincipalPermissionTests.cs
@@ -1,10 +1,10 @@
-﻿// Author:
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Author:
 //	Sebastien Pouliot (spouliot@motus.com)
 //
 // (C) 2003 Motus Technologies Inc. (http://www.motus.com)
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 
@@ -16,8 +16,7 @@ namespace System.Security.Permissions.Tests
         public void PermissionStateNone()
         {
             PrincipalPermission p = new PrincipalPermission(PermissionState.None);
-            string className = "System.Security.Permissions.PrincipalPermission, ";
-            Assert.NotNull(p);
+            const string className = "System.Security.Permissions.PrincipalPermission, ";
             Assert.True(!p.IsUnrestricted());
             PrincipalPermission copy = (PrincipalPermission)p.Copy();
             Assert.Equal(p.IsUnrestricted(), copy.IsUnrestricted());
@@ -30,7 +29,6 @@ namespace System.Security.Permissions.Tests
         public void PermissionStateUnrestricted()
         {
             PrincipalPermission p = new PrincipalPermission(PermissionState.Unrestricted);
-            Assert.NotNull(p);
             Assert.True(p.IsUnrestricted());
             PrincipalPermission copy = (PrincipalPermission)p.Copy();
             Assert.Equal(p.IsUnrestricted(), copy.IsUnrestricted());
@@ -40,43 +38,65 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public void Name()
         {
-            PrincipalPermission p = new PrincipalPermission("user", null);
+            const string userName = "UniqueUserName1";
+            PrincipalPermission p = new PrincipalPermission(userName, null);
             Assert.True(!p.IsUnrestricted());
+            SecurityElement pele = (SecurityElement)(p.ToXml().Children[0]);
+            Assert.Contains(userName, pele.ToString());
         }
 
         [Fact]
         public void UnauthenticatedName()
         {
-            PrincipalPermission p = new PrincipalPermission("user", null, false);
+            const string userName = "UniqueUserName1";
+            PrincipalPermission p = new PrincipalPermission(userName, null, false);
             Assert.True(!p.IsUnrestricted());
+            SecurityElement pele = (SecurityElement)(p.ToXml().Children[0]);
+            Assert.Contains(userName, pele.ToString());
         }
 
         [Fact]
         public void Role()
         {
-            PrincipalPermission p = new PrincipalPermission(null, "users");
+            const string roleName = "ThisIsARoleName";
+            PrincipalPermission p = new PrincipalPermission(null, roleName);
             Assert.True(!p.IsUnrestricted());
+            SecurityElement pele = (SecurityElement)(p.ToXml().Children[0]);
+            Assert.Contains(roleName, pele.ToString());
         }
 
         [Fact]
         public void UnauthenticatedRole()
         {
-            PrincipalPermission p = new PrincipalPermission(null, "users", false);
+            const string roleName = "ThisIsARoleName";
+            PrincipalPermission p = new PrincipalPermission(null, roleName, false);
             Assert.True(!p.IsUnrestricted());
+            SecurityElement pele = (SecurityElement)(p.ToXml().Children[0]);
+            Assert.Contains(roleName, pele.ToString());
         }
 
         [Fact]
         public void NameRole()
         {
-            PrincipalPermission p = new PrincipalPermission("user", "users", true);
+            const string userName = "UniqueUserName1";
+            const string roleName = "ThisIsARoleName";
+            PrincipalPermission p = new PrincipalPermission(userName, roleName);
             Assert.True(!p.IsUnrestricted());
+            SecurityElement pele = (SecurityElement)(p.ToXml().Children[0]);
+            Assert.Contains(userName, pele.ToString());
+            Assert.Contains(roleName, pele.ToString());
         }
 
         [Fact]
         public void UnauthenticatedNameRole()
         {
-            PrincipalPermission p = new PrincipalPermission("user", "users", false);
+            const string userName = "UniqueUserName1";
+            const string roleName = "ThisIsARoleName";
+            PrincipalPermission p = new PrincipalPermission(userName, roleName, false);
             Assert.True(!p.IsUnrestricted());
+            SecurityElement pele = (SecurityElement)(p.ToXml().Children[0]);
+            Assert.Contains(userName, pele.ToString());
+            Assert.Contains(roleName, pele.ToString());
         }
 
         [Fact]
@@ -169,8 +189,11 @@ namespace System.Security.Permissions.Tests
             PrincipalPermission p1 = new PrincipalPermission("user A", "role A");
             PrincipalPermission p2 = new PrincipalPermission("user B", "role B", false);
             PrincipalPermission p3 = (PrincipalPermission)p1.Union(p2);
-            Assert.True(p3.ToString().IndexOf("user A") >= 0);
-            Assert.True(p3.ToString().IndexOf("user B") >= 0);
+            string union = p3.ToString();
+            Assert.Contains("user A", union);
+            Assert.Contains("user B", union);
+            Assert.Contains("role A", union);
+            Assert.Contains("role B", union);
         }
 
         [Fact]
@@ -220,9 +243,11 @@ namespace System.Security.Permissions.Tests
             PrincipalPermission p2 = new PrincipalPermission("user C", "role 1");
             PrincipalPermission p3 = (PrincipalPermission)p2.Intersect(p1);
             Assert.NotNull(p3);
-            Assert.True(p3.ToString().IndexOf("user A") < 0);
-            Assert.True(p3.ToString().IndexOf("user C") < 0);
-            Assert.True(p3.ToString().IndexOf("role 1") >= 0);
+
+            string intersection = p3.ToString();
+            Assert.DoesNotContain("user A", intersection);
+            Assert.DoesNotContain("user C", intersection);
+            Assert.Contains("role 1", intersection);
         }
 
         [Fact]
@@ -315,6 +340,10 @@ namespace System.Security.Permissions.Tests
             PrincipalPermission p4 = new PrincipalPermission(null, null, true); // unrestricted
             Assert.True(!p4.IsSubsetOf(p1));
             Assert.True(p1.IsSubsetOf(p4));
+
+            PrincipalPermission p5 = new PrincipalPermission("user A", null);
+            Assert.True(p1.IsSubsetOf(p5));
+            Assert.True(!p5.IsSubsetOf(p1));
         }
 
         [Fact]
@@ -323,7 +352,6 @@ namespace System.Security.Permissions.Tests
             PrincipalPermission p1 = new PrincipalPermission("user", null);
             EnvironmentPermission ep2 = new EnvironmentPermission(PermissionState.Unrestricted);
             Assert.Throws<ArgumentException>(() => p1.IsSubsetOf(ep2));
-            // Assert.True(p1.IsSubsetOf(ep2));
         }
     }
 }

--- a/src/System.Security.Permissions/tests/PrincipalPermissionTests.cs
+++ b/src/System.Security.Permissions/tests/PrincipalPermissionTests.cs
@@ -1,0 +1,329 @@
+﻿// Author:
+//	Sebastien Pouliot (spouliot@motus.com)
+//
+// (C) 2003 Motus Technologies Inc. (http://www.motus.com)
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class PrincipalPermissionTest
+    {
+        [Fact]
+        public void PermissionStateNone()
+        {
+            PrincipalPermission p = new PrincipalPermission(PermissionState.None);
+            string className = "System.Security.Permissions.PrincipalPermission, ";
+            Assert.NotNull(p);
+            Assert.True(!p.IsUnrestricted());
+            PrincipalPermission copy = (PrincipalPermission)p.Copy();
+            Assert.Equal(p.IsUnrestricted(), copy.IsUnrestricted());
+            SecurityElement se = p.ToXml();
+            Assert.True((se.Attributes["class"] as string).StartsWith(className));
+            Assert.Equal("1", (se.Attributes["version"] as string));
+        }
+
+        [Fact]
+        public void PermissionStateUnrestricted()
+        {
+            PrincipalPermission p = new PrincipalPermission(PermissionState.Unrestricted);
+            Assert.NotNull(p);
+            Assert.True(p.IsUnrestricted());
+            PrincipalPermission copy = (PrincipalPermission)p.Copy();
+            Assert.Equal(p.IsUnrestricted(), copy.IsUnrestricted());
+            // Note: Unrestricted isn't shown in XML
+        }
+
+        [Fact]
+        public void Name()
+        {
+            PrincipalPermission p = new PrincipalPermission("user", null);
+            Assert.True(!p.IsUnrestricted());
+        }
+
+        [Fact]
+        public void UnauthenticatedName()
+        {
+            PrincipalPermission p = new PrincipalPermission("user", null, false);
+            Assert.True(!p.IsUnrestricted());
+        }
+
+        [Fact]
+        public void Role()
+        {
+            PrincipalPermission p = new PrincipalPermission(null, "users");
+            Assert.True(!p.IsUnrestricted());
+        }
+
+        [Fact]
+        public void UnauthenticatedRole()
+        {
+            PrincipalPermission p = new PrincipalPermission(null, "users", false);
+            Assert.True(!p.IsUnrestricted());
+        }
+
+        [Fact]
+        public void NameRole()
+        {
+            PrincipalPermission p = new PrincipalPermission("user", "users", true);
+            Assert.True(!p.IsUnrestricted());
+        }
+
+        [Fact]
+        public void UnauthenticatedNameRole()
+        {
+            PrincipalPermission p = new PrincipalPermission("user", "users", false);
+            Assert.True(!p.IsUnrestricted());
+        }
+
+        [Fact]
+        public void AuthenticatedNullNull()
+        {
+            PrincipalPermission p = new PrincipalPermission(null, null, true);
+            Assert.True(p.IsUnrestricted());
+        }
+
+        [Fact]
+        public void FromXmlNull()
+        {
+            PrincipalPermission p = new PrincipalPermission(PermissionState.None);
+            Assert.Throws<ArgumentNullException>(() => p.FromXml(null));
+        }
+
+        [Fact]
+        public void FromXmlInvalidPermission()
+        {
+            PrincipalPermission p = new PrincipalPermission(PermissionState.None);
+            SecurityElement se = p.ToXml();
+            // can't modify - so we create our own
+            SecurityElement se2 = new SecurityElement("IInvalidPermission", se.Text);
+            se2.AddAttribute("class", se.Attribute("class"));
+            se2.AddAttribute("version", se.Attribute("version"));
+            Assert.Throws<ArgumentException>(() => p.FromXml(se2));
+        }
+
+        [Fact]
+        public void FromXmlWrongVersion()
+        {
+            PrincipalPermission p = new PrincipalPermission(PermissionState.None);
+            SecurityElement se = p.ToXml();
+            // can't modify - so we create our own
+            SecurityElement se2 = new SecurityElement(se.Tag, se.Text);
+            se2.AddAttribute("class", se.Attribute("class"));
+            se2.AddAttribute("version", "2");
+            Assert.Throws<ArgumentException>(() => p.FromXml(se2));
+        }
+
+        [Fact]
+        public void FromXml()
+        {
+            PrincipalPermission p = new PrincipalPermission(PermissionState.None);
+            SecurityElement se = p.ToXml();
+            Assert.NotNull(se);
+
+            PrincipalPermission p2 = (PrincipalPermission)p.Copy();
+            p2.FromXml(se);
+            Assert.Equal(p.ToString(), p2.ToString());
+
+            string className = (string)se.Attributes["class"];
+            string version = (string)se.Attributes["version"];
+
+            SecurityElement se2 = new SecurityElement(se.Tag);
+            se2.AddAttribute("class", className);
+            se2.AddAttribute("version", version);
+            p2.FromXml(se2);
+
+            SecurityElement sec = new SecurityElement("Identity");
+            sec.AddAttribute("Authenticated", "true");
+            se2.AddChild(sec);
+            p2.FromXml(se2);
+            Assert.True(p2.IsUnrestricted());
+        }
+
+        [Fact]
+        public void UnionWithNull()
+        {
+            PrincipalPermission p1 = new PrincipalPermission("user", null);
+            PrincipalPermission p2 = null;
+            PrincipalPermission p3 = (PrincipalPermission)p1.Union(p2);
+            Assert.Equal(p1.ToXml().ToString(), p3.ToXml().ToString());
+        }
+
+        [Fact]
+        public void UnionWithUnrestricted()
+        {
+            PrincipalPermission p1 = new PrincipalPermission(PermissionState.Unrestricted);
+            PrincipalPermission p2 = new PrincipalPermission("user", "role");
+            PrincipalPermission p3 = (PrincipalPermission)p1.Union(p2);
+            Assert.True(p3.IsUnrestricted());
+            p3 = (PrincipalPermission)p2.Union(p1);
+            Assert.True(p3.IsUnrestricted());
+        }
+
+        [Fact]
+        public void Union()
+        {
+            PrincipalPermission p1 = new PrincipalPermission("user A", "role A");
+            PrincipalPermission p2 = new PrincipalPermission("user B", "role B", false);
+            PrincipalPermission p3 = (PrincipalPermission)p1.Union(p2);
+            Assert.True(p3.ToString().IndexOf("user A") >= 0);
+            Assert.True(p3.ToString().IndexOf("user B") >= 0);
+        }
+
+        [Fact]
+        public void UnionWithBadPermission()
+        {
+            PrincipalPermission p1 = new PrincipalPermission("user", null);
+            EnvironmentPermission ep2 = new EnvironmentPermission(PermissionState.Unrestricted);
+            Assert.Throws<ArgumentException>(() => p1.Union(ep2));
+        }
+
+        [Fact]
+        public void IntersectWithNull()
+        {
+            PrincipalPermission p1 = new PrincipalPermission("user", "role");
+            PrincipalPermission p2 = null;
+            PrincipalPermission p3 = (PrincipalPermission)p1.Intersect(p2);
+            Assert.Null(p3);
+        }
+
+        [Fact]
+        public void IntersectWithUnrestricted()
+        {
+            PrincipalPermission p1 = new PrincipalPermission(PermissionState.Unrestricted);
+            PrincipalPermission p2 = new PrincipalPermission("user", "role");
+            PrincipalPermission p3 = (PrincipalPermission)p1.Intersect(p2);
+            Assert.True(!p3.IsUnrestricted());
+            Assert.Equal(p2.ToXml().ToString(), p3.ToXml().ToString());
+            p3 = (PrincipalPermission)p2.Intersect(p1);
+            Assert.True(!p3.IsUnrestricted());
+            Assert.Equal(p2.ToXml().ToString(), p3.ToXml().ToString());
+        }
+
+        [Fact]
+        public void Intersect_NoIntersection()
+        {
+            // no intersection
+            PrincipalPermission p1 = new PrincipalPermission("user A", "role 1");
+            PrincipalPermission p2 = new PrincipalPermission("user B", "role 2");
+            PrincipalPermission p3 = (PrincipalPermission)p1.Intersect(p2);
+            Assert.Null(p3);
+        }
+
+        [Fact]
+        public void Intersect_IntersectionInRole()
+        {
+            PrincipalPermission p1 = new PrincipalPermission("user A", "role 1");
+            PrincipalPermission p2 = new PrincipalPermission("user C", "role 1");
+            PrincipalPermission p3 = (PrincipalPermission)p2.Intersect(p1);
+            Assert.NotNull(p3);
+            Assert.True(p3.ToString().IndexOf("user A") < 0);
+            Assert.True(p3.ToString().IndexOf("user C") < 0);
+            Assert.True(p3.ToString().IndexOf("role 1") >= 0);
+        }
+
+        [Fact]
+        public void Intersect_IntersectionInRoleWithoutAuthentication()
+        {
+            PrincipalPermission p1 = new PrincipalPermission("user A", "role 1");
+            PrincipalPermission p2 = new PrincipalPermission("user C", "role 1", false);
+            PrincipalPermission p3 = (PrincipalPermission)p2.Intersect(p1);
+            Assert.Null(p3);
+        }
+
+        [Fact]
+        public void IntersectNullName()
+        {
+            PrincipalPermission p1 = new PrincipalPermission("user", "role");
+            PrincipalPermission p2 = new PrincipalPermission(null, "role");
+            PrincipalPermission p3 = (PrincipalPermission)p1.Intersect(p2);
+            Assert.Equal(p1.ToString(), p3.ToString());
+            p3 = (PrincipalPermission)p2.Intersect(p1);
+            Assert.Equal(p1.ToString(), p3.ToString());
+        }
+
+        [Fact]
+        public void IntersectNullRole()
+        {
+            PrincipalPermission p1 = new PrincipalPermission("user", "role");
+            PrincipalPermission p2 = new PrincipalPermission("user", null);
+            PrincipalPermission p3 = (PrincipalPermission)p1.Intersect(p2);
+            Assert.Equal(p1.ToString(), p3.ToString());
+            p3 = (PrincipalPermission)p2.Intersect(p1);
+            Assert.Equal(p1.ToString(), p3.ToString());
+        }
+
+        [Fact]
+        public void IntersectWithBadPermission()
+        {
+            PrincipalPermission p1 = new PrincipalPermission("user", null);
+            EnvironmentPermission ep2 = new EnvironmentPermission(PermissionState.Unrestricted);
+            Assert.Throws<ArgumentException>(() => p1.Intersect(ep2));
+        }
+
+        [Fact]
+        public void IsSubsetOfNull()
+        {
+            PrincipalPermission p = new PrincipalPermission("user", null);
+            Assert.True(!p.IsSubsetOf(null));
+
+            p = new PrincipalPermission(PermissionState.None);
+            Assert.True(p.IsSubsetOf(null));
+
+            p = new PrincipalPermission(PermissionState.Unrestricted);
+            Assert.True(!p.IsSubsetOf(null));
+        }
+
+        [Fact]
+        public void IsSubsetOfNone()
+        {
+            PrincipalPermission none = new PrincipalPermission(PermissionState.None);
+            PrincipalPermission p = new PrincipalPermission("user", null);
+            Assert.True(!p.IsSubsetOf(none));
+
+            p = new PrincipalPermission(PermissionState.None);
+            Assert.True(p.IsSubsetOf(none));
+
+            p = new PrincipalPermission(PermissionState.Unrestricted);
+            Assert.True(!p.IsSubsetOf(none));
+        }
+
+        [Fact]
+        public void IsSubsetOfUnrestricted()
+        {
+            PrincipalPermission p1 = new PrincipalPermission(PermissionState.Unrestricted);
+            PrincipalPermission p2 = new PrincipalPermission("user", "role", false);
+            Assert.True(!p1.IsSubsetOf(p2));
+            Assert.True(p2.IsSubsetOf(p1));
+        }
+
+        [Fact]
+        public void IsSubsetOf()
+        {
+            PrincipalPermission p1 = new PrincipalPermission("user A", "role 1");
+            PrincipalPermission p2 = new PrincipalPermission(null, "role 1");
+            Assert.True(p1.IsSubsetOf(p2));
+            Assert.True(!p2.IsSubsetOf(p1));
+
+            PrincipalPermission p3 = new PrincipalPermission("user A", "role 1", false);
+            Assert.True(!p3.IsSubsetOf(p1));
+            Assert.True(!p1.IsSubsetOf(p3));
+
+            PrincipalPermission p4 = new PrincipalPermission(null, null, true); // unrestricted
+            Assert.True(!p4.IsSubsetOf(p1));
+            Assert.True(p1.IsSubsetOf(p4));
+        }
+
+        [Fact]
+        public void IsSubsetOfBadPermission()
+        {
+            PrincipalPermission p1 = new PrincipalPermission("user", null);
+            EnvironmentPermission ep2 = new EnvironmentPermission(PermissionState.Unrestricted);
+            Assert.Throws<ArgumentException>(() => p1.IsSubsetOf(ep2));
+            // Assert.True(p1.IsSubsetOf(ep2));
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/SecurityElementTests.cs
+++ b/src/System.Security.Permissions/tests/SecurityElementTests.cs
@@ -1,4 +1,7 @@
-﻿// Authors:
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
+// Authors:
 //	Lawrence Pit (loz@cable.a2000.nl)
 //	Sebastien Pouliot  <sebastien@ximian.com>
 //
@@ -23,9 +26,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections;
 using System.Globalization;
@@ -62,49 +62,40 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public void Constructor1()
         {
-            SecurityElement se = new SecurityElement("tag");
+            const string tagName = "testTag";
+            SecurityElement se = new SecurityElement(tagName);
             Assert.Null(se.Attributes);
             Assert.Null(se.Children);
-            Assert.Equal("tag", se.Tag);
+            Assert.Equal(tagName, se.Tag);
             Assert.Null(se.Text);
+        }
 
-            se = new SecurityElement(string.Empty);
+        [Fact]
+        public void Constructor1_EmptyString()
+        {
+            SecurityElement se = new SecurityElement(string.Empty);
             Assert.Null(se.Attributes);
             Assert.Null(se.Children);
             Assert.Equal(string.Empty, se.Tag);
             Assert.Null(se.Text);
         }
 
-        [Fact]
-        public void Constructor1_Tag_Invalid()
+        [Theory]
+        [InlineData("Nam>e")]
+        [InlineData("Na<me")]
+        public void Constructor1_Tag_Invalid(string tagName)
         {
             try
             {
-                new SecurityElement("Na<me");
+                new SecurityElement(tagName);
                 Assert.False(true);
             }
             catch (ArgumentException ex)
             {
-                // Invalid element tag Nam<e
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
                 Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("Na<me") != -1);
-                Assert.Null(ex.ParamName);
-            }
-
-            try
-            {
-                new SecurityElement("Nam>e");
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Invalid element tag Nam>e
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("Nam>e") != -1);
+                Assert.True(ex.Message.IndexOf(tagName) != -1);
                 Assert.Null(ex.ParamName);
             }
         }
@@ -137,36 +128,22 @@ namespace System.Security.Permissions.Tests
             Assert.Equal("text", se.Text);
         }
 
-        [Fact]
-        public void Constructor2_Tag_Invalid()
+        [Theory]
+        [InlineData("Nam>e")]
+        [InlineData("Na<me")]
+        public void Constructor2_Tag_Invalid(string invalid)
         {
             try
             {
-                new SecurityElement("Na<me", "text");
+                new SecurityElement(invalid, "text");
                 Assert.False(true);
             }
             catch (ArgumentException ex)
             {
-                // Invalid element tag Nam<e
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
                 Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("Na<me") != -1);
-                Assert.Null(ex.ParamName);
-            }
-
-            try
-            {
-                new SecurityElement("Nam>e", "text");
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Invalid element tag Nam>e
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("Nam>e") != -1);
+                Assert.True(ex.Message.IndexOf(invalid) != -1);
                 Assert.Null(ex.ParamName);
             }
         }
@@ -317,7 +294,7 @@ namespace System.Security.Permissions.Tests
             SecurityElement elem = CreateElement();
             Hashtable h = elem.Attributes;
             h.Add("<invalid>", "valid");
-            Assert.Throws<InvalidCastException>(() => elem.Attributes = h);
+            Assert.Throws<ArgumentException>(() => elem.Attributes = h);
         }
 
         [Fact]
@@ -333,7 +310,6 @@ namespace System.Security.Permissions.Tests
             }
             catch (ArgumentException ex)
             {
-                // Invalid attribute value '"invalid"'
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
                 Assert.NotNull(ex.Message);
@@ -359,18 +335,12 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public void Equal()
         {
-            int iTest = 0;
             SecurityElement elem = CreateElement();
             SecurityElement elem2 = CreateElement();
-            iTest++;
             Assert.True(elem.Equal(elem2));
-            iTest++;
             SecurityElement child = (SecurityElement)elem2.Children[0];
-            iTest++;
             child = (SecurityElement)child.Children[1];
-            iTest++;
             child.Text = "some text";
-            iTest++;
             Assert.False(elem.Equal(elem2));
         }
 
@@ -520,38 +490,23 @@ namespace System.Security.Permissions.Tests
                 se.ToString());
         }
 
-        [Fact]
-        public void Tag_Invalid()
+        [Theory]
+        [InlineData("Nam>e")]
+        [InlineData("Na<me")]
+        public void Tag_Invalid(string invalid)
         {
             SecurityElement se = new SecurityElement("Values");
-
             try
             {
-                se.Tag = "Na<me";
+                se.Tag = invalid;
                 Assert.False(true);
             }
             catch (ArgumentException ex)
             {
-                // Invalid element tag Nam<e
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
                 Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("Na<me") != -1);
-                Assert.Null(ex.ParamName);
-            }
-
-            try
-            {
-                se.Tag = "Nam>e";
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Invalid element tag Nam>e
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("Nam>e") != -1);
+                Assert.True(ex.Message.IndexOf(invalid) != -1);
                 Assert.Null(ex.ParamName);
             }
         }
@@ -579,49 +534,33 @@ namespace System.Security.Permissions.Tests
         public void Text()
         {
             SecurityElement elem = CreateElement();
-            elem.Text = "Miguel&S�bastien";
-            Assert.Equal("Miguel&S�bastien", elem.Text);
+            elem.Text = "Basic string";
+            Assert.Equal("Basic string", elem.Text);
             elem.Text = null;
             Assert.Null(elem.Text);
-            elem.Text = "S�bastien\"Miguel";
-            Assert.Equal("S�bastien\"Miguel", elem.Text);
             elem.Text = string.Empty;
             Assert.Equal(string.Empty, elem.Text);
             elem.Text = "&lt;sample&amp;practice&unresolved;&gt;";
             Assert.Equal("<sample&practice&unresolved;>", elem.Text);
         }
 
-        [Fact]
-        public void Text_Invalid()
+        [Theory]
+        [InlineData("TagWith<Bracket")]
+        [InlineData("TagWith>Bracket")]
+        public void Text_Invalid(string invalid)
         {
             SecurityElement elem = CreateElement();
             try
             {
-                elem.Text = "Mig<uelS�bastien";
+                elem.Text = invalid;
                 Assert.False(true);
             }
             catch (ArgumentException ex)
             {
-                // Invalid element tag Mig<uelS�bastien
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
                 Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("Mig<uelS�bastien") != -1);
-                Assert.Null(ex.ParamName);
-            }
-
-            try
-            {
-                elem.Text = "Mig>uelS�bastien";
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Invalid element tag Mig>uelS�bastien
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("Mig>uelS�bastien") != -1);
+                Assert.True(ex.Message.IndexOf(invalid) != -1);
                 Assert.Null(ex.ParamName);
             }
         }
@@ -633,7 +572,7 @@ namespace System.Security.Permissions.Tests
             se.AddAttribute("Attribute1", "One");
             se.AddAttribute("Attribute2", "Two");
 
-            string expected = String.Format("<Multiple Attribute1=\"One\"{0}Attribute2=\"Two\"/>{0}", Environment.NewLine);
+            string expected = string.Format("<Multiple Attribute1=\"One\"{0}Attribute2=\"Two\"/>{0}", Environment.NewLine);
             Assert.Equal(expected, se.ToString());
         }
 

--- a/src/System.Security.Permissions/tests/SecurityElementTests.cs
+++ b/src/System.Security.Permissions/tests/SecurityElementTests.cs
@@ -1,0 +1,658 @@
+﻿// Authors:
+//	Lawrence Pit (loz@cable.a2000.nl)
+//	Sebastien Pouliot  <sebastien@ximian.com>
+//
+// Portions (C) 2004 Motus Technologies Inc. (http://www.motus.com)
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+namespace System.Security.Permissions.Tests
+{
+    public class SecurityElementTest
+    {
+        private static SecurityElement CreateElement()
+        {
+            SecurityElement elem = new SecurityElement("IPermission");
+            elem.AddAttribute("class", "System");
+            elem.AddAttribute("version", "1");
+
+            SecurityElement child = new SecurityElement("ConnectAccess");
+            elem.AddChild(child);
+
+            SecurityElement grandchild = new SecurityElement("ENDPOINT", "some text");
+            grandchild.AddAttribute("transport", "All");
+            grandchild.AddAttribute("host", "localhost");
+            grandchild.AddAttribute("port", "8080");
+            child.AddChild(grandchild);
+
+            SecurityElement grandchild2 = new SecurityElement("ENDPOINT");
+            grandchild2.AddAttribute("transport", "Tcp");
+            grandchild2.AddAttribute("host", "www.ximian.com");
+            grandchild2.AddAttribute("port", "All");
+            child.AddChild(grandchild2);
+
+            return elem;
+        }
+
+        [Fact]
+        public void Constructor1()
+        {
+            SecurityElement se = new SecurityElement("tag");
+            Assert.Null(se.Attributes);
+            Assert.Null(se.Children);
+            Assert.Equal("tag", se.Tag);
+            Assert.Null(se.Text);
+
+            se = new SecurityElement(string.Empty);
+            Assert.Null(se.Attributes);
+            Assert.Null(se.Children);
+            Assert.Equal(string.Empty, se.Tag);
+            Assert.Null(se.Text);
+        }
+
+        [Fact]
+        public void Constructor1_Tag_Invalid()
+        {
+            try
+            {
+                new SecurityElement("Na<me");
+                Assert.False(true);
+            }
+            catch (ArgumentException ex)
+            {
+                // Invalid element tag Nam<e
+                Assert.Equal(typeof(ArgumentException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.True(ex.Message.IndexOf("Na<me") != -1);
+                Assert.Null(ex.ParamName);
+            }
+
+            try
+            {
+                new SecurityElement("Nam>e");
+                Assert.False(true);
+            }
+            catch (ArgumentException ex)
+            {
+                // Invalid element tag Nam>e
+                Assert.Equal(typeof(ArgumentException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.True(ex.Message.IndexOf("Nam>e") != -1);
+                Assert.Null(ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Constructor1_Tag_Null()
+        {
+            try
+            {
+                new SecurityElement(null);
+                Assert.False(true);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.NotNull(ex.ParamName);
+                Assert.Equal("tag", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Constructor2()
+        {
+            SecurityElement se = new SecurityElement("tag", "text");
+            Assert.Null(se.Attributes);
+            Assert.Null(se.Children);
+            Assert.Equal("tag", se.Tag);
+            Assert.Equal("text", se.Text);
+        }
+
+        [Fact]
+        public void Constructor2_Tag_Invalid()
+        {
+            try
+            {
+                new SecurityElement("Na<me", "text");
+                Assert.False(true);
+            }
+            catch (ArgumentException ex)
+            {
+                // Invalid element tag Nam<e
+                Assert.Equal(typeof(ArgumentException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.True(ex.Message.IndexOf("Na<me") != -1);
+                Assert.Null(ex.ParamName);
+            }
+
+            try
+            {
+                new SecurityElement("Nam>e", "text");
+                Assert.False(true);
+            }
+            catch (ArgumentException ex)
+            {
+                // Invalid element tag Nam>e
+                Assert.Equal(typeof(ArgumentException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.True(ex.Message.IndexOf("Nam>e") != -1);
+                Assert.Null(ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Constructor2_Tag_Null()
+        {
+            try
+            {
+                new SecurityElement(null, "text");
+                Assert.False(true);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.NotNull(ex.ParamName);
+                Assert.Equal("tag", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Constructor2_Text_Null()
+        {
+            SecurityElement se = new SecurityElement("tag", null);
+            Assert.Null(se.Attributes);
+            Assert.Null(se.Children);
+            Assert.Equal("tag", se.Tag);
+            Assert.Null(se.Text);
+        }
+
+        [Fact]
+        public void AddAttribute_Name_Null()
+        {
+            SecurityElement elem = CreateElement();
+            try
+            {
+                elem.AddAttribute(null, "valid");
+                Assert.False(true);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.NotNull(ex.ParamName);
+                Assert.Equal("name", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void AddAttribute_Value_Null()
+        {
+            SecurityElement elem = CreateElement();
+            try
+            {
+                elem.AddAttribute("valid", null);
+                Assert.False(true);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.NotNull(ex.ParamName);
+                Assert.Equal("value", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void AddAttribute_Name_Invalid()
+        {
+            SecurityElement elem = CreateElement();
+            Assert.Throws<ArgumentException>(() => elem.AddAttribute("<invalid>", "valid"));
+        }
+
+        [Fact]
+        public void AddAttribute_Value_Invalid()
+        {
+            SecurityElement elem = CreateElement();
+            Assert.Throws<ArgumentException>(() => elem.AddAttribute("valid", "invalid\""));
+        }
+
+        [Fact]
+        public void AddAttribute_InvalidValue2()
+        {
+            SecurityElement elem = CreateElement();
+            elem.AddAttribute("valid", "valid&");
+            // in xml world this is actually not considered valid
+            // but it is by MS.Net
+        }
+
+        [Fact]
+        public void AddAttribute_InvalidValue3()
+        {
+            SecurityElement elem = CreateElement();
+            Assert.Throws<ArgumentException>(() => elem.AddAttribute("valid", "<invalid>"));
+        }
+
+        [Fact]
+        public void AddAttribute_Duplicate()
+        {
+            SecurityElement elem = CreateElement();
+            elem.AddAttribute("valid", "first time");
+            Assert.Throws<ArgumentException>(() => elem.AddAttribute("valid", "second time"));
+        }
+
+        [Fact]
+        public void AddAttribute()
+        {
+            SecurityElement elem = CreateElement();
+            elem.AddAttribute("valid", "valid\'");
+        }
+
+        [Fact]
+        public void AddChild_Null()
+        {
+            SecurityElement elem = CreateElement();
+            try
+            {
+                elem.AddChild(null);
+                Assert.False(true);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.NotNull(ex.ParamName);
+                Assert.Equal("child", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void AddChild()
+        {
+            SecurityElement elem = CreateElement();
+            int n = elem.Children.Count;
+            // add itself
+            elem.AddChild(elem);
+            Assert.Equal((n + 1), elem.Children.Count);
+        }
+
+        [Fact]
+        public void Attributes_Name_Invalid_MS()
+        {
+            SecurityElement elem = CreateElement();
+            Hashtable h = elem.Attributes;
+            h.Add("<invalid>", "valid");
+            Assert.Throws<InvalidCastException>(() => elem.Attributes = h);
+        }
+
+        [Fact]
+        public void Attributes_Value_Invalid()
+        {
+            SecurityElement elem = CreateElement();
+            Hashtable h = elem.Attributes;
+            h.Add("valid", "\"invalid\"");
+            try
+            {
+                elem.Attributes = h;
+                Assert.False(true);
+            }
+            catch (ArgumentException ex)
+            {
+                // Invalid attribute value '"invalid"'
+                Assert.Equal(typeof(ArgumentException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.True(ex.Message.IndexOf("\"invalid\"") != -1);
+                Assert.Null(ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Attributes()
+        {
+            SecurityElement elem = CreateElement();
+            Hashtable h = elem.Attributes;
+
+            h = elem.Attributes;
+            h.Add("foo", "bar");
+            Assert.True(elem.Attributes.Count != h.Count);
+
+            elem.Attributes = h;
+            Assert.NotNull(elem.Attribute("foo"));
+        }
+
+        [Fact]
+        public void Equal()
+        {
+            int iTest = 0;
+            SecurityElement elem = CreateElement();
+            SecurityElement elem2 = CreateElement();
+            iTest++;
+            Assert.True(elem.Equal(elem2));
+            iTest++;
+            SecurityElement child = (SecurityElement)elem2.Children[0];
+            iTest++;
+            child = (SecurityElement)child.Children[1];
+            iTest++;
+            child.Text = "some text";
+            iTest++;
+            Assert.False(elem.Equal(elem2));
+        }
+
+        [Fact]
+        public void Escape()
+        {
+            Assert.Equal("foo&lt;&gt;&quot;&apos;&amp; bar",
+                SecurityElement.Escape("foo<>\"'& bar"));
+            Assert.Null(SecurityElement.Escape(null));
+        }
+
+        [Fact]
+        public void IsValidAttributeName()
+        {
+            Assert.False(SecurityElement.IsValidAttributeName("x x"));
+            Assert.False(SecurityElement.IsValidAttributeName("x<x"));
+            Assert.False(SecurityElement.IsValidAttributeName("x>x"));
+            Assert.True(SecurityElement.IsValidAttributeName("x\"x"));
+            Assert.True(SecurityElement.IsValidAttributeName("x'x"));
+            Assert.True(SecurityElement.IsValidAttributeName("x&x"));
+            Assert.False(SecurityElement.IsValidAttributeName(null));
+            Assert.True(SecurityElement.IsValidAttributeName(string.Empty));
+        }
+
+        [Fact]
+        public void IsValidAttributeValue()
+        {
+            Assert.True(SecurityElement.IsValidAttributeValue("x x"));
+            Assert.False(SecurityElement.IsValidAttributeValue("x<x"));
+            Assert.False(SecurityElement.IsValidAttributeValue("x>x"));
+            Assert.False(SecurityElement.IsValidAttributeValue("x\"x"));
+            Assert.True(SecurityElement.IsValidAttributeValue("x'x"));
+            Assert.True(SecurityElement.IsValidAttributeValue("x&x"));
+            Assert.False(SecurityElement.IsValidAttributeValue(null));
+            Assert.True(SecurityElement.IsValidAttributeValue(string.Empty));
+        }
+
+        [Fact]
+        public void IsValidTag()
+        {
+            Assert.False(SecurityElement.IsValidTag("x x"));
+            Assert.False(SecurityElement.IsValidTag("x<x"));
+            Assert.False(SecurityElement.IsValidTag("x>x"));
+            Assert.True(SecurityElement.IsValidTag("x\"x"));
+            Assert.True(SecurityElement.IsValidTag("x'x"));
+            Assert.True(SecurityElement.IsValidTag("x&x"));
+            Assert.False(SecurityElement.IsValidTag(null));
+            Assert.True(SecurityElement.IsValidTag(string.Empty));
+        }
+
+        [Fact]
+        public void IsValidText()
+        {
+            Assert.True(SecurityElement.IsValidText("x x"));
+            Assert.False(SecurityElement.IsValidText("x<x"));
+            Assert.False(SecurityElement.IsValidText("x>x"));
+            Assert.True(SecurityElement.IsValidText("x\"x"));
+            Assert.True(SecurityElement.IsValidText("x'x"));
+            Assert.True(SecurityElement.IsValidText("x&x"));
+            Assert.False(SecurityElement.IsValidText(null));
+            Assert.True(SecurityElement.IsValidText(string.Empty));
+        }
+
+        [Fact]
+        public void SearchForChildByTag_Null()
+        {
+            SecurityElement elem = CreateElement();
+            try
+            {
+                elem.SearchForChildByTag(null);
+                Assert.False(true);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.NotNull(ex.ParamName);
+                Assert.Equal("tag", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void SearchForChildByTag()
+        {
+            SecurityElement elem = CreateElement();
+            SecurityElement child = elem.SearchForChildByTag("doesnotexist");
+            Assert.Null(child);
+
+            child = elem.SearchForChildByTag("ENDPOINT");
+            Assert.Null(child);
+
+            child = (SecurityElement)elem.Children[0];
+            child = child.SearchForChildByTag("ENDPOINT");
+            Assert.Equal("All", child.Attribute("transport"));
+        }
+
+        [Fact]
+        public void SearchForTextOfTag_Tag_Null()
+        {
+            SecurityElement elem = CreateElement();
+            try
+            {
+                elem.SearchForTextOfTag(null);
+                Assert.False(true);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.NotNull(ex.ParamName);
+                Assert.Equal("tag", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void SearchForTextOfTag()
+        {
+            SecurityElement elem = CreateElement();
+            string s = elem.SearchForTextOfTag("ENDPOINT");
+            Assert.Equal("some text", s);
+        }
+
+        [Fact]
+        public void Tag()
+        {
+            SecurityElement se = new SecurityElement("Values");
+            Assert.Equal("Values", se.Tag);
+            Assert.Equal(string.Format(CultureInfo.InvariantCulture,
+                "<Values/>{0}", Environment.NewLine),
+                se.ToString());
+            se.Tag = "abc:Name";
+            Assert.Equal("abc:Name", se.Tag);
+            Assert.Equal(string.Format(CultureInfo.InvariantCulture,
+                "<abc:Name/>{0}", Environment.NewLine),
+                se.ToString());
+            se.Tag = "Name&Address";
+            Assert.Equal("Name&Address", se.Tag);
+            Assert.Equal(string.Format(CultureInfo.InvariantCulture,
+                "<Name&Address/>{0}", Environment.NewLine),
+                se.ToString());
+            se.Tag = string.Empty;
+            Assert.Equal(string.Empty, se.Tag);
+            Assert.Equal(string.Format(CultureInfo.InvariantCulture,
+                "</>{0}", Environment.NewLine),
+                se.ToString());
+        }
+
+        [Fact]
+        public void Tag_Invalid()
+        {
+            SecurityElement se = new SecurityElement("Values");
+
+            try
+            {
+                se.Tag = "Na<me";
+                Assert.False(true);
+            }
+            catch (ArgumentException ex)
+            {
+                // Invalid element tag Nam<e
+                Assert.Equal(typeof(ArgumentException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.True(ex.Message.IndexOf("Na<me") != -1);
+                Assert.Null(ex.ParamName);
+            }
+
+            try
+            {
+                se.Tag = "Nam>e";
+                Assert.False(true);
+            }
+            catch (ArgumentException ex)
+            {
+                // Invalid element tag Nam>e
+                Assert.Equal(typeof(ArgumentException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.True(ex.Message.IndexOf("Nam>e") != -1);
+                Assert.Null(ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Tag_Null()
+        {
+            SecurityElement elem = CreateElement();
+            try
+            {
+                elem.Tag = null;
+                Assert.False(true);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.NotNull(ex.ParamName);
+                Assert.Equal("Tag", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Text()
+        {
+            SecurityElement elem = CreateElement();
+            elem.Text = "Miguel&S�bastien";
+            Assert.Equal("Miguel&S�bastien", elem.Text);
+            elem.Text = null;
+            Assert.Null(elem.Text);
+            elem.Text = "S�bastien\"Miguel";
+            Assert.Equal("S�bastien\"Miguel", elem.Text);
+            elem.Text = string.Empty;
+            Assert.Equal(string.Empty, elem.Text);
+            elem.Text = "&lt;sample&amp;practice&unresolved;&gt;";
+            Assert.Equal("<sample&practice&unresolved;>", elem.Text);
+        }
+
+        [Fact]
+        public void Text_Invalid()
+        {
+            SecurityElement elem = CreateElement();
+            try
+            {
+                elem.Text = "Mig<uelS�bastien";
+                Assert.False(true);
+            }
+            catch (ArgumentException ex)
+            {
+                // Invalid element tag Mig<uelS�bastien
+                Assert.Equal(typeof(ArgumentException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.True(ex.Message.IndexOf("Mig<uelS�bastien") != -1);
+                Assert.Null(ex.ParamName);
+            }
+
+            try
+            {
+                elem.Text = "Mig>uelS�bastien";
+                Assert.False(true);
+            }
+            catch (ArgumentException ex)
+            {
+                // Invalid element tag Mig>uelS�bastien
+                Assert.Equal(typeof(ArgumentException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.True(ex.Message.IndexOf("Mig>uelS�bastien") != -1);
+                Assert.Null(ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void MultipleAttributes()
+        {
+            SecurityElement se = new SecurityElement("Multiple");
+            se.AddAttribute("Attribute1", "One");
+            se.AddAttribute("Attribute2", "Two");
+
+            string expected = String.Format("<Multiple Attribute1=\"One\"{0}Attribute2=\"Two\"/>{0}", Environment.NewLine);
+            Assert.Equal(expected, se.ToString());
+        }
+
+        [Fact]
+        public void FromString_Null()
+        {
+            try
+            {
+                SecurityElement.FromString(null);
+                Assert.False(true);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.NotNull(ex.ParamName);
+                Assert.Equal("xml", ex.ParamName);
+            }
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.builds
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Security.Permissions.Tests.csproj">
-      <TestTFMs>netcoreapp1.1</TestTFMs>
-    </Project>
+    <Project Include="System.Security.Permissions.Tests.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.builds
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.builds
@@ -2,7 +2,9 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Security.Permissions.Tests.csproj" />
+    <Project Include="System.Security.Permissions.Tests.csproj">
+      <TestTFMs>netcoreapp1.1</TestTFMs>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -1,28 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Security.Permissions.Tests</RootNamespace>
     <AssemblyName>System.Security.Permissions.Tests</AssemblyName>
-    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
-    <TestTFM>netcoreapp1.1</TestTFM>
     <ProjectGuid>{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}</ProjectGuid>
     <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <ProjectReference Include="..\pkg\System.Security.Permissions.pkgproj">
       <Name>System.Security.Permissions</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
+    <Compile Include="PrincipalPermissionTests.cs" />
+    <Compile Include="SecurityElementTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApplicationTrustTests.cs" />


### PR DESCRIPTION
- Ports desktop code for SecurityELement and PrincipalPermission
- To be used in Security.Permissions, some of the members in System.Sec.Principal.Windows need to be moved into common.
- Fixes the old desktop implementation of the two functions to work in .net core. Originally the plan was to only implement PrincipalPermission, but it relied heavily on SecurityElement functionality so I opted to implement that as well. The only remaining item not fully implemented is SecurityElement.FromString.
- Required splitting PrincipalPermission (and the assembly) based on Unix/Windows.
- Adds tests for SecurityElement and PrincipalPermission

resolves https://github.com/dotnet/corefx/issues/9641

@AlexGhiondea @joperezr @stephentoub 