### PR TITLE
Disable sockets perf tests on OSX

### DIFF
--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -20,6 +20,7 @@ namespace System.Net.Sockets.Performance.Tests
             _log = TestLogging.GetInstance();
         }
 
+        [ActiveIssue(13349, TestPlatforms.OSX)]
         [OuterLoop]
         [Fact]
         public void SocketPerformance_SingleSocketClientAsync_LocalHostServerAsync()
@@ -41,6 +42,7 @@ namespace System.Net.Sockets.Performance.Tests
                 socket_instances);
         }
 
+        [ActiveIssue(13349, TestPlatforms.OSX)]
         [OuterLoop]
         [Fact]
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync()


### PR DESCRIPTION
We're getting unhandled ObjectDisposedExceptions on most runs.
https://github.com/dotnet/corefx/issues/13349