### PR TITLE
Improve File.Replace implementation on Unix

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -43,17 +43,39 @@ namespace System.IO
 
         public override void ReplaceFile(string sourceFullPath, string destFullPath, string destBackupFullPath, bool ignoreMetadataErrors)
         {
-            // Copy the destination file to a backup.
             if (destBackupFullPath != null)
             {
-                CopyFile(destFullPath, destBackupFullPath, overwrite: true);
+                // We're backing up the destination file to the backup file, so we need to first delete the backup
+                // file, if it exists.  If deletion fails for a reason other than the file not existing, fail.
+                if (Interop.Sys.Unlink(destBackupFullPath) != 0)
+                {
+                    Interop.ErrorInfo errno = Interop.Sys.GetLastErrorInfo();
+                    if (errno.Error != Interop.Error.ENOENT)
+                    {
+                        throw Interop.GetExceptionForIoErrno(errno, destBackupFullPath);
+                    }
+                }
+
+                // Now that the backup is gone, link the backup to point to the same file as destination.
+                // This way, we don't lose any data in the destination file, no copy is necessary, etc.
+                Interop.CheckIo(Interop.Sys.Link(destFullPath, destBackupFullPath), destFullPath);
+            }
+            else
+            {
+                // There is no backup file.  Just make sure the destination file exists, throwing if it doesn't.
+                Interop.Sys.FileStatus ignored;
+                if (Interop.Sys.Stat(destFullPath, out ignored) != 0)
+                {
+                    Interop.ErrorInfo errno = Interop.Sys.GetLastErrorInfo();
+                    if (errno.Error == Interop.Error.ENOENT)
+                    {
+                        throw Interop.GetExceptionForIoErrno(errno, destBackupFullPath);
+                    }
+                }
             }
 
-            // Then copy the contents of the source file to the destination file.
-            CopyFile(sourceFullPath, destFullPath, overwrite: true);
-
-            // Finally, delete the source file.
-            DeleteFile(sourceFullPath);
+            // Finally, rename the source to the destination, overwriting the destination.
+            Interop.CheckIo(Interop.Sys.Rename(sourceFullPath, destFullPath));
         }
 
         public override void MoveFile(string sourceFullPath, string destFullPath)

--- a/src/System.IO.FileSystem/tests/File/Replace.cs
+++ b/src/System.IO.FileSystem/tests/File/Replace.cs
@@ -50,9 +50,10 @@ namespace System.IO.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Backup_FileCopiedAndDeleted_DestCopied(bool ignoreMetadataErrors)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Backup_FileCopiedAndDeleted_DestCopied(bool backupExists, bool ignoreMetadataErrors)
         {
             string srcPath = GetTestFilePath();
             string destPath = GetTestFilePath();
@@ -64,6 +65,11 @@ namespace System.IO.Tests
             byte[] destContents = new byte[] { 6, 7, 8, 9, 10 };
             File.WriteAllBytes(destPath, destContents);
 
+            if (backupExists)
+            {
+                File.Create(destBackupPath).Dispose();
+            }
+
             Replace(srcPath, destPath, destBackupPath, ignoreMetadataErrors);
 
             Assert.False(File.Exists(srcPath));
@@ -72,9 +78,19 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void NonExistentSourcePath()
+        public void NonExistentSourcePath_ThrowsException()
         {
-            Assert.Throws<FileNotFoundException>(() => Replace(GetTestFilePath(), GetTestFilePath(), null));
+            string dest = GetTestFilePath();
+            File.Create(dest).Dispose();
+            Assert.Throws<FileNotFoundException>(() => Replace(GetTestFilePath(), dest, null));
+        }
+
+        [Fact]
+        public void NonExistentDestPath_ThrowsException()
+        {
+            string src = GetTestFilePath();
+            File.Create(src).Dispose();
+            Assert.Throws<FileNotFoundException>(() => Replace(src, GetTestFilePath(), null));
         }
 
         [Fact]


### PR DESCRIPTION
Bring the behavior closer to the Windows implementation.

cc: @ianhays, @JeremyKuhne, @binki
Fixes https://github.com/dotnet/corefx/issues/10583