### PR TITLE
Fix Ctor_DateTime test with DST problem

### DIFF
--- a/src/System.Runtime/tests/System/DateTimeOffsetTests.cs
+++ b/src/System.Runtime/tests/System/DateTimeOffsetTests.cs
@@ -40,7 +40,7 @@ namespace System.Tests
             VerifyDateTimeOffset(dateTimeOffset, 1986, 8, 15, 10, 20, 5, 4, null);
 
             DateTimeOffset today = new DateTimeOffset(DateTime.Today);
-            DateTimeOffset now = DateTimeOffset.Now;
+            DateTimeOffset now = DateTimeOffset.Now.Date;
             VerifyDateTimeOffset(today, now.Year, now.Month, now.Day, 0, 0, 0, 0, now.Offset);
 
             today = new DateTimeOffset(new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second, DateTimeKind.Utc));


### PR DESCRIPTION
The test is trying to validate the Offset of a DateTimeOffset constructed from DateTime.Today, and it does so by comparing it to the Offset of a DateTimeOffset.Now.  But on a day like today in a location when/where DST changes, the offset of DateTimeOffset.Now is different from the offset of DateTime.Today, which has the same offset as DateTimeOffset.Now.Date, as the DateTime lacks the time portion and thus maps to 12am, which is before DST changed.

I'm fixing the test by comparing ```new DateTimeOffset(DateTime.Today)``` to ```DateTimeOffset.Now.Date``` instead of to ```DateTimeOffset.Now```.

Fixes https://github.com/dotnet/corefx/issues/13401
cc: @tarekgh