### PR TITLE
Fix TimeZoneInfo test

### DIFF
--- a/src/System.Runtime/tests/TimeZoneInfoTests.netstandard1.7.cs
+++ b/src/System.Runtime/tests/TimeZoneInfoTests.netstandard1.7.cs
@@ -143,16 +143,16 @@ namespace System.Tests
             // Test the ambiguous date
             DateTime utcAmbiguous = new DateTime(2016, 10, 30, 0, 14, 49, DateTimeKind.Utc);
             DateTime convertedAmbiguous = TimeZoneInfo.ConvertTimeFromUtc(utcAmbiguous, london);
-            Assert.Equal(convertedAmbiguous.Kind, DateTimeKind.Unspecified);
+            Assert.Equal(DateTimeKind.Unspecified, convertedAmbiguous.Kind);
             Assert.True(london.IsAmbiguousTime(convertedAmbiguous), $"Expected to have {convertedAmbiguous} is ambiguous");
 
             // convert to London time and back
             DateTime utc = DateTime.UtcNow;
             Assert.Equal(DateTimeKind.Utc, utc.Kind);
             DateTime converted = TimeZoneInfo.ConvertTimeFromUtc(utc, london);
-            Assert.Equal(converted.Kind, DateTimeKind.Unspecified);
+            Assert.Equal(DateTimeKind.Unspecified, converted.Kind);
             DateTime back = TimeZoneInfo.ConvertTimeToUtc(converted, london);
-            Assert.Equal(back.Kind, DateTimeKind.Utc);
+            Assert.Equal(DateTimeKind.Utc, back.Kind);
 
             if (london.IsAmbiguousTime(converted))
             {

--- a/src/System.Runtime/tests/TimeZoneInfoTests.netstandard1.7.cs
+++ b/src/System.Runtime/tests/TimeZoneInfoTests.netstandard1.7.cs
@@ -140,6 +140,12 @@ namespace System.Tests
             // Kind and source types don't match
             VerifyConvertToUtcException<ArgumentException>(new DateTime(2007, 5, 3, 12, 8, 0, DateTimeKind.Local), london);
 
+            // Test the ambiguous date
+            DateTime utcAmbiguous = new DateTime(2016, 10, 30, 0, 14, 49, DateTimeKind.Utc);
+            DateTime convertedAmbiguous = TimeZoneInfo.ConvertTimeFromUtc(utcAmbiguous, london);
+            Assert.Equal(convertedAmbiguous.Kind, DateTimeKind.Unspecified);
+            Assert.True(london.IsAmbiguousTime(convertedAmbiguous), $"Expected to have {convertedAmbiguous} is ambiguous");
+
             // convert to London time and back
             DateTime utc = DateTime.UtcNow;
             Assert.Equal(DateTimeKind.Utc, utc.Kind);
@@ -147,6 +153,14 @@ namespace System.Tests
             Assert.Equal(converted.Kind, DateTimeKind.Unspecified);
             DateTime back = TimeZoneInfo.ConvertTimeToUtc(converted, london);
             Assert.Equal(back.Kind, DateTimeKind.Utc);
+
+            if (london.IsAmbiguousTime(converted))
+            {
+                // if the time is ambiguous this will not round trip the original value because this ambiguous time can be mapped into
+                // 2 UTC times. usually we return the value with the DST delta added to it.
+                back = back.AddTicks(- london.GetAdjustmentRules()[0].DaylightDelta.Ticks);
+            }
+
             Assert.Equal(utc, back);
         }
 


### PR DESCRIPTION
The test is using UtcNow which can have the chance to run on time that is ambiguous in the used TZ
The fix is just handle such specific case