### PR TITLE
Remove some minor redundancies and nits in Linq.Expressions.

### DIFF
--- a/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
+++ b/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
@@ -15,7 +15,6 @@ namespace System.Linq.Expressions.Compiler
     {
         private static AssemblyGen s_assembly;
 
-        private readonly AssemblyBuilder _myAssembly;
         private readonly ModuleBuilder _myModule;
 
         private int _index;
@@ -41,8 +40,8 @@ namespace System.Linq.Expressions.Compiler
                 new CustomAttributeBuilder(typeof(SecurityTransparentAttribute).GetConstructor(Type.EmptyTypes), Array.Empty<object>())
             };
 
-            _myAssembly = AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.Run, attributes);
-            _myModule = _myAssembly.DefineDynamicModule(name.Name);
+            AssemblyBuilder myAssembly = AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.Run, attributes);
+            _myModule = myAssembly.DefineDynamicModule(name.Name);
         }
 
         private TypeBuilder DefineType(string name, Type parent, TypeAttributes attr)

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicMetaObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicMetaObject.cs
@@ -82,14 +82,8 @@ namespace System.Dynamic
                     {
                         return ct;
                     }
-                    if (Value != null)
-                    {
-                        return Value.GetType();
-                    }
-                    else
-                    {
-                        return null;
-                    }
+
+                    return Value?.GetType();
                 }
                 else
                 {

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoClass.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoClass.cs
@@ -19,7 +19,7 @@ namespace System.Dynamic
 
         private const int EmptyHashCode = 6551;                     // hash code of the empty ExpandoClass.
 
-        internal static ExpandoClass Empty = new ExpandoClass();    // The empty Expando class - all Expando objects start off w/ this class.
+        internal static readonly ExpandoClass Empty = new ExpandoClass();    // The empty Expando class - all Expando objects start off w/ this class.
 
         /// <summary>
         /// Constructs the empty ExpandoClass.  This is the class used when an

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -1007,7 +1007,7 @@ namespace System.Dynamic
         /// </summary>
         private class ExpandoData
         {
-            internal static readonly ExpandoData Empty = new ExpandoData();
+            internal static ExpandoData Empty = new ExpandoData();
 
             /// <summary>
             /// the dynamically assigned class associated with the Expando object

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -305,7 +305,7 @@ namespace System.Dynamic
         // open types (from MSDN http://msdn.microsoft.com/en-us/library/d8eyd8zc.aspx).
         private sealed class KeyCollectionDebugView
         {
-            private ICollection<string> _collection;
+            private readonly ICollection<string> _collection;
 
             public KeyCollectionDebugView(ICollection<string> collection)
             {
@@ -444,7 +444,7 @@ namespace System.Dynamic
         // open types (from MSDN http://msdn.microsoft.com/en-us/library/d8eyd8zc.aspx).
         private sealed class ValueCollectionDebugView
         {
-            private ICollection<object> _collection;
+            private readonly ICollection<object> _collection;
 
             public ValueCollectionDebugView(ICollection<object> collection)
             {
@@ -1007,7 +1007,7 @@ namespace System.Dynamic
         /// </summary>
         private class ExpandoData
         {
-            internal static ExpandoData Empty = new ExpandoData();
+            internal static readonly ExpandoData Empty = new ExpandoData();
 
             /// <summary>
             /// the dynamically assigned class associated with the Expando object

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -795,7 +795,6 @@ namespace System.Linq.Expressions
             if (IsValidLiftedConditionalLogicalOperator(left, right, pms))
             {
                 left = left.GetNonNullableType();
-                right = left.GetNonNullableType();
             }
             MethodInfo opTrue = TypeUtils.GetBooleanOperator(method.DeclaringType, "op_True");
             MethodInfo opFalse = TypeUtils.GetBooleanOperator(method.DeclaringType, "op_False");

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
@@ -149,15 +149,14 @@ namespace System.Linq.Expressions.Compiler
         private sealed class LocalBoxStorage : Storage
         {
             private readonly LocalBuilder _boxLocal;
-            private readonly Type _boxType;
             private readonly FieldInfo _boxValueField;
 
             internal LocalBoxStorage(LambdaCompiler compiler, ParameterExpression variable)
                 : base(compiler, variable)
             {
-                _boxType = typeof(StrongBox<>).MakeGenericType(variable.Type);
-                _boxValueField = _boxType.GetField("Value");
-                _boxLocal = compiler.GetNamedLocal(_boxType, variable);
+                Type boxType = typeof(StrongBox<>).MakeGenericType(variable.Type);
+                _boxValueField = boxType.GetField("Value");
+                _boxLocal = compiler.GetNamedLocal(boxType, variable);
             }
 
             internal override void EmitLoad()

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/HoistedLocals.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/HoistedLocals.cs
@@ -78,10 +78,7 @@ namespace System.Linq.Expressions.Compiler
             Indexes = new ReadOnlyDictionary<Expression, int>(indexes);
         }
 
-        internal ParameterExpression ParentVariable
-        {
-            get { return Parent != null ? Parent.SelfVariable : null; }
-        }
+        internal ParameterExpression ParentVariable => Parent?.SelfVariable;
 
         internal static object[] GetParent(object[] locals)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -812,7 +812,7 @@ namespace System.Linq.Expressions.Compiler
 
                 TypeCode tc = typeFrom.GetTypeCode();
 
-                MethodInfo method = null;
+                MethodInfo method;
 
                 switch (tc)
                 {
@@ -958,13 +958,11 @@ namespace System.Linq.Expressions.Compiler
         {
             Debug.Assert(typeFrom.IsNullableType());
             Debug.Assert(typeTo.IsNullableType());
-            Label labIfNull = default(Label);
-            Label labEnd = default(Label);
-            LocalBuilder locFrom = null;
-            LocalBuilder locTo = null;
-            locFrom = il.DeclareLocal(typeFrom);
+            Label labIfNull;
+            Label labEnd;
+            LocalBuilder locFrom = il.DeclareLocal(typeFrom);
             il.Emit(OpCodes.Stloc, locFrom);
-            locTo = il.DeclareLocal(typeTo);
+            LocalBuilder locTo = il.DeclareLocal(typeTo);
             // test for null
             il.Emit(OpCodes.Ldloca, locFrom);
             il.EmitHasValue(typeFrom);
@@ -994,8 +992,7 @@ namespace System.Linq.Expressions.Compiler
         {
             Debug.Assert(!typeFrom.IsNullableType());
             Debug.Assert(typeTo.IsNullableType());
-            LocalBuilder locTo = null;
-            locTo = il.DeclareLocal(typeTo);
+            LocalBuilder locTo = il.DeclareLocal(typeTo);
             Type nnTypeTo = typeTo.GetNonNullableType();
             il.EmitConvertToType(typeFrom, nnTypeTo, isChecked);
             ConstructorInfo ci = typeTo.GetConstructor(new Type[] { nnTypeTo });
@@ -1021,8 +1018,7 @@ namespace System.Linq.Expressions.Compiler
             Debug.Assert(typeFrom.IsNullableType());
             Debug.Assert(!typeTo.IsNullableType());
             Debug.Assert(typeTo.GetTypeInfo().IsValueType);
-            LocalBuilder locFrom = null;
-            locFrom = il.DeclareLocal(typeFrom);
+            LocalBuilder locFrom = il.DeclareLocal(typeFrom);
             il.Emit(OpCodes.Stloc, locFrom);
             il.Emit(OpCodes.Ldloca, locFrom);
             il.EmitGetValue(typeFrom);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Compiler
                 ParameterExpression p1 = Expression.Variable(b.Left.Type.GetNonNullableType(), name: null);
                 ParameterExpression p2 = Expression.Variable(b.Right.Type.GetNonNullableType(), name: null);
                 MethodCallExpression mc = Expression.Call(null, b.Method, p1, p2);
-                Type resultType = null;
+                Type resultType;
                 if (b.IsLiftedToNull)
                 {
                     resultType = mc.Type.GetNullableType();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
@@ -181,10 +181,7 @@ namespace System.Linq.Expressions.Compiler
             /// <remarks>
             /// This is a performance optimization to lower the overall number of temporaries needed.
             /// </remarks>
-            internal int Mark()
-            {
-                return _usedTemps != null ? _usedTemps.Count : 0;
-            }
+            internal int Mark() => _usedTemps?.Count ?? 0;
 
             /// <summary>
             /// Frees temporaries created since the last marking using <see cref="Mark"/>.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
@@ -187,7 +187,6 @@ namespace System.Linq.Expressions.Compiler
                         currentScope.Definitions.Add(v, VariableStorageKind.Local);
                     }
                 }
-                node = block;
                 body = block.Expressions;
             }
             return body;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
@@ -203,9 +203,7 @@ namespace System.Linq.Expressions
 
         private Flow GetFlow(Flow flow)
         {
-            Flow last;
-
-            last = CheckBreak(_flow);
+            Flow last = CheckBreak(_flow);
             flow = CheckBreak(flow);
 
             // Get the biggest flow that is requested None < Space < NewLine

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
@@ -1009,11 +1009,7 @@ namespace System.Linq.Expressions
                 )
             );
 
-            Type delegateType = info.DelegateType;
-            if (delegateType == null)
-            {
-                delegateType = info.MakeDelegateType(returnType, arg0);
-            }
+            Type delegateType = info.DelegateType ?? info.MakeDelegateType(returnType, arg0);
 
             return DynamicExpression.Make(returnType, delegateType, binder, arg0);
         }
@@ -1052,11 +1048,7 @@ namespace System.Linq.Expressions
                 )
             );
 
-            Type delegateType = info.DelegateType;
-            if (delegateType == null)
-            {
-                delegateType = info.MakeDelegateType(returnType, arg0, arg1);
-            }
+            Type delegateType = info.DelegateType ?? info.MakeDelegateType(returnType, arg0, arg1);
 
             return DynamicExpression.Make(returnType, delegateType, binder, arg0, arg1);
         }
@@ -1100,11 +1092,7 @@ namespace System.Linq.Expressions
                 )
             );
 
-            Type delegateType = info.DelegateType;
-            if (delegateType == null)
-            {
-                delegateType = info.MakeDelegateType(returnType, arg0, arg1, arg2);
-            }
+            Type delegateType = info.DelegateType ?? info.MakeDelegateType(returnType, arg0, arg1, arg2);
 
             return DynamicExpression.Make(returnType, delegateType, binder, arg0, arg1, arg2);
         }
