### PR TITLE
Shift Expressions Tests and Refactoring

### DIFF
--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -22,12 +21,32 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableByteShiftTest(bool useInterpreter)
+        {
+            byte?[] array = { 0, 1, byte.MaxValue, null };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyNullableByteShift(array[i], useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckSByteShiftTest(bool useInterpreter)
         {
             sbyte[] array = new sbyte[] { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
                 VerifySByteShift(array[i], useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableSByteShiftTest(bool useInterpreter)
+        {
+            sbyte?[] array = { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue, null };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyNullableSByteShift(array[i], useInterpreter);
             }
         }
 
@@ -42,12 +61,32 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableUShortShiftTest(bool useInterpreter)
+        {
+            ushort?[] array = { 0, 1, ushort.MaxValue, null };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyNullableUShortShift(array[i], useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckShortShiftTest(bool useInterpreter)
         {
             short[] array = new short[] { 0, 1, -1, short.MinValue, short.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
                 VerifyShortShift(array[i], useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableShortShiftTest(bool useInterpreter)
+        {
+            short?[] array = { 0, 1, -1, short.MinValue, short.MaxValue, null };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyNullableShortShift(array[i], useInterpreter);
             }
         }
 
@@ -62,12 +101,32 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableUIntShiftTest(bool useInterpreter)
+        {
+            uint?[] array = { 0, 1, uint.MaxValue, null };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyNullableUIntShift(array[i], useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckIntShiftTest(bool useInterpreter)
         {
             int[] array = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
                 VerifyIntShift(array[i], useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableIntShiftTest(bool useInterpreter)
+        {
+            int?[] array = { 0, 1, -1, int.MinValue, int.MaxValue, null };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyNullableIntShift(array[i], useInterpreter);
             }
         }
 
@@ -82,12 +141,32 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableULongShiftTest(bool useInterpreter)
+        {
+            ulong?[] array = { 0, 1, ulong.MaxValue, null };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyNullableULongShift(array[i], useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckLongShiftTest(bool useInterpreter)
         {
             long[] array = new long[] { 0, 1, -1, long.MinValue, long.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
                 VerifyLongShift(array[i], useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableLongShiftTest(bool useInterpreter)
+        {
+            long?[] array = { 0, 1, -1, long.MinValue, long.MaxValue, null };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyNullableLongShift(array[i], useInterpreter);
             }
         }
 
@@ -104,6 +183,9 @@ namespace System.Linq.Expressions.Tests
                 VerifyByteShift(a, b, true, useInterpreter);
                 VerifyByteShift(a, b, false, useInterpreter);
             }
+
+            VerifyNullShift(a, true, useInterpreter);
+            VerifyNullShift(a, false, useInterpreter);
         }
 
         private static void VerifyByteShift(byte a, int b, bool left, bool useInterpreter)
@@ -124,6 +206,72 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             Assert.Equal((byte)(left ? a << b : a >> b), f());
+
+            Expression<Func<byte?>> en =
+                Expression.Lambda<Func<byte?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(byte)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(byte)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            Func<byte?> fn = en.Compile(useInterpreter);
+
+            Assert.Equal((byte)(left ? a << b : a >> b), fn());
+        }
+
+        private static void VerifyNullableByteShift(byte? a, bool useInterpreter)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyNullableByteShift(a, b, true, useInterpreter);
+                VerifyNullableByteShift(a, b, false, useInterpreter);
+            }
+
+            VerifyNullableNullShift(a, true, useInterpreter);
+            VerifyNullableNullShift(a, false, useInterpreter);
+        }
+
+        private static void VerifyNullableByteShift(byte? a, int b, bool left, bool useInterpreter)
+        {
+            Expression<Func<byte?>> e =
+                Expression.Lambda<Func<byte?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(byte?)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(byte?)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<byte?> f = e.Compile(useInterpreter);
+
+            Assert.Equal((byte?)(left ? a << b : a >> b), f());
+
+            e =
+                Expression.Lambda<Func<byte?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(byte?)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(byte?)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            f = e.Compile(useInterpreter);
+
+            Assert.Equal((byte?)(left ? a << b : a >> b), f());
         }
 
         private static void VerifySByteShift(sbyte a, bool useInterpreter)
@@ -133,6 +281,9 @@ namespace System.Linq.Expressions.Tests
                 VerifySByteShift(a, b, true, useInterpreter);
                 VerifySByteShift(a, b, false, useInterpreter);
             }
+
+            VerifyNullShift(a, true, useInterpreter);
+            VerifyNullShift(a, false, useInterpreter);
         }
 
         private static void VerifySByteShift(sbyte a, int b, bool left, bool useInterpreter)
@@ -153,6 +304,72 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             Assert.Equal((sbyte)(left ? a << b : a >> b), f());
+
+            Expression<Func<sbyte?>> en =
+                Expression.Lambda<Func<sbyte?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(sbyte)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(sbyte)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            Func<sbyte?> fn = en.Compile(useInterpreter);
+
+            Assert.Equal((sbyte)(left ? a << b : a >> b), fn());
+        }
+
+        private static void VerifyNullableSByteShift(sbyte? a, bool useInterpreter)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyNullableSByteShift(a, b, true, useInterpreter);
+                VerifyNullableSByteShift(a, b, false, useInterpreter);
+            }
+
+            VerifyNullableNullShift(a, true, useInterpreter);
+            VerifyNullableNullShift(a, false, useInterpreter);
+        }
+
+        private static void VerifyNullableSByteShift(sbyte? a, int b, bool left, bool useInterpreter)
+        {
+            Expression<Func<sbyte?>> e =
+                Expression.Lambda<Func<sbyte?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(sbyte?)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(sbyte?)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<sbyte?> f = e.Compile(useInterpreter);
+
+            Assert.Equal((sbyte?)(left ? a << b : a >> b), f());
+
+            e =
+                Expression.Lambda<Func<sbyte?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(sbyte?)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(sbyte?)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            f = e.Compile(useInterpreter);
+
+            Assert.Equal((sbyte?)(left ? a << b : a >> b), f());
         }
 
         private static void VerifyUShortShift(ushort a, bool useInterpreter)
@@ -162,6 +379,9 @@ namespace System.Linq.Expressions.Tests
                 VerifyUShortShift(a, b, true, useInterpreter);
                 VerifyUShortShift(a, b, false, useInterpreter);
             }
+
+            VerifyNullShift(a, true, useInterpreter);
+            VerifyNullShift(a, false, useInterpreter);
         }
 
         private static void VerifyUShortShift(ushort a, int b, bool left, bool useInterpreter)
@@ -182,6 +402,72 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             Assert.Equal((ushort)(left ? a << b : a >> b), f());
+
+            Expression<Func<ushort?>> en =
+                Expression.Lambda<Func<ushort?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(ushort)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(ushort)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            Func<ushort?> fn = en.Compile(useInterpreter);
+
+            Assert.Equal((ushort)(left ? a << b : a >> b), fn());
+        }
+
+        private static void VerifyNullableUShortShift(ushort? a, bool useInterpreter)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyNullableUShortShift(a, b, true, useInterpreter);
+                VerifyNullableUShortShift(a, b, false, useInterpreter);
+            }
+
+            VerifyNullableNullShift(a, true, useInterpreter);
+            VerifyNullableNullShift(a, false, useInterpreter);
+        }
+
+        private static void VerifyNullableUShortShift(ushort? a, int b, bool left, bool useInterpreter)
+        {
+            Expression<Func<ushort?>> e =
+                Expression.Lambda<Func<ushort?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(ushort?)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(ushort?)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<ushort?> f = e.Compile(useInterpreter);
+
+            Assert.Equal((ushort?)(left ? a << b : a >> b), f());
+
+            e =
+                Expression.Lambda<Func<ushort?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(ushort?)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(ushort?)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            f = e.Compile(useInterpreter);
+
+            Assert.Equal((ushort?)(left ? a << b : a >> b), f());
         }
 
         private static void VerifyShortShift(short a, bool useInterpreter)
