### PR TITLE
Fix SslStream.WriteAsync with 0-byte write

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -424,7 +424,7 @@ namespace System.Net.Security
                     {
                         // If it's an empty message and the PAL doesn't support that,
                         // we're done.
-                        return;
+                        break;
                     }
 
                     // Request a write IO slot.

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -95,7 +95,7 @@ namespace System.Net.Security.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
-        public void SslStream_StreamToStream_Successive_ClientWrite_Sync_WithZeroBytes_Success()
+        public void SslStream_StreamToStream_Successive_ClientWrite_WithZeroBytes_Success()
         {
             byte[] recvBuf = new byte[_sampleMsg.Length];
             VirtualNetwork network = new VirtualNetwork();
@@ -110,6 +110,7 @@ namespace System.Net.Security.Tests
                 Assert.True(result, "Handshake completed.");
 
                 clientSslStream.Write(Array.Empty<byte>());
+                clientSslStream.WriteAsync(Array.Empty<byte>(), 0, 0).Wait();
                 clientSslStream.Write(_sampleMsg);
 
                 serverSslStream.Read(recvBuf, 0, _sampleMsg.Length);
@@ -117,6 +118,7 @@ namespace System.Net.Security.Tests
                 Assert.True(VerifyOutput(recvBuf, _sampleMsg), "verify first read data is as expected.");
 
                 clientSslStream.Write(_sampleMsg);
+                clientSslStream.WriteAsync(Array.Empty<byte>(), 0, 0).Wait();
                 clientSslStream.Write(Array.Empty<byte>());
 
                 serverSslStream.Read(recvBuf, 0, _sampleMsg.Length);


### PR DESCRIPTION
A previous fix (https://github.com/dotnet/corefx/pull/13083) added an early exit when 0-byte writes aren't supported by the underlying SSL implementation.  But in doing so, WriteAsync(..., 0) ends up returning a Task that never completes (due to the IAsyncResult never completing).

cc: @bartonjs, @davidsh, @cipop
Fixes https://github.com/dotnet/corefx/issues/13369