### PR TITLE
More aggressively clean up disposable resources in Http tests

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
@@ -34,8 +34,8 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         {
             var handler = new WinHttpHandler();
             using (var client = new HttpClient(handler))
+            using (HttpResponseMessage response = await client.GetAsync(Configuration.Http.SecureRemoteEchoServer))
             {
-                HttpResponseMessage response = await client.GetAsync(Configuration.Http.SecureRemoteEchoServer);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.False(_validationCallbackHistory.WasCalled);
             }
@@ -48,8 +48,8 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             var handler = new WinHttpHandler();
             handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
             using (var client = new HttpClient(handler))
+            using (HttpResponseMessage response = await client.GetAsync(Configuration.Http.RemoteEchoServer))
             {
-                HttpResponseMessage response = await client.GetAsync(Configuration.Http.RemoteEchoServer);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.False(_validationCallbackHistory.WasCalled);
             }
@@ -62,8 +62,8 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             var handler = new WinHttpHandler();
             handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
             using (var client = new HttpClient(handler))
+            using (HttpResponseMessage response = await client.GetAsync(Configuration.Http.SecureRemoteEchoServer))
             {
-                HttpResponseMessage response = await client.GetAsync(Configuration.Http.SecureRemoteEchoServer);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.True(_validationCallbackHistory.WasCalled);
                 
@@ -80,8 +80,8 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             var handler = new WinHttpHandler();
             handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
             using (var client = new HttpClient(handler))
+            using (HttpResponseMessage response = await client.GetAsync(uri))
             {
-                HttpResponseMessage response = await client.GetAsync(uri);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.True(_validationCallbackHistory.WasCalled);
                 

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/ClientCertificateScenarioTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/ClientCertificateScenarioTest.cs
@@ -38,14 +38,12 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         public void NonSecureRequest_AddNoCertificates_CertificateContextNotSet()
         {
             using (var handler = new WinHttpHandler())
+            using (HttpResponseMessage response = SendRequestHelper.Send(
+                handler,
+                () => { },
+                TestServer.FakeServerEndpoint))
             {
-                using (HttpResponseMessage response = SendRequestHelper.Send(
-                    handler,
-                    () => { },
-                    TestServer.FakeServerEndpoint))
-                {
-                    Assert.Equal(0, APICallHistory.WinHttpOptionClientCertContext.Count);
-                }
+                Assert.Equal(0, APICallHistory.WinHttpOptionClientCertContext.Count);
             }
         }
 
@@ -69,15 +67,13 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         public void SecureRequest_AddNoCertificates_NullCertificateContextSet()
         {
             using (var handler = new WinHttpHandler())
+            using (HttpResponseMessage response = SendRequestHelper.Send(
+                handler,
+                () => { },
+                TestServer.FakeSecureServerEndpoint))
             {
-                using (HttpResponseMessage response = SendRequestHelper.Send(
-                    handler,
-                    () => { },
-                    TestServer.FakeSecureServerEndpoint))
-                {
-                    Assert.Equal(1, APICallHistory.WinHttpOptionClientCertContext.Count);
-                    Assert.Equal(IntPtr.Zero, APICallHistory.WinHttpOptionClientCertContext[0]);
-                }
+                Assert.Equal(1, APICallHistory.WinHttpOptionClientCertContext.Count);
+                Assert.Equal(IntPtr.Zero, APICallHistory.WinHttpOptionClientCertContext[0]);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/DelegatingHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DelegatingHandlerTest.cs
@@ -58,14 +58,15 @@ namespace System.Net.Http.Functional.Tests
             var transport = new MockTransportHandler();
             handler.InnerHandler = transport;
 
-            HttpResponseMessage response = await handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None);
+            using (HttpResponseMessage response = await handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None))
+            {
+                Assert.NotNull(response);
+                Assert.Equal(1, handler.SendAsyncCount);
+                Assert.Equal(1, transport.SendAsyncCount);
 
-            Assert.NotNull(response);
-            Assert.Equal(1, handler.SendAsyncCount);
-            Assert.Equal(1, transport.SendAsyncCount);
-
-            Assert.Throws<InvalidOperationException>(() => handler.InnerHandler = transport);
-            Assert.Equal(transport, handler.InnerHandler);
+                Assert.Throws<InvalidOperationException>(() => handler.InnerHandler = transport);
+                Assert.Equal(transport, handler.InnerHandler);
+            }
         }
 
         [Fact]
@@ -77,12 +78,13 @@ namespace System.Net.Http.Functional.Tests
             handler.InnerHandler = transport1;
             handler.InnerHandler = transport2;
 
-            HttpResponseMessage response = await handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None);
-
-            Assert.NotNull(response);
-            Assert.Equal(1, handler.SendAsyncCount);
-            Assert.Equal(0, transport1.SendAsyncCount);
-            Assert.Equal(1, transport2.SendAsyncCount);
+            using (HttpResponseMessage response = await handler.TestSendAsync(new HttpRequestMessage(), CancellationToken.None))
+            {
+                Assert.NotNull(response);
+                Assert.Equal(1, handler.SendAsyncCount);
+                Assert.Equal(0, transport1.SendAsyncCount);
+                Assert.Equal(1, transport2.SendAsyncCount);
+            }
         }
 
         [Fact]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -55,7 +55,10 @@ namespace System.Net.Http.Functional.Tests
                 handler.DefaultProxyCredentials = wrongCreds;
 
                 Task<HttpResponseMessage> responseTask = client.GetAsync(Configuration.Http.RemoteEchoServer);
