### PR TITLE
[WIP] Fix Inconsistencies in HashSetEqualityComparer

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1625,7 +1625,7 @@ namespace System.Collections.Generic
         /// to specified comparer.
         /// 
         /// Because items are hashed according to a specific equality comparer, we have to resort
-        /// to n^2 search if they're using different equality comparers.
+        /// to building a new set if neither use that equality comparer.
         /// </summary>
         /// <param name="set1"></param>
         /// <param name="set2"></param>
@@ -1652,26 +1652,12 @@ namespace System.Collections.Generic
             {
                 return set2.ContainsAllElements(set1);
             }
-            else
-            {  // n^2 search because items are hashed according to their respective ECs
-                foreach (T set2Item in set2)
-                {
-                    bool found = false;
-                    foreach (T set1Item in set1)
-                    {
-                        if (comparer.Equals(set2Item, set1Item))
-                        {
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found)
-                    {
-                        return false;
-                    }
-                }
-                return true;
-            }
+            
+            // Creating a new set is O(n), but allows us to then do the
+            // equality comparison as an O(n) check rather than an O(n2)
+            // comparison of each element in the first set with each in
+            // the second.
+            return new HashSet<T>(set1, comparer).ContainsAllElements(set2);
         }
 
         /// <summary>

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1645,15 +1645,12 @@ namespace System.Collections.Generic
 
             if (comparer.Equals(set1._comparer))
             {
-                // suffices to check subset
-                foreach (T item in set2)
-                {
-                    if (!set1.Contains(item))
-                    {
-                        return false;
-                    }
-                }
-                return true;
+                return set1.ContainsAllElements(set2);
+            }
+
+            if (comparer.Equals(set2._comparer))
+            {
+                return set2.ContainsAllElements(set1);
             }
             else
             {  // n^2 search because items are hashed according to their respective ECs

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1633,23 +1633,18 @@ namespace System.Collections.Generic
         /// <returns></returns>
         internal static bool HashSetEquals(HashSet<T> set1, HashSet<T> set2, IEqualityComparer<T> comparer)
         {
-            // handle null cases first
-            if (set1 == null)
+            if (set1 == set2)
             {
-                return (set2 == null);
+                return true;
             }
-            else if (set2 == null)
+
+            if (set1 == null | set2 == null || set1.Count != set2.Count)
             {
-                // set1 != null
                 return false;
             }
 
             if (comparer.Equals(set1._comparer))
             {
-                if (set1.Count != set2.Count)
-                {
-                    return false;
-                }
                 // suffices to check subset
                 foreach (T item in set2)
                 {

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1644,8 +1644,7 @@ namespace System.Collections.Generic
                 return false;
             }
 
-            // all comparers are the same; this is faster
-            if (AreEqualityComparersEqual(set1, set2))
+            if (comparer.Equals(set1._comparer))
             {
                 if (set1.Count != set2.Count)
                 {

--- a/src/System.Collections/src/System/Collections/Generic/HashSetEqualityComparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSetEqualityComparer.cs
@@ -31,14 +31,17 @@ namespace System.Collections.Generic
 
         public int GetHashCode(HashSet<T> obj)
         {
-            int hashCode = 0;
-            if (obj != null)
+            if (obj == null)
             {
-                foreach (T t in obj)
-                {
-                    hashCode = hashCode ^ (_comparer.GetHashCode(t) & 0x7FFFFFFF);
-                }
-            } // else returns hashcode of 0 for null hashsets
+                return 0;
+            }
+
+            int hashCode = -889270259;
+            foreach (T t in obj)
+            {
+                hashCode = hashCode ^ _comparer.GetHashCode(t);
+            }
+
             return hashCode;
         }
 


### PR DESCRIPTION
Fixes #12560 by fixing the logic for selecting the fast-path. Unlike what was suggested in the thread for that issue, **this could be a breaking change**, that should be considered before accepting. It also makes some further changes so this is little commits now to aid examining each. They should be rebased into a single commit first if this is accepted.

427b429bb49f1f98ed621ca08b1243ef63f599b3 is the actual fix, changing a comparison of the two sets' comparers with a comparison between that of the first set and the comparer that is meant to be used by the method. Hence it's fast-path now works.

ff7ef41f5ecb1485372dbf35724849fa712cdf9c improves the short-circuiting at the beginning. As well as being an improvement in itself, it moves the `Count` check out of the fast-path aiding the next step…

adcf7717c0d8d119e581381cee6ff8aaa84ffaa5 uses `ContainsAllElements` instead of the loop, since that's what the loop is doing. It also covers the case were the same fast path can be used in the other direction because the second set has the appropriate comparer though the first did not.

6ec726e5c93ea613dbb59b0e83355565a0b90206 improves the non-fast-path approach for most cases (there are times when the previous code would return false sooner, but this O(n) approach should beat its O(n<sup>2</sup>)  approach most of the time.

1de6790a8fde0361ba171ff5580a69b74538586e is a minor improvement to `HashSetEqualityComparer.GetHashCode()` because improving it was the original suggestion in #12560 though this minor improvement was all I could see to do there. It means empty sets don't has the same as null, and removes an operation per item that doesn't add anything to the hash quality.

This also needs some test coverage.