### PR TITLE
BinaryReader: Use cached default encoding instance

### DIFF
--- a/src/System.IO/src/System/IO/BinaryReader.cs
+++ b/src/System.IO/src/System/IO/BinaryReader.cs
@@ -24,7 +24,7 @@ namespace System.IO
         private bool _isMemoryStream; // "do we sit on MemoryStream?" for Read/ReadInt32 perf
         private bool _leaveOpen;
 
-        public BinaryReader(Stream input) : this(input, new UTF8Encoding(), false)
+        public BinaryReader(Stream input) : this(input, Encoding.UTF8, false)
         {
         }
 


### PR DESCRIPTION
Preemptive port of https://github.com/dotnet/coreclr/pull/8017

A new instance of `UTF8Encoding` is created every time `BinaryReader.ctor(Stream)` is called, which creates an instance of `UTF8Encoding` that has no preamble. However, `BinaryReader` does not use the preamble at all, so it doesn't matter if the encoding has a preamble or not. Thus, the cached `Encoding.UTF8` instance can be used instead (which has a preamble).

cc: @ianhays, @stephentoub