### PR TITLE
Throw InvalidOperationException on attempting to throw an object not derived from Exception in the interpreter.

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -654,4 +654,7 @@
   <data name="SameKeyExistsInExpando" xml:space="preserve">
     <value>An element with the same key '{0}' already exists in the ExpandoObject.</value>
   </data>
+  <data name="InterpreterCannotThrowNonExceptions" xml:space="preserve">
+    <value>Interpreted expressions cannot throw an object of a type that is not derived from System.Exception.</value>
+  </data>
 </root>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -1322,6 +1322,11 @@ namespace System.Linq.Expressions
             return new InvalidProgramException();
         }
 
+        internal static InvalidOperationException InterpreterCannotThrowNonExceptions()
+        {
+            return new InvalidOperationException(Strings.InterpreterCannotThrowNonExceptions);
+        }
+
         private static string GetParamName(string paramName, int index)
         {
             if (index >= 0)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -767,12 +767,14 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            var ex = (Exception)frame.Pop();
+            object ex = frame.Pop();
             if (_rethrow)
             {
                 throw new RethrowException();
             }
-            throw ex;
+
+            // If ex is null then throwing it will result in an appropriate NullReferenceException.
+            throw ex == null ? null : ex as Exception ?? Error.InterpreterCannotThrowNonExceptions();
         }
     }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -1071,5 +1071,10 @@ namespace System.Linq.Expressions
         /// A string like "The constructor should not be declared on an abstract class"
         /// </summary>
         internal static string NonAbstractConstructorRequired => SR.NonAbstractConstructorRequired;
+
+        /// <summary>
+        /// A string like "Interpreted expressions cannot throw an object of a type that is not derived from System.Exception.".
+        /// </summary>
+        internal static string InterpreterCannotThrowNonExceptions => SR.InterpreterCannotThrowNonExceptions;
     }
 }

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -119,22 +119,22 @@ namespace System.Linq.Expressions.Tests
             CannotRethrowWithinFaultWithinCatch(false);
         }
 
-        [Theory]
-        [InlineData(false)]
-        public void CanCatchAndThrowNonExceptions(bool useInterpreter)
+        [Fact]
+        public void CompilerCanCatchAndThrowNonExceptions()
         {
             TryExpression throwCatchString = Expression.TryCatch(
                 Expression.Throw(Expression.Constant("Hello")),
                 Expression.Catch(typeof(string), Expression.Empty())
                 );
-            Expression.Lambda<Action>(throwCatchString).Compile(useInterpreter)();
+            Expression.Lambda<Action>(throwCatchString).Compile(false)();
         }
 
         [Fact]
-        [ActiveIssue(5898)]
-        public void CanCatchAndThrowNonExceptionsInterpreted()
+        public void InterpreterCannotThrowNonExceptions()
         {
-            CanCatchAndThrowNonExceptions(true);
+            UnaryExpression throwString = Expression.Throw(Expression.Constant("Hello"));
+            var act = Expression.Lambda<Action>(throwString).Compile(true);
+            Assert.Throws<InvalidOperationException>(act);
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #5898

As suggested by @bartdesmet  at https://github.com/dotnet/corefx/issues/5898#issuecomment-180063270 (CC  @svick and @VSadov who also commented in that thread) this accepts the failure of the interpreter to throw non-Exception types, but throws a more explanatory exception than the mysterious `InvalidCastException` thrown.

Rather than the `NotSupportedException` suggested, I went for `InvalidOperationException` that seems more apt. (There's no failure to support a method, but an inability act with the provided state).

This throws on execution. Throwing on compilation would be preferable, but there would still be cases where an expression typed as `object` was thrown (allowed as long as the actual value is an exception) failed at run-time, so this is more consistent. It would certainly be possible to also throw on compilation if the type thrown is neither `Exception`-derived nor `object` if people thought that was desirable.