-                Task<string> responseStringTask = responseTask.ContinueWith(t => t.Result.Content.ReadAsStringAsync(), TaskScheduler.Default).Unwrap();
+                Task<string> responseStringTask = responseTask.ContinueWith(t =>
+                {
+                    using (t.Result) return t.Result.Content.ReadAsStringAsync();
+                }, TaskScheduler.Default).Unwrap();
                 Task.WaitAll(proxyTask, responseTask, responseStringTask);
 
                 TestHelper.VerifyResponseBody(responseStringTask.Result, responseTask.Result.Content.Headers.ContentMD5, false, null);
@@ -91,7 +94,10 @@ namespace System.Net.Http.Functional.Tests
                     handler.DefaultProxyCredentials = creds;
 
                     Task<HttpResponseMessage> responseTask = client.GetAsync(Configuration.Http.RemoteEchoServer);
-                    Task<string> responseStringTask = responseTask.ContinueWith(t => t.Result.Content.ReadAsStringAsync(), TaskScheduler.Default).Unwrap();
+                    Task<string> responseStringTask = responseTask.ContinueWith(t =>
+                    {
+                        using (t.Result) return t.Result.Content.ReadAsStringAsync();
+                    }, TaskScheduler.Default).Unwrap();
                     Task.WaitAll(responseTask, responseStringTask);
 
                     TestHelper.VerifyResponseBody(responseStringTask.Result, responseTask.Result.Content.Headers.ContentMD5, false, null);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -58,8 +58,10 @@ namespace System.Net.Http.Functional.Tests
                     Configuration.Http.SecureRemoteEchoServer,
                     new StringContent("This is a test"));
                 Task.WaitAll(proxyTask, responseTask);
-
-                Assert.Equal(HttpStatusCode.ProxyAuthenticationRequired, responseTask.Result.StatusCode);
+                using (responseTask.Result)
+                {
+                    Assert.Equal(HttpStatusCode.ProxyAuthenticationRequired, responseTask.Result.StatusCode);
+                }
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpMessageInvokerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpMessageInvokerTest.cs
@@ -22,18 +22,22 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public void SendAsync_Null_ThrowsArgumentNullException()
         {
-            var invoker = new HttpMessageInvoker(new MockHandler());
-            Assert.Throws<ArgumentNullException>(() => { Task t = invoker.SendAsync(null, CancellationToken.None); });
+            using (var invoker = new HttpMessageInvoker(new MockHandler()))
+            {
+                Assert.Throws<ArgumentNullException>(() => { Task t = invoker.SendAsync(null, CancellationToken.None); });
+            }
         }
 
         [Fact]
         public async Task SendAsync_Request_HandlerInvoked()
         {
             var handler = new MockHandler();
-            var invoker = new HttpMessageInvoker(handler);
-            HttpResponseMessage response = await invoker.SendAsync(new HttpRequestMessage(), CancellationToken.None);
-            Assert.NotNull(response);
-            Assert.Equal(1, handler.SendAsyncCount);
+            using (var invoker = new HttpMessageInvoker(handler))
+            using (HttpResponseMessage response = await invoker.SendAsync(new HttpRequestMessage(), CancellationToken.None))
+            {
+                Assert.NotNull(response);
+                Assert.Equal(1, handler.SendAsyncCount);
+            }
         }
         
         [Fact]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
