### PR TITLE
Fix procfs parsing for modules with a space.

### DIFF
--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -161,7 +161,7 @@ internal static partial class Interop
                 {
                     continue;
                 }
-                string pathname = parser.ExtractCurrent();
+                string pathname = parser.ExtractCurrentToEnd();
 
                 // We only get here if a we have a non-empty pathname and
                 // the permissions included both readability and executability.

--- a/src/Common/src/System/IO/StringParser.cs
+++ b/src/Common/src/System/IO/StringParser.cs
@@ -311,6 +311,18 @@ namespace System.IO
             return selector(_buffer, ref _startIndex, ref _endIndex);
         }
 
+        /// <summary>
+        /// Gets the current subcomponent and all remaining components of the string as a string.
+        /// </summary>
+        public string ExtractCurrentToEnd()
+        {
+            if (_buffer == null || _startIndex == -1)
+            {
+                throw new InvalidOperationException();
+            }
+            return _buffer.Substring(_startIndex);
+        }
+
         /// <summary>Throws unconditionally for invalid data.</summary>
         private static void ThrowForInvalidData()
         {

--- a/src/Common/tests/Tests/System/IO/StringParserTests.cs
+++ b/src/Common/tests/Tests/System/IO/StringParserTests.cs
@@ -148,5 +148,18 @@ namespace Tests.System.IO
             Assert.Equal("fter brace", sp.MoveAndExtractNext());
             Assert.Equal("", sp.MoveAndExtractNext());
         }
+
+        [Fact]
+        public void TestExtractCurrentToEnd()
+        {
+            string buffer = "This has a /path/to my favorite file/with a space";
+            char separator = ' ';
+            StringParser sp = new StringParser(buffer, separator);
+            Assert.Equal("This", sp.MoveAndExtractNext());
+            Assert.Equal("has", sp.MoveAndExtractNext());
+            Assert.Equal("a", sp.MoveAndExtractNext());
+            Assert.True(sp.MoveNext());
+            Assert.Equal("/path/to my favorite file/with a space", sp.ExtractCurrentToEnd());
+        }
     }
 }


### PR DESCRIPTION
When parsing a proc maps file, the path would be improperly read if the path contained a space.
This changes the behavior to read to the end of the line since the module path is the last
component in the maps file.

Fixes #13452