@@ -1153,11 +1141,7 @@ namespace System.Linq.Expressions
                 )
             );
 
-            Type delegateType = info.DelegateType;
-            if (delegateType == null)
-            {
-                delegateType = info.MakeDelegateType(returnType, arg0, arg1, arg2, arg3);
-            }
+            Type delegateType = info.DelegateType ?? info.MakeDelegateType(returnType, arg0, arg1, arg2, arg3);
 
             return DynamicExpression.Make(returnType, delegateType, binder, arg0, arg1, arg2, arg3);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.netstandard1.7.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.netstandard1.7.cs
@@ -73,11 +73,7 @@ namespace System.Linq.Expressions
                 )
             );
 
-            Type delegateType = info.DelegateType;
-            if (delegateType == null)
-            {
-                delegateType = info.MakeDelegateType(returnType, arg0);
-            }
+            Type delegateType = info.DelegateType ?? info.MakeDelegateType(returnType, arg0);
 
             return DynamicExpression.Make(returnType, delegateType, binder, arg0);
         }
@@ -116,11 +112,7 @@ namespace System.Linq.Expressions
                 )
             );
 
-            Type delegateType = info.DelegateType;
-            if (delegateType == null)
-            {
-                delegateType = info.MakeDelegateType(returnType, arg0, arg1);
-            }
+            Type delegateType = info.DelegateType ?? info.MakeDelegateType(returnType, arg0, arg1);
 
             return DynamicExpression.Make(returnType, delegateType, binder, arg0, arg1);
         }
