### PR TITLE
Remove boxed Int32 from every Socket async send/receive

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
@@ -12,7 +12,7 @@ using Microsoft.Win32;
 namespace System.Net.Sockets
 {
     // AcceptOverlappedAsyncResult - used to take care of storage for async Socket BeginAccept call.
-    internal partial class AcceptOverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal sealed partial class AcceptOverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         private Socket _acceptedSocket;
 
@@ -29,7 +29,7 @@ namespace System.Net.Sockets
         public void CompletionCallback(IntPtr acceptedFileDescriptor, byte[] socketAddress, int socketAddressLen, SocketError errorCode)
         {
             _buffer = null;
-            _localBytesTransferred = 0;
+            _numBytes = 0;
 
 			if (errorCode == SocketError.Success)
 			{
@@ -46,6 +46,7 @@ namespace System.Net.Sockets
 
         internal override object PostCompletion(int numBytes)
         {
+            _numBytes = numBytes;
             return (SocketError)ErrorCode == SocketError.Success ? _acceptedSocket : null;
         }
     }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
@@ -12,7 +12,7 @@ using Microsoft.Win32;
 namespace System.Net.Sockets
 {
     // AcceptOverlappedAsyncResult - used to take care of storage for async Socket BeginAccept call.
-    internal partial class AcceptOverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal sealed partial class AcceptOverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         private Socket _acceptSocket;
         private int _addressBufferLength;
@@ -26,7 +26,7 @@ namespace System.Net.Sockets
             Internals.SocketAddress remoteSocketAddress = null;
             if (errorCode == SocketError.Success)
             {
-                _localBytesTransferred = numBytes;
+                _numBytes = numBytes;
                 if (NetEventSource.IsEnabled) LogBuffer(numBytes);
 
                 // get the endpoint

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.cs
@@ -11,9 +11,8 @@ using Microsoft.Win32;
 namespace System.Net.Sockets
 {
     // AcceptOverlappedAsyncResult - used to take care of storage for async Socket BeginAccept call.
-    internal partial class AcceptOverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal sealed partial class AcceptOverlappedAsyncResult : BaseOverlappedAsyncResult
     {
-        private int _localBytesTransferred;
         private Socket _listenSocket;
         private byte[] _buffer;
 
@@ -35,7 +34,7 @@ namespace System.Net.Sockets
         {
             get
             {
-                return _localBytesTransferred;
+                return _numBytes;
             }
         }
     }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ConnectOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ConnectOverlappedAsyncResult.Unix.cs
@@ -11,7 +11,7 @@ using Microsoft.Win32;
 namespace System.Net.Sockets
 {
     // ConnectOverlappedAsyncResult - used to take care of storage for async Socket BeginConnect call.
-    internal partial class ConnectOverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal sealed partial class ConnectOverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         public void CompletionCallback(SocketError errorCode)
         {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ConnectOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ConnectOverlappedAsyncResult.Windows.cs
@@ -11,7 +11,7 @@ using Microsoft.Win32;
 namespace System.Net.Sockets
 {
     // ConnectOverlappedAsyncResult - used to take care of storage for async Socket BeginConnect call.
-    internal partial class ConnectOverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal sealed partial class ConnectOverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         // This method is called by base.CompletionPortCallback base.OverlappedCallback as part of IO completion
         internal override object PostCompletion(int numBytes)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ConnectOverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ConnectOverlappedAsyncResult.cs
@@ -11,7 +11,7 @@ using Microsoft.Win32;
 namespace System.Net.Sockets
 {
     // ConnectOverlappedAsyncResult - used to take care of storage for async Socket BeginConnect call.
-    internal partial class ConnectOverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal sealed partial class ConnectOverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         private EndPoint _endPoint;
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/DisconnectOverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/DisconnectOverlappedAsyncResult.cs
@@ -5,7 +5,7 @@
 namespace System.Net.Sockets
 {
     // DisconnectOverlappedAsyncResult - used to take care of storage for async Socket BeginAccept call.
-    internal class DisconnectOverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal sealed class DisconnectOverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         internal DisconnectOverlappedAsyncResult(Socket socket, Object asyncState, AsyncCallback asyncCallback) :
             base(socket, asyncState, asyncCallback)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Unix.cs
@@ -10,7 +10,7 @@ namespace System.Net.Sockets
     //
     // This class is used to take care of storage for async Socket operation
     // from the BeginSend, BeginSendTo, BeginReceive, BeginReceiveFrom calls.
-    internal partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal sealed partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         private int _socketAddressSize;
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
@@ -16,7 +16,7 @@ namespace System.Net.Sockets
     //
     // This class is used to take care of storage for async Socket operation
     // from the BeginSend, BeginSendTo, BeginReceive, BeginReceiveFrom calls.
-    internal partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal sealed partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         internal WSABuffer _singleBuffer;
         internal WSABuffer[] _wsaBuffers;
@@ -109,7 +109,7 @@ namespace System.Net.Sockets
                 LogBuffer(numBytes);
             }
 
-            return numBytes;
+            return base.PostCompletion(numBytes);
         }
 
         private void LogBuffer(int size)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.cs
@@ -15,7 +15,7 @@ namespace System.Net.Sockets
     //
     // This class is used to take care of storage for async Socket operation
     // from the BeginSend, BeginSendTo, BeginReceive, BeginReceiveFrom calls.
-    internal partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal sealed partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         private Internals.SocketAddress _socketAddress;
         private Internals.SocketAddress _socketAddressOriginal; // Needed for partial BeginReceiveFrom/EndReceiveFrom completion.

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Unix.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace System.Net.Sockets
 {
-    unsafe internal partial class ReceiveMessageOverlappedAsyncResult : BaseOverlappedAsyncResult
+    unsafe internal sealed partial class ReceiveMessageOverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         private int _socketAddressSize;
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace System.Net.Sockets
 {
-    unsafe internal partial class ReceiveMessageOverlappedAsyncResult : BaseOverlappedAsyncResult
+    unsafe internal sealed partial class ReceiveMessageOverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         private Interop.Winsock.WSAMsg* _message;
         private WSABuffer* _wsaBuffer;
@@ -157,7 +157,7 @@ namespace System.Net.Sockets
                 LogBuffer(numBytes);
             }
 
-            return (int)numBytes;
+            return base.PostCompletion(numBytes);
         }
 
         private void LogBuffer(int size)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace System.Net.Sockets
 {
-    unsafe internal partial class ReceiveMessageOverlappedAsyncResult : BaseOverlappedAsyncResult
+    unsafe internal sealed partial class ReceiveMessageOverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         private Internals.SocketAddress _socketAddressOriginal;
         private Internals.SocketAddress _socketAddress;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2817,7 +2817,7 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.Format(SR.net_io_invalidendcall, "EndSend"));
             }
 
-            int bytesTransferred = (int)castedAsyncResult.InternalWaitForCompletion();
+            int bytesTransferred = castedAsyncResult.InternalWaitForCompletionInt32Result();
             castedAsyncResult.EndCalled = true;
 
             if (s_perfCountersEnabled)
@@ -2997,7 +2997,7 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.Format(SR.net_io_invalidendcall, "EndSendTo"));
             }
 
-            int bytesTransferred = (int)castedAsyncResult.InternalWaitForCompletion();
+            int bytesTransferred = castedAsyncResult.InternalWaitForCompletionInt32Result();
             castedAsyncResult.EndCalled = true;
 
             if (s_perfCountersEnabled)
@@ -3316,7 +3316,7 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.Format(SR.net_io_invalidendcall, "EndReceive"));
             }
 
-            int bytesTransferred = (int)castedAsyncResult.InternalWaitForCompletion();
+            int bytesTransferred = castedAsyncResult.InternalWaitForCompletionInt32Result();
             castedAsyncResult.EndCalled = true;
 
             if (s_perfCountersEnabled)
@@ -3518,7 +3518,7 @@ namespace System.Net.Sockets
 
             Internals.SocketAddress socketAddressOriginal = SnapshotAndSerialize(ref endPoint);
 
-            int bytesTransferred = (int)castedAsyncResult.InternalWaitForCompletion();
+            int bytesTransferred = castedAsyncResult.InternalWaitForCompletionInt32Result();
             castedAsyncResult.EndCalled = true;
 
             // Update socket address size.
@@ -3752,7 +3752,7 @@ namespace System.Net.Sockets
 
             Internals.SocketAddress socketAddressOriginal = SnapshotAndSerialize(ref endPoint);
 
-            int bytesTransferred = (int)castedAsyncResult.InternalWaitForCompletion();
+            int bytesTransferred = castedAsyncResult.InternalWaitForCompletionInt32Result();
             castedAsyncResult.EndCalled = true;
 
             // Update socket address size.


### PR DESCRIPTION
Every async send/receive operation was boxing its Int32 result.

cc: @davidsh, @cipop, @geoffkizer