### PR TITLE
Disable on Framework TcpDefaultForAzureTest.AzureNoProtocolConnectionTest

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/TcpDefaultForAzureTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/TcpDefaultForAzureTest.cs
@@ -65,6 +65,7 @@ namespace System.Data.SqlClient.Tests
 
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void AzureNoProtocolConnectionTest()
         {
             foreach (string extension in AzureExtensions)


### PR DESCRIPTION
Fixes #13242 

Disabling the test System.Data.SqlClient.Tests.TcpDefaultForAzureTest.AzureNoProtocolConnectionTest on .Net framework.
The .Net framework doesn't have the feature yet.