@@ -217,11 +209,7 @@ namespace System.Linq.Expressions
                 )
             );
 
-            Type delegateType = info.DelegateType;
-            if (delegateType == null)
-            {
-                delegateType = info.MakeDelegateType(returnType, arg0, arg1, arg2, arg3);
-            }
+            Type delegateType = info.DelegateType ?? info.MakeDelegateType(returnType, arg0, arg1, arg2, arg3);
 
             return DynamicExpression.Make(returnType, delegateType, binder, arg0, arg1, arg2, arg3);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
@@ -670,7 +670,7 @@ namespace System.Linq.Expressions
         {
             Out("catch (");
             Out(node.Test.Name);
-            if (node.Variable != null && !string.IsNullOrEmpty(node.Variable.Name))
+            if (!string.IsNullOrEmpty(node.Variable?.Name))
             {
                 Out(' ');
                 Out(node.Variable.Name);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
@@ -32,14 +32,7 @@ namespace System.Linq.Expressions
         /// <param name="node">The expression to visit.</param>
         /// <returns>The modified expression, if it or any subexpression was modified;
         /// otherwise, returns the original expression.</returns>
-        public virtual Expression Visit(Expression node)
-        {
-            if (node != null)
-            {
-                return node.Accept(this);
-            }
-            return null;
-        }
+        public virtual Expression Visit(Expression node) => node?.Accept(this);
 
         /// <summary>
         /// Dispatches the list of expressions to one of the more specialized visit methods in this class.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -283,9 +283,7 @@ namespace System.Linq.Expressions
 
         private static bool IsCompatible(PropertyInfo pi, Expression[] args)
         {
-            MethodInfo mi;
-
-            mi = pi.GetGetMethod(nonPublic: true);
+            MethodInfo mi = pi.GetGetMethod(nonPublic: true);
             ParameterInfo[] parms;
             if (mi != null)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -710,7 +710,7 @@ namespace System.Linq.Expressions.Interpreter
     /// </summary>
     internal sealed class LeaveExceptionHandlerInstruction : IndexedBranchInstruction
     {
-        private static LeaveExceptionHandlerInstruction[] s_cache = new LeaveExceptionHandlerInstruction[2 * CacheSize];
+        private static readonly LeaveExceptionHandlerInstruction[] s_cache = new LeaveExceptionHandlerInstruction[2 * CacheSize];
 
         private readonly bool _hasValue;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -299,7 +299,7 @@ namespace System.Linq.Expressions.Interpreter
                 _maxStackDepth,
                 _maxContinuationDepth,
                 _instructions.ToArray(),
-                (_objects != null) ? _objects.ToArray() : null,
+                _objects?.ToArray(),
                 BuildRuntimeLabels(),
                 _debugCookies
             );

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -19,7 +19,7 @@ namespace System.Linq.Expressions.Interpreter
         internal InterpretedFrame _parent;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2105:ArrayFieldsShouldNotBeReadOnly")]
-        private int[] _continuations;
+        private readonly int[] _continuations;
         private int _continuationIndex;
         private int _pendingContinuation;
         private object _pendingValue;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2037,7 +2037,7 @@ namespace System.Linq.Expressions.Interpreter
                     enterTryInstr.SetTryHandler(
                         new TryCatchFinallyHandler(tryStart, tryEnd, gotoEnd.TargetIndex,
                             startOfFinally.TargetIndex, _instructions.Count,
-                            exHandlers != null ? exHandlers.ToArray() : null));
+                            exHandlers?.ToArray()));
                     PopLabelBlock(LabelScopeKind.Finally);
                 }
                 else

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -292,7 +292,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private readonly StackGuard _guard = new StackGuard();
 
