### PR TITLE
Use std::nothrow with new operator in native shims

### DIFF
--- a/src/Native/Unix/System.Native/pal_interfaceaddresses.cpp
+++ b/src/Native/Unix/System.Native/pal_interfaceaddresses.cpp
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <assert.h>
 #include <ifaddrs.h>
+#include <memory>
 #include <net/if.h>
 #include <netinet/in.h>
 #include <string.h>
@@ -151,12 +152,22 @@ extern "C" int32_t SystemNative_EnumerateGatewayAddressesForInterface(uint32_t i
         return -1;
     }
 
-    uint8_t* buffer = new uint8_t[byteCount];
+    uint8_t* buffer = new (std::nothrow) uint8_t[byteCount];
+    if (buffer == nullptr)
+    {
+        errno = ENOMEM;
+        return -1;
+    }
 
     while (sysctl(routeDumpName, 6, buffer, &byteCount, nullptr, 0) != 0)
     {
         delete[] buffer;
-        buffer = new uint8_t[byteCount];
+        buffer = new (std::nothrow) uint8_t[byteCount];
+        if (buffer == nullptr)
+        {
+            errno = ENOMEM;
+            return -1;
+        }
     }
 
     rt_msghdr* hdr;

--- a/src/Native/Unix/System.Native/pal_networkstatistics.cpp
+++ b/src/Native/Unix/System.Native/pal_networkstatistics.cpp
@@ -18,6 +18,7 @@
 #include "pal_safecrt.h"
 
 #include <errno.h>
+#include <memory>
 #include <net/route.h>
 
 #include <sys/types.h>
@@ -248,7 +249,13 @@ extern "C" int32_t SystemNative_GetActiveTcpConnectionInfos(NativeTcpConnectionI
     assert(infoCount != nullptr);
 
     size_t estimatedSize = GetEstimatedTcpPcbSize();
-    uint8_t* buffer = new uint8_t[estimatedSize];
+    uint8_t* buffer = new (std::nothrow) uint8_t[estimatedSize];
+    if (buffer == nullptr)
+    {
+        errno = ENOMEM;
+        return -1;
+    }
+
     void* newp = nullptr;
     size_t newlen = 0;
 
@@ -256,7 +263,12 @@ extern "C" int32_t SystemNative_GetActiveTcpConnectionInfos(NativeTcpConnectionI
     {
         delete[] buffer;
         estimatedSize = estimatedSize * 2;
-        buffer = new uint8_t[estimatedSize];
+        buffer = new (std::nothrow) uint8_t[estimatedSize];
+        if (buffer == nullptr)
+        {
+            errno = ENOMEM;
+            return -1;
+        }
     }
 
     int32_t count = static_cast<int32_t>(estimatedSize / sizeof(xtcpcb));
@@ -336,7 +348,13 @@ extern "C" int32_t SystemNative_GetActiveUdpListeners(IPEndPointInfo* infos, int
     assert(infoCount != nullptr);
 
     size_t estimatedSize = GetEstimatedUdpPcbSize();
-    uint8_t* buffer = new uint8_t[estimatedSize];
+    uint8_t* buffer = new (std::nothrow) uint8_t[estimatedSize];
+    if (buffer == nullptr)
+    {
+        errno = ENOMEM;
+        return -1;
+    }
+
     void* newp = nullptr;
     size_t newlen = 0;
 
@@ -344,7 +362,12 @@ extern "C" int32_t SystemNative_GetActiveUdpListeners(IPEndPointInfo* infos, int
     {
         delete[] buffer;
         estimatedSize = estimatedSize * 2;
-        buffer = new uint8_t[estimatedSize];
+        buffer = new (std::nothrow) uint8_t[estimatedSize];
+        if (buffer == nullptr)
+        {
+            errno = ENOMEM;
+            return -1;
+        }
     }
     int32_t count = static_cast<int32_t>(estimatedSize / sizeof(xtcpcb));
     if (count > *infoCount)
@@ -409,7 +432,13 @@ extern "C" int32_t SystemNative_GetNativeIPInterfaceStatistics(char* interfaceNa
         return -1;
     }
 
-    uint8_t* buffer = new uint8_t[len];
+    uint8_t* buffer = new (std::nothrow) uint8_t[len];
+    if (buffer == nullptr)
+    {
+        errno = ENOMEM;
+        return -1;
+    }
+
     if (sysctl(statisticsMib, 6, buffer, &len, nullptr, 0) == -1)
     {
         // Not enough space.
@@ -461,7 +490,13 @@ extern "C" int32_t SystemNative_GetNumRoutes()
         return -1;
     }
 
-    uint8_t* buffer = new uint8_t[len];
+    uint8_t* buffer = new (std::nothrow) uint8_t[len];
+    if (buffer == nullptr)
+    {
+        errno = ENOMEM;
+        return -1;
+    }
+
     if (sysctl(routeDumpMib, 6, buffer, &len, nullptr, 0) == -1)
     {
         delete[] buffer;


### PR DESCRIPTION
To avoid exceptions propagating out of native shims and crashing at interop boundary.

Fixes https://github.com/dotnet/corefx/issues/13383
cc: @jkotas 