### PR TITLE
Filling out missing members of System.Linq.Expressions namespace

### DIFF
--- a/src/System.Linq.Expressions/ref/System.Linq.Expressions.cs
+++ b/src/System.Linq.Expressions/ref/System.Linq.Expressions.cs
@@ -358,8 +358,7 @@ namespace System.Linq.Expressions
     public abstract partial class DynamicExpressionVisitor : System.Linq.Expressions.ExpressionVisitor
     {
         protected DynamicExpressionVisitor() { }
-        // Member is excluded in the base so it is automatically excluded for this type without any way to override that behavior
-        protected virtual Expression VisitDynamic(DynamicExpression node) { throw null; }
+        protected internal virtual new System.Linq.Expressions.Expression VisitDynamic(System.Linq.Expressions.DynamicExpression node) { throw null; }
     }
     public sealed partial class ElementInit : System.Linq.Expressions.IArgumentProvider
     {
@@ -701,6 +700,7 @@ namespace System.Linq.Expressions
         protected internal override System.Linq.Expressions.Expression Accept(System.Linq.Expressions.ExpressionVisitor visitor) { throw null; }
         public new TDelegate Compile() { throw null; }
         public new TDelegate Compile(bool preferInterpretation) { throw null; }
+        public new TDelegate Compile(System.Runtime.CompilerServices.DebugInfoGenerator debugInfoGenerator) { throw null; }
         public System.Linq.Expressions.Expression<TDelegate> Update(System.Linq.Expressions.Expression body, System.Collections.Generic.IEnumerable<System.Linq.Expressions.ParameterExpression> parameters) { throw null; }
     }
     public enum ExpressionType
@@ -806,6 +806,7 @@ namespace System.Linq.Expressions
         protected internal virtual System.Linq.Expressions.Expression VisitConstant(System.Linq.Expressions.ConstantExpression node) { throw null; }
         protected internal virtual System.Linq.Expressions.Expression VisitDebugInfo(System.Linq.Expressions.DebugInfoExpression node) { throw null; }
         protected internal virtual System.Linq.Expressions.Expression VisitDefault(System.Linq.Expressions.DefaultExpression node) { throw null; }
+        protected internal virtual System.Linq.Expressions.Expression VisitDynamic(System.Linq.Expressions.DynamicExpression node) { throw null; }
         protected virtual System.Linq.Expressions.ElementInit VisitElementInit(System.Linq.Expressions.ElementInit node) { throw null; }
         protected internal virtual System.Linq.Expressions.Expression VisitExtension(System.Linq.Expressions.Expression node) { throw null; }
         protected internal virtual System.Linq.Expressions.Expression VisitGoto(System.Linq.Expressions.GotoExpression node) { throw null; }
@@ -916,6 +917,7 @@ namespace System.Linq.Expressions
         public sealed override System.Type Type { get { throw null; } }
         public System.Delegate Compile() { throw null; }
         public System.Delegate Compile(bool preferInterpretation) { throw null; }
+        public System.Delegate Compile(System.Runtime.CompilerServices.DebugInfoGenerator debugInfoGenerator) { throw null; }
     }
     public sealed partial class ListInitExpression : System.Linq.Expressions.Expression
     {
@@ -948,6 +950,8 @@ namespace System.Linq.Expressions
     }
     public abstract partial class MemberBinding
     {
+        [System.ObsoleteAttribute("Do not use this constructor. It will be removed in future releases.")]
+        protected MemberBinding(System.Linq.Expressions.MemberBindingType type, System.Reflection.MemberInfo member) { }
         internal MemberBinding() { }
         public System.Linq.Expressions.MemberBindingType BindingType { get { throw null; } }
         public System.Reflection.MemberInfo Member { get { throw null; } }
@@ -1171,11 +1175,26 @@ namespace System.Runtime.CompilerServices
     {
         public static bool IsInternalFrame(System.Reflection.MethodBase mb) { throw null; }
     }
+    public abstract partial class DebugInfoGenerator
+    {
+        protected DebugInfoGenerator() { }
+        public static System.Runtime.CompilerServices.DebugInfoGenerator CreatePdbGenerator() { throw null; }
+        public abstract void MarkSequencePoint(System.Linq.Expressions.LambdaExpression method, int ilOffset, System.Linq.Expressions.DebugInfoExpression sequencePoint);
+    }
+    public partial interface IRuntimeVariables
+    {
+        int Count { get; }
+        object this[int index] { get; set; }
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(10636))]
     public sealed partial class DynamicAttribute : System.Attribute
     {
         public DynamicAttribute() { }
         public DynamicAttribute(bool[] transformFlags) { }
         public System.Collections.Generic.IList<bool> TransformFlags { get { throw null; } }
+    }
+    public partial class RuleCache<T> where T : class
+    {
+        internal RuleCache() { }
     }
 }

