### PR TITLE
Add more serialization attribution

### DIFF
--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -192,6 +192,14 @@
     <Compile Include="System\Dynamic\UnaryOperationBinder.cs" />
     <Compile Include="System\Dynamic\IInvokeOnGetBinder.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.6'">
+    <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
+      <Link>Common\System\SerializableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\NonSerializedAttribute.cs">
+      <Link>Common\System\NonSerializedAttribute.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup Condition=" '$(IsInterpreting)' != 'true' And '$(TargetGroup)' != 'net463'">
     <Compile Include="$(CommonPath)\System\Collections\Generic\ReferenceEqualityComparer.cs">
       <Link>Common\System\Collections\Generic\ReferenceEqualityComparer.cs</Link>

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
@@ -12,6 +12,7 @@ namespace System.Runtime.CompilerServices
     /// Builder for read only collections.
     /// </summary>
     /// <typeparam name="T">The type of the collection element.</typeparam>
+    [Serializable]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
     public sealed class ReadOnlyCollectionBuilder<T> : IList<T>, System.Collections.IList
     {
@@ -21,6 +22,7 @@ namespace System.Runtime.CompilerServices
         private int _size;
         private int _version;
 
+        [NonSerialized]
         private Object _syncRoot;
 
         /// <summary>
@@ -498,6 +500,7 @@ namespace System.Runtime.CompilerServices
             throw new ArgumentException(Strings.InvalidObjectType(value != null ? value.GetType() : (object)"null", typeof(T)), argument);
         }
 