-        private static LocalDefinition[] s_emptyLocals = Array.Empty<LocalDefinition>();
+        private static readonly LocalDefinition[] s_emptyLocals = Array.Empty<LocalDefinition>();
 
         public LightCompiler()
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -170,10 +170,9 @@ namespace System.Linq.Expressions.Interpreter
                         Indent();
                     }
 
-                    Instruction instruction = instructions[i];
                     InstructionList.DebugView.InstructionView instructionView = instructionViews[i];
 
-                    sb.AppendFormat(string.Format(CultureInfo.InvariantCulture, "{0}IP_{1}: {2}", _indent, i.ToString().PadLeft(4, '0'), instructionView.GetValue())).AppendLine();
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0}IP_{1}: {2}", _indent, i.ToString().PadLeft(4, '0'), instructionView.GetValue()).AppendLine();
                 }
 
                 EmitExits(sb, instructions.Length);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -415,7 +415,7 @@ namespace System.Linq.Expressions.Interpreter
 
             public override int Run(InterpretedFrame frame)
             {
-                object value = default(object);
+                object value;
 
                 try
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -197,14 +197,7 @@ namespace System.Linq.Expressions.Interpreter
             {
                 object dflt = frame.Pop();
                 object obj = frame.Pop();
-                if (obj == null)
-                {
-                    frame.Push(dflt);
-                }
-                else
-                {
-                    frame.Push(obj);
-                }
+                frame.Push(obj ?? dflt);
                 return +1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberAssignment.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberAssignment.cs
@@ -12,7 +12,7 @@ namespace System.Linq.Expressions
     /// </summary>
     public sealed class MemberAssignment : MemberBinding
     {
-        private Expression _expression;
+        private readonly Expression _expression;
 
         internal MemberAssignment(MemberInfo member, Expression expression)
 #pragma warning disable 618

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -158,11 +158,8 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(fieldName, nameof(fieldName));
 
             // bind to public names first
-            FieldInfo fi = expression.Type.GetField(fieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
-            if (fi == null)
-            {
-                fi = expression.Type.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
-            }
+            FieldInfo fi = expression.Type.GetField(fieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy)
+                           ?? expression.Type.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
             if (fi == null)
             {
                 throw Error.InstanceFieldNotDefinedForType(fieldName, expression.Type);
@@ -184,11 +181,8 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(type, nameof(type));
 
             // bind to public names first
-            FieldInfo fi = type.GetField(fieldName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
-            if (fi == null)
-            {
-                fi = type.GetField(fieldName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
-            }
+            FieldInfo fi = type.GetField(fieldName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy)
+                           ?? type.GetField(fieldName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
 
             if (fi == null)
             {
@@ -212,11 +206,8 @@ namespace System.Linq.Expressions
             RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(propertyName, nameof(propertyName));
             // bind to public names first
-            PropertyInfo pi = expression.Type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
-            if (pi == null)
-            {
-                pi = expression.Type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
-            }
+            PropertyInfo pi = expression.Type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy)
+                              ?? expression.Type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
             if (pi == null)
             {
                 throw Error.InstancePropertyNotDefinedForType(propertyName, expression.Type, nameof(propertyName));
@@ -236,11 +227,8 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(type, nameof(type));
             ContractUtils.RequiresNotNull(propertyName, nameof(propertyName));
             // bind to public names first
-            PropertyInfo pi = type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
-            if (pi == null)
-            {
-                pi = type.GetProperty(propertyName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
-            }
+            PropertyInfo pi = type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy)
+                              ?? type.GetProperty(propertyName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
             if (pi == null)
             {
                 throw Error.PropertyNotDefinedForType(propertyName, type, nameof(propertyName));

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -189,10 +189,10 @@ namespace System.Linq.Expressions
             {
                 throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
             }
-            ConstructorInfo ci = null;
+
             if (!type.GetTypeInfo().IsValueType)
             {
-                ci = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).SingleOrDefault(c => c.GetParameters().Length == 0);
+                ConstructorInfo ci = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).SingleOrDefault(c => c.GetParameters().Length == 0);
                 if (ci == null)
                 {
                     throw Error.TypeMissingDefaultConstructor(type, nameof(type));


### PR DESCRIPTION
Remove unused local and `string.Format` feeding to `sb.AppendFormat`.

Replace fields with local when only used immediately after assignment.

Remove unused assignments. Join declaration with first real assignment when possible.

Make init-only fields `readonly`.

Replace assign-and-check with ??

Use null-propagation where applicable and reduces assign-and-check.