### PR TITLE
Eliminate SecBufferDesc allocations in System.Net.Security

### DIFF
--- a/src/Common/src/Interop/Windows/sspicli/Interop.SSPI.cs
+++ b/src/Common/src/Interop/Windows/sspicli/Interop.SSPI.cs
@@ -228,7 +228,7 @@ internal static partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe class SecBufferDesc
+        internal unsafe struct SecBufferDesc
         {
             public readonly int ulVersion;
             public readonly int cBuffers;
@@ -258,14 +258,14 @@ internal static partial class Interop
         internal static extern int EncryptMessage(
               ref CredHandle contextHandle,
               [In] uint qualityOfProtection,
-              [In, Out] SecBufferDesc inputOutput,
+              [In, Out] ref SecBufferDesc inputOutput,
               [In] uint sequenceNumber
               );
 
         [DllImport(Interop.Libraries.Sspi, ExactSpelling = true, SetLastError = true)]
         internal static unsafe extern int DecryptMessage(
               [In] ref CredHandle contextHandle,
-              [In, Out] SecBufferDesc inputOutput,
+              [In, Out] ref SecBufferDesc inputOutput,
               [In] uint sequenceNumber,
                    uint* qualityOfProtection
               );
@@ -293,11 +293,11 @@ internal static partial class Interop
         internal unsafe static extern int AcceptSecurityContext(
                   ref CredHandle credentialHandle,
                   [In] void* inContextPtr,
-                  [In] SecBufferDesc inputBuffer,
+                  [In] SecBufferDesc* inputBuffer,
                   [In] ContextFlags inFlags,
                   [In] Endianness endianness,
                   ref CredHandle outContextPtr,
-                  [In, Out] SecBufferDesc outputBuffer,
+                  [In, Out] ref SecBufferDesc outputBuffer,
                   [In, Out] ref ContextFlags attributes,
                   out long timeStamp
                   );
@@ -380,10 +380,10 @@ internal static partial class Interop
                   [In] ContextFlags inFlags,
                   [In] int reservedI,
                   [In] Endianness endianness,
-                  [In] SecBufferDesc inputBuffer,
+                  [In] SecBufferDesc* inputBuffer,
                   [In] int reservedII,
                   ref CredHandle outContextPtr,
-                  [In, Out] SecBufferDesc outputBuffer,
+                  [In, Out] ref SecBufferDesc outputBuffer,
                   [In, Out] ref ContextFlags attributes,
                   out long timeStamp
                   );
@@ -391,13 +391,13 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Sspi, ExactSpelling = true, SetLastError = true)]
         internal unsafe static extern int CompleteAuthToken(
                   [In] void* inContextPtr,
-                  [In, Out] SecBufferDesc inputBuffers
+                  [In, Out] ref SecBufferDesc inputBuffers
                   );
 
         [DllImport(Interop.Libraries.Sspi, ExactSpelling = true, SetLastError = true)]
         internal unsafe static extern int ApplyControlToken(
           [In] void* inContextPtr,
-          [In, Out] SecBufferDesc inputBuffers
+          [In, Out] ref SecBufferDesc inputBuffers
           );
 
         [DllImport(Interop.Libraries.Sspi, ExactSpelling = true, SetLastError = true)]

--- a/src/Common/src/Interop/Windows/sspicli/SSPIAuthType.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIAuthType.cs
@@ -72,14 +72,14 @@ namespace System.Net
             return SafeDeleteContext.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, endianness, null, inputBuffers, outputBuffer, ref outFlags);
         }
 
