### PR TITLE
Correctly encode the 0-subidentifier in DerEncoder

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DerEncoder.cs
+++ b/src/Common/src/System/Security/Cryptography/DerEncoder.cs
@@ -791,7 +791,7 @@ namespace System.Security.Cryptography
             Stack<byte> littleEndianBytes = new Stack<byte>();
             byte continuance = 0;
 
-            while (unencoded != BigInteger.Zero)
+            do
             {
                 BigInteger remainder;
                 unencoded = BigInteger.DivRem(unencoded, divisor, out remainder);
@@ -803,6 +803,7 @@ namespace System.Security.Cryptography
                 continuance = 0x80;
                 littleEndianBytes.Push(octet);
             }
+            while (unencoded != BigInteger.Zero);
 
             encodedData.AddRange(littleEndianBytes);
         }

--- a/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
@@ -122,6 +122,7 @@ namespace System.Security.Cryptography.Encoding.Tests
         [Theory]
         [InlineData("1.3.6.1.5.5.7.3.1", "08", "2B06010505070301")]
         [InlineData("1.3.6.1.5.5.7.3.2", "08", "2B06010505070302")]
+        [InlineData("1.3.132.0.34", "05", "2B81040022")]
         [InlineData("2.999.3", "03", "883703")]
         [InlineData("2.999.19427512891.25", "08", "8837C8AFE1A43B19")]
         public static void ValidateOidEncodings(string oidValue, string hexLength, string encodedData)

--- a/src/System.Security.Cryptography.Encoding/tests/DerSequenceReaderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerSequenceReaderTests.cs
@@ -53,10 +53,11 @@ namespace System.Security.Cryptography.Encoding.Tests
                 0x10, 0x20, 0x30, 0x04, 0x05,
 
                 // Data
-                0x30, 27,
+                0x30, 34,
                 0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x0B,
                 0x06, 0x03, 0x55, 0x04, 0x03,
                 0x06, 0x09, 0x2B, 0x06, 0x01, 0x04, 0x01, 0x82, 0x37, 0x15, 0x07,
+                0x06, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x22,
 
                 // More noise.
                 0x85, 0x71, 0x23, 0x74, 0x01,
@@ -64,7 +65,7 @@ namespace System.Security.Cryptography.Encoding.Tests
 
             DerSequenceReader reader = new DerSequenceReader(derEncoded, 5, derEncoded.Length - 10);
             Assert.True(reader.HasData);
-            Assert.Equal(27, reader.ContentLength);
+            Assert.Equal(34, reader.ContentLength);
 
             Oid first = reader.ReadOid();
             Assert.Equal("1.2.840.113549.1.1.11", first.Value);
@@ -74,6 +75,9 @@ namespace System.Security.Cryptography.Encoding.Tests
 
             Oid third = reader.ReadOid();
             Assert.Equal("1.3.6.1.4.1.311.21.7", third.Value);
+
+            Oid fourth = reader.ReadOid();
+            Assert.Equal("1.3.132.0.34", fourth.Value);
 
             // And... done.
             Assert.False(reader.HasData);


### PR DESCRIPTION
During the ECDSA-on-AppleCrypto work it was observed that two of the three
supported curves didn't import successfully due to the curve OIDs being
incorrect. These curves both had a sub-identifier with value 0, which was not
correctly handled by the DerEncoder class.

By changing while (!=0) to do..while(!=0) the 0-subidentifier gets a zero byte
pushed onto the data stack, making it encode as { 0x00 } instead of { }.

Added tests for both reading and writing.

cc: @stephentoub @steveharter 