### PR TITLE
Adding Client hostname to Sql server connection

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
@@ -892,6 +892,10 @@ namespace System.Data.Common
             return result;
         }
 
+        static internal string MachineName() 
+        {
+            return Environment.MachineName;
+        }
 
         static internal string BuildQuotedString(string quotePrefix, string quoteSuffix, string unQuotedString)
         {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
@@ -521,7 +521,8 @@ namespace System.Data.SqlClient
                 // permission to obtain Environment.MachineName is Asserted
                 // since permission to open the connection has been granted
                 // the information is shared with the server, but not directly with the user
-                result = string.Empty;
+                result = ADP.MachineName();
+                ValidateValueLength(result, TdsEnums.MAXLEN_HOSTNAME, KEY.Workstation_Id);
             }
             return result;
         }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Data.SqlClient.ManualTesting.Tests
+{
+    public static class ConnectivityParametersTest
+    {
+        private const string COL_PROGRAM_NAME = "ProgramName";
+        private const string COL_HOSTNAME = "HostName";
+
+        [CheckConnStrSetupFact]
+        public static void EnvironmentHostNameTest()
+        {
+            SqlConnectionStringBuilder builder = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { Pooling = true });
+            builder.ApplicationName = "HostNameTest";
+
+            using (SqlConnection sqlConnection = new SqlConnection(builder.ConnectionString))
+            {
+                sqlConnection.Open();
+                using (SqlCommand command = new SqlCommand("sp_who2", sqlConnection))
+                {
+                    using (SqlDataReader reader = command.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            int programNameOrdinal = reader.GetOrdinal(COL_PROGRAM_NAME);
+                            string programName = reader.GetString(programNameOrdinal);
+                            
+                            if (programName != null && programName.Trim().Equals(builder.ApplicationName))
+                            {
+                                // Get the hostname
+                                int hostnameOrdinal = reader.GetOrdinal(COL_HOSTNAME);
+                                string hostnameFromServer = reader.GetString(hostnameOrdinal);
+                                string expectedMachineName = Environment.MachineName.ToUpper();
+                                string hostNameFromServer = hostnameFromServer.Trim().ToUpper();
+                                Assert.Matches(expectedMachineName, hostNameFromServer);
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+            Assert.True(false, "No non-empty hostname found for the application");
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
@@ -46,8 +46,9 @@
     <Compile Include="SQL\AsyncTest\AsyncTest.cs" />
     <Compile Include="SQL\CommandCancelTest\CommandCancelTest.cs" />
     <Compile Include="SQL\ConnectionPoolTest\ConnectionPoolTest.cs" />
-    <Compile Include="SQL\DataStreamTest\DataStreamTest.cs" />
+    <Compile Include="SQL\ConnectivityTests\ConnectivityTest.cs" />
     <Compile Include="SQL\ExceptionTest\ExceptionTest.cs" />
+    <Compile Include="SQL\DataStreamTest\DataStreamTest.cs" />
     <Compile Include="SQL\DateTimeTest\DateTimeTest.cs" />
     <Compile Include="SQL\InstanceNameTest\InstanceNameTest.cs" />
     <Compile Include="SQL\MARSSessionPoolingTest\MARSSessionPoolingTest.cs" />


### PR DESCRIPTION
While connecting to the Sql Server, the SqlClient was sending an empty hostname to the server. 
In this pull request we use using the Environment.MachineName to populate the hostname while connecting to SqlServer.

Fixes #12627 

cc @stephentoub @corivera 