-        public int EncryptMessage(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
+        public int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
         {
             try
             {
                 bool ignore = false;
 
                 context.DangerousAddRef(ref ignore);
-                return Interop.SspiCli.EncryptMessage(ref context._handle, 0, inputOutput, sequenceNumber);
+                return Interop.SspiCli.EncryptMessage(ref context._handle, 0, ref inputOutput, sequenceNumber);
             }
             finally
             {
@@ -87,7 +87,7 @@ namespace System.Net
             }
         }
 
-        public unsafe int DecryptMessage(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
+        public unsafe int DecryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
         {
             int status = (int)Interop.SECURITY_STATUS.InvalidHandle;
             uint qop = 0;
@@ -96,7 +96,7 @@ namespace System.Net
             {
                 bool ignore = false;
                 context.DangerousAddRef(ref ignore);
-                status = Interop.SspiCli.DecryptMessage(ref context._handle, inputOutput, sequenceNumber, &qop);
+                status = Interop.SspiCli.DecryptMessage(ref context._handle, ref inputOutput, sequenceNumber, &qop);
             }
             finally
             {
@@ -112,7 +112,7 @@ namespace System.Net
             return status;
         }
 
-        public int MakeSignature(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
+        public int MakeSignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
         {
             try
             {
@@ -120,7 +120,7 @@ namespace System.Net
 
                 context.DangerousAddRef(ref ignore);
 
-                return Interop.SspiCli.EncryptMessage(ref context._handle, Interop.SspiCli.SECQOP_WRAP_NO_ENCRYPT, inputOutput, sequenceNumber);
+                return Interop.SspiCli.EncryptMessage(ref context._handle, Interop.SspiCli.SECQOP_WRAP_NO_ENCRYPT, ref inputOutput, sequenceNumber);
             }
             finally
             {
@@ -128,7 +128,7 @@ namespace System.Net
             }
         }
 
-        public unsafe int VerifySignature(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
+        public unsafe int VerifySignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
         {
             try
             {
@@ -136,7 +136,7 @@ namespace System.Net
                 uint qop = 0;
 
                 context.DangerousAddRef(ref ignore);
-                return Interop.SspiCli.DecryptMessage(ref context._handle, inputOutput, sequenceNumber, &qop);
+                return Interop.SspiCli.DecryptMessage(ref context._handle, ref inputOutput, sequenceNumber, &qop);
             }
             finally
             {

--- a/src/Common/src/Interop/Windows/sspicli/SSPIInterface.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIInterface.cs
@@ -20,10 +20,10 @@ namespace System.Net
         int AcceptSecurityContext(SafeFreeCredentials credential, ref SafeDeleteContext context, SecurityBuffer[] inputBuffers, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags);
         int InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags);
         int InitializeSecurityContext(SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags);
-        int EncryptMessage(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
-        int DecryptMessage(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
-        int MakeSignature(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
-        int VerifySignature(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
+        int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
+        int DecryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
+        int MakeSignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
+        int VerifySignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
 
         int QueryContextChannelBinding(SafeDeleteContext phContext, Interop.SspiCli.ContextAttribute attribute, out SafeFreeContextBufferChannelBinding refHandle);
         int QueryContextAttributes(SafeDeleteContext phContext, Interop.SspiCli.ContextAttribute attribute, byte[] buffer, Type handleType, out SafeHandle refHandle);

--- a/src/Common/src/Interop/Windows/sspicli/SSPISecureChannelType.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPISecureChannelType.cs
@@ -70,13 +70,13 @@ namespace System.Net
             return SafeDeleteContext.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, endianness, null, inputBuffers, outputBuffer, ref outFlags);
         }
 
-        public int EncryptMessage(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
+        public int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
         {
             try
             {
                 bool ignore = false;
                 context.DangerousAddRef(ref ignore);
-                return Interop.SspiCli.EncryptMessage(ref context._handle, 0, inputOutput, sequenceNumber);
+                return Interop.SspiCli.EncryptMessage(ref context._handle, 0, ref inputOutput, sequenceNumber);
             }
             finally
             {
@@ -84,14 +84,14 @@ namespace System.Net
             }
         }
 
-        public unsafe int DecryptMessage(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput,
+        public unsafe int DecryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput,
             uint sequenceNumber)
         {
             try
             {
                 bool ignore = false;
                 context.DangerousAddRef(ref ignore);
-                return Interop.SspiCli.DecryptMessage(ref context._handle, inputOutput, sequenceNumber, null);
+                return Interop.SspiCli.DecryptMessage(ref context._handle, ref inputOutput, sequenceNumber, null);
             }
             finally
             {
@@ -99,12 +99,12 @@ namespace System.Net
             }
         }
 
-        public int MakeSignature(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
+        public int MakeSignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
         {
             throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }
 
-        public int VerifySignature(SafeDeleteContext context, Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
+        public int VerifySignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
         {
             throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }

--- a/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
@@ -300,19 +300,19 @@ namespace System.Net
                     switch (op)
                     {
                         case OP.Encrypt:
-                            errorCode = secModule.EncryptMessage(context, sdcInOut, sequenceNumber);
+                            errorCode = secModule.EncryptMessage(context, ref sdcInOut, sequenceNumber);
                             break;
 
                         case OP.Decrypt:
-                            errorCode = secModule.DecryptMessage(context, sdcInOut, sequenceNumber);
+                            errorCode = secModule.DecryptMessage(context, ref sdcInOut, sequenceNumber);
                             break;
 
                         case OP.MakeSignature:
-                            errorCode = secModule.MakeSignature(context, sdcInOut, sequenceNumber);
+                            errorCode = secModule.MakeSignature(context, ref sdcInOut, sequenceNumber);
                             break;
 
                         case OP.VerifySignature:
-                            errorCode = secModule.VerifySignature(context, sdcInOut, sequenceNumber);
+                            errorCode = secModule.VerifySignature(context, ref sdcInOut, sequenceNumber);
                             break;
 
                         default:

--- a/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
@@ -520,14 +520,17 @@ namespace System.Net.Security
                 throw new ArgumentNullException(nameof(inCredentials));
             }
 
-            Interop.SspiCli.SecBufferDesc inSecurityBufferDescriptor = null;
+            Interop.SspiCli.SecBufferDesc inSecurityBufferDescriptor = default(Interop.SspiCli.SecBufferDesc);
+            bool haveInSecurityBufferDescriptor = false;
             if (inSecBuffer != null)
             {
                 inSecurityBufferDescriptor = new Interop.SspiCli.SecBufferDesc(1);
+                haveInSecurityBufferDescriptor = true;
             }
             else if (inSecBuffers != null)
             {
                 inSecurityBufferDescriptor = new Interop.SspiCli.SecBufferDesc(inSecBuffers.Length);
+                haveInSecurityBufferDescriptor = true;
             }
 
             Interop.SspiCli.SecBufferDesc outSecurityBufferDescriptor = new Interop.SspiCli.SecBufferDesc(1);
@@ -552,10 +555,10 @@ namespace System.Net.Security
             try
             {
                 pinnedOutBytes = GCHandle.Alloc(outSecBuffer.token, GCHandleType.Pinned);
-                Interop.SspiCli.SecBuffer[] inUnmanagedBuffer = new Interop.SspiCli.SecBuffer[inSecurityBufferDescriptor == null ? 1 : inSecurityBufferDescriptor.cBuffers];
+                Interop.SspiCli.SecBuffer[] inUnmanagedBuffer = new Interop.SspiCli.SecBuffer[haveInSecurityBufferDescriptor ? inSecurityBufferDescriptor.cBuffers : 1];
                 fixed (void* inUnmanagedBufferPtr = inUnmanagedBuffer)
                 {
-                    if (inSecurityBufferDescriptor != null)
+                    if (haveInSecurityBufferDescriptor)
                     {
                         // Fix Descriptor pointer that points to unmanaged SecurityBuffers.
                         inSecurityBufferDescriptor.pBuffers = inUnmanagedBufferPtr;
@@ -630,9 +633,9 @@ namespace System.Net.Security
                                             (byte*)(((object)targetName == (object)dummyStr) ? null : namePtr),
                                             inFlags,
                                             endianness,
-                                            inSecurityBufferDescriptor,
+                                            haveInSecurityBufferDescriptor ? &inSecurityBufferDescriptor : null,
                                             refContext,
-                                            outSecurityBufferDescriptor,
+                                            ref outSecurityBufferDescriptor,
                                             ref outFlags,
                                             outFreeContextBuffer);
                         }
@@ -691,9 +694,9 @@ namespace System.Net.Security
             byte* targetName,
             Interop.SspiCli.ContextFlags inFlags,
             Interop.SspiCli.Endianness endianness,
-            Interop.SspiCli.SecBufferDesc inputBuffer,
+            Interop.SspiCli.SecBufferDesc* inputBuffer,
             SafeDeleteContext outContext,
-            Interop.SspiCli.SecBufferDesc outputBuffer,
+            ref Interop.SspiCli.SecBufferDesc outputBuffer,
             ref Interop.SspiCli.ContextFlags attributes,
             SafeFreeContextBuffer handleTemplate)
         {
@@ -719,7 +722,7 @@ namespace System.Net.Security
                                 inputBuffer,
                                 0,
                                 ref outContext._handle,
-                                outputBuffer,
+                                ref outputBuffer,
                                 ref attributes,
                                 out timeStamp);
             }
@@ -808,14 +811,17 @@ namespace System.Net.Security
                 throw new ArgumentNullException(nameof(inCredentials));
             }
 
-            Interop.SspiCli.SecBufferDesc inSecurityBufferDescriptor = null;
+            Interop.SspiCli.SecBufferDesc inSecurityBufferDescriptor = default(Interop.SspiCli.SecBufferDesc);
+            bool haveInSecurityBufferDescriptor = false;
             if (inSecBuffer != null)
             {
                 inSecurityBufferDescriptor = new Interop.SspiCli.SecBufferDesc(1);
+                haveInSecurityBufferDescriptor = true;
             }
             else if (inSecBuffers != null)
             {
                 inSecurityBufferDescriptor = new Interop.SspiCli.SecBufferDesc(inSecBuffers.Length);
+                haveInSecurityBufferDescriptor = true;
             }
 
             Interop.SspiCli.SecBufferDesc outSecurityBufferDescriptor = new Interop.SspiCli.SecBufferDesc(1);
@@ -840,10 +846,10 @@ namespace System.Net.Security
             try
             {
                 pinnedOutBytes = GCHandle.Alloc(outSecBuffer.token, GCHandleType.Pinned);
-                var inUnmanagedBuffer = new Interop.SspiCli.SecBuffer[inSecurityBufferDescriptor == null ? 1 : inSecurityBufferDescriptor.cBuffers];
+                var inUnmanagedBuffer = new Interop.SspiCli.SecBuffer[haveInSecurityBufferDescriptor ? inSecurityBufferDescriptor.cBuffers : 1];
                 fixed (void* inUnmanagedBufferPtr = inUnmanagedBuffer)
                 {
-                    if (inSecurityBufferDescriptor != null)
+                    if (haveInSecurityBufferDescriptor)
                     {
                         // Fix Descriptor pointer that points to unmanaged SecurityBuffers.
                         inSecurityBufferDescriptor.pBuffers = inUnmanagedBufferPtr;
@@ -910,11 +916,11 @@ namespace System.Net.Security
                         errorCode = MustRunAcceptSecurityContext_SECURITY(
                                         ref inCredentials,
                                         contextHandle.IsZero ? null : &contextHandle,
-                                        inSecurityBufferDescriptor,
+                                        haveInSecurityBufferDescriptor ? &inSecurityBufferDescriptor : null,
                                         inFlags,
                                         endianness,
                                         refContext,
-                                        outSecurityBufferDescriptor,
+                                        ref outSecurityBufferDescriptor,
                                         ref outFlags,
                                         outFreeContextBuffer);
 
@@ -970,11 +976,11 @@ namespace System.Net.Security
         private static unsafe int MustRunAcceptSecurityContext_SECURITY(
             ref SafeFreeCredentials inCredentials,
             void* inContextPtr,
-            Interop.SspiCli.SecBufferDesc inputBuffer,
+            Interop.SspiCli.SecBufferDesc* inputBuffer,
             Interop.SspiCli.ContextFlags inFlags,
             Interop.SspiCli.Endianness endianness,
             SafeDeleteContext outContext,
-            Interop.SspiCli.SecBufferDesc outputBuffer,
+            ref Interop.SspiCli.SecBufferDesc outputBuffer,
             ref Interop.SspiCli.ContextFlags outFlags,
             SafeFreeContextBuffer handleTemplate)
         {
@@ -998,7 +1004,7 @@ namespace System.Net.Security
                                 inFlags,
                                 endianness,
                                 ref outContext._handle,
-                                outputBuffer,
+                                ref outputBuffer,
                                 ref outFlags,
                                 out timeStamp);
             }
@@ -1120,7 +1126,7 @@ namespace System.Net.Security
                     {
                         bool ignore = false;
                         refContext.DangerousAddRef(ref ignore);
-                        errorCode = Interop.SspiCli.CompleteAuthToken(contextHandle.IsZero ? null : &contextHandle, inSecurityBufferDescriptor);
+                        errorCode = Interop.SspiCli.CompleteAuthToken(contextHandle.IsZero ? null : &contextHandle, ref inSecurityBufferDescriptor);
                     }
                     finally
                     {
@@ -1223,7 +1229,7 @@ namespace System.Net.Security
                     {
                         bool ignore = false;
                         refContext.DangerousAddRef(ref ignore);
-                        errorCode = Interop.SspiCli.ApplyControlToken(contextHandle.IsZero ? null : &contextHandle, inSecurityBufferDescriptor);
+                        errorCode = Interop.SspiCli.ApplyControlToken(contextHandle.IsZero ? null : &contextHandle, ref inSecurityBufferDescriptor);
                     }
                     finally
                     {

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -178,7 +178,7 @@ namespace System.Net.Security
                 emptySecBuffer->cbBuffer = 0;
                 emptySecBuffer->pvBuffer = IntPtr.Zero;
 
-                int errorCode = GlobalSSPI.SSPISecureChannel.EncryptMessage(securityContext, sdcInOut, 0);
+                int errorCode = GlobalSSPI.SSPISecureChannel.EncryptMessage(securityContext, ref sdcInOut, 0);
 
                 if (errorCode != 0)
                 {
@@ -216,7 +216,7 @@ namespace System.Net.Security
                     emptyBuffer->cbBuffer = 0;
                 }
 
-                Interop.SECURITY_STATUS errorCode = (Interop.SECURITY_STATUS)GlobalSSPI.SSPISecureChannel.DecryptMessage(securityContext, sdcInOut, 0);
+                Interop.SECURITY_STATUS errorCode = (Interop.SECURITY_STATUS)GlobalSSPI.SSPISecureChannel.DecryptMessage(securityContext, ref sdcInOut, 0);
 
                 // Decrypt may repopulate the sec buffers, likely with header + data + trailer + empty.
                 // We need to find the data.


### PR DESCRIPTION
Each SSPI operation in System.Net.Security allocates a SecBufferDesc to pass down to native code.  This PR changes it from a class to a struct to avoid the heap allocation on each operation.  As the data is passed around, it's now passed by ref, except for the few code paths where we need to be able to pass null to the native code, in which case a ```SecBufferDesc*``` is used instead of a ```ref SecBufferDesc```.

Before (10K reads / 10K writes):
![image](https://cloud.githubusercontent.com/assets/2642209/19976678/2c3b53b2-a1c7-11e6-9a5b-232bfb5f4c54.png)

After (10K reads / 10K writes):
![image](https://cloud.githubusercontent.com/assets/2642209/19976664/1afff814-a1c7-11e6-871c-1a802669d2e3.png)

After this, the only remaining allocations per operations are the IAsyncResult and Task objects.

Fixes https://github.com/dotnet/corefx/issues/11826
cc: @davidsh, @ericeil, @geoffkizer, @benaadams, @davidfowl 