### PR TITLE
Fix BufferedStream.FlushAsync bug where the incorrect property was checked

### DIFF
--- a/src/System.IO/tests/BufferedStream/BufferedStream.FlushTests.cs
+++ b/src/System.IO/tests/BufferedStream/BufferedStream.FlushTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Tests
@@ -10,18 +11,19 @@ namespace System.IO.Tests
     public class BufferedStreamFlushTests
     {
         [Fact]
-        public async void ShouldNotFlushUnderlyingStreamIfReadOnly()
+        public async Task ShouldNotFlushUnderlyingStreamIfReadOnly()
         {
             var underlying = new DelegateStream(
                 // These properties are necessary for the codepath in question to be hit.
                 canReadFunc: () => true,
                 canWriteFunc: () => false,
                 canSeekFunc: () => true,
-                readFunc: (buffer, offset, count) => 123,
-                writeFunc: (buffer, offset, count) =>
+                readFunc: (_, __, ___) => 123,
+                writeFunc: (_, __, ___) =>
                 {
                     throw new NotSupportedException();
-                }
+                },
+                seekFunc: (_, __) => 123L
             );
             // These properties are necessary for the codepath in question to be hit.
             Debug.Assert(underlying.CanRead && !underlying.CanWrite && underlying.CanSeek);
@@ -36,6 +38,41 @@ namespace System.IO.Tests
 
             await buffered.FlushAsync();
             Assert.Equal(0, wrapper.TimesCalled(nameof(wrapper.FlushAsync)));
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task ShouldAlwaysFlushUnderlyingStreamIfWritable(bool underlyingCanRead, bool underlyingCanSeek)
+        {
+            var underlying = new DelegateStream(
+                canReadFunc: () => underlyingCanRead,
+                canWriteFunc: () => true,
+                canSeekFunc: () => underlyingCanSeek,
+                readFunc: (_, __, ___) => 123,
+                writeFunc: (_, __, ___) => { },
+                seekFunc: (_, __) => 123L
+            );
+
+            var wrapper = new CallTrackingStream(underlying);
+
+            var buffered = new BufferedStream(wrapper);
+            
+            buffered.Flush();
+            Assert.Equal(1, wrapper.TimesCalled(nameof(wrapper.Flush)));
+
+            await buffered.FlushAsync();
+            Assert.Equal(1, wrapper.TimesCalled(nameof(wrapper.FlushAsync)));
+
+            buffered.WriteByte(0);
+            
+            buffered.Flush();
+            Assert.Equal(2, wrapper.TimesCalled(nameof(wrapper.Flush)));
+
+            await buffered.FlushAsync();
+            Assert.Equal(2, wrapper.TimesCalled(nameof(wrapper.FlushAsync)));
         }
     }
 }

