### PR TITLE
Fix System.Xml.Linq.XNodeBuilder outerloop test failures

### DIFF
--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/System.Xml.Linq.xNodeBuilder.Tests.csproj
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/System.Xml.Linq.xNodeBuilder.Tests.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
     <ProjectReference Include="..\XDocument.Common\XDocument.Common.csproj" />
     <ProjectReference Include="..\XDocument.Test.ModuleCore\XDocument.Test.ModuleCore.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Resolves https://github.com/dotnet/corefx/issues/13284

This P2P reference was missing in outerloop test runs. (caused by recent changes in Xml.Linq tests)

cc: @stephentoub 