### PR TITLE
Further reduce peak memory usage in BigInteger tests

### DIFF
--- a/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
@@ -579,7 +579,7 @@ namespace System.Numerics.Tests
         [OuterLoop]
         public static void RunDoubleExplicitCastFromLargeBigIntegerTests()
         {
-            DoubleExplicitCastFromLargeBigIntegerTests(0, 4, 64, 3);
+            DoubleExplicitCastFromLargeBigIntegerTests(0, 4, 32, 3);
         }
 
         [Fact]
@@ -723,7 +723,7 @@ namespace System.Numerics.Tests
 
                 for (int j = 0; j < bigShiftLoopLimit; j++)
                 {
-                    temp = temp << Int32.MaxValue;
+                    temp = temp << (int.MaxValue / 2);
                     VerifyDoubleExplicitCastFromBigInteger(Double.PositiveInfinity, temp);
                     VerifyDoubleExplicitCastFromBigInteger(Double.NegativeInfinity, -temp);
                 }


### PR DESCRIPTION
This change reduces the peak usage of this test to ~3 GB on my machine.