### PR TITLE
Fix BufferedStream.CopyToAsync flushing

### DIFF
--- a/src/System.IO/tests/BufferedStream/BufferedStreamTests.cs
+++ b/src/System.IO/tests/BufferedStream/BufferedStreamTests.cs
@@ -76,6 +76,30 @@ namespace System.IO.Tests
 
             Assert.Equal(data, dst.ToArray());
         }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task CopyToAsyncTest_ReadBeforeCopy_CopiesAllData(bool wrappedStreamCanSeek)
+        {
+            byte[] data = Enumerable.Range(0, 1000).Select(i => (byte)(i % 256)).ToArray();
+
+            var wrapped = new ManuallyReleaseAsyncOperationsStream();
+            wrapped.Release();
+            wrapped.Write(data, 0, data.Length);
+            wrapped.Position = 0;
+            wrapped.SetCanSeek(wrappedStreamCanSeek);
+            var src = new BufferedStream(wrapped, 100);
+
+            src.ReadByte();
+
+            var dst = new MemoryStream();
+            await src.CopyToAsync(dst);
+
+            var expected = new byte[data.Length - 1];
+            Array.Copy(data, 1, expected, 0, expected.Length);
+            Assert.Equal(expected, dst.ToArray());
+        }
     }
 
     public class BufferedStream_StreamMethods : StreamMethods
@@ -210,6 +234,11 @@ namespace System.IO.Tests
     internal sealed class ManuallyReleaseAsyncOperationsStream : MemoryStream
     {
         private readonly TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool _canSeek = true;
+
+        public override bool CanSeek => _canSeek;
+
+        public void SetCanSeek(bool canSeek) => _canSeek = canSeek;
 
         public void Release() { _tcs.SetResult(true); }
 


### PR DESCRIPTION
We recently added an override of CopyToAsync to BufferedStream; it flushes data from the buffer and then hands off to the source stream to copy directly to the destination.  But the flushing support was flawed: a) we don't actually want to flush read data back to the source stream, instead wanting to instead write any read data to the destination stream, and b) even if we did, that fails for non-seekable source stream.

The fix is to handle the "flushing" directly.  If there's any read data in the buffer, we need to write that data to the destination.  If there's any write data in the buffer, we need to flush that to the source.   And then we can do the copy.  We also need to follow the same locking scheme used elsewhere, and protect the whole operation with the stream's semaphore.

cc: @ianhays, @jamesqo