+        [Serializable]
         private class Enumerator : IEnumerator<T>, System.Collections.IEnumerator
         {
             private readonly ReadOnlyCollectionBuilder<T> _builder;

--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/KeyedCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/KeyedCollection.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 
 namespace System.Collections.ObjectModel
 {
+    [Serializable]
     [DebuggerTypeProxy(typeof(CollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
     public abstract class KeyedCollection<TKey, TItem> : Collection<TItem>

--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
@@ -14,6 +14,7 @@ namespace System.Collections.ObjectModel
     /// implementing INotifyCollectionChanged to notify listeners
     /// when items get added, removed or the whole list is refreshed.
     /// </summary>
+    [Serializable]
     [DebuggerTypeProxy(typeof(CollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
     public class ObservableCollection<T> : Collection<T>, INotifyCollectionChanged, INotifyPropertyChanged
@@ -120,6 +121,7 @@ namespace System.Collections.ObjectModel
         /// <remarks>
         /// see <seealso cref="INotifyCollectionChanged"/>
         /// </remarks>
+        [field: NonSerialized]
         public virtual event NotifyCollectionChangedEventHandler CollectionChanged;
 
         #endregion Public Events
@@ -219,6 +221,7 @@ namespace System.Collections.ObjectModel
         /// <summary>
         /// PropertyChanged event (per <see cref="INotifyPropertyChanged" />).
         /// </summary>
+        [field: NonSerialized]
         protected virtual event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>
@@ -347,6 +350,7 @@ namespace System.Collections.ObjectModel
 
         #region Private Types
 
+        [Serializable]
         private struct BlockReentrancyDisposable : IDisposable
         {
             private readonly ObservableCollection<T> _collection;

--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -10,13 +10,17 @@ using System.Diagnostics.Contracts;
 
 namespace System.Collections.ObjectModel
 {
+    [Serializable]
     [DebuggerTypeProxy(typeof(DictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
     public class ReadOnlyDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
     {
         private readonly IDictionary<TKey, TValue> _dictionary;
+        [NonSerialized]
         private Object _syncRoot;
+        [NonSerialized]
         private KeyCollection _keys;
+        [NonSerialized]
         private ValueCollection _values;
 
         public ReadOnlyDictionary(IDictionary<TKey, TValue> dictionary)
@@ -350,6 +354,7 @@ namespace System.Collections.ObjectModel
             }
         }
 
+        [Serializable]
         private struct DictionaryEnumerator : IDictionaryEnumerator
         {
             private readonly IDictionary<TKey, TValue> _dictionary;
@@ -414,11 +419,13 @@ namespace System.Collections.ObjectModel
 
         #endregion IReadOnlyDictionary members
 
+        [Serializable]
         [DebuggerTypeProxy(typeof(CollectionDebugView<>))]
         [DebuggerDisplay("Count = {Count}")]
         public sealed class KeyCollection : ICollection<TKey>, ICollection, IReadOnlyCollection<TKey>
         {
             private readonly ICollection<TKey> _collection;
+            [NonSerialized]
             private Object _syncRoot;
 
             internal KeyCollection(ICollection<TKey> collection)
@@ -521,11 +528,13 @@ namespace System.Collections.ObjectModel
             #endregion
         }
 
+        [Serializable]
         [DebuggerTypeProxy(typeof(CollectionDebugView<>))]
         [DebuggerDisplay("Count = {Count}")]
         public sealed class ValueCollection : ICollection<TValue>, ICollection, IReadOnlyCollection<TValue>
         {
             private readonly ICollection<TValue> _collection;
+            [NonSerialized]
             private Object _syncRoot;
 
             internal ValueCollection(ICollection<TValue> collection)

--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyObservableCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyObservableCollection.cs
@@ -15,6 +15,7 @@ namespace System.Collections.ObjectModel
     /// <summary>
     /// Read-only wrapper around an ObservableCollection.
     /// </summary>
+    [Serializable]
     [DebuggerTypeProxy(typeof(CollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
     public class ReadOnlyObservableCollection<T> : ReadOnlyCollection<T>, INotifyCollectionChanged, INotifyPropertyChanged
@@ -64,6 +65,7 @@ namespace System.Collections.ObjectModel
         /// <remarks>
         /// see <seealso cref="INotifyCollectionChanged"/>
         /// </remarks>
+        [field: NonSerialized]
         protected virtual event NotifyCollectionChangedEventHandler CollectionChanged;
 
         /// <summary>
@@ -96,6 +98,7 @@ namespace System.Collections.ObjectModel
         /// <remarks>
         /// see <seealso cref="INotifyPropertyChanged"/>
         /// </remarks>
+        [field: NonSerialized]
         protected virtual event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>

--- a/src/System.ObjectModel/tests/KeyedCollection/Serialization.netstandard1.7.cs
+++ b/src/System.ObjectModel/tests/KeyedCollection/Serialization.netstandard1.7.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.Serialization.Formatters.Tests;
+using Xunit;
+
+namespace System.Collections.ObjectModel.Tests
+{
+    public partial class KeyedCollection_Serialization
+    {
+        public static IEnumerable<object[]> SerializeDeserialize_Roundtrips_MemberData()
+        {
+            yield return new object[] { new TestCollection() };
+            yield return new object[] { new TestCollection() { "hello" } };
+            yield return new object[] { new TestCollection() { "hello", "world" } };
+        }
+
+        [ActiveIssue("https://github.com/dotnet/coreclr/pull/7966")]
+        [Theory]
+        [MemberData(nameof(SerializeDeserialize_Roundtrips_MemberData))]
+        public void SerializeDeserialize_Roundtrips(TestCollection c)
+        {
+            TestCollection clone = BinaryFormatterHelpers.Clone(c);
+            Assert.NotSame(c, clone);
+            Assert.Equal(c, clone);
+        }
+
+        [Serializable]
+        public sealed class TestCollection : KeyedCollection<string, string>
+        {
+            protected override string GetKeyForItem(string item) => item;
+        }
+    }
+}

--- a/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_Serialization.netstandard1.7.cs
+++ b/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_Serialization.netstandard1.7.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.Serialization.Formatters.Tests;
+using Xunit;
+
+namespace System.Collections.ObjectModel.Tests
+{
+    public partial class ObservableCollection_Serialization
+    {
+        public static IEnumerable<object[]> SerializeDeserialize_Roundtrips_MemberData()
+        {
+            yield return new object[] { new ObservableCollection<int>() };
+            yield return new object[] { new ObservableCollection<int>() { 42 } };
+            yield return new object[] { new ObservableCollection<int>() { 1, 5, 3, 4, 2 } };
+        }
+
+        [Theory]
+        [MemberData(nameof(SerializeDeserialize_Roundtrips_MemberData))]
+        public void SerializeDeserialize_Roundtrips(ObservableCollection<int> c)
+        {
+            ObservableCollection<int> clone = BinaryFormatterHelpers.Clone(c);
+            Assert.NotSame(c, clone);
+            Assert.Equal(c, clone);
+        }
+    }
+}

--- a/src/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionary_SerializationTests.netstandard1.7.cs
+++ b/src/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionary_SerializationTests.netstandard1.7.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.Serialization.Formatters.Tests;
+using Xunit;
+
+namespace System.Collections.ObjectModel.Tests
+{
+    public partial class ReadOnlyDictionary_Serialization
+    {
+        public static IEnumerable<object[]> SerializeDeserialize_Roundtrips_MemberData()
+        {
+            yield return new object[] { new ReadOnlyDictionary<string, string>(new Dictionary<string, string>()) };
+            yield return new object[] { new ReadOnlyDictionary<string, string>(new Dictionary<string, string>() { { "a", "b" } }) };
+            yield return new object[] { new ReadOnlyDictionary<string, string>(new Dictionary<string, string>() { { "a", "b" }, { "c", "d" } }) };
+        }
+
+        [Theory]
+        [MemberData(nameof(SerializeDeserialize_Roundtrips_MemberData))]
+        public void SerializeDeserialize_Roundtrips(ReadOnlyDictionary<string, string> d)
+        {
+            ReadOnlyDictionary<string, string> clone = BinaryFormatterHelpers.Clone(d);
+            Assert.NotSame(d, clone);
+            Assert.Equal(d, clone);
+
+            ReadOnlyDictionary<string, string>.KeyCollection keys = d.Keys;
+            ReadOnlyDictionary<string, string>.KeyCollection keysClone = BinaryFormatterHelpers.Clone(keys);
+            Assert.NotSame(keys, keysClone);
+            Assert.Equal(keys, keysClone);
+
+            ReadOnlyDictionary<string, string>.ValueCollection values = d.Values;
+            ReadOnlyDictionary<string, string>.ValueCollection valuesClone = BinaryFormatterHelpers.Clone(values);
+            Assert.NotSame(values, valuesClone);
+            Assert.Equal(values, valuesClone);
+        }
+    }
+}

--- a/src/System.ObjectModel/tests/ReadOnlyObservableCollection/ReadOnlyObservableCollection_SerializationTests.netstandard1.7.cs
+++ b/src/System.ObjectModel/tests/ReadOnlyObservableCollection/ReadOnlyObservableCollection_SerializationTests.netstandard1.7.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.Serialization.Formatters.Tests;
+using Xunit;
+
+namespace System.Collections.ObjectModel.Tests
+{
+    public partial class ReadOnlyObservableCollection_Serialization
+    {
+        public static IEnumerable<object[]> SerializeDeserialize_Roundtrips_MemberData()
+        {
+            yield return new object[] { new ReadOnlyObservableCollection<int>(new ObservableCollection<int>()) };
+            yield return new object[] { new ReadOnlyObservableCollection<int>(new ObservableCollection<int>() { 1 }) };
+            yield return new object[] { new ReadOnlyObservableCollection<int>(new ObservableCollection<int>() { 1, 2 }) };
+            yield return new object[] { new ReadOnlyObservableCollection<int>(new ObservableCollection<int>() { 1, 2, 3 }) };
+        }
+
+        [Theory]
+        [MemberData(nameof(SerializeDeserialize_Roundtrips_MemberData))]
+        public void SerializeDeserialize_Roundtrips(ReadOnlyObservableCollection<int> c)
+        {
+            ReadOnlyObservableCollection<int> clone = BinaryFormatterHelpers.Clone(c);
+            Assert.NotSame(c, clone);
+            Assert.Equal(c, clone);
+        }
+    }
+}

--- a/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -39,7 +39,6 @@
     <Compile Include="KeyedCollection\ConcreteTestClasses.cs" />
     <Compile Include="KeyedCollection\Utils.cs" />
     <Compile Include="ObservableCollection\ObservableCollection_ConstructorAndPropertyTests.cs" />
-    <Compile Include="ObservableCollection\ObservableCollection_ConstructorAndPropertyTests.netstandard1.7.cs" Condition="'$(TargetGroup)'==''" />
     <Compile Include="ObservableCollection\ObservableCollection_MethodsTest.cs" />
     <Compile Include="ObservableCollection\ObservableCollection_ReentrancyTests.cs" />
     <Compile Include="ReadOnlyDictionary\ReadOnlyDictionaryTests.cs" />
@@ -47,6 +46,16 @@
     <Compile Include="ReadOnlyObservableCollection\ReadOnlyObservableCollectionTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'==''">
+    <Compile Include="KeyedCollection\Serialization.netstandard1.7.cs" />
+    <Compile Include="ObservableCollection\ObservableCollection_ConstructorAndPropertyTests.netstandard1.7.cs" />
+    <Compile Include="ObservableCollection\ObservableCollection_Serialization.netstandard1.7.cs" />
+    <Compile Include="ReadOnlyDictionary\ReadOnlyDictionary_SerializationTests.netstandard1.7.cs" />
+    <Compile Include="ReadOnlyObservableCollection\ReadOnlyObservableCollection_SerializationTests.netstandard1.7.cs" />
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Runtime.Extensions/src/System/Context.cs
+++ b/src/System.Runtime.Extensions/src/System/Context.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization;
 
 namespace System
 {
+    [Serializable]
     public abstract class ContextBoundObject : System.MarshalByRefObject
     {
         protected ContextBoundObject() { }
@@ -35,6 +36,7 @@ namespace System
         }
     }
 
+    [Serializable]
     [AttributeUsage(AttributeTargets.Field, Inherited = false)]
     [System.Runtime.InteropServices.ComVisible(true)]
     public partial class ContextStaticAttribute : System.Attribute

--- a/src/System.Security.Principal/src/System/Security/Principal/TokenImpersonationLevel.cs
+++ b/src/System.Security.Principal/src/System/Security/Principal/TokenImpersonationLevel.cs
@@ -6,6 +6,7 @@ using System;
 
 namespace System.Security.Principal
 {
+    [Serializable]
     public enum TokenImpersonationLevel
     {
         None = 0,


### PR DESCRIPTION
My tool was incorrectly handling generic names and their default representation via reflection and Roslyn (it uses the former to determine what's serializable in desktop and the latter to determine what's serializable in corefx).  Fixing that revealed a few more types to be made serializable.  The tool also highlighted a few more types that were recently added to corefx that lacked proper attribution.

Fixes https://github.com/dotnet/corefx/issues/13283
cc: @danmosemsft, @shmao, @AlexGhiondea 