### PR TITLE
Use or remove unused parameters in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -604,7 +604,7 @@ namespace System.Linq.Expressions
         private static BinaryExpression GetMethodBasedBinaryOperator(ExpressionType binaryType, Expression left, Expression right, MethodInfo method, bool liftToNull)
         {
             System.Diagnostics.Debug.Assert(method != null);
-            ValidateOperator(method, nameof(method));
+            ValidateOperator(method);
             ParameterInfo[] pms = method.GetParametersCached();
             if (pms.Length != 2)
                 throw Error.IncorrectNumberOfMethodCallArguments(method, nameof(method));
@@ -729,9 +729,9 @@ namespace System.Linq.Expressions
             }
         }
         
-        private static void ValidateOperator(MethodInfo method, string paramName)
+        private static void ValidateOperator(MethodInfo method)
         {
-            System.Diagnostics.Debug.Assert(method != null);
+            Debug.Assert(method != null);
             ValidateMethodInfo(method, nameof(method));
             if (!method.IsStatic)
                 throw Error.UserDefinedOperatorMustBeStatic(method, nameof(method));
@@ -775,7 +775,7 @@ namespace System.Linq.Expressions
         
         private static void ValidateUserDefinedConditionalLogicOperator(ExpressionType nodeType, Type left, Type right, MethodInfo method)
         {
-            ValidateOperator(method, nameof(method));
+            ValidateOperator(method);
             ParameterInfo[] pms = method.GetParametersCached();
             if (pms.Length != 2)
                 throw Error.IncorrectNumberOfMethodCallArguments(method, nameof(method));

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -228,7 +228,7 @@ namespace System.Linq.Expressions
         /// </summary>
         internal static Exception PropertyTypeMustMatchSetter(string paramName)
         {
-            return new ArgumentException(Strings.PropertyTypeMustMatchSetter);
+            return new ArgumentException(Strings.PropertyTypeMustMatchSetter, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Both accessors must be static."

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -401,8 +401,8 @@ namespace System.Linq.Expressions
 
         private static UnaryExpression GetMethodBasedUnaryOperator(ExpressionType unaryType, Expression operand, MethodInfo method)
         {
-            System.Diagnostics.Debug.Assert(method != null);
-            ValidateOperator(method, nameof(method));
+            Debug.Assert(method != null);
+            ValidateOperator(method);
             ParameterInfo[] pms = method.GetParametersCached();
             if (pms.Length != 1)
                 throw Error.IncorrectNumberOfMethodCallArguments(method, nameof(method));
@@ -447,8 +447,8 @@ namespace System.Linq.Expressions
 
         private static UnaryExpression GetMethodBasedCoercionOperator(ExpressionType unaryType, Expression operand, Type convertToType, MethodInfo method)
         {
-            System.Diagnostics.Debug.Assert(method != null);
-            ValidateOperator(method, nameof(method));
+            Debug.Assert(method != null);
+            ValidateOperator(method);
             ParameterInfo[] pms = method.GetParametersCached();
             if (pms.Length != 1)
             {


### PR DESCRIPTION
Remove one unused parameter in a validation check (It would always have the same value, so changing to use it has no value).

Make use of one currently unused parameter in an exception.

Change parameter name in validator method to match that of calling methods so that throws will make use of parameter names matching the public interface. Reformat to make lack of coverage of error cases more obvious.

CC @hughbe @bartdesmet @VSadov 