### PR TITLE
Fix WorkingSet{64} on Linux to be bytes, not pages

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -117,7 +117,7 @@ namespace System.Diagnostics
                 ProcessName = procFsStat.comm,
                 BasePriority = (int)procFsStat.nice,
                 VirtualBytes = (long)procFsStat.vsize,
-                WorkingSet = procFsStat.rss,
+                WorkingSet = procFsStat.rss * Environment.SystemPageSize,
                 SessionId = procFsStat.session,
 
                 // We don't currently fill in the other values.


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/13423

cc: @priya91, @ayende