### PR TITLE
Use entry assembly's name in Trace messages, instead of DEFAULT_APPNAME

### DIFF
--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
@@ -5,6 +5,7 @@
 using System.Threading;
 using System.IO;
 using System.Collections;
+using System.Reflection;
 
 namespace System.Diagnostics
 {
@@ -55,9 +56,7 @@ namespace System.Diagnostics
             {
                 if (s_appName == null)
                 {
-                    // This needs to be updated once we have the correct property implemented in the Environment class.
-                    // Bug:895000 is tracking this.
-                    s_appName = "DEFAULT_APPNAME";
+                    s_appName = Assembly.GetEntryAssembly().GetName().Name;
                 }
                 return s_appName;
             }

--- a/src/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
@@ -10,6 +10,8 @@ namespace System.Diagnostics.TraceSourceTests
 
     public class TraceClassTests : IDisposable
     {
+        private const string TestRunnerAssemblyName = "xunit.console.netcore";
+
         void IDisposable.Dispose()
         {
             TraceTestHelper.ResetState();
@@ -332,7 +334,7 @@ namespace System.Diagnostics.TraceSourceTests
             var expected =
                 String.Format(
                     "Message start." + newLine + "    This message should be indented.{0} Error: 0 : This error not be indented." + newLine + "    {0} Error: 0 : This error is indented" + newLine + "    {0} Warning: 0 : This warning is indented" + newLine + "    {0} Warning: 0 : This warning is also indented" + newLine + "    {0} Information: 0 : This information in indented" + newLine + "    {0} Information: 0 : This information is also indented" + newLine + "Message end." + newLine + "",
-                    "DEFAULT_APPNAME" //DEFAULT_APPNAME this a bug which needs to be fixed.
+                    TestRunnerAssemblyName
                 );
 
             Assert.Equal(expected, textTL.Output);


### PR DESCRIPTION
Resolves https://github.com/dotnet/corefx/issues/9669.

Previously, trace would output messages that looked like this:

```
DEFAULT_APPNAME Error: 0 : No assemblies loaded for ...
```
and afterwards:
```
GenFacades Error: 0 : No assemblies loaded for ...
```