### PR TITLE
FileSystem: Use path-based StreamReader/Writer ctors

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
@@ -125,20 +125,17 @@ namespace System.IO
         [System.Security.SecuritySafeCritical]  // auto-generated
         public StreamReader OpenText()
         {
-            Stream stream = new FileStream(FullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            return new StreamReader(stream, Encoding.UTF8, true);
+            return new StreamReader(FullPath, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
         }
 
         public StreamWriter CreateText()
         {
-            Stream stream = new FileStream(FullPath, FileMode.Create, FileAccess.Write, FileShare.Read);
-            return new StreamWriter(stream);
+            return new StreamWriter(FullPath, append: false);
         }
 
         public StreamWriter AppendText()
         {
-            Stream stream = new FileStream(FullPath, FileMode.Append, FileAccess.Write, FileShare.Read);
-            return new StreamWriter(stream);
+            return new StreamWriter(FullPath, append: true);
         }
 
 

--- a/src/System.IO.FileSystem/src/System/IO/ReadLinesIterator.cs
+++ b/src/System.IO.FileSystem/src/System/IO/ReadLinesIterator.cs
@@ -97,7 +97,7 @@ namespace System.IO
 
         private static ReadLinesIterator CreateIterator(string path, Encoding encoding, StreamReader reader)
         {
-            return new ReadLinesIterator(path, encoding, reader ?? new StreamReader(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read), encoding));
+            return new ReadLinesIterator(path, encoding, reader ?? new StreamReader(path, encoding));
         }
     }
 }


### PR DESCRIPTION
Following up on https://github.com/dotnet/corefx/pull/13229#discussion_r86106948.

Now that the path-based constructors have been added back, make use of them.

@JeremyKuhne, hopefully this doesn't conflict with any work you have in-progress. I was looking at consolidating uses of `UTF8NoBOM` and found that I could get rid of it on `File` by calling the appropriate `StreamReader`/`StreamWriter` constructors, and figured I might as well change uses over to the path-based ctors while I was at it.

cc: @ianhays, @stephentoub