@@ -17,25 +17,27 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public void Ctor_Default_CorrectDefaults()
         {
-            var rm = new HttpResponseMessage();
-            
-            Assert.Equal(HttpStatusCode.OK, rm.StatusCode);
-            Assert.Equal("OK", rm.ReasonPhrase);
-            Assert.Equal(new Version(1, 1), rm.Version);
-            Assert.Equal(null, rm.Content);
-            Assert.Equal(null, rm.RequestMessage);
+            using (var rm = new HttpResponseMessage())
+            {
+                Assert.Equal(HttpStatusCode.OK, rm.StatusCode);
+                Assert.Equal("OK", rm.ReasonPhrase);
+                Assert.Equal(new Version(1, 1), rm.Version);
+                Assert.Equal(null, rm.Content);
+                Assert.Equal(null, rm.RequestMessage);
+            }
         }
 
         [Fact]
         public void Ctor_SpecifiedValues_CorrectValues()
         {
-            var rm = new HttpResponseMessage(HttpStatusCode.Accepted);
-
-            Assert.Equal(HttpStatusCode.Accepted, rm.StatusCode);
-            Assert.Equal("Accepted", rm.ReasonPhrase);
-            Assert.Equal(new Version(1, 1), rm.Version);
-            Assert.Equal(null, rm.Content);
-            Assert.Equal(null, rm.RequestMessage);
+            using (var rm = new HttpResponseMessage(HttpStatusCode.Accepted))
+            {
+                Assert.Equal(HttpStatusCode.Accepted, rm.StatusCode);
+                Assert.Equal("Accepted", rm.ReasonPhrase);
+                Assert.Equal(new Version(1, 1), rm.Version);
+                Assert.Equal(null, rm.Content);
+                Assert.Equal(null, rm.RequestMessage);
+            }
         }
 
         [Fact]
@@ -50,197 +52,232 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public void Dispose_DisposeObject_ContentGetsDisposedAndSettersWillThrowButGettersStillWork()
         {
-            var rm = new HttpResponseMessage(HttpStatusCode.OK);
-            var content = new MockContent();
-            rm.Content = content;
-            Assert.False(content.IsDisposed);
+            using (var rm = new HttpResponseMessage(HttpStatusCode.OK))
+            {
+                var content = new MockContent();
+                rm.Content = content;
+                Assert.False(content.IsDisposed);
 
-            rm.Dispose();
-            rm.Dispose(); // Multiple calls don't throw.
+                rm.Dispose();
+                rm.Dispose(); // Multiple calls don't throw.
 
-            Assert.True(content.IsDisposed);
-            Assert.Throws<ObjectDisposedException>(() => { rm.StatusCode = HttpStatusCode.BadRequest; });
-            Assert.Throws<ObjectDisposedException>(() => { rm.ReasonPhrase = "Bad Request"; });
-            Assert.Throws<ObjectDisposedException>(() => { rm.Version = new Version(1, 0); });
-            Assert.Throws<ObjectDisposedException>(() => { rm.Content = null; });
+                Assert.True(content.IsDisposed);
+                Assert.Throws<ObjectDisposedException>(() => { rm.StatusCode = HttpStatusCode.BadRequest; });
+                Assert.Throws<ObjectDisposedException>(() => { rm.ReasonPhrase = "Bad Request"; });
+                Assert.Throws<ObjectDisposedException>(() => { rm.Version = new Version(1, 0); });
+                Assert.Throws<ObjectDisposedException>(() => { rm.Content = null; });
 
-            // Property getters should still work after disposing.
-            Assert.Equal(HttpStatusCode.OK, rm.StatusCode);
-            Assert.Equal("OK", rm.ReasonPhrase);
-            Assert.Equal(new Version(1, 1), rm.Version);
-            Assert.Equal(content, rm.Content);
+                // Property getters should still work after disposing.
+                Assert.Equal(HttpStatusCode.OK, rm.StatusCode);
+                Assert.Equal("OK", rm.ReasonPhrase);
+                Assert.Equal(new Version(1, 1), rm.Version);
+                Assert.Equal(content, rm.Content);
+            }
         }
 
         [Fact]
         public void Headers_ReadProperty_HeaderCollectionInitialized()
         {
-            var rm = new HttpResponseMessage();
-            Assert.NotNull(rm.Headers);
+            using (var rm = new HttpResponseMessage())
+            {
+                Assert.NotNull(rm.Headers);
+            }
         }
 
