### PR TITLE
Re-enable SecureString tests

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -641,7 +641,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
 #if netcoreapp11
-        [ActiveIssue(13471)]
         [Fact]
         public static void ExportCert_SecureString()
         {

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -40,7 +40,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
 #if netcoreapp11
-        [ActiveIssue(13471)]
         [Theory]
         [MemberData(nameof(StorageFlags))]
         public static void TestConstructor_SecureString(X509KeyStorageFlags keyStorageFlags)

--- a/src/System.Security.SecureString/tests/SecureStringTests.cs
+++ b/src/System.Security.SecureString/tests/SecureStringTests.cs
@@ -102,7 +102,6 @@ namespace System.Security.Tests
         }
 
         [Fact]
-        [ActiveIssue(13331)]
         public static void Dispose_AllOtherOperationsThrow()
         {
             SecureString ss = CreateSecureString("test");
@@ -300,13 +299,12 @@ namespace System.Security.Tests
         }
 
         [Fact]
-        [ActiveIssue(13331)]
         public static void SecureStringMarshal_NullArgsAllowed_IntPtrZero()
         {
-            Assert.Equal(IntPtr.Zero, SecureStringMarshal.SecureStringToCoTaskMemAnsi(null));
-            Assert.Equal(IntPtr.Zero, SecureStringMarshal.SecureStringToCoTaskMemUnicode(null));
-            Assert.Equal(IntPtr.Zero, SecureStringMarshal.SecureStringToGlobalAllocAnsi(null));
-            Assert.Equal(IntPtr.Zero, SecureStringMarshal.SecureStringToGlobalAllocUnicode(null));
+            Assert.Throws<ArgumentNullException>("s", () => SecureStringMarshal.SecureStringToCoTaskMemAnsi(null));
+            Assert.Throws<ArgumentNullException>("s", () => SecureStringMarshal.SecureStringToCoTaskMemUnicode(null));
+            Assert.Throws<ArgumentNullException>("s", () => SecureStringMarshal.SecureStringToGlobalAllocAnsi(null));
+            Assert.Throws<ArgumentNullException>("s", () => SecureStringMarshal.SecureStringToGlobalAllocUnicode(null));
         }
 
         [Fact]
@@ -319,7 +317,6 @@ namespace System.Security.Tests
             }
         }
 
-        [ActiveIssue(13331)]
         [Theory]
         [InlineData(0, false)]
         [InlineData(0, true)]
@@ -361,7 +358,6 @@ namespace System.Security.Tests
             }
         }
 
-        [ActiveIssue(13331)]
         [Theory]
         [InlineData(0, false)]
         [InlineData(0, true)]
@@ -452,7 +448,6 @@ namespace System.Security.Tests
         [OuterLoop]
         [Theory]
         [InlineData(5)]
-        [ActiveIssue(13331)]
         public static void ThreadSafe_Stress(int executionTimeSeconds) // do some minimal verification that an instance can be used concurrently
         {
             using (var ss = new SecureString())
@@ -510,8 +505,7 @@ namespace System.Security.Tests
 
         private static unsafe void AssertEquals(string expected, SecureString actual)
         {
-            // ActiveIssue(13331) -- please re-enable the code below.
-            //Assert.Equal(expected, CreateString(actual));
+            Assert.Equal(expected, CreateString(actual));
         }
 
         private static string CreateString(int length)


### PR DESCRIPTION
cc: @AlexGhiondea 
Fixes #13331 
Fixes #13471 

One thing to note: it looks like there was a discrepancy between SecureStringMarshal and Marshal in their handling of null SecureString inputs.  SecureStringMarshal was returning IntPtr.Zero for a null input, whereas Marshal is throwing an ArgumentNullException.  I've changed the tests to match the Marshal behavior, which is the same behavior that exists on desktop.  We should confirm we're ok with this change from .NET Core 1.1, though, and address it subsequently in both the implementation and tests if we're not.