### PR TITLE
Suppressing FxCop warning CA229 about lack of serialization construct…

### DIFF
--- a/src/System.Transactions/src/System/Transactions/CommittableTransaction.cs
+++ b/src/System.Transactions/src/System/Transactions/CommittableTransaction.cs
@@ -7,6 +7,7 @@ using System.Transactions.Diagnostics;
 
 namespace System.Transactions
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2229", Justification="Serialization not yet supported and will be done using DistributedTransaction")]
     [Serializable]
     public sealed class CommittableTransaction : Transaction, IAsyncResult
     {

--- a/src/System.Transactions/src/System/Transactions/DependentTransaction.cs
+++ b/src/System.Transactions/src/System/Transactions/DependentTransaction.cs
@@ -6,6 +6,7 @@ using System.Transactions.Diagnostics;
 
 namespace System.Transactions
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2229", Justification = "Serialization not yet supported and will be done using DistributedTransaction")]
     [Serializable]
     public sealed class DependentTransaction : Transaction
     {

--- a/src/System.Transactions/src/System/Transactions/SubordinateTransaction.cs
+++ b/src/System.Transactions/src/System/Transactions/SubordinateTransaction.cs
@@ -4,6 +4,7 @@
 
 namespace System.Transactions
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2229", Justification = "Serialization not yet supported and will be done using DistributedTransaction")]
     [Serializable]
     public sealed class SubordinateTransaction : Transaction
     {

--- a/src/System.Transactions/src/System/Transactions/Transaction.cs
+++ b/src/System.Transactions/src/System/Transactions/Transaction.cs
@@ -53,6 +53,7 @@ namespace System.Transactions
 
     // When we serialize a Transaction, we specify the type DistributedTransaction, so a Transaction never
     // actually gets deserialized.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2229", Justification = "Serialization not yet supported and will be done using DistributedTransaction")]
     [Serializable]
     public class Transaction : IDisposable, ISerializable
     {

--- a/src/System.Transactions/src/project.json
+++ b/src/System.Transactions/src/project.json
@@ -10,6 +10,7 @@
         "System.Diagnostics.Debug": "4.4.0-beta-24701-01",
         "System.Globalization": "4.4.0-beta-24701-01",
         "System.Diagnostics.Process": "4.4.0-beta-24701-01",
+        "System.Diagnostics.Tools": "4.4.0-beta-24701-01",
         "System.Diagnostics.TraceSource": "4.4.0-beta-24701-01",
         "System.IO": "4.4.0-beta-24701-01",
         "System.Resources.ResourceManager": "4.4.0-beta-24701-01",


### PR DESCRIPTION
…ors.

When we support distributed transactions, transaction serialization will actually happen through something like an abstract DistributedTransaction base class.