### PR TITLE
Make HttpClient on Unix treat SslProtocols.None as meaning system defaults

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -282,8 +282,6 @@ namespace System.Net.Http
             }
         }
 
-        private SslProtocols ActualSslProtocols => this.SslProtocols != SslProtocols.None ? this.SslProtocols : SecurityProtocol.DefaultSecurityProtocols;
-
         internal bool SupportsAutomaticDecompression => s_supportsAutomaticDecompression;
 
         internal DecompressionMethods AutomaticDecompression


### PR DESCRIPTION
Per discussion at https://github.com/dotnet/corefx/pull/13075#discussion_r85246226.  Prior to this change, specifying SslProtocols.None for HttpClientHandler.SslProtocols meant that the default hardcoded into System.Net.Http should be used.  This changes it to mean the underlying system's default, i.e. that of libcurl and OpenSSL on Unix.

cc: @bartonjs, @cipop, @davidsh