### PR TITLE
Shrink ContextAwareResult.StateFlags from Int32 to Byte

### DIFF
--- a/src/Common/src/System/Net/ContextAwareResult.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.cs
@@ -73,7 +73,7 @@ namespace System.Net
     internal partial class ContextAwareResult : LazyAsyncResult
     {
         [Flags]
-        private enum StateFlags
+        private enum StateFlags : byte
         {
             None = 0x00,
             CaptureIdentity = 0x01,


### PR DESCRIPTION
It's a flags enum with fewer than 8 bits used; we can make its underlying type Byte rather than Int32.  This shrinks the size of the ContextAwareResult._flags field accordingly.

cc: @davidsh, @cipop, @geoffkizer