### PR TITLE
[ARM/CI] Change rootfs directories

### DIFF
--- a/scripts/arm32_ci_script.sh
+++ b/scripts/arm32_ci_script.sh
@@ -237,7 +237,7 @@ exit_if_empty "$__ARMRootfsMountPath" "--mountPath is a mandatory argument, not 
 exit_if_empty "$__buildConfig" "--buildConfig is a mandatory argument, not provided" true
 exit_if_path_absent "$__ARMEmulPath/platform/$__ARMRootfsImageBase" "Path specified in --emulatorPath does not have the rootfs" false
 
-__ARMRootfsMountPath="${__ARMRootfsMountPath}/${__buildArch}"
+__ARMRootfsMountPath="${__ARMRootfsMountPath}_${__buildArch}"
 
 set -x
 set -e


### PR DESCRIPTION
rootfs directory `/opt/linux-arm-emulator-root/` is still in use from coreclr ARM-CI
so changing it to `/opt/linux-arm-emulator-root_{arm|arm-softfp}/`.