### PR TITLE
Re-enable the buinding of VB projects outside of Windows.

### DIFF
--- a/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.builds
+++ b/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.builds
@@ -2,8 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <!-- Temporary workaround, VisualBasic projects cannot be built on non-Windows platforms. See issue #5230. -->
-    <Project Include="Microsoft.VisualBasic.vbproj" Condition="'$(OS)'=='Windows_NT'" />
+    <Project Include="Microsoft.VisualBasic.vbproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.builds
+++ b/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.builds
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <!-- Temporary workaround, VisualBasic projects cannot be built on non-Windows platforms. See issue #5230. -->
-    <Project Include="Microsoft.VisualBasic.Tests.csproj" Condition="'$(OS)'=='Windows_NT'">
+    <Project Include="Microsoft.VisualBasic.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcore50;netcoreapp1.0;netcoreapp1.1;net46;net461;net462;net463</TestTFMs>
     </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/5230.

We have a workaround in buildtools that lets us build these projects outside of Windows. https://github.com/ellismg/buildtools/commit/cf1b15fc9272636d44f1dbb16e06f9e90070fd1d

@ellismg 