### PR TITLE
Adjust ticks to allow positive UTC offsets

### DIFF
--- a/src/System.Net.Requests/tests/HttpRequestCachePolicyTest.cs
+++ b/src/System.Net.Requests/tests/HttpRequestCachePolicyTest.cs
@@ -18,7 +18,7 @@ namespace System.Net.Tests
             {
                 yield return new object[] { new HttpRequestCachePolicy(level), level, TimeSpan.MaxValue, TimeSpan.MinValue, TimeSpan.MinValue, DateTime.MinValue };
             }
-            yield return new object[] { new HttpRequestCachePolicy(new DateTime(42)), HttpRequestCacheLevel.Default, TimeSpan.MaxValue, TimeSpan.MinValue, TimeSpan.MinValue, new DateTime(42) };
+            yield return new object[] { new HttpRequestCachePolicy(new DateTime(504000000000)), HttpRequestCacheLevel.Default, TimeSpan.MaxValue, TimeSpan.MinValue, TimeSpan.MinValue, new DateTime(504000000000) };
             yield return new object[] { new HttpRequestCachePolicy(HttpCacheAgeControl.MaxAge, TimeSpan.FromSeconds(1)), HttpRequestCacheLevel.Default, TimeSpan.FromSeconds(1), TimeSpan.MinValue, TimeSpan.MinValue, DateTime.MinValue };
             yield return new object[] { new HttpRequestCachePolicy(HttpCacheAgeControl.MaxStale, TimeSpan.FromSeconds(1)), HttpRequestCacheLevel.Default, TimeSpan.MaxValue, TimeSpan.FromSeconds(1), TimeSpan.MinValue, DateTime.MinValue };
             yield return new object[] { new HttpRequestCachePolicy(HttpCacheAgeControl.MinFresh, TimeSpan.FromSeconds(1)), HttpRequestCacheLevel.Default, TimeSpan.MaxValue, TimeSpan.MinValue, TimeSpan.FromSeconds(1), DateTime.MinValue };


### PR DESCRIPTION
HttpRequestCachePolicy internally stores cacheSyncTime as UTC and convert it
as local time before returning (which may leads to lossy transformation)

Its testcase currently uses 42 tick as an input, which is valid only when
UTC offset is negative (42 tick is usually lost during conversion if UTC
offset is positive), which leads to #13462.

This commit uses 504000000000 (14 * 60 * 60 * 10^7) as an input to fix #13462.