### PR TITLE
Adding back GetTypeCode and DBNull uses in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -65,45 +65,7 @@ namespace System.Dynamic.Utils
             return (mi.IsConstructor) ? mi.DeclaringType : ((MethodInfo)mi).ReturnType;
         }
 
-        public static TypeCode GetTypeCode(this Type type)
-        {
-            if (type == null)
-                return TypeCode.Empty;
-            else if (type == typeof(bool))
-                return TypeCode.Boolean;
-            else if (type == typeof(char))
-                return TypeCode.Char;
-            else if (type == typeof(sbyte))
-                return TypeCode.SByte;
-            else if (type == typeof(byte))
-                return TypeCode.Byte;
-            else if (type == typeof(short))
-                return TypeCode.Int16;
-            else if (type == typeof(ushort))
-                return TypeCode.UInt16;
-            else if (type == typeof(int))
-                return TypeCode.Int32;
-            else if (type == typeof(uint))
-                return TypeCode.UInt32;
-            else if (type == typeof(long))
-                return TypeCode.Int64;
-            else if (type == typeof(ulong))
-                return TypeCode.UInt64;
-            else if (type == typeof(float))
-                return TypeCode.Single;
-            else if (type == typeof(double))
-                return TypeCode.Double;
-            else if (type == typeof(decimal))
-                return TypeCode.Decimal;
-            else if (type == typeof(DateTime))
-                return TypeCode.DateTime;
-            else if (type == typeof(string))
-                return TypeCode.String;
-            else if (type.GetTypeInfo().IsEnum)
-                return Enum.GetUnderlyingType(type).GetTypeCode();
-            else
-                return TypeCode.Object;
-        }
+        public static TypeCode GetTypeCode(this Type type) => Type.GetTypeCode(type);
 
         public static IEnumerable<MethodInfo> GetStaticMethods(this Type type)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -157,8 +157,8 @@ namespace System.Linq.Expressions.Interpreter
                     return default(float);
                 case TypeCode.Double:
                     return default(double);
-                //case TypeCode.DBNull: 
-                //    return default(DBNull); 
+                case TypeCode.DBNull: 
+                    return default(DBNull); 
                 case TypeCode.DateTime:
                     return default(DateTime);
                 case TypeCode.Decimal:


### PR DESCRIPTION
This fixes issue #11328 and reintroduces the use of `Type.GetTypeCode`. Also addressing commented out code for `DBNull`.

CC @stephentoub