### PR TITLE
Fix DummyTcpServer used in System.Net.Security tests

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/DummyTcpServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/DummyTcpServer.cs
@@ -109,14 +109,12 @@ namespace System.Net.Security.Tests
                 _log.WriteLine(
                     "Server disconnecting from client during authentication.  No shared SSL/TLS algorithm. ({0})",
                     authEx);
+                state.Dispose();
             }
             catch (Exception ex)
             {
                 _log.WriteLine("Server disconnecting from client during authentication.  Exception: {0}",
                     ex.Message);
-            }
-            finally
-            {
                 state.Dispose();
             }
         }


### PR DESCRIPTION
We've been seeing recurring failures in some of the System.Net.Security tests, with errors citing "This operation is only allowed using a successfully authenticated context."  It looks like this is a test bug, with the DummyTcpServer being used in the System.Net.Security tests disposing of the state for an operation before the test is actually done with it.

cc: @davidsh, @ericeil 
Fixes https://github.com/dotnet/corefx/issues/12939 (I hope)