### PR TITLE
Fix Latest.txt update when all nupkgs stable (release/1.0.0)

### DIFF
--- a/UpdatePublishedVersions.ps1
+++ b/UpdatePublishedVersions.ps1
@@ -123,7 +123,8 @@ foreach ($package in $packages)
 
 if (!$prereleaseVersion)
 {
-    throw "Could not find a Prerelease version in '$newPackages'"
+    # value here is no longer needed, use "stable" to indicate that prerelease is no longer valid and a human will have to do the update to stable.
+    $prereleaseVersion = "stable"
 }
 
 $versionFilePath = "$versionsRepoPath/Latest.txt"


### PR DESCRIPTION
When there are no prerelease packages, the versions repo updater throws an exception, but it's actually expected on release branches for all packages to be stable. This commit changes the script to set Latest.txt to "stable" when this happens rather than breaking the build.

Ported from https://github.com/dotnet/coreclr/pull/5749.

This matches the behavior in https://github.com/dotnet/buildtools/pull/1174 for newer branches.

@gkhanna79 @weshaggard 
