### PR TITLE
Add GSSAPI and NTLM authentication support for smtp.

### DIFF
--- a/src/System.Net.Mail/src/System.Net.Mail.csproj
+++ b/src/System.Net.Mail/src/System.Net.Mail.csproj
@@ -73,6 +73,9 @@
     <Compile Include="System\Net\Mail\SmtpStatusCode.cs" />
     <Compile Include="System\Net\Mail\SmtpTransport.cs" />
     <Compile Include="System\Net\Mail\SmtpLoginAuthenticationModule.cs" />
+    <Compile Include="System\Net\Mail\NTAuthenticationStub.cs" />
+    <Compile Include="System\Net\Mail\SmtpNegotiateAuthenticationModule.cs" />
+    <Compile Include="System\Net\Mail\SmtpNtlmAuthenticationModule.cs" />
     <Compile Include="System\Net\DelegatedStream.cs" />
     <Compile Include="$(CommonPath)\System\Net\TlsStream.cs">
       <Link>Common\System\Net\TlsStream.cs</Link>

--- a/src/System.Net.Mail/src/System/Net/Mail/NTAuthenticationStub.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/NTAuthenticationStub.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Net.Security;
+using System.Security.Authentication.ExtendedProtection;
+using System.Diagnostics;
+
+namespace System.Net
+{
+    internal class NTAuthentication
+    {
+        private static readonly Type s_type = typeof(NegotiateStream).Assembly.GetType("System.Net.NTAuthentication");
+        private const BindingFlags NonPublicInstance = BindingFlags.NonPublic | BindingFlags.Instance;
+
+        private readonly ConstructorInfo _ntAuthentication;
+        private readonly MethodInfo _getOutgoingBlogString;
+        private readonly MethodInfo _getOutgoingBlobBytes;
+        private readonly MethodInfo _verifySignature;
+        private readonly MethodInfo _makeSignature;
+        private readonly MethodInfo _closeContext;
+        private readonly MethodInfo _isCompleted;
+        private object _instance;
+
+        internal NTAuthentication(bool isServer, string package, NetworkCredential credential, string spn, ContextFlags requestedContextFlags, ChannelBinding channelBinding)
+        {
+            ConstructorInfo[] ctors = s_type.GetConstructors(NonPublicInstance & ~BindingFlags.Default);
+            Debug.Assert(ctors.Length == 1);
+
+            _ntAuthentication = ctors[0];
+            _getOutgoingBlogString = s_type.GetMethod("GetOutgoingBlob", NonPublicInstance, null, new Type[] { typeof(string)}, null);
+            _getOutgoingBlobBytes = s_type.GetMethod("GetOutgoingBlob", NonPublicInstance, null, new Type[] { typeof(byte[]), typeof(bool) }, null);
+            _verifySignature = s_type.GetMethod("VerifySignature", NonPublicInstance);
+            _makeSignature = s_type.GetMethod("MakeSignature", NonPublicInstance);
+            _closeContext = s_type.GetMethod("CloseContext", NonPublicInstance);
+            _isCompleted = s_type.GetProperty("IsCompleted", NonPublicInstance).GetMethod;
+
+            _instance = _ntAuthentication.Invoke(new object[] { isServer, package, credential, spn, requestedContextFlags, channelBinding });
+        }
+
+        internal string GetOutgoingBlob(string challenge)
+        {
+            return (string)_getOutgoingBlogString.Invoke(_instance, new object[] { challenge });
+        }
+
+        internal byte[] GetOutgoingBlob(byte[] incomingBlob, bool throwOnError)
+        {
+            return (byte[])_getOutgoingBlobBytes.Invoke(_instance, new object[] { incomingBlob, throwOnError });
+        }
+
+        internal int VerifySignature(byte[] buffer, int offset, int count)
+        {
+            return (int)_verifySignature.Invoke(_instance, new object[] { buffer, offset, count });
+        }
+
+        internal int MakeSignature(byte[] buffer, int offset, int count, ref byte[] output)
+        {
+            return (int)_makeSignature.Invoke(_instance, new object[] { buffer, offset, count, output });
+        }
+
+        internal void CloseContext()
+        {
+            _closeContext.Invoke(_instance, null);
+        }
+
+        internal bool IsCompleted => (bool)_isCompleted.Invoke(_instance, null);
+    }
+
+    [Flags]
+    internal enum ContextFlags
+    {
+        None = 0,
+        Delegate = 0x00000001,
+        MutualAuth = 0x00000002,
+        ReplayDetect = 0x00000004,
+        SequenceDetect = 0x00000008,
+        Confidentiality = 0x00000010,
+        UseSessionKey = 0x00000020,
+        //AllocateMemory = 0x00000100,
+        Connection = 0x00000800,
+        InitExtendedError = 0x00004000,
+        AcceptExtendedError = 0x00008000,
+        InitStream = 0x00008000,
+        AcceptStream = 0x00010000,
+        InitIntegrity = 0x00010000,
+        AcceptIntegrity = 0x00020000,
+        InitManualCredValidation = 0x00080000,
+        InitUseSuppliedCreds = 0x00000080,
+        InitIdentify = 0x00020000,
+        AcceptIdentify = 0x00080000,
+        ProxyBindings = 0x04000000,
+        AllowMissingBindings = 0x10000000,
+        UnverifiedTargetName = 0x20000000,
+    }
+}

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpAuthenticationManager.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpAuthenticationManager.cs
@@ -12,6 +12,8 @@ namespace System.Net.Mail
 
         static SmtpAuthenticationManager()
         {
+            Register(new SmtpNegotiateAuthenticationModule());
+            Register(new SmtpNtlmAuthenticationModule());
             Register(new SmtpLoginAuthenticationModule());
         }
 

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.Auth.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.Auth.cs
@@ -7,7 +7,9 @@ namespace System.Net.Mail
     internal enum SupportedAuth
     {
         None = 0,
-        Login = 1
+        Login = 1,
+        NTLM = 2,
+        GSSAPI = 4
     };
 
     internal partial class SmtpConnection
