### PR TITLE
Expression casts tests and fix boolean-enum casts

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -947,6 +947,10 @@ namespace System.Linq.Expressions.Compiler
                                 il.Emit(OpCodes.Conv_I8);
                             }
                             break;
+                        case TypeCode.Boolean:
+                            il.Emit(OpCodes.Ldc_I4_0);
+                            il.Emit(OpCodes.Cgt_Un);
+                            break;
                         default:
                             throw Error.UnhandledConvert(typeTo);
                     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -816,6 +816,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public void EmitCastReferenceToEnum(Type toType)
         {
+            Debug.Assert(_instructions[_instructions.Count - 1] == NullCheckInstruction.Instance);
             Emit(new CastReferenceToEnumInstruction(toType));
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
@@ -101,6 +101,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.Single: return (float)obj;
                         case TypeCode.Double: return (double)obj;
                         case TypeCode.Decimal: return (decimal)obj;
+                        case TypeCode.Boolean: return obj != 0;
                         default: throw ContractUtils.Unreachable;
                     }
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -471,65 +471,57 @@ namespace System.Linq.Expressions.Interpreter
         public override int Run(InterpretedFrame frame)
         {
             object from = frame.Pop();
-            if (from == null)
+            Debug.Assert(from != null);
+            Type underlying = Enum.GetUnderlyingType(_t);
+            // Order checks in order of likelihood. int first as the vast majority of enums
+            // are int-based, then long as that is sometimes used when required for a large set of flags
+            // and so-on.
+            if (underlying == typeof(int))
             {
-                frame.Push(null);
+                // If from is neither an int nor a type assignable to int (viz. an int-backed enum)
+                // this will cause an InvalidCastException, which is what this operation should
+                // throw in this case.
+                frame.Push(Enum.ToObject(_t, (int)from));
+            }
+            else if (underlying == typeof(long))
+            {
+                frame.Push(Enum.ToObject(_t, (long)from));
+            }
+            else if (underlying == typeof(uint))
+            {
+                frame.Push(Enum.ToObject(_t, (uint)from));
+            }
+            else if (underlying == typeof(ulong))
+            {
+                frame.Push(Enum.ToObject(_t, (ulong)from));
+            }
+            else if (underlying == typeof(byte))
+            {
+                frame.Push(Enum.ToObject(_t, (byte)from));
+            }
+            else if (underlying == typeof(sbyte))
+            {
+                frame.Push(Enum.ToObject(_t, (sbyte)from));
+            }
+            else if (underlying == typeof(short))
+            {
+                frame.Push(Enum.ToObject(_t, (short)from));
+            }
+            else if (underlying == typeof(ushort))
+            {
+                frame.Push(Enum.ToObject(_t, (ushort)from));
+            }
+            else if (underlying == typeof(char))
+            {
+                // Disallowed in C#, but allowed in CIL
+                frame.Push(Enum.ToObject(_t, (char)from));
             }
             else
             {
-                Type underlying = _t.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(_t) : _t;
-                // Order checks in order of likelihood. int first as the vast majority of enums
-                // are int-based, then long as that is sometimes used when required for a large set of flags
-                // and so-on.
-                if (underlying == typeof(int))
-                {
-                    // If from is neither an int nor a type assignable to int (viz. an int-backed enum)
-                    // this will cause an InvalidCastException, which is what this operation should
-                    // throw in this case.
-                    frame.Push(Enum.ToObject(_t, (int)from));
-                }
-                else if (underlying == typeof(long))
-                {
-                    frame.Push(Enum.ToObject(_t, (long)from));
-                }
-                else if (underlying == typeof(uint))
-                {
-                    frame.Push(Enum.ToObject(_t, (uint)from));
-                }
-                else if (underlying == typeof(ulong))
-                {
-                    frame.Push(Enum.ToObject(_t, (ulong)from));
-                }
-                else if (underlying == typeof(byte))
-                {
-                    frame.Push(Enum.ToObject(_t, (byte)from));
-                }
-                else if (underlying == typeof(sbyte))
-                {
-                    frame.Push(Enum.ToObject(_t, (sbyte)from));
-                }
-                else if (underlying == typeof(short))
-                {
-                    frame.Push(Enum.ToObject(_t, (short)from));
-                }
-                else if (underlying == typeof(ushort))
-                {
-                    frame.Push(Enum.ToObject(_t, (ushort)from));
-                }
-                else if (underlying == typeof(char))
-                {
-                    // Disallowed in C#, but allowed in CIL
-                    frame.Push(Enum.ToObject(_t, (char)from));
-                }
-                else if (underlying == typeof(bool))
-                {
-                    // Disallowed in C#, but allowed in CIL
-                    frame.Push(Enum.ToObject(_t, (bool)from));
-                }
-                else
-                {
-                    throw new InvalidCastException();
-                }
+                // Only remaining possible type.
+                // Disallowed in C#, but allowed in CIL
+                Debug.Assert(underlying == typeof(bool));
+                frame.Push(Enum.ToObject(_t, (bool)from));
             }
 
             return 1;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -394,26 +394,24 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type t)
         {
-            if (!t.GetTypeInfo().IsEnum)
+            Debug.Assert(!t.GetTypeInfo().IsEnum);
+            switch (t.GetTypeCode())
             {
-                switch (t.GetTypeCode())
-                {
-                    case TypeCode.Boolean: return s_boolean ?? (s_boolean = new CastInstructionT<bool>());
-                    case TypeCode.Byte: return s_byte ?? (s_byte = new CastInstructionT<byte>());
-                    case TypeCode.Char: return s_char ?? (s_char = new CastInstructionT<char>());
-                    case TypeCode.DateTime: return s_dateTime ?? (s_dateTime = new CastInstructionT<DateTime>());
-                    case TypeCode.Decimal: return s_decimal ?? (s_decimal = new CastInstructionT<decimal>());
-                    case TypeCode.Double: return s_double ?? (s_double = new CastInstructionT<double>());
-                    case TypeCode.Int16: return s_int16 ?? (s_int16 = new CastInstructionT<short>());
-                    case TypeCode.Int32: return s_int32 ?? (s_int32 = new CastInstructionT<int>());
-                    case TypeCode.Int64: return s_int64 ?? (s_int64 = new CastInstructionT<long>());
-                    case TypeCode.SByte: return s_SByte ?? (s_SByte = new CastInstructionT<sbyte>());
-                    case TypeCode.Single: return s_single ?? (s_single = new CastInstructionT<float>());
-                    case TypeCode.String: return s_string ?? (s_string = new CastInstructionT<string>());
-                    case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new CastInstructionT<ushort>());
-                    case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new CastInstructionT<uint>());
-                    case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new CastInstructionT<ulong>());
-                }
+                case TypeCode.Boolean: return s_boolean ?? (s_boolean = new CastInstructionT<bool>());
+                case TypeCode.Byte: return s_byte ?? (s_byte = new CastInstructionT<byte>());
+                case TypeCode.Char: return s_char ?? (s_char = new CastInstructionT<char>());
+                case TypeCode.DateTime: return s_dateTime ?? (s_dateTime = new CastInstructionT<DateTime>());
+                case TypeCode.Decimal: return s_decimal ?? (s_decimal = new CastInstructionT<decimal>());
+                case TypeCode.Double: return s_double ?? (s_double = new CastInstructionT<double>());
+                case TypeCode.Int16: return s_int16 ?? (s_int16 = new CastInstructionT<short>());
+                case TypeCode.Int32: return s_int32 ?? (s_int32 = new CastInstructionT<int>());
+                case TypeCode.Int64: return s_int64 ?? (s_int64 = new CastInstructionT<long>());
+                case TypeCode.SByte: return s_SByte ?? (s_SByte = new CastInstructionT<sbyte>());
+                case TypeCode.Single: return s_single ?? (s_single = new CastInstructionT<float>());
+                case TypeCode.String: return s_string ?? (s_string = new CastInstructionT<string>());
+                case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new CastInstructionT<ushort>());
+                case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new CastInstructionT<uint>());
+                case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new CastInstructionT<ulong>());
             }
 
             return CastInstructionNoT.Create(t);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -433,27 +433,13 @@ namespace System.Linq.Expressions.Interpreter
         public override int Run(InterpretedFrame frame)
         {
             object from = frame.Pop();
-            switch (Convert.GetTypeCode(from))
-            {
-                case TypeCode.Empty:
-                    frame.Push(null);
-                    break;
-                case TypeCode.Int32:
-                case TypeCode.SByte:
-                case TypeCode.Int16:
-                case TypeCode.Int64:
-                case TypeCode.UInt32:
-                case TypeCode.Byte:
-                case TypeCode.UInt16:
-                case TypeCode.UInt64:
-                case TypeCode.Char:
-                case TypeCode.Boolean:
-                    frame.Push(Enum.ToObject(_t, from));
-                    break;
-                default:
-                    throw new InvalidCastException();
-            }
-
+            Debug.Assert(
+                new[]
+                {
+                    TypeCode.Empty, TypeCode.Int32, TypeCode.SByte, TypeCode.Int16, TypeCode.Int64, TypeCode.UInt32,
+                    TypeCode.Byte, TypeCode.UInt16, TypeCode.UInt64, TypeCode.Char, TypeCode.Boolean
+                }.Contains(Convert.GetTypeCode(from)));
+            frame.Push(from == null ? null : Enum.ToObject(_t, from));
             return +1;
         }
     }

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -1000,6 +1000,12 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsDateTime(bool useInterpreter)
+        {
+            CheckGenericWithStructRestrictionCastValueTypeHelper<DateTime>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void ConvertValueTypeCastGenericWithStructRestrictionAsEnum(bool useInterpreter)
         {
             CheckValueTypeCastGenericWithStructRestrictionHelper<E>(useInterpreter);
@@ -1009,6 +1015,12 @@ namespace System.Linq.Expressions.Tests
         public static void ConvertValueTypeCastGenericWithStructRestrictionAsStruct(bool useInterpreter)
         {
             CheckValueTypeCastGenericWithStructRestrictionHelper<S>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertValueTypeCastGenericWithDateTime(bool useInterpreter)
+        {
+            CheckValueTypeCastGenericWithStructRestrictionHelper<DateTime>(useInterpreter);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -2335,10 +2335,10 @@ namespace System.Linq.Expressions.Tests
                 Assert.Throws<NullReferenceException>(() => f());
             else
             {
-                Ts expected = default(Ts);
+                Ts expected;
                 try
                 {
-                    expected = f();
+                    expected = (Ts)value;
                 }
                 catch(InvalidCastException)
                 {

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Reflection.Emit;
 
 namespace System.Linq.Expressions.Tests
 {
@@ -345,6 +346,52 @@ namespace System.Linq.Expressions.Tests
     public enum UInt32Enum : uint { A = UInt32.MaxValue }
     public enum Int64Enum : long { A = Int64.MaxValue }
     public enum UInt64Enum : ulong { A = UInt64.MaxValue }
+
+    public static class NonCSharpTypes
+    {
+        private static Type _charEnumType;
+        private static Type _boolEnumType;
+
+        private static ModuleBuilder GetModuleBuilder()
+        {
+            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName("Name"), AssemblyBuilderAccess.Run);
+            return assembly.DefineDynamicModule("Name");
+        }
+
+        public static Type CharEnumType
+        {
+            get
+            {
+                if (_charEnumType == null)
+                {
+                    EnumBuilder eb = GetModuleBuilder().DefineEnum("CharEnumType", TypeAttributes.Public, typeof(char));
+                    eb.DefineLiteral("A", 'A');
+                    eb.DefineLiteral("B", 'B');
+                    eb.DefineLiteral("C", 'C');
+                    _charEnumType = eb.CreateTypeInfo().AsType();
+                }
+
+                return _charEnumType;
+            }
+        }
+
+        public static Type BoolEnumType
+        {
+            get
+            {
+                if (_boolEnumType == null)
+                {
+                    EnumBuilder eb = GetModuleBuilder().DefineEnum("BoolEnumType", TypeAttributes.Public, typeof(bool));
+                    eb.DefineLiteral("False", false);
+                    eb.DefineLiteral("True", true);
+                    _boolEnumType = eb.CreateTypeInfo().AsType();
+                }
+
+                return _boolEnumType;
+            }
+        }
+    }
 
     public class FakeExpression : Expression
     {


### PR DESCRIPTION
Fix bug in cast test where result wasn't correctly verified.

Tests for casting reference type to enum for all underlying types.

Remove always-true branching on .GetTypeInfo().IsEnum (Already asserted in constructor).

Replace if (from == null) case with assertion. Add assertion in instruction emit backing this up.

Remove unreachable case for enum base.

Add tests for casting to enum types from underlying types.

Fix compiler and interpreter for bool → bool-backed-enum. Fixes #13516

Remove unreachable case in CastToEnumInstruction.Run() and simplify test from method call and multiple-branched switch to null-check.

Test cast tests on DateTime as they are specialised (should they be?)