-        [Fact]
-        public void IsSuccessStatusCode_VariousStatusCodes_ReturnTrueFor2xxFalseOtherwise()
+        [Theory]
+        [InlineData(null, true)]
+        [InlineData(HttpStatusCode.OK, true)]
+        [InlineData(HttpStatusCode.PartialContent, true)]
+        [InlineData(HttpStatusCode.MultipleChoices, false)]
+        [InlineData(HttpStatusCode.Continue, false)]
+        [InlineData(HttpStatusCode.BadRequest, false)]
+        [InlineData(HttpStatusCode.BadGateway, false)]
+        public void IsSuccessStatusCode_VariousStatusCodes_ReturnTrueFor2xxFalseOtherwise(HttpStatusCode? status, bool expectedSuccess)
         {
-            Assert.True((new HttpResponseMessage()).IsSuccessStatusCode);
-            Assert.True((new HttpResponseMessage(HttpStatusCode.OK)).IsSuccessStatusCode);
-            Assert.True((new HttpResponseMessage(HttpStatusCode.PartialContent)).IsSuccessStatusCode);
-
-            Assert.False((new HttpResponseMessage(HttpStatusCode.MultipleChoices)).IsSuccessStatusCode);
-            Assert.False((new HttpResponseMessage(HttpStatusCode.Continue)).IsSuccessStatusCode);
-            Assert.False((new HttpResponseMessage(HttpStatusCode.BadRequest)).IsSuccessStatusCode);
-            Assert.False((new HttpResponseMessage(HttpStatusCode.BadGateway)).IsSuccessStatusCode);
+            using (var m = status.HasValue ? new HttpResponseMessage(status.Value) : new HttpResponseMessage())
+            {
+                Assert.Equal(expectedSuccess, m.IsSuccessStatusCode);
+            }
         }
 
         [Fact]
         public void EnsureSuccessStatusCode_VariousStatusCodes_ThrowIfNot2xx()
         {
-            Assert.Throws<HttpRequestException>(() =>
-                (new HttpResponseMessage(HttpStatusCode.MultipleChoices)).EnsureSuccessStatusCode());
-            Assert.Throws<HttpRequestException>(() =>
-                (new HttpResponseMessage(HttpStatusCode.BadGateway)).EnsureSuccessStatusCode());
+            using (var m = new HttpResponseMessage(HttpStatusCode.MultipleChoices))
+            {
+                Assert.Throws<HttpRequestException>(() => m.EnsureSuccessStatusCode());
+            }
 
-            var response = new HttpResponseMessage(HttpStatusCode.OK);
-            Assert.Same(response, response.EnsureSuccessStatusCode());
+            using (var m = new HttpResponseMessage(HttpStatusCode.BadGateway))
+            {
+                Assert.Throws<HttpRequestException>(() => m.EnsureSuccessStatusCode());
+            }
+
+            using (var response = new HttpResponseMessage(HttpStatusCode.OK))
+            {
+                Assert.Same(response, response.EnsureSuccessStatusCode());
+            }
         }
 
         [Fact]
         public void EnsureSuccessStatusCode_AddContentToMessage_ContentIsDisposed()
         {
-            var response404 = new HttpResponseMessage(HttpStatusCode.NotFound);
-            response404.Content = new MockContent();
-            Assert.Throws<HttpRequestException>(() => response404.EnsureSuccessStatusCode());
-            Assert.True((response404.Content as MockContent).IsDisposed);
+            using (var response404 = new HttpResponseMessage(HttpStatusCode.NotFound))
+            {
+                response404.Content = new MockContent();
+                Assert.Throws<HttpRequestException>(() => response404.EnsureSuccessStatusCode());
+                Assert.True((response404.Content as MockContent).IsDisposed);
+            }
 
-            var response200 = new HttpResponseMessage(HttpStatusCode.OK);
-            response200.Content = new MockContent();
-            response200.EnsureSuccessStatusCode(); // No exception.
-            Assert.False((response200.Content as MockContent).IsDisposed);
+            using (var response200 = new HttpResponseMessage(HttpStatusCode.OK))
+            {
+                response200.Content = new MockContent();
+                response200.EnsureSuccessStatusCode(); // No exception.
+                Assert.False((response200.Content as MockContent).IsDisposed);
+            }
         }
 
         [Fact]
         public void Properties_SetPropertiesAndGetTheirValue_MatchingValues()
         {
-            var rm = new HttpResponseMessage();
+            using (var rm = new HttpResponseMessage())
+            {
+                var content = new MockContent();
+                HttpStatusCode statusCode = HttpStatusCode.LengthRequired;
+                string reasonPhrase = "Length Required";
+                var version = new Version(1, 0);
+                var requestMessage = new HttpRequestMessage();
 
-            var content = new MockContent();
-            HttpStatusCode statusCode = HttpStatusCode.LengthRequired;
-            string reasonPhrase = "Length Required";
-            var version = new Version(1, 0);
-            var requestMessage = new HttpRequestMessage();
-            
-            rm.Content = content;
-            rm.ReasonPhrase = reasonPhrase;
-            rm.RequestMessage = requestMessage;
-            rm.StatusCode = statusCode;
-            rm.Version = version;
+                rm.Content = content;
+                rm.ReasonPhrase = reasonPhrase;
+                rm.RequestMessage = requestMessage;
+                rm.StatusCode = statusCode;
+                rm.Version = version;
 
-            Assert.Equal(content, rm.Content);
-            Assert.Equal(reasonPhrase, rm.ReasonPhrase);
-            Assert.Equal(requestMessage, rm.RequestMessage);
-            Assert.Equal(statusCode, rm.StatusCode);
-            Assert.Equal(version, rm.Version);
-            
-            Assert.NotNull(rm.Headers);
+                Assert.Equal(content, rm.Content);
+                Assert.Equal(reasonPhrase, rm.ReasonPhrase);
+                Assert.Equal(requestMessage, rm.RequestMessage);
+                Assert.Equal(statusCode, rm.StatusCode);
+                Assert.Equal(version, rm.Version);
+
+                Assert.NotNull(rm.Headers);
+            }
         }
 
         [Fact]
         public void Version_SetToNull_ThrowsArgumentNullException()
         {
-            var rm = new HttpResponseMessage();
-            Assert.Throws<ArgumentNullException>(() => { rm.Version = null; });
+            using (var rm = new HttpResponseMessage())
+            {
+                Assert.Throws<ArgumentNullException>(() => { rm.Version = null; });
+            }
         }
 
         [Fact]
         public void ReasonPhrase_ContainsCRChar_ThrowsFormatException()
         {
-            var rm = new HttpResponseMessage();
-            Assert.Throws<FormatException>(() => { rm.ReasonPhrase = "text\rtext"; });
+            using (var rm = new HttpResponseMessage())
+            {
+                Assert.Throws<FormatException>(() => { rm.ReasonPhrase = "text\rtext"; });
+            }
         }
 
         [Fact]
         public void ReasonPhrase_ContainsLFChar_ThrowsFormatException()
         {
-            var rm = new HttpResponseMessage();
-            Assert.Throws<FormatException>(() => { rm.ReasonPhrase = "text\ntext"; });
+            using (var rm = new HttpResponseMessage())
+            {
+                Assert.Throws<FormatException>(() => { rm.ReasonPhrase = "text\ntext"; });
+            }
         }
 
         [Fact]
         public void ReasonPhrase_SetToNull_Accepted()
         {
-            var rm = new HttpResponseMessage();
-            rm.ReasonPhrase = null;
-            Assert.Equal("OK", rm.ReasonPhrase); // Default provided.
+            using (var rm = new HttpResponseMessage())
+            {
+                rm.ReasonPhrase = null;
+                Assert.Equal("OK", rm.ReasonPhrase); // Default provided.
+            }
         }
 
         [Fact]
         public void ReasonPhrase_UnknownStatusCode_Null()
         {
-            var rm = new HttpResponseMessage();
-            rm.StatusCode = (HttpStatusCode)150; // Default reason unknown.
-            Assert.Null(rm.ReasonPhrase); // No default provided.
+            using (var rm = new HttpResponseMessage())
+            {
+                rm.StatusCode = (HttpStatusCode)150; // Default reason unknown.
+                Assert.Null(rm.ReasonPhrase); // No default provided.
+            }
         }
 
         [Fact]
         public void ReasonPhrase_SetToEmpty_Accepted()
         {
-            var rm = new HttpResponseMessage();
-            rm.ReasonPhrase = String.Empty;
-            Assert.Equal(String.Empty, rm.ReasonPhrase);
+            using (var rm = new HttpResponseMessage())
+            {
+                rm.ReasonPhrase = String.Empty;
+                Assert.Equal(String.Empty, rm.ReasonPhrase);
+            }
         }
 
         [Fact]
         public void Content_SetToNull_Accepted()
         {
-            var rm = new HttpResponseMessage();
-            rm.Content = null;
-            Assert.Null(rm.Content);
+            using (var rm = new HttpResponseMessage())
+            {
+                rm.Content = null;
+                Assert.Null(rm.Content);
+            }
         }
 
         [Fact]
         public void StatusCode_InvalidStatusCodeRange_ThrowsArgumentOutOfRangeException()
         {
-            var rm = new HttpResponseMessage();
-
-            int x = -1;
-            Assert.Throws<ArgumentOutOfRangeException>(() => { rm.StatusCode = (HttpStatusCode)x; });
-            x = 1000;
-            Assert.Throws<ArgumentOutOfRangeException>(() => { rm.StatusCode = (HttpStatusCode)x; });
+            using (var rm = new HttpResponseMessage())
+            {
+                int x = -1;
+                Assert.Throws<ArgumentOutOfRangeException>(() => { rm.StatusCode = (HttpStatusCode)x; });
+                x = 1000;
+                Assert.Throws<ArgumentOutOfRangeException>(() => { rm.StatusCode = (HttpStatusCode)x; });
+            }
         }
 
         [Fact]
         public void ToString_DefaultAndNonDefaultInstance_DumpAllFields()
         {
-            var rm = new HttpResponseMessage();
-            Assert.Equal("StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: <null>, Headers:\r\n{\r\n}",
-                rm.ToString());
+            using (var rm = new HttpResponseMessage())
+            {
+                Assert.Equal("StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: <null>, Headers:\r\n{\r\n}", rm.ToString());
 
-            rm.StatusCode = HttpStatusCode.BadRequest;
-            rm.ReasonPhrase = null;
-            rm.Version = new Version(1, 0);
-            rm.Content = new StringContent("content");
+                rm.StatusCode = HttpStatusCode.BadRequest;
+                rm.ReasonPhrase = null;
+                rm.Version = new Version(1, 0);
+                rm.Content = new StringContent("content");
 
-            // Note that there is no Content-Length header: The reason is that the value for Content-Length header
-            // doesn't get set by StringContent..ctor, but only if someone actually accesses the ContentLength property.
-            Assert.Equal(
-                "StatusCode: 400, ReasonPhrase: 'Bad Request', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:\r\n" +
-                "{\r\n" +
-                "  Content-Type: text/plain; charset=utf-8\r\n" +
-                "}", rm.ToString());
+                // Note that there is no Content-Length header: The reason is that the value for Content-Length header
+                // doesn't get set by StringContent..ctor, but only if someone actually accesses the ContentLength property.
+                Assert.Equal(
+                    "StatusCode: 400, ReasonPhrase: 'Bad Request', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:\r\n" +
+                    "{\r\n" +
+                    "  Content-Type: text/plain; charset=utf-8\r\n" +
+                    "}", rm.ToString());
 
-            rm.Headers.AcceptRanges.Add("bytes");
-            rm.Headers.AcceptRanges.Add("pages");
-            rm.Headers.Add("Custom-Response-Header", "value1");
-            rm.Content.Headers.Add("Custom-Content-Header", "value2");
+                rm.Headers.AcceptRanges.Add("bytes");
+                rm.Headers.AcceptRanges.Add("pages");
+                rm.Headers.Add("Custom-Response-Header", "value1");
+                rm.Content.Headers.Add("Custom-Content-Header", "value2");
 
-            Assert.Equal(
-                "StatusCode: 400, ReasonPhrase: 'Bad Request', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:\r\n" +
-                "{\r\n" +
-                "  Accept-Ranges: bytes\r\n" +
-                "  Accept-Ranges: pages\r\n" +
-                "  Custom-Response-Header: value1\r\n" +
-                "  Content-Type: text/plain; charset=utf-8\r\n" +
-                "  Custom-Content-Header: value2\r\n" +
-                "}", rm.ToString());
+                Assert.Equal(
+                    "StatusCode: 400, ReasonPhrase: 'Bad Request', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:\r\n" +
+                    "{\r\n" +
+                    "  Accept-Ranges: bytes\r\n" +
+                    "  Accept-Ranges: pages\r\n" +
+                    "  Custom-Response-Header: value1\r\n" +
+                    "  Content-Type: text/plain; charset=utf-8\r\n" +
+                    "  Custom-Content-Header: value2\r\n" +
+                    "}", rm.ToString());
+            }
         }
 
         #region Helper methods

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -217,8 +217,7 @@ namespace System.Net.Http.Functional.Tests
                 // Send HEAD request to help bypass the 401 auth challenge for the latter POST assuming
                 // that the authentication will be cached and re-used later when PreAuthenticate is true.
                 var request = new HttpRequestMessage(HttpMethod.Head, serverUri);
