### PR TITLE
Special-case Fedora 24 in a Globalization test case

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -57,6 +57,7 @@ namespace System
         public static bool IsUbuntu1604 { get; } = IsDistroAndVersion("ubuntu", "16.04");
         public static bool IsUbuntu1610 { get; } = IsDistroAndVersion("ubuntu", "16.10");
         public static bool IsFedora23 { get; } = IsDistroAndVersion("fedora", "23");
+        public static bool IsFedora24 { get; } = IsDistroAndVersion("fedora", "24");
 
         /// <summary>
         /// Get whether the OS platform matches the given Linux distro and optional version.

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
@@ -15,7 +15,8 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-US").NumberFormat, new int[] { 3 } };
 
             // TODO: when dotnet/corefx#2103 is addressed, we should also check fr-FR
-            if (!PlatformDetection.IsUbuntu1510 && !PlatformDetection.IsUbuntu1604 && !PlatformDetection.IsUbuntu1610 && !PlatformDetection.IsWindows7)
+            if (!PlatformDetection.IsUbuntu1510 && !PlatformDetection.IsUbuntu1604
+                && !PlatformDetection.IsUbuntu1610 && !PlatformDetection.IsWindows7 && !PlatformDetection.IsFedora24)
             {
                 yield return new object[] { new CultureInfo("ur-IN").NumberFormat, NumberFormatInfoData.UrINNumberGroupSizes() };
             }


### PR DESCRIPTION
Fedora 24 is using libicu56, which has the same data that Ubuntu 16.04 (libicu55) and Ubuntu 16.10 (libicu57) have for this test case.

@ellismg 