### PR TITLE
Added Members of DataContractSerializer that are Missing.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -283,6 +283,11 @@ namespace System.Runtime.Serialization
             WriteEndObjectHandleExceptions(new XmlWriterDelegator(writer));
         }
 
+        public void WriteObject(XmlDictionaryWriter writer, object graph, DataContractResolver dataContractResolver)
+        {
+            WriteObjectHandleExceptions(new XmlWriterDelegator(writer), graph, dataContractResolver);
+        }
+
         public override object ReadObject(XmlReader reader)
         {
             return ReadObjectHandleExceptions(new XmlReaderDelegator(reader), true /*verifyObjectName*/);
@@ -306,6 +311,11 @@ namespace System.Runtime.Serialization
         public override bool IsStartObject(XmlDictionaryReader reader)
         {
             return IsStartObjectHandleExceptions(new XmlReaderDelegator(reader));
+        }
+
+        public object ReadObject(XmlDictionaryReader reader, bool verifyObjectName, DataContractResolver dataContractResolver)
+        {
+            return ReadObjectHandleExceptions(new XmlReaderDelegator(reader), verifyObjectName, dataContractResolver);
         }
 
         internal override void InternalWriteStartObject(XmlWriterDelegator writer, object graph)

--- a/src/System.Runtime.Serialization.Xml/ref/System.Runtime.Serialization.Xml.cs
+++ b/src/System.Runtime.Serialization.Xml/ref/System.Runtime.Serialization.Xml.cs
@@ -23,6 +23,7 @@ namespace System.Runtime.Serialization
         public DataContractSerializer(System.Type type, string rootName, string rootNamespace, System.Collections.Generic.IEnumerable<System.Type> knownTypes) { }
         public DataContractSerializer(System.Type type, System.Xml.XmlDictionaryString rootName, System.Xml.XmlDictionaryString rootNamespace) { }
         public DataContractSerializer(System.Type type, System.Xml.XmlDictionaryString rootName, System.Xml.XmlDictionaryString rootNamespace, System.Collections.Generic.IEnumerable<System.Type> knownTypes) { }
+        public System.Runtime.Serialization.DataContractResolver DataContractResolver { get { throw null; } }
         public bool IgnoreExtensionDataObject { get { throw null; } }
         public System.Collections.ObjectModel.ReadOnlyCollection<System.Type> KnownTypes { get { throw null; } }
         public int MaxItemsInObjectGraph { get { throw null; } }
@@ -31,10 +32,12 @@ namespace System.Runtime.Serialization
         public override bool IsStartObject(System.Xml.XmlDictionaryReader reader) { throw null; }
         public override bool IsStartObject(System.Xml.XmlReader reader) { throw null; }
         public override object ReadObject(System.Xml.XmlDictionaryReader reader, bool verifyObjectName) { throw null; }
+        public object ReadObject(System.Xml.XmlDictionaryReader reader, bool verifyObjectName, System.Runtime.Serialization.DataContractResolver dataContractResolver) { throw null; }
         public override object ReadObject(System.Xml.XmlReader reader) { throw null; }
         public override object ReadObject(System.Xml.XmlReader reader, bool verifyObjectName) { throw null; }
         public override void WriteEndObject(System.Xml.XmlDictionaryWriter writer) { }
         public override void WriteEndObject(System.Xml.XmlWriter writer) { }
+        public void WriteObject(System.Xml.XmlDictionaryWriter writer, object graph, System.Runtime.Serialization.DataContractResolver dataContractResolver) { }
         public override void WriteObject(System.Xml.XmlWriter writer, object graph) { }
         public override void WriteObjectContent(System.Xml.XmlDictionaryWriter writer, object graph) { }
         public override void WriteObjectContent(System.Xml.XmlWriter writer, object graph) { }


### PR DESCRIPTION
Some members of DataContractSerializer are in NetStandard2.0, but they are missing from NetCore. The PR added these members and added tests for them.

Fix #13268.

cc: @zhenlan @mconnew @huanwu 