-                HttpResponseMessage response;
-                using (response = await client.SendAsync(request))
+                using (HttpResponseMessage response = await client.SendAsync(request))
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 }
@@ -229,7 +228,7 @@ namespace System.Net.Http.Functional.Tests
                 requestContent.Headers.ContentLength = null;
                 request.Headers.TransferEncodingChunked = true;
 
-                using (response = await client.PostAsync(serverUri, requestContent))
+                using (HttpResponseMessage response = await client.PostAsync(serverUri, requestContent))
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                     string responseContent = await response.Content.ReadAsStringAsync();

--- a/src/System.Net.Http/tests/UnitTests/Headers/AuthenticationHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/AuthenticationHeaderValueTest.cs
@@ -36,30 +36,32 @@ namespace System.Net.Http.Tests
         [Fact]
         public void ToString_UseBothNoParameterAndSetParameter_AllSerializedCorrectly()
         {
-            HttpResponseMessage response = new HttpResponseMessage();
-            string input = string.Empty;
+            using (HttpResponseMessage response = new HttpResponseMessage())
+            {
+                string input = string.Empty;
 
-            AuthenticationHeaderValue auth = new AuthenticationHeaderValue("Digest",
-                "qop=\"auth\",algorithm=MD5-sess,nonce=\"+Upgraded+v109e309640b\",charset=utf-8,realm=\"Digest\"");
+                AuthenticationHeaderValue auth = new AuthenticationHeaderValue("Digest",
+                    "qop=\"auth\",algorithm=MD5-sess,nonce=\"+Upgraded+v109e309640b\",charset=utf-8,realm=\"Digest\"");
 
-            Assert.Equal(
-                "Digest qop=\"auth\",algorithm=MD5-sess,nonce=\"+Upgraded+v109e309640b\",charset=utf-8,realm=\"Digest\"",
-                auth.ToString());
-            response.Headers.ProxyAuthenticate.Add(auth);
-            input += auth.ToString();
+                Assert.Equal(
+                    "Digest qop=\"auth\",algorithm=MD5-sess,nonce=\"+Upgraded+v109e309640b\",charset=utf-8,realm=\"Digest\"",
+                    auth.ToString());
+                response.Headers.ProxyAuthenticate.Add(auth);
+                input += auth.ToString();
 
-            auth = new AuthenticationHeaderValue("Negotiate");
-            Assert.Equal("Negotiate", auth.ToString());
-            response.Headers.ProxyAuthenticate.Add(auth);
-            input += ", " + auth.ToString();
+                auth = new AuthenticationHeaderValue("Negotiate");
+                Assert.Equal("Negotiate", auth.ToString());
+                response.Headers.ProxyAuthenticate.Add(auth);
+                input += ", " + auth.ToString();
 
-            auth = new AuthenticationHeaderValue("Custom", ""); // empty string should be treated like 'null'.
-            Assert.Equal("Custom", auth.ToString());
-            response.Headers.ProxyAuthenticate.Add(auth);
-            input += ", " + auth.ToString();
+                auth = new AuthenticationHeaderValue("Custom", ""); // empty string should be treated like 'null'.
+                Assert.Equal("Custom", auth.ToString());
+                response.Headers.ProxyAuthenticate.Add(auth);
+                input += ", " + auth.ToString();
 
-            string result = response.Headers.ProxyAuthenticate.ToString();
-            Assert.Equal(input, result);
+                string result = response.Headers.ProxyAuthenticate.ToString();
+                Assert.Equal(input, result);
+            }
         }
 
         [Fact]