--- a/src/System.Linq.Expressions/ref/System.Linq.Expressions.cs
+++ b/src/System.Linq.Expressions/ref/System.Linq.Expressions.cs
@@ -358,7 +358,7 @@ namespace System.Linq.Expressions
     public abstract partial class DynamicExpressionVisitor : System.Linq.Expressions.ExpressionVisitor
     {
         protected DynamicExpressionVisitor() { }
-        protected internal virtual new System.Linq.Expressions.Expression VisitDynamic(System.Linq.Expressions.DynamicExpression node) { throw null; }
+        protected internal override System.Linq.Expressions.Expression VisitDynamic(System.Linq.Expressions.DynamicExpression node) { throw null; }
     }
     public sealed partial class ElementInit : System.Linq.Expressions.IArgumentProvider
     {

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -159,6 +159,8 @@
     <Compile Include="System\Linq\Expressions\DynamicExpressionVisitor.cs" />
     <Compile Include="System\Linq\Expressions\DynamicExpression.cs" />
     <Compile Include="System\Linq\Expressions\Expression.netstandard1.7.cs" />
+    <Compile Include="System\Linq\Expressions\LambdaExpression.netstandard1.7.cs" />
+    <Compile Include="System\Linq\Expressions\ExpressionVisitor.netstandard1.7.cs" />
     <Compile Include="System\Linq\Expressions\Compiler\TypeInfoExtensions.cs" />
     <Compile Include="System\Linq\Expressions\Compiler\DelegateHelpers.netstandard1.7.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuleCache.cs" />
@@ -167,6 +169,7 @@
     <Compile Include="System\Runtime\CompilerServices\CallSiteOps.cs" />
     <Compile Include="System\Runtime\CompilerServices\CallSiteHelpers.cs" />
     <Compile Include="System\Runtime\CompilerServices\DynamicAttribute.cs" />
+    <Compile Include="System\Runtime\CompilerServices\DebugInfoGenerator.cs" />
     <Compile Include="System\Dynamic\Utils\CollectionExtensions.cs" />
     <Compile Include="System\Dynamic\Utils\ContractUtils.cs" />
     <Compile Include="System\Dynamic\UpdateDelegates.Generated.cs" />

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpressionVisitor.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpressionVisitor.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions
         /// <param name="node">The expression to visit.</param>
         /// <returns>The modified expression, if it or any subexpression was modified;
         /// otherwise, returns the original expression.</returns>
-        protected new internal virtual Expression VisitDynamic(DynamicExpression node)
+        protected internal override Expression VisitDynamic(DynamicExpression node)
         {
             Expression[] a = ExpressionVisitorUtils.VisitArguments(this, node);
             if (a == null)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions
     /// classes whose functionality requires traversing, examining or copying
     /// an expression tree.
     /// </remarks>
-    public abstract class ExpressionVisitor
+    public abstract partial class ExpressionVisitor
     {
         /// <summary>
         /// Initializes a new instance of <see cref="ExpressionVisitor"/>.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.netstandard1.7.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.netstandard1.7.cs
@@ -2,15 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Dynamic.Utils;
-
 namespace System.Linq.Expressions
 {
-    public class DynamicExpressionVisitor : ExpressionVisitor
+    public abstract partial class ExpressionVisitor
     {
         /// <summary>
         /// Visits the children of the <see cref="DynamicExpression" />.
@@ -18,9 +12,9 @@ namespace System.Linq.Expressions
         /// <param name="node">The expression to visit.</param>
         /// <returns>The modified expression, if it or any subexpression was modified;
         /// otherwise, returns the original expression.</returns>
-        protected new internal virtual Expression VisitDynamic(DynamicExpression node)
+        protected internal virtual Expression VisitDynamic(DynamicExpression node)
         {
-            Expression[] a = ExpressionVisitorUtils.VisitArguments(this, node);
+            Expression[] a = VisitArguments((IArgumentProvider)node);
             if (a == null)
             {
                 return node;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions
     /// Lambda expressions take input through parameters and are expected to be fully bound.
     /// </remarks>
     [DebuggerTypeProxy(typeof(LambdaExpressionProxy))]
-    public abstract class LambdaExpression : Expression
+    public abstract partial class LambdaExpression : Expression
     {
         private readonly string _name;
         private readonly Expression _body;
@@ -141,7 +141,7 @@ namespace System.Linq.Expressions
     /// <remarks>
     /// Lambda expressions take input through parameters and are expected to be fully bound.
     /// </remarks>
-    public sealed class Expression<TDelegate> : LambdaExpression
+    public sealed partial class Expression<TDelegate> : LambdaExpression
     {
         internal Expression(Expression body, string name, bool tailCall, ReadOnlyCollection<ParameterExpression> parameters)
             : base(typeof(TDelegate), name, body, tailCall, parameters)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.netstandard1.7.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.netstandard1.7.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.Dynamic.Utils;
-using System.Reflection;
 
 namespace System.Linq.Expressions
 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.netstandard1.7.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.netstandard1.7.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Dynamic.Utils;
+using System.Reflection;
+
+namespace System.Linq.Expressions
+{
+    public sealed partial class Expression<TDelegate> : LambdaExpression
+    {
+        /// <summary>
+        /// Produces a delegate that represents the lambda expression.
+        /// </summary>
+        /// <param name="debugInfoGenerator">Debugging information generator used by the compiler to mark sequence points and annotate local variables.</param>
+        /// <returns>A delegate containing the compiled version of the lambda.</returns>
+        public new TDelegate Compile(DebugInfoGenerator debugInfoGenerator)
+        {
+            return Compile();
+        }
+    }
+
+    public abstract partial class LambdaExpression : Expression
+    {
+        /// <summary>
+        /// Produces a delegate that represents the lambda expression.
+        /// </summary>
+        /// <param name="debugInfoGenerator">Debugging information generator used by the compiler to mark sequence points and annotate local variables.</param>
+        /// <returns>A delegate containing the compiled version of the lambda.</returns>
+        public Delegate Compile(DebugInfoGenerator debugInfoGenerator)
+        {
+            return Compile();
+        }
+    }
+}

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/DebugInfoGenerator.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/DebugInfoGenerator.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.CompilerServices
         public static DebugInfoGenerator CreatePdbGenerator()
         {
             // Creating PDBs is not suported in .NET Core
-            throw new NotSupportedException();
+            throw new PlatformNotSupportedException();
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/DebugInfoGenerator.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/DebugInfoGenerator.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Generates debug information for lambdas in an expression tree.
+    /// </summary>
+    public abstract class DebugInfoGenerator
+    {
+        /// <summary>
+        /// Creates PDB symbol generator.
+        /// </summary>
+        /// <returns>PDB symbol generator.</returns>
+        public static DebugInfoGenerator CreatePdbGenerator()
+        {
+            // Creating PDBs is not suported in .NET Core
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Marks a sequence point.
+        /// </summary>
+        /// <param name="method">The lambda being generated.</param>
+        /// <param name="ilOffset">IL offset where to mark the sequence point.</param>
+        /// <param name="sequencePoint">Debug informaton corresponding to the sequence point.</param>
+        public abstract void MarkSequencePoint(LambdaExpression method, int ilOffset, DebugInfoExpression sequencePoint);
+
+        internal virtual void MarkSequencePoint(LambdaExpression method, MethodBase methodBase, ILGenerator ilg, DebugInfoExpression sequencePoint)
+        {
+            MarkSequencePoint(method, ilg.ILOffset, sequencePoint);
+        }
+
+        internal virtual void SetLocalName(LocalBuilder localBuilder, string name)
+        {
+            // nop
+        }
+    }
+}

--- a/src/System.Runtime.CompilerServices.VisualC/ref/System.Runtime.CompilerServices.VisualC.cs
+++ b/src/System.Runtime.CompilerServices.VisualC/ref/System.Runtime.CompilerServices.VisualC.cs
@@ -9,6 +9,9 @@
 
 namespace System.Runtime.CompilerServices
 {
+    public static class CompilerMarshalOverride
+    {
+    }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public partial class CallConvCdecl
     {

--- a/src/System.Runtime.CompilerServices.VisualC/src/System/Runtime/CompilerServices/Attributes.cs
+++ b/src/System.Runtime.CompilerServices.VisualC/src/System/Runtime/CompilerServices/Attributes.cs
@@ -87,4 +87,20 @@ namespace System.Runtime.CompilerServices
             get { return this.requiredContract; }
         }
     }
+    // The CLR data marshaler has some behaviors that are incompatible with
+    // C++. Specifically, C++ treats boolean variables as byte size, whereas 
+    // the marshaller treats them as 4-byte size.  Similarly, C++ treats
+    // wchar_t variables as 4-byte size, whereas the marshaller treats them
+    // as single byte size under certain conditions.  In order to work around
+    // such issues, the C++ compiler will emit a type that the marshaller will
+    // marshal using the correct sizes.  In addition, the compiler will place
+    // this modopt onto the variables to indicate that the specified type is
+    // not the true type.  Any compiler that needed to deal with similar
+    // marshalling incompatibilities could use this attribute as well.
+    //
+    // Indicates that the modified instance differs from its true type for
+    // correct marshalling.
+    public static class CompilerMarshalOverride
+    {
+    }
 }


### PR DESCRIPTION
Fixes #13483 #13332 

Filling out missing members of System.Linq.Expressions namespace.