@@ -191,6 +477,9 @@ namespace System.Linq.Expressions.Tests
                 VerifyShortShift(a, b, true, useInterpreter);
                 VerifyShortShift(a, b, false, useInterpreter);
             }
+
+            VerifyNullShift(a, true, useInterpreter);
+            VerifyNullShift(a, false, useInterpreter);
         }
 
         private static void VerifyShortShift(short a, int b, bool left, bool useInterpreter)
@@ -211,6 +500,72 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             Assert.Equal((short)(left ? a << b : a >> b), f());
+
+            Expression<Func<short?>> en =
+                Expression.Lambda<Func<short?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(short)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(short)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            Func<short?> fn = en.Compile(useInterpreter);
+
+            Assert.Equal((short)(left ? a << b : a >> b), fn());
+        }
+
+        private static void VerifyNullableShortShift(short? a, bool useInterpreter)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyNullableShortShift(a, b, true, useInterpreter);
+                VerifyNullableShortShift(a, b, false, useInterpreter);
+            }
+
+            VerifyNullableNullShift(a, true, useInterpreter);
+            VerifyNullableNullShift(a, false, useInterpreter);
+        }
+
+        private static void VerifyNullableShortShift(short? a, int b, bool left, bool useInterpreter)
+        {
+            Expression<Func<short?>> e =
+                Expression.Lambda<Func<short?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(short?)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(short?)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<short?> f = e.Compile(useInterpreter);
+
+            Assert.Equal((short?)(left ? a << b : a >> b), f());
+
+            e =
+                Expression.Lambda<Func<short?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(short?)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(short?)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            f = e.Compile(useInterpreter);
+
+            Assert.Equal((short?)(left ? a << b : a >> b), f());
         }
 
         private static void VerifyUIntShift(uint a, bool useInterpreter)
