### PR TITLE
StreamWriter/BinaryWriter: Use same cached encoding instance

### DIFF
--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net462' and '$(TargetGroup)' != 'net463'">
     <Compile Include="System\CodeDom\Compiler\IndentedTextWriter.cs" />
+    <Compile Include="System\IO\EncodingCache.cs" />
     <Compile Include="System\IO\StreamReader.cs" />
     <Compile Include="System\IO\StreamWriter.cs" />
     <Compile Include="System\IO\StringReader.cs" />

--- a/src/System.IO/src/System/IO/BinaryWriter.cs
+++ b/src/System.IO/src/System/IO/BinaryWriter.cs
@@ -34,11 +34,11 @@ namespace System.IO
         {
             OutStream = Stream.Null;
             _buffer = new byte[16];
-            _encoding = new UTF8Encoding(false, true);
+            _encoding = EncodingCache.UTF8NoBOM;
             _encoder = _encoding.GetEncoder();
         }
 
-        public BinaryWriter(Stream output) : this(output, new UTF8Encoding(false, true), false)
+        public BinaryWriter(Stream output) : this(output, EncodingCache.UTF8NoBOM, false)
         {
         }
 

--- a/src/System.IO/src/System/IO/EncodingCache.cs
+++ b/src/System.IO/src/System/IO/EncodingCache.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace System.IO
+{
+    internal static class EncodingCache
+    {
+        internal static readonly Encoding UTF8NoBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    }
+}

--- a/src/System.IO/src/System/IO/StreamWriter.cs
+++ b/src/System.IO/src/System/IO/StreamWriter.cs
@@ -27,7 +27,7 @@ namespace System.IO
         private const int DontCopyOnWriteLineThreshold = 512;
 
         // Bit bucket - Null has no backing store. Non closable.
-        public new static readonly StreamWriter Null = new StreamWriter(Stream.Null, new UTF8Encoding(false, true), MinBufferSize, true);
+        public new static readonly StreamWriter Null = new StreamWriter(Stream.Null, UTF8NoBOM, MinBufferSize, true);
 
         private Stream _stream;
         private Encoding _encoding;
@@ -66,22 +66,7 @@ namespace System.IO
         // Even Close() will hit the exception as it would try to flush the unwritten data. 
         // Maybe we can add a DiscardBufferedData() method to get out of such situation (like 
         // StreamReader though for different reason). Either way, the buffered data will be lost!
-        private static volatile Encoding s_utf8NoBOM;
-
-        internal static Encoding UTF8NoBOM
-        {
-            //[FriendAccessAllowed]
-            get
-            {
-                if (s_utf8NoBOM == null)
-                {
-                    // No need for double lock - we just want to avoid extra
-                    // allocations in the common case.
-                    s_utf8NoBOM = new UTF8Encoding(false, true);
-                }
-                return s_utf8NoBOM;
-            }
-        }
+        private static Encoding UTF8NoBOM => EncodingCache.UTF8NoBOM;
 
 
         internal StreamWriter() : base(null)


### PR DESCRIPTION
`StreamWriter` lazily allocates and caches a `UTF8NoBOM` instance, while `BinaryWriter` always allocates new instances. Instead, the same cached instance can be shared between both writers.

(I realize `BinaryWriter` is currently only used for AOT builds; I'm looking at doing a similar change for `BinaryWriter` in coreclr repo).

cc: @ianhays, @stephentoub