@@ -15,6 +17,7 @@ namespace System.Net.Mail
         private bool _serverSupportsEai;
         private bool _dsnEnabled;
         private bool _serverSupportsStartTls;
+        private bool _sawNegotiate;
         private SupportedAuth _supportedAuth = SupportedAuth.None;
         private readonly ISmtpAuthenticationModule[] _authenticationModules;
 
@@ -25,6 +28,8 @@ namespace System.Net.Mail
         private static readonly char[] s_authExtensionSplitters = new char[] { ' ', '=' };
         private const string AuthExtension = "auth";
         private const string AuthLogin = "login";
+        private const string AuthNtlm = "ntlm";
+        private const string AuthGssapi = " gssapi";
 
         internal SmtpConnection(ISmtpAuthenticationModule[] authenticationModules)
         {
@@ -54,6 +59,14 @@ namespace System.Net.Mail
                         {
                             _supportedAuth |= SupportedAuth.Login;
                         }
+                        else if (string.Compare(authType, AuthNtlm, StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            _supportedAuth |= SupportedAuth.NTLM;
+                        }
+                        else if (string.Compare(authType, AuthGssapi, StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            _supportedAuth |= SupportedAuth.GSSAPI;
+                        }
                     }
                 }
                 else if (string.Compare(extension, 0, "dsn ", 0, 3, StringComparison.OrdinalIgnoreCase) == 0)
@@ -73,7 +86,31 @@ namespace System.Net.Mail
 
         internal bool AuthSupported(ISmtpAuthenticationModule module)
         {
-            return module is SmtpLoginAuthenticationModule && (_supportedAuth & SupportedAuth.Login) > 0;
+            if (module is SmtpLoginAuthenticationModule)
+            {
+                if ((_supportedAuth & SupportedAuth.Login) > 0)
+                {
+                    return true;
+                }
+            }
+            else if (module is SmtpNegotiateAuthenticationModule)
+            {
+                if ((_supportedAuth & SupportedAuth.GSSAPI) > 0)
+                {
+                    _sawNegotiate = true;
+                    return true;
+                }
+            }
+            else if (module is SmtpNtlmAuthenticationModule)
+            {
+                // Don't try ntlm if negotiate has been tried
+                if ((!_sawNegotiate && (_supportedAuth & SupportedAuth.NTLM) > 0))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.Auth.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.Auth.cs
@@ -59,11 +59,11 @@ namespace System.Net.Mail
                         {
                             _supportedAuth |= SupportedAuth.Login;
                         }
-                        else if (string.Compare(authType, AuthNtlm, StringComparison.OrdinalIgnoreCase) == 0)
+                        else if (string.Equals(authType, AuthNtlm, StringComparison.OrdinalIgnoreCase))
                         {
                             _supportedAuth |= SupportedAuth.NTLM;
                         }
-                        else if (string.Compare(authType, AuthGssapi, StringComparison.OrdinalIgnoreCase) == 0)
+                        else if (string.Equals(authType, AuthGssapi, StringComparison.OrdinalIgnoreCase))
                         {
                             _supportedAuth |= SupportedAuth.GSSAPI;
                         }

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpLoginAuthenticationModule.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpLoginAuthenticationModule.cs
@@ -4,11 +4,10 @@
 
 using System.Collections.Generic;
 using System.Security.Authentication.ExtendedProtection;
-using System.Security.Permissions;
 
 namespace System.Net.Mail
 {
-    internal class SmtpLoginAuthenticationModule : ISmtpAuthenticationModule
+    internal sealed class SmtpLoginAuthenticationModule : ISmtpAuthenticationModule
     {
         private Dictionary<object, NetworkCredential> _sessions = new Dictionary<object, NetworkCredential>();
 
@@ -16,9 +15,6 @@ namespace System.Net.Mail
         {
         }
 
-        // Security this method will access NetworkCredential properties that demand UnmanagedCode and Environment Permission
-        [EnvironmentPermission(SecurityAction.Assert, Unrestricted = true)]
-        [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.UnmanagedCode)]
         public Authorization Authenticate(string challenge, NetworkCredential credential, object sessionCookie, string spn, ChannelBinding channelBindingToken)
         {
             if (NetEventSource.IsEnabled) NetEventSource.Enter(this);

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
@@ -5,24 +5,20 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Security.Authentication.ExtendedProtection;
-using System.Security.Permissions;
 
 namespace System.Net.Mail
 {
-    internal class SmtpNegotiateAuthenticationModule : ISmtpAuthenticationModule
+    internal sealed class SmtpNegotiateAuthenticationModule : ISmtpAuthenticationModule
     {
-        private Dictionary<object, NTAuthentication> _sessions = new Dictionary<object, NTAuthentication>();
+        private readonly Dictionary<object, NTAuthentication> _sessions = new Dictionary<object, NTAuthentication>();
 
         internal SmtpNegotiateAuthenticationModule()
         {
         }
 
-        // Security this method will access NetworkCredential properties that demand UnmanagedCode and Environment Permission
-        [EnvironmentPermission(SecurityAction.Assert, Unrestricted = true)]
-        [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.UnmanagedCode)]
         public Authorization Authenticate(string challenge, NetworkCredential credential, object sessionCookie, string spn, ChannelBinding channelBindingToken)
         {
-            NetEventSource.Enter(this, "Authenticate");
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, "Authenticate");
             try
             {
                 lock (_sessions)
@@ -81,7 +77,7 @@ namespace System.Net.Mail
             }
             finally
             {
-                NetEventSource.Exit(this, "Authenticate");
+                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, "Authenticate");
             }
         }
 

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
@@ -75,6 +75,11 @@ namespace System.Net.Mail
                     return new Authorization(resp, clientContext.IsCompleted);
                 }
             }
+            // From reflected type NTAuthentication in System.Net.Security.
+            catch (NullReferenceException)
+            {
+                return null;
+            }
             finally
             {
                 if (NetEventSource.IsEnabled) NetEventSource.Exit(this, "Authenticate");

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
@@ -1,0 +1,199 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Security.Authentication.ExtendedProtection;
+using System.Security.Permissions;
+
+namespace System.Net.Mail
+{
+    internal class SmtpNegotiateAuthenticationModule : ISmtpAuthenticationModule
+    {
+        private Dictionary<object, NTAuthentication> _sessions = new Dictionary<object, NTAuthentication>();
+
+        internal SmtpNegotiateAuthenticationModule()
+        {
+        }
+
+        // Security this method will access NetworkCredential properties that demand UnmanagedCode and Environment Permission
+        [EnvironmentPermission(SecurityAction.Assert, Unrestricted = true)]
+        [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        public Authorization Authenticate(string challenge, NetworkCredential credential, object sessionCookie, string spn, ChannelBinding channelBindingToken)
+        {
+            NetEventSource.Enter(this, "Authenticate");
+            try
+            {
+                lock (_sessions)
+                {
+                    NTAuthentication clientContext;
+                    if (!_sessions.TryGetValue(sessionCookie, out clientContext))
+                    {
+                        if (credential == null)
+                        {
+                            return null;
+                        }
+
+                        _sessions[sessionCookie] =
+                            clientContext =
+                            new NTAuthentication(false, "Negotiate", credential, spn,
+                                                 ContextFlags.Connection | ContextFlags.InitIntegrity, channelBindingToken);
+                    }
+
+                    byte[] byteResp;
+                    string resp = null;
+
+                    if (!clientContext.IsCompleted)
+                    {
+
+                        // If auth is not yet completed keep producing
+                        // challenge responses with GetOutgoingBlob
+
+                        byte[] decodedChallenge = null;
+                        if (challenge != null)
+                        {
+                            decodedChallenge =
+                                Convert.FromBase64String(challenge);
+                        }
+                        byteResp = clientContext.GetOutgoingBlob(decodedChallenge, false);
+                        if (clientContext.IsCompleted && byteResp == null)
+                        {
+                            resp = "\r\n";
+                        }
+                        if (byteResp != null)
+                        {
+                            resp = Convert.ToBase64String(byteResp);
+                        }
+                    }
+                    else
+                    {
+                        // If auth completed and still have a challenge then
+                        // server may be doing "correct" form of GSSAPI SASL.
+                        // Validate incoming and produce outgoing SASL security 
+                        // layer negotiate message.
+
+                        resp = GetSecurityLayerOutgoingBlob(challenge, clientContext);
+                    }
+
+                    return new Authorization(resp, clientContext.IsCompleted);
+                }
+            }
+            finally
+            {
+                NetEventSource.Exit(this, "Authenticate");
+            }
+        }
+
+        public string AuthenticationType
+        {
+            get
+            {
+                return "gssapi";
+            }
+        }
+
+        public void CloseContext(object sessionCookie)
+        {
+            NTAuthentication clientContext = null;
+            lock (_sessions)
+            {
+                if (_sessions.TryGetValue(sessionCookie, out clientContext))
+                {
+                    _sessions.Remove(sessionCookie);
+                }
+            }
+            if (clientContext != null)
+            {
+                clientContext.CloseContext();
+            }
+        }
+
+        // Function for SASL security layer negotiation after
+        // authorization completes.   
+        //
+        // Returns null for failure, Base64 encoded string on
+        // success.
+        private string GetSecurityLayerOutgoingBlob(string challenge, NTAuthentication clientContext)
+        {
+            // must have a security layer challenge
+
+            if (challenge == null)
+                return null;
+
+            // "unwrap" challenge
+
+            byte[] input = Convert.FromBase64String(challenge);
+
+            int len;
+
+            try
+            {
+                len = clientContext.VerifySignature(input, 0, input.Length);
+            }
+            catch (Win32Exception)
+            {
+                // any decrypt failure is an auth failure
+                return null;
+            }
+
+            // Per RFC 2222 Section 7.2.2:
+            //   the client should then expect the server to issue a 
+            //   token in a subsequent challenge.  The client passes
+            //   this token to GSS_Unwrap and interprets the first 
+            //   octet of cleartext as a bit-mask specifying the 
+            //   security layers supported by the server and the 
+            //   second through fourth octets as the maximum size 
+            //   output_message to send to the server.   
+            // Section 7.2.3
+            //   The security layer and their corresponding bit-masks
+            //   are as follows:
+            //     1 No security layer
+            //     2 Integrity protection
+            //       Sender calls GSS_Wrap with conf_flag set to FALSE
+            //     4 Privacy protection
+            //       Sender calls GSS_Wrap with conf_flag set to TRUE
+            //
+            // Exchange 2007 and our client only support 
+            // "No security layer". Therefore verify first byte is value 1
+            // and the 2nd-4th bytes are value zero since token size is not
+            // applicable when there is no security layer.
+
+            if (len < 4 ||          // expect 4 bytes
+                input[0] != 1 ||    // first value 1
+                input[1] != 0 ||    // rest value 0
+                input[2] != 0 ||
+                input[3] != 0)
+            {
+                return null;
+            }
+
+            // Continuing with RFC 2222 section 7.2.2:
+            //   The client then constructs data, with the first octet 
+            //   containing the bit-mask specifying the selected security
+            //   layer, the second through fourth octets containing in 
+            //   network byte order the maximum size output_message the client
+            //   is able to receive, and the remaining octets containing the
+            //   authorization identity.  
+            // 
+            // So now this contructs the "wrapped" response.  The response is
+            // payload is identical to the received server payload and the 
+            // "authorization identity" is not supplied as it is unnecessary.
+
+            // let MakeSignature figure out length of output
+            byte[] output = null;
+            try
+            {
+                len = clientContext.MakeSignature(input, 0, 4, ref output);
+            }
+            catch (Win32Exception)
+            {
+                // any encrypt failure is an auth failure
+                return null;
+            }
+
+            // return Base64 encoded string of signed payload
+            return Convert.ToBase64String(output, 0, len);
+        }
+    }
+}

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpNtlmAuthenticationModule.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpNtlmAuthenticationModule.cs
@@ -49,6 +49,11 @@ namespace System.Net.Mail
                     }
                 }
             }
+            // From reflected type NTAuthentication in System.Net.Security.
+            catch (NullReferenceException)
+            {
+                return null;
+            }
             finally
             {
                 if (NetEventSource.IsEnabled) NetEventSource.Exit(this, "Authenticate");

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpNtlmAuthenticationModule.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpNtlmAuthenticationModule.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Security.Authentication.ExtendedProtection;
+using System.Security.Permissions;
+
+namespace System.Net.Mail
+{
+    internal class SmtpNtlmAuthenticationModule : ISmtpAuthenticationModule
+    {
+        private Dictionary<object, NTAuthentication> _sessions = new Dictionary<object, NTAuthentication>();
+
+        internal SmtpNtlmAuthenticationModule()
+        {
+        }
+
+        // Security this method will access NetworkCredential properties that demand UnmanagedCode and Environment Permission
+        [EnvironmentPermission(SecurityAction.Assert, Unrestricted = true)]
+        [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        public Authorization Authenticate(string challenge, NetworkCredential credential, object sessionCookie, string spn, ChannelBinding channelBindingToken)
+        {
+            NetEventSource.Enter(this, "Authenticate");
+            try
+            {
+                lock (_sessions)
+                {
+                    NTAuthentication clientContext;
+                    if (!_sessions.TryGetValue(sessionCookie, out clientContext))
+                    {
+                        if (credential == null)
+                        {
+                            return null;
+                        }
+
+                        _sessions[sessionCookie] =
+                            clientContext =
+                            new NTAuthentication(false, "Ntlm", credential, spn, ContextFlags.Connection, channelBindingToken);
+
+                    }
+
+                    string resp = clientContext.GetOutgoingBlob(challenge);
+
+                    if (!clientContext.IsCompleted)
+                    {
+                        return new Authorization(resp, false);
+                    }
+                    else
+                    {
+                        _sessions.Remove(sessionCookie);
+                        return new Authorization(resp, true);
+                    }
+                }
+            }
+            finally
+            {
+                NetEventSource.Exit(this, "Authenticate");
+            }
+        }
+
+        public string AuthenticationType
+        {
+            get
+            {
+                return "ntlm";
+            }
+        }
+
+        public void CloseContext(object sessionCookie)
+        {
+            // This is a no-op since the context is not
+            // kept open by this module beyond auth completion.
+        }
+    }
+}

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpNtlmAuthenticationModule.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpNtlmAuthenticationModule.cs
@@ -4,24 +4,20 @@
 
 using System.Collections.Generic;
 using System.Security.Authentication.ExtendedProtection;
-using System.Security.Permissions;
 
 namespace System.Net.Mail
 {
-    internal class SmtpNtlmAuthenticationModule : ISmtpAuthenticationModule
+    internal sealed class SmtpNtlmAuthenticationModule : ISmtpAuthenticationModule
     {
-        private Dictionary<object, NTAuthentication> _sessions = new Dictionary<object, NTAuthentication>();
+        private readonly Dictionary<object, NTAuthentication> _sessions = new Dictionary<object, NTAuthentication>();
 
         internal SmtpNtlmAuthenticationModule()
         {
         }
 
-        // Security this method will access NetworkCredential properties that demand UnmanagedCode and Environment Permission
-        [EnvironmentPermission(SecurityAction.Assert, Unrestricted = true)]
-        [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.UnmanagedCode)]
         public Authorization Authenticate(string challenge, NetworkCredential credential, object sessionCookie, string spn, ChannelBinding channelBindingToken)
         {
-            NetEventSource.Enter(this, "Authenticate");
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, "Authenticate");
             try
             {
                 lock (_sessions)
@@ -55,7 +51,7 @@ namespace System.Net.Mail
             }
             finally
             {
-                NetEventSource.Exit(this, "Authenticate");
+                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, "Authenticate");
             }
         }
 

--- a/src/System.Net.Mail/tests/Unit/NTAuthenticationStubTests.cs
+++ b/src/System.Net.Mail/tests/Unit/NTAuthenticationStubTests.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Net.Mail.Tests
+{
+    public class NTAuthenticationStubTests
+    {
+        [Fact]
+        [ActiveIssue(12535)]
+        public void TestReflectedTypes()
+        {
+            Assert.NotNull(NTAuthentication.s_type);
+            Assert.NotNull(NTAuthentication.s_ntAuthentication);
+            Assert.NotNull(NTAuthentication.s_getOutgoingBlogString);
+            Assert.NotNull(NTAuthentication.s_getOutgoingBlobBytes);
+            Assert.NotNull(NTAuthentication.s_verifySignature);
+            Assert.NotNull(NTAuthentication.s_makeSignature);
+            Assert.NotNull(NTAuthentication.s_closeContext);
+            Assert.NotNull(NTAuthentication.s_isCompleted);
+        }
+    }
+}

--- a/src/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
+++ b/src/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="MessageTests\MessageEncodeHeadersTest.cs" />
     <Compile Include="MessageTests\MessageHeaderBehaviorTest.cs" />
     <Compile Include="MessageTests\ReplyToListTest.cs" />
+    <Compile Include="NTAuthenticationStubTests.cs" />
     <Compile Include="QuotedPrintableStreamTest.cs" />
     <Compile Include="SmtpConnectionTests\EhloParseExtensionsTest.cs" />
     <Compile Include="SmtpDateTimeTest.cs" />

--- a/src/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
+++ b/src/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
@@ -55,6 +55,15 @@
     <Compile Include="..\..\src\System\Net\Mail\SmtpLoginAuthenticationModule.cs">
       <Link>ProductionCode\SmtpLoginAuthenticationModule.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Mail\SmtpNegotiateAuthenticationModule.cs">
+      <Link>ProductionCode\SmtpNegotiateAuthenticationModule.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Mail\NTAuthenticationStub.cs">
+      <Link>ProductionCode\NTAuthenticationStub.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Mail\SmtpNtlmAuthenticationModule.cs">
+      <Link>ProductionCode\SmtpNtlmAuthenticationModule.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Mail\MailAddressCollection.cs">
       <Link>ProductionCode\MailAddressCollection.cs</Link>
     </Compile>

--- a/src/System.Net.Mail/tests/Unit/project.json
+++ b/src/System.Net.Mail/tests/Unit/project.json
@@ -21,6 +21,7 @@
     "System.Text.Encoding": "4.4.0-beta-24703-01",
     "System.Security.Permissions": "4.4.0-beta-24703-01",
     "System.Net.Requests": "4.4.0-beta-24703-01",
+    "System.Net.Security": "4.4.0-beta-24703-01",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -335,6 +335,43 @@ namespace System.Net.Security
             return GssUnwrap(((SafeDeleteNegoContext)securityContext).GssContext, buffer, offset, count);
         }
 
+        internal static int VerifySignature(SafeDeleteContext securityContext, byte[] buffer, int offset, int count)
+        {
+            if (offset < 0 || offset > (buffer == null ? 0 : buffer.Length))
+            {
+                NetEventSource.Fail(securityContext, "Argument 'offset' out of range");
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+
+            if (count < 0 || count > (buffer == null ? 0 : buffer.Length - offset))
+            {
+                NetEventSource.Fail(securityContext, "Argument 'count' out of range.");
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            return GssUnwrap(((SafeDeleteNegoContext)securityContext).GssContext, buffer, offset, count);
+        }
+
+        internal static int MakeSignature(SafeDeleteContext securityContext, byte[] buffer, int offset, int count, ref byte[] output)
+        {
+            SafeDeleteNegoContext gssContext = (SafeDeleteNegoContext)securityContext;
+            byte[] tempOutput = GssWrap(gssContext.GssContext, false, buffer, offset, count);
+            // Create space for prefixing with the length
+            const int prefixLength = 4;
+            output = new byte[tempOutput.Length + prefixLength];
+            Array.Copy(tempOutput, 0, output, prefixLength, tempOutput.Length);
+            int resultSize = tempOutput.Length;
+            unchecked
+            {
+                output[0] = (byte)((resultSize) & 0xFF);
+                output[1] = (byte)(((resultSize) >> 8) & 0xFF);
+                output[2] = (byte)(((resultSize) >> 16) & 0xFF);
+                output[3] = (byte)(((resultSize) >> 24) & 0xFF);
+            }
+
+            return resultSize + 4;
+        }
+
         private static SecurityStatusPal EstablishSecurityContext(
           SafeFreeNegoCredentials credential,
           ref SafeDeleteContext context,

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Windows.cs
@@ -212,7 +212,7 @@ namespace System.Net.Security
             if (offset < 0 || offset > (buffer == null ? 0 : buffer.Length))
             {
                 NetEventSource.Info("Argument 'offset' out of range.");
-                throw new ArgumentOutOfRangeException("offset");
+                throw new ArgumentOutOfRangeException(nameof(offset));
             }
 
             // validate count within offset and end of buffer
@@ -220,7 +220,7 @@ namespace System.Net.Security
                 count > (buffer == null ? 0 : buffer.Length - offset))
             {
                 NetEventSource.Info("Argument 'count' out of range.");
-                throw new ArgumentOutOfRangeException("count");
+                throw new ArgumentOutOfRangeException(nameof(count));
             }
 
             // setup security buffers for ssp call

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Windows.cs
@@ -206,6 +206,88 @@ namespace System.Net.Security
             return new Win32Exception((int)SecurityStatusAdapterPal.GetInteropFromSecurityStatusPal(statusCode));
         }
 
+        internal static int VerifySignature(SafeDeleteContext securityContext, byte[] buffer, int offset, int count)
+        {
+            // validate offset within length
+            if (offset < 0 || offset > (buffer == null ? 0 : buffer.Length))
+            {
+                NetEventSource.Info("Argument 'offset' out of range.");
+                throw new ArgumentOutOfRangeException("offset");
+            }
+
+            // validate count within offset and end of buffer
+            if (count < 0 ||
+                count > (buffer == null ? 0 : buffer.Length - offset))
+            {
+                NetEventSource.Info("Argument 'count' out of range.");
+                throw new ArgumentOutOfRangeException("count");
+            }
+
+            // setup security buffers for ssp call
+            // one points at signed data
+            // two will receive payload if signature is valid
+            SecurityBuffer[] securityBuffer = new SecurityBuffer[2];
+            securityBuffer[0] = new SecurityBuffer(buffer, offset, count, SecurityBufferType.SECBUFFER_STREAM);
+            securityBuffer[1] = new SecurityBuffer(0, SecurityBufferType.SECBUFFER_DATA);
+
+            // call SSP function
+            int errorCode = SSPIWrapper.VerifySignature(
+                                GlobalSSPI.SSPIAuth,
+                                securityContext,
+                                securityBuffer,
+                                0);
+            // throw if error
+            if (errorCode != 0)
+            {
+                NetEventSource.Info($"VerifySignature threw error: {errorCode.ToString("x",NumberFormatInfo.InvariantInfo)}");
+                throw new Win32Exception(errorCode);
+            }
+
+            // not sure why this is here - retained from Encrypt code above
+            if (securityBuffer[1].type != SecurityBufferType.SECBUFFER_DATA)
+                throw new InternalException();
+
+            // return validated payload size 
+            return securityBuffer[1].size;
+        }
+
+        internal static int MakeSignature(SafeDeleteContext securityContext, byte[] buffer, int offset, int count, ref byte[] output)
+        {
+            SecPkgContext_Sizes sizes = SSPIWrapper.QueryContextAttributes(
+                GlobalSSPI.SSPIAuth,
+                securityContext,
+                Interop.SspiCli.ContextAttribute.SECPKG_ATTR_SIZES
+                ) as SecPkgContext_Sizes;
+
+            // alloc new output buffer if not supplied or too small
+            int resultSize = count + sizes.cbMaxSignature;
+            if (output == null || output.Length < resultSize)
+            {
+                output = new byte[resultSize];
+            }
+
+            // make a copy of user data for in-place encryption
+            Buffer.BlockCopy(buffer, offset, output, sizes.cbMaxSignature, count);
+
+            // setup security buffers for ssp call
+            SecurityBuffer[] securityBuffer = new SecurityBuffer[2];
+            securityBuffer[0] = new SecurityBuffer(output, 0, sizes.cbMaxSignature, SecurityBufferType.SECBUFFER_TOKEN);
+            securityBuffer[1] = new SecurityBuffer(output, sizes.cbMaxSignature, count, SecurityBufferType.SECBUFFER_DATA);
+
+            // call SSP Function
+            int errorCode = SSPIWrapper.MakeSignature(GlobalSSPI.SSPIAuth, securityContext, securityBuffer, 0);
+
+            // throw if error
+            if (errorCode != 0)
+            {
+                NetEventSource.Info($"MakeSignature threw error: {errorCode.ToString("x", NumberFormatInfo.InvariantInfo)}");
+                throw new Win32Exception(errorCode);
+            }
+
+            // return signed size
+            return securityBuffer[0].size + securityBuffer[1].size;
+        }
+
         internal static int Encrypt(
             SafeDeleteContext securityContext,
             byte[] buffer,


### PR DESCRIPTION
cc @davidsh @CIPop @ericeil @stephentoub @karelz 

fixes #12535 

- Tested the NTLM part
- [WIP] Testing GSSAPI.

Put up the PR for review, and but will merge once the the GSSAPI testing is done, especially the Linux codepaths of VerifySignature and MakeSignature on Client side needs to be tested. 

Please comment of any smtp servers with GSSAPI available, currently trying to configure Windows Server 2008 SMTP Server feature.