@@ -220,6 +575,9 @@ namespace System.Linq.Expressions.Tests
                 VerifyUIntShift(a, b, true, useInterpreter);
                 VerifyUIntShift(a, b, false, useInterpreter);
             }
+
+            VerifyNullShift(a, true, useInterpreter);
+            VerifyNullShift(a, false, useInterpreter);
         }
 
         private static void VerifyUIntShift(uint a, int b, bool left, bool useInterpreter)
@@ -240,6 +598,72 @@ namespace System.Linq.Expressions.Tests
             Func<uint> f = e.Compile(useInterpreter);
 
             Assert.Equal(left ? a << b : a >> b, f());
+
+            Expression<Func<uint?>> en =
+                Expression.Lambda<Func<uint?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(uint)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(uint)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            Func<uint?> fn = en.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, fn());
+        }
+
+        private static void VerifyNullableUIntShift(uint? a, bool useInterpreter)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyNullableUIntShift(a, b, true, useInterpreter);
+                VerifyNullableUIntShift(a, b, false, useInterpreter);
+            }
+
+            VerifyNullableNullShift(a, true, useInterpreter);
+            VerifyNullableNullShift(a, false, useInterpreter);
+        }
+
+        private static void VerifyNullableUIntShift(uint? a, int b, bool left, bool useInterpreter)
+        {
+            Expression<Func<uint?>> e =
+                Expression.Lambda<Func<uint?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(uint?)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(uint?)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<uint?> f = e.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, f());
+
+            e =
+                Expression.Lambda<Func<uint?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(uint?)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(uint?)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            f = e.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, f());
         }
 
         private static void VerifyIntShift(int a, bool useInterpreter)
@@ -249,6 +673,9 @@ namespace System.Linq.Expressions.Tests
                 VerifyIntShift(a, b, true, useInterpreter);
                 VerifyIntShift(a, b, false, useInterpreter);
             }
+
+            VerifyNullShift(a, true, useInterpreter);
+            VerifyNullShift(a, false, useInterpreter);
         }
 
         private static void VerifyIntShift(int a, int b, bool left, bool useInterpreter)
@@ -269,6 +696,72 @@ namespace System.Linq.Expressions.Tests
             Func<int> f = e.Compile(useInterpreter);
 
             Assert.Equal(left ? a << b : a >> b, f());
+
+            Expression<Func<int?>> en =
+                Expression.Lambda<Func<int?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(int)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(int)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            Func<int?> fn = en.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, fn());
+        }
+
+        private static void VerifyNullableIntShift(int? a, bool useInterpreter)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyNullableIntShift(a, b, true, useInterpreter);
+                VerifyNullableIntShift(a, b, false, useInterpreter);
+            }
+
+            VerifyNullableNullShift(a, true, useInterpreter);
+            VerifyNullableNullShift(a, false, useInterpreter);
+        }
+
+        private static void VerifyNullableIntShift(int? a, int b, bool left, bool useInterpreter)
+        {
+            Expression<Func<int?>> e =
+                Expression.Lambda<Func<int?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(int?)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(int?)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<int?> f = e.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, f());
+
+            e =
+                Expression.Lambda<Func<int?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(int?)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(int?)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            f = e.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, f());
         }
 
         private static void VerifyULongShift(ulong a, bool useInterpreter)
@@ -278,6 +771,9 @@ namespace System.Linq.Expressions.Tests
                 VerifyULongShift(a, b, true, useInterpreter);
                 VerifyULongShift(a, b, false, useInterpreter);
             }
+
+            VerifyNullShift(a, true, useInterpreter);
+            VerifyNullShift(a, false, useInterpreter);
         }
 
         private static void VerifyULongShift(ulong a, int b, bool left, bool useInterpreter)
@@ -298,6 +794,72 @@ namespace System.Linq.Expressions.Tests
             Func<ulong> f = e.Compile(useInterpreter);
 
             Assert.Equal(left ? a << b : a >> b, f());
+
+            Expression<Func<ulong?>> en =
+                Expression.Lambda<Func<ulong?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(ulong)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(ulong)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            Func<ulong?> fn = en.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, fn());
+        }
+
+        private static void VerifyNullableULongShift(ulong? a, bool useInterpreter)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyNullableULongShift(a, b, true, useInterpreter);
+                VerifyNullableULongShift(a, b, false, useInterpreter);
+            }
+
+            VerifyNullableNullShift(a, true, useInterpreter);
+            VerifyNullableNullShift(a, false, useInterpreter);
+        }
+
+        private static void VerifyNullableULongShift(ulong? a, int b, bool left, bool useInterpreter)
+        {
+            Expression<Func<ulong?>> e =
+                Expression.Lambda<Func<ulong?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(ulong?)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(ulong?)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<ulong?> f = e.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, f());
+
+            e =
+                Expression.Lambda<Func<ulong?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(ulong?)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(ulong?)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            f = e.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, f());
         }
 
         private static void VerifyLongShift(long a, bool useInterpreter)
@@ -307,6 +869,9 @@ namespace System.Linq.Expressions.Tests
                 VerifyLongShift(a, b, true, useInterpreter);
                 VerifyLongShift(a, b, false, useInterpreter);
             }
+
+            VerifyNullShift(a, true, useInterpreter);
+            VerifyNullShift(a, false, useInterpreter);
         }
 
         private static void VerifyLongShift(long a, int b, bool left, bool useInterpreter)
@@ -327,6 +892,112 @@ namespace System.Linq.Expressions.Tests
             Func<long> f = e.Compile(useInterpreter);
 
             Assert.Equal(left ? a << b : a >> b, f());
+
+            Expression<Func<long?>> en =
+                Expression.Lambda<Func<long?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(long)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(long)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            Func<long?> fn = en.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, fn());
+        }
+
+        private static void VerifyNullableLongShift(long? a, bool useInterpreter)
+        {
+            foreach (var b in s_shifts)
+            {
+                VerifyNullableLongShift(a, b, true, useInterpreter);
+                VerifyNullableLongShift(a, b, false, useInterpreter);
+            }
+
+            VerifyNullableNullShift(a, true, useInterpreter);
+            VerifyNullableNullShift(a, false, useInterpreter);
+        }
+
+        private static void VerifyNullableLongShift(long? a, int b, bool left, bool useInterpreter)
+        {
+            Expression<Func<long?>> e =
+                Expression.Lambda<Func<long?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(long?)),
+                        Expression.Constant(b, typeof(int)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(long?)),
+                        Expression.Constant(b, typeof(int)))
+                    );
+
+            Func<long?> f = e.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, f());
+
+            e =
+                Expression.Lambda<Func<long?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(long?)),
+                        Expression.Constant(b, typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(long?)),
+                        Expression.Constant(b, typeof(int?)))
+                    );
+
+            f = e.Compile(useInterpreter);
+
+            Assert.Equal(left ? a << b : a >> b, f());
+        }
+
+        private static void VerifyNullShift<T>(T a, bool left, bool useInterpreter) where T : struct
+        {
+            Expression<Func<T?>> e =
+                Expression.Lambda<Func<T?>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(T)),
+                        Expression.Default(typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(T)),
+                        Expression.Default(typeof(int?)))
+                    );
+
+            Func<T?> f = e.Compile(useInterpreter);
+
+            Assert.Null(f());
+        }
+
+        private static void VerifyNullableNullShift<T>(T a, bool left, bool useInterpreter)
+        {
+            Expression<Func<T>> e =
+                Expression.Lambda<Func<T>>(
+                    left
+                    ?
+                    Expression.LeftShift(
+                        Expression.Constant(a, typeof(T)),
+                        Expression.Default(typeof(int?)))
+                    :
+                    Expression.RightShift(
+                        Expression.Constant(a, typeof(T)),
+                        Expression.Default(typeof(int?)))
+                    );
+
+            Func<T> f = e.Compile(useInterpreter);
+
+            Assert.Null(f());
         }
 
         #endregion
@@ -417,6 +1088,25 @@ namespace System.Linq.Expressions.Tests
 
             var e2 = Expression.RightShift(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a >> b)", e2.ToString());
+        }
+
+        [Theory, InlineData(typeof(E)), InlineData(typeof(El)), InlineData(typeof(string))]
+        public static void IncorrectLHSTypes(Type type)
+        {
+            var lhs = Expression.Default(type);
+            var rhs = Expression.Constant(0);
+            Assert.Throws<InvalidOperationException>(() => Expression.LeftShift(lhs, rhs));
+            Assert.Throws<InvalidOperationException>(() => Expression.RightShift(lhs, rhs));
+        }
+
+        [Theory, InlineData(typeof(E)), InlineData(typeof(El)), InlineData(typeof(string)), InlineData(typeof(long)),
+         InlineData(typeof(short)), InlineData(typeof(uint))]
+        public static void IncorrectRHSTypes(Type type)
+        {
+            var lhs = Expression.Constant(0);
+            var rhs = Expression.Default(type);
+            Assert.Throws<InvalidOperationException>(() => Expression.LeftShift(lhs, rhs));
+            Assert.Throws<InvalidOperationException>(() => Expression.RightShift(lhs, rhs));
         }
     }
 }


### PR DESCRIPTION
Add tests for nullable operands to shift expressions.

Add tests for invalid types on shift expression creation.

Remove interpreter support for methodless shifts on enums.

These aren't valid expressions, so this code is dead. Remove.

Interpreter throws runtime exception on invalid LHS to shift instruction, but this is already checked in earlier validation. Replace runtime exception with assertion.

Refactor commonality in LeftShiftInstruction and RightShiftInstruction

The related classes have a lot of code duplication, so refactor to remove that.

Contributes to #3836 and #1198