--- a/src/System.Net.Http/tests/UnitTests/Headers/CurlResponseHeaderReaderTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/CurlResponseHeaderReaderTest.cs
@@ -63,10 +63,12 @@ namespace System.Net.Http.Tests
             fixed (byte* pBuffer = buffer)
             {
                 var reader = new CurlResponseHeaderReader(new IntPtr(pBuffer), checked((ulong)buffer.Length));
-                var response = new HttpResponseMessage();
-                Assert.True(reader.ReadStatusLine(response));
-                Assert.Equal(expectedCode, response.StatusCode);
-                Assert.Equal(expectedPhrase, response.ReasonPhrase);
+                using (var response = new HttpResponseMessage())
+                {
+                    Assert.True(reader.ReadStatusLine(response));
+                    Assert.Equal(expectedCode, response.StatusCode);
+                    Assert.Equal(expectedPhrase, response.ReasonPhrase);
+                }
             }
         }
 
@@ -78,8 +80,10 @@ namespace System.Net.Http.Tests
             fixed (byte* pBuffer = buffer)
             {
                 var reader = new CurlResponseHeaderReader(new IntPtr(pBuffer), checked((ulong)buffer.Length));
-                var response = new HttpResponseMessage();
-                Assert.Throws<HttpRequestException>(() => reader.ReadStatusLine(response));
+                using (var response = new HttpResponseMessage())
+                {
+                    Assert.Throws<HttpRequestException>(() => reader.ReadStatusLine(response));
+                }
             }
         }
 
