### PR TITLE
Update pipeline.json with recent PipeBuild commits

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -217,14 +217,16 @@
       },
       "ReportingParameters": {
         "Type": "test/functional/cli",
-        "TargetQueue": {}
+        "TargetQueue": {},
+        "TargetTestCategory": {}        
       },
       "Definitions": [
         {
           "Name": "DotNet-CoreFx-Trusted-Windows-Build-Test",
           "Parameters": {
             "TargetQueue": "Windows.10.Amd64",
-            "TestContainerSuffix": "windows10"
+            "TestContainerSuffix": "windows10",
+            "TargetTestCategory": "Core Tests"
           },
           "ReportingParameters": {
             "TargetQueue": null,
@@ -247,6 +249,7 @@
           "Parameters": {
             "TargetQueue": "Windows.10.Amd64",
             "TestContainerSuffix": "windows10ilc",
+            "TargetTestCategory": "UWP ILC",            
             "FilterToTestTFM": "netcore50",
             "TestNugetRuntimeId": "win10-x64-aot",
             "UseDotNetNativeToolchain": "true",
@@ -262,6 +265,7 @@
           "Parameters": {
             "TargetQueue": "Windows.10.Amd64",
             "TestContainerSuffix": "windows10uwp",
+            "TargetTestCategory": "UWP",            
             "FilterToTestTFM": "netcore50",
             "TestNugetRuntimeId": "win10-x64",
             "EnableCloudTest": "true"
@@ -276,6 +280,7 @@
           "Parameters": {
             "TargetQueue": "Windows.10.Amd64",
             "TestContainerSuffix": "windows10desktop",
+            "TargetTestCategory": "Full Framework",
             "FilterToTestTFM": "net46",
             "TestNugetRuntimeId": "win10-x64",
             "EnableCloudTest": "true"
@@ -497,12 +502,18 @@
         "TargetsWindows": "true",
         "TestNugetRuntimeId": "win7-x64"
       },
+      "ReportingParameters": {
+        "Type": "test/functional/cli",
+        "TargetQueue": {},
+        "TargetTestCategory": {}
+      },      
       "Definitions": [
         {
           "Name": "DotNet-CoreFx-Trusted-Windows-Build-Test",
           "Parameters": {
             "TargetQueue": "Windows.10.Amd64",
-            "TestContainerSuffix": "windows10"
+            "TestContainerSuffix": "windows10",
+            "TargetTestCategory": "Core Tests"
           },
           "ReportingParameters": {
             "TargetQueue": null,
@@ -525,6 +536,7 @@
           "Parameters": {
             "TargetQueue": "Windows.10.Amd64",
             "TestContainerSuffix": "windows10ilc",
+            "TargetTestCategory": "UWP ILC",            
             "FilterToTestTFM": "netcore50",
             "TestNugetRuntimeId": "win10-x64-aot",
             "UseDotNetNativeToolchain": "true",
@@ -540,6 +552,7 @@
           "Parameters": {
             "TargetQueue": "Windows.10.Amd64",
             "TestContainerSuffix": "windows10uwp",
+            "TargetTestCategory": "UWP",            
             "FilterToTestTFM": "netcore50",
             "TestNugetRuntimeId": "win10-x64",
             "EnableCloudTest": "true"
@@ -554,6 +567,7 @@
           "Parameters": {
             "TargetQueue": "Windows.10.Amd64",
             "TestContainerSuffix": "windows10desktop",
+            "TargetTestCategory": "Full Framework",            
             "FilterToTestTFM": "net46",
             "TestNugetRuntimeId": "win10-x64",
             "EnableCloudTest": "true"

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -332,7 +332,7 @@
           "Name": "DotNet-Trusted-Tests-Publish",
           "Parameters": {
             "TestContainerSuffix": "windows10",
-            "TestTFM": "netcoreapp1.0"
+            "TestTFM": "netcoreapp1.1"
           },
           "ReportingParameters": {
             "Type": "build/publish/"

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -32,6 +32,15 @@
           }
         },
         {
+          "Name": "CoreFx-Linux-Product-Native-Trusted",
+          "Parameters": {
+            "DockerTag": "fedora24_prereqs_v4"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Fedora 24"
+          }
+        },        
+        {
           "Name": "DotNet-CoreFx-Trusted-Linux-Native",
           "Parameters": {
             "DockerTag": "opensuse132_prereqs_v4"
@@ -97,6 +106,15 @@
             "Type": "build/product/"
           }
         },
+        {
+          "Name": "CoreFx-Linux-Product-Native-Trusted",
+          "Parameters": {
+            "DockerTag": "alpine_prereqs"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Alpine 3.4.3"
+          }
+        },        
         {
           "Name": "DotNet-CoreFx-Trusted-Mac-Native",
           "ReportingParameters": {


### PR DESCRIPTION
There have been a few recent updates to pipeline.corefx.json which need to be ported to our checked in pipeline.json file for parity and to unblock our pipeline builds based off of checked in definitions.

PR 41428: Add native builds for Alpine 3.4.3
PR 41360: Add package build for Fedora 24
PR 41017: Adding reportParameter TargetTestCategory for CoreFx
Change TestTFM to netcoreapp1.1 for the archive step

@weshaggard 