### PR TITLE
StreamReader: Use cached instance for UTF32BE

### DIFF
--- a/src/System.IO/src/System/IO/StreamReader.cs
+++ b/src/System.IO/src/System/IO/StreamReader.cs
@@ -526,7 +526,10 @@ namespace System.IO
                 _byteBuffer[2] == 0xFE && _byteBuffer[3] == 0xFF)
             {
                 // Big Endian UTF32
-                _encoding = new UTF32Encoding(bigEndian: true, byteOrderMark: true);
+                // Unfortunately, there is no public Encoding.BigEndianUTF32 property, so instead
+                // we call Encoding.GetEncoding, which will retrieve a cached instance.
+                const int CodePageUTF32BE = 12001;
+                _encoding = Encoding.GetEncoding(CodePageUTF32BE);
                 CompressBuffer(4);
                 changedEncoding = true;
             }


### PR DESCRIPTION
Instead of always allocating a new instance of `UTF32Encoding` for Big Endian UTF32, use `Encoding.GetEncoding(12001)`, which will return a cached instance.

Follow up from https://github.com/dotnet/corefx/pull/12346#discussion_r82081246

cc: @ianhays, @stephentoub