@@ -91,18 +95,20 @@ namespace System.Net.Http.Tests
             fixed (byte* pBuffer = buffer)
             {
                 var reader = new CurlResponseHeaderReader(new IntPtr(pBuffer), checked((ulong)buffer.Length));
-                var response = new HttpResponseMessage();
-                Assert.True(reader.ReadStatusLine(response));
-                int expectedMajor = 0;
-                int expectedMinor = 0;
-                if (major == 1 && (minor == 0 || minor == 1))
+                using (var response = new HttpResponseMessage())
                 {
-                    expectedMajor = 1;
-                    expectedMinor = minor;
-                }
+                    Assert.True(reader.ReadStatusLine(response));
+                    int expectedMajor = 0;
+                    int expectedMinor = 0;
+                    if (major == 1 && (minor == 0 || minor == 1))
+                    {
+                        expectedMajor = 1;
+                        expectedMinor = minor;
+                    }
 
-                Assert.Equal(expectedMajor, response.Version.Major);
-                Assert.Equal(expectedMinor, response.Version.Minor);
+                    Assert.Equal(expectedMajor, response.Version.Major);
+                    Assert.Equal(expectedMinor, response.Version.Minor);
+                }
             }
         }
 

--- a/src/System.Net.Http/tests/UnitTests/Headers/HttpHeaderValueCollectionTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HttpHeaderValueCollectionTest.cs
@@ -860,29 +860,35 @@ namespace System.Net.Http.Tests
         [Fact]
         public void ToString_SingleValue_Success()
         {
-            HttpResponseMessage response = new HttpResponseMessage();
-            string input = "Basic";
-            response.Headers.Add(HttpKnownHeaderNames.WWWAuthenticate, input);
-            string result = response.Headers.WwwAuthenticate.ToString();
-            Assert.Equal(input, result);
+            using (var response = new HttpResponseMessage())
+            {
+                string input = "Basic";
+                response.Headers.Add(HttpKnownHeaderNames.WWWAuthenticate, input);
+                string result = response.Headers.WwwAuthenticate.ToString();
+                Assert.Equal(input, result);
+            }
         }
 
         [Fact]
         public void ToString_MultipleValue_Success()
         {
-            HttpResponseMessage response = new HttpResponseMessage();
-            string input = "Basic, NTLM, Negotiate, Custom";
-            response.Headers.Add(HttpKnownHeaderNames.WWWAuthenticate, input);
-            string result = response.Headers.WwwAuthenticate.ToString();
-            Assert.Equal(input, result);
+            using (var response = new HttpResponseMessage())
+            {
+                string input = "Basic, NTLM, Negotiate, Custom";
+                response.Headers.Add(HttpKnownHeaderNames.WWWAuthenticate, input);
+                string result = response.Headers.WwwAuthenticate.ToString();
+                Assert.Equal(input, result);
+            }
         }
 
         [Fact]
         public void ToString_EmptyValue_Success()
         {
-            HttpResponseMessage response = new HttpResponseMessage();
-            string result = response.Headers.WwwAuthenticate.ToString();
-            Assert.Equal(string.Empty, result);
+            using (var response = new HttpResponseMessage())
+            {
+                string result = response.Headers.WwwAuthenticate.ToString();
+                Assert.Equal(string.Empty, result);
+            }
         }
 
         #region Helper methods


### PR DESCRIPTION
Most of these likely don't matter, but some of these can be keeping alive the underlying connections associated with the HttpClient instance, and it's possible that can lead to more resource contention / exhaustion.

(This will be most easily reviewed with the ignore-whitespace view: https://github.com/dotnet/corefx/pull/13312/files?w=1)

cc: @davidsh, @ericeil