### PR TITLE
Update EntryPointNotFoundException.#ctor parameter name

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -83,7 +83,7 @@ namespace System
     {
         public EntryPointNotFoundException() { }
         public EntryPointNotFoundException(string message) { }
-        public EntryPointNotFoundException(string message, Exception innerException) { }
+        public EntryPointNotFoundException(string message, Exception inner) { }
         protected EntryPointNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
 


### PR DESCRIPTION
Renamed innerException to inner:

```csharp
public class EntryPointNotFoundException : TypeLoadException {
      public EntryPointNotFoundException(string message, Exception inner);
}
```
Fixes #13176 

I just needed to update this parameter because what was left on the issue was already fixed on this [commit](https://github.com/dotnet/corefx/commit/81a39d4414ad873a2554b1aa42d0e976c5c3b59f).

cc @AlexGhiondea @joperezr @danmosemsft 