### PR TITLE
Made DCS/DCJS support NonSerializedAttribute and OptionalFieldAttribute.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -1148,6 +1148,12 @@ namespace System.Runtime.Serialization
                         FieldInfo field = member as FieldInfo;
 
                         bool canSerializeMember;
+
+                        // Previously System.SerializableAttribute was not available in NetCore, so we had
+                        // a list of known [Serializable] types for type in the framework. Although now SerializableAttribute
+                        // is available in NetCore, some framework types still do not have [Serializable] 
+                        // yet, e.g. ReadOnlyDictionary<TKey, TValue>. So, we still need to maintain the known serializable
+                        // type list.
                         if (IsKnownSerializableType(type))
                         {
                             canSerializeMember = CanSerializeMember(field);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -1162,7 +1162,7 @@ namespace System.Runtime.Serialization
                             DataMember memberContract = new DataMember(member);
 
                             memberContract.Name = DataContract.EncodeLocalName(member.Name);
-                            object[] optionalFields = null; // TODO 11477: Add back optional field support
+                            object[] optionalFields = field.GetCustomAttributes(Globals.TypeOfOptionalFieldAttribute, false);
                             if (optionalFields == null || optionalFields.Length == 0)
                             {
                                 if (this.IsReference)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -1145,12 +1145,19 @@ namespace System.Runtime.Serialization
                     }
                     else
                     {
-                        // [Serializible] and [NonSerialized] are deprecated on FxCore
-                        // Try to mimic the behavior by allowing certain known types to go through
-                        // POD types are fine also
-
                         FieldInfo field = member as FieldInfo;
-                        if (CanSerializeMember(field))
+
+                        bool canSerializeMember;
+                        if (IsKnownSerializableType(type))
+                        {
+                            canSerializeMember = CanSerializeMember(field);
+                        }
+                        else
+                        {
+                            canSerializeMember = field != null && !field.IsNotSerialized;
+                        }
+
+                        if (canSerializeMember)
                         {
                             DataMember memberContract = new DataMember(member);
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/EnumDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/EnumDataContract.cs
@@ -262,7 +262,7 @@ namespace System.Runtime.Serialization
                     }
                     else
                     {
-                        //if (!field.IsNotSerialized)
+                        if (!field.IsNotSerialized)
                         {
                             DataMember memberContract = new DataMember(field);
                             memberContract.Name = field.Name;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/EnumDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/EnumDataContract.cs
@@ -262,10 +262,13 @@ namespace System.Runtime.Serialization
                     }
                     else
                     {
-                        DataMember memberContract = new DataMember(field);
-                        memberContract.Name = field.Name;
-                        ClassDataContract.CheckAndAddMember(tempMembers, memberContract, memberValuesTable);
-                        enumMemberValid = true;
+                        //if (!field.IsNotSerialized)
+                        {
+                            DataMember memberContract = new DataMember(field);
+                            memberContract.Name = field.Name;
+                            ClassDataContract.CheckAndAddMember(tempMembers, memberContract, memberValuesTable);
+                            enumMemberValid = true;
+                        }
                     }
 
                     if (enumMemberValid)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -412,6 +412,20 @@ namespace System.Runtime.Serialization
             }
         }
 
+        private static Type s_typeOfOptionalFieldAttribute;
+        internal static Type TypeOfOptionalFieldAttribute
+        {
+            get
+            {
+                if (s_typeOfOptionalFieldAttribute == null)
+                {
+                    s_typeOfOptionalFieldAttribute = typeof(OptionalFieldAttribute);
+                }
+
+                return s_typeOfOptionalFieldAttribute;
+            }
+        }
+
         [SecurityCritical]
         private static Type s_typeOfObjectArray;
         internal static Type TypeOfObjectArray

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2324,7 +2324,7 @@ public static partial class DataContractJsonSerializerTests
         Assert.Equal(value.Member2, actual.Member2);
 
         int member1Value = 11;
-        string payloadMissingOptionalField = $"{{\"Member1\":{11}}}";
+        string payloadMissingOptionalField = $"{{\"Member1\":{member1Value}}}";
         var deserialized = DeserializeString<TypeWithOptionalField>(payloadMissingOptionalField);
         Assert.Equal(member1Value, deserialized.Member1);
         Assert.Equal(0, deserialized.Member2);

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2294,6 +2294,23 @@ public static partial class DataContractJsonSerializerTests
         }
     }
 
+    [Fact]
+    public static void DCJS_TypeWithNonSerializedField()
+    {
+        var value = new TypeWithSerializableAttributeAndNonSerializedField();
+        value.Member1 = 11;
+        value.Member2 = "22";
+        value.SetMember3(33);
+        value.Member4 = "44";
+
+        var actual = SerializeAndDeserialize(value, "{\"Member1\":11,\"_member2\":\"22\",\"_member3\":33}");
+        Assert.NotNull(actual);
+        Assert.Equal(value.Member1, actual.Member1);
+        Assert.Equal(value.Member2, actual.Member2);
+        Assert.Equal(value.Member3, actual.Member3);
+        Assert.Null(actual.Member4);
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractJsonSerializer dcjs;

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2748,6 +2748,26 @@ public static partial class DataContractSerializerTests
         Assert.Equal(value.StringValue, actual.StringValue);
     }
 
+    [Fact]
+    public static void DCS_TypeWithNonSerializedField()
+    {
+        var value = new TypeWithSerializableAttributeAndNonSerializedField();
+        value.Member1 = 11;
+        value.Member2 = "22";
+        value.SetMember3(33);
+        value.Member4 = "44";
+
+        var actual = SerializeAndDeserialize(
+            value, 
+            "<TypeWithSerializableAttributeAndNonSerializedField xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Member1>11</Member1><_member2>22</_member2><_member3>33</_member3></TypeWithSerializableAttributeAndNonSerializedField>",
+            skipStringCompare: false);
+        Assert.NotNull(actual);
+        Assert.Equal(value.Member1, actual.Member1);
+        Assert.Equal(value.Member2, actual.Member2);
+        Assert.Equal(value.Member3, actual.Member3);
+        Assert.Null(actual.Member4);
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2787,6 +2787,20 @@ public static partial class DataContractSerializerTests
         Assert.Equal(0, deserialized.Member2);
     }
 
+    [Fact]
+    public static void DCS_SerializableEnumWithNonSerializedValue()
+    {
+        var value1 = new TypeWithSerializableEnum();
+        value1.EnumField = SerializableEnumWithNonSerializedValue.One;
+        var actual1 = SerializeAndDeserialize(value1, "<TypeWithSerializableEnum xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><EnumField>One</EnumField></TypeWithSerializableEnum>");
+        Assert.NotNull(actual1);
+        Assert.Equal(value1.EnumField, actual1.EnumField);
+
+        var value2 = new TypeWithSerializableEnum();
+        value2.EnumField = SerializableEnumWithNonSerializedValue.Two;
+        Assert.Throws<SerializationException>(() => SerializeAndDeserialize(value2, ""));
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2768,6 +2768,25 @@ public static partial class DataContractSerializerTests
         Assert.Null(actual.Member4);
     }
 
+    [Fact]
+    public static void DCS_TypeWithOptionalField()
+    {
+        var value = new TypeWithOptionalField();
+        value.Member1 = 11;
+        value.Member2 = 22;
+
+        var actual = SerializeAndDeserialize(value, "<TypeWithOptionalField xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Member1>11</Member1><Member2>22</Member2></TypeWithOptionalField>");
+        Assert.NotNull(actual);
+        Assert.Equal(value.Member1, actual.Member1);
+        Assert.Equal(value.Member2, actual.Member2);
+
+        int member1Value = 11;
+        string payloadMissingOptionalField = $"<TypeWithOptionalField xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Member1>{member1Value}</Member1></TypeWithOptionalField>";
+        var deserialized = DeserializeString<TypeWithOptionalField>(payloadMissingOptionalField);
+        Assert.Equal(member1Value, deserialized.Member1);
+        Assert.Equal(0, deserialized.Member2);
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -3976,3 +3976,11 @@ public class TypeWithSerializableAttributeAndNonSerializedField
         _member3 = value;
     }
 }
+
+[Serializable]
+public class TypeWithOptionalField
+{
+    public int Member1;
+    [OptionalField]
+    public int Member2;
+}

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -3939,3 +3939,40 @@ public class TypeForRootNameTest
     [DataMember]
     public string StringProperty { get; set; }
 }
+
+[Serializable]
+public class TypeWithSerializableAttributeAndNonSerializedField
+{
+    public int Member1;
+    private string _member2;
+    private int _member3;
+
+    [NonSerialized()]
+    public string Member4;
+
+    public string Member2
+    {
+        get
+        {
+            return _member2;
+        }
+
+        set
+        {
+            _member2 = value;
+        }
+    }
+
+    public int Member3
+    {
+        get
+        {
+            return _member3;
+        }
+    }
+
+    public void SetMember3(int value)
+    {
+        _member3 = value;
+    }
+}

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -3984,3 +3984,16 @@ public class TypeWithOptionalField
     [OptionalField]
     public int Member2;
 }
+
+[Serializable]
+public enum SerializableEnumWithNonSerializedValue
+{
+    One = 1,
+    [NonSerialized]
+    Two = 2,
+}
+
+public class TypeWithSerializableEnum
+{
+    public SerializableEnumWithNonSerializedValue EnumField;
+}


### PR DESCRIPTION
The PR is to make DCS/DCJS to respect NonSerializedAttribute and OptionalFieldAttribute.

Fix https://github.com/dotnet/corefx/issues/13367

cc: @zhenlan @mconnew @huanwu 