--- a/src/System.IO/tests/BufferedStream/BufferedStream.FlushTests.cs
+++ b/src/System.IO/tests/BufferedStream/BufferedStream.FlushTests.cs
@@ -10,14 +10,15 @@ namespace System.IO.Tests
 {
     public class BufferedStreamFlushTests
     {
-        [Fact]
-        public async Task ShouldNotFlushUnderlyingStreamIfReadOnly()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ShouldNotFlushUnderlyingStreamIfReadOnly(bool underlyingCanSeek)
         {
             var underlying = new DelegateStream(
-                // These properties are necessary for the codepath in question to be hit.
                 canReadFunc: () => true,
                 canWriteFunc: () => false,
-                canSeekFunc: () => true,
+                canSeekFunc: () => underlyingCanSeek,
                 readFunc: (_, __, ___) => 123,
                 writeFunc: (_, __, ___) =>
                 {
@@ -25,8 +26,6 @@ namespace System.IO.Tests
                 },
                 seekFunc: (_, __) => 123L
             );
-            // These properties are necessary for the codepath in question to be hit.
-            Debug.Assert(underlying.CanRead && !underlying.CanWrite && underlying.CanSeek);
 
             var wrapper = new CallTrackingStream(underlying);
 

--- a/src/System.IO/tests/BufferedStream/BufferedStream.FlushTests.cs
+++ b/src/System.IO/tests/BufferedStream/BufferedStream.FlushTests.cs
@@ -9,7 +9,7 @@ namespace System.IO.Tests
 {
     public class BufferedStreamFlushTests
     {
-        [Theory]
+        [Fact]
         public async void ShouldNotFlushUnderlyingStreamIfReadOnly()
         {
             var underlying = new DelegateStream(

--- a/src/System.IO/tests/BufferedStream/BufferedStream.FlushTests.cs
+++ b/src/System.IO/tests/BufferedStream/BufferedStream.FlushTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class BufferedStreamFlushTests
+    {
+        [Theory]
+        public async void ShouldNotFlushUnderlyingStreamIfReadOnly()
+        {
+            var underlying = new DelegateStream(
+                // These properties are necessary for the codepath in question to be hit.
+                canReadFunc: () => true,
+                canWriteFunc: () => false,
+                canSeekFunc: () => true,
+                readFunc: (buffer, offset, count) => 123,
+                writeFunc: (buffer, offset, count) =>
+                {
+                    throw new NotSupportedException();
+                }
+            );
+            // These properties are necessary for the codepath in question to be hit.
+            Debug.Assert(underlying.CanRead && !underlying.CanWrite && underlying.CanSeek);
+
+            var wrapper = new CallTrackingStream(underlying);
+
+            var buffered = new BufferedStream(wrapper);
+            buffered.ReadByte();
+
+            buffered.Flush();
+            Assert.Equal(0, wrapper.TimesCalled(nameof(wrapper.Flush)));
+
+            await buffered.FlushAsync();
+            Assert.Equal(0, wrapper.TimesCalled(nameof(wrapper.FlushAsync)));
+        }
+    }
+}

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -30,6 +30,7 @@
     <Compile Include="BinaryWriter\BinaryWriter.WriteByteCharTests.cs" />
     <Compile Include="BinaryWriter\BinaryWriter.WriteTests.cs" />
     <Compile Include="BinaryWriter\BinaryWriterTests.cs" />
+    <Compile Include="BufferedStream\BufferedStream.FlushTests.cs" />
     <Compile Include="BufferedStream\BufferedStream.InvalidParameters.cs" />
     <Compile Include="BufferedStream\BufferedStreamTests.cs" />
     <Compile Include="BufferedStream\BufferedStreamTests.netcoreapp1.1.cs" Condition="'$(TargetGroup)' == 'netcoreapp1.1'" />

--- a/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
@@ -285,7 +285,8 @@ namespace System.IO
                 if (_stream.CanWrite)
                     _stream.Flush();
 
-                Debug.Assert(_writePos == 0 && _readPos == 0 && _readLen == 0);
+                // If the Stream was seekable, then we should have called FlushRead which resets _readPos & _readLen.
+                Debug.Assert(_writePos == 0 && (!_stream.CanSeek || (_readPos == 0 && _readLen == 0)));
                 return;
             }
 
@@ -337,7 +338,8 @@ namespace System.IO
                     if (_stream.CanWrite)
                         await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-                    Debug.Assert(_writePos == 0 && _readPos == 0 && _readLen == 0);
+                    // If the Stream was seekable, then we should have called FlushRead which resets _readPos & _readLen.
+                    Debug.Assert(_writePos == 0 && (!_stream.CanSeek || (_readPos == 0 && _readLen == 0)));
                     return;
                 }
 

--- a/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
@@ -274,10 +274,10 @@ namespace System.IO
                 // If the underlying stream is not seekable AND we have something in the read buffer, then FlushRead would throw.
                 // We can either throw away the buffer resulting in data loss (!) or ignore the Flush.
                 // (We cannot throw because it would be a breaking change.) We opt into ignoring the Flush in that situation.
-                if (!_stream.CanSeek)
-                    return;
-
-                FlushRead();
+                if (_stream.CanSeek)
+                {
+                    FlushRead();
+                }
 
                 // User streams may have opted to throw from Flush if CanWrite is false (although the abstract Stream does not do so).
                 // However, if we do not forward the Flush to the underlying stream, we may have problems when chaining several streams.
@@ -326,10 +326,10 @@ namespace System.IO
                     // If the underlying stream is not seekable AND we have something in the read buffer, then FlushRead would throw.
                     // We can either throw away the buffer resulting in date loss (!) or ignore the Flush. (We cannot throw because it
                     // would be a breaking change.) We opt into ignoring the Flush in that situation.
-                    if (!_stream.CanSeek)
-                        return;
-
-                    FlushRead();  // not async; it uses Seek, but there's no SeekAsync
+                    if (_stream.CanSeek)
+                    {
+                        FlushRead();  // not async; it uses Seek, but there's no SeekAsync
+                    }
 
                     // User streams may have opted to throw from Flush if CanWrite is false (although the abstract Stream does not do so).
                     // However, if we do not forward the Flush to the underlying stream, we may have problems when chaining several streams.

--- a/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
@@ -334,7 +334,7 @@ namespace System.IO
                     // User streams may have opted to throw from Flush if CanWrite is false (although the abstract Stream does not do so).
                     // However, if we do not forward the Flush to the underlying stream, we may have problems when chaining several streams.
                     // Let us make a best effort attempt:
-                    if (_stream.CanRead)
+                    if (_stream.CanWrite)
                         await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
                     Debug.Assert(_writePos == 0 && _readPos == 0 && _readLen == 0);


### PR DESCRIPTION
See #13297 for more details.

Fixes #13297

@ianhays, @JeremyKuhne, @stephentoub 