### PR TITLE
Matching AsyncCompletedEvent.RaiseExceptionIfNecessary with Full Framework

### DIFF
--- a/src/System.ComponentModel.EventBasedAsync/src/Resources/Strings.resx
+++ b/src/System.ComponentModel.EventBasedAsync/src/Resources/Strings.resx
@@ -126,6 +126,9 @@
   <data name="Async_OperationCancelled" xml:space="preserve">
     <value>Operation has been cancelled.</value>
   </data>
+  <data name="Async_ExceptionOccurred" xml:space="preserve">
+    <value>An exception occurred during the operation, making the result invalid.  Check InnerException for exception details.</value>
+  </data>
   <data name="BackgroundWorker_WorkerAlreadyRunning" xml:space="preserve">
     <value>This BackgroundWorker is currently busy and cannot run multiple tasks concurrently.</value>
   </data>

--- a/src/System.ComponentModel.EventBasedAsync/src/System/ComponentModel/AsyncCompletedEvent.cs
+++ b/src/System.ComponentModel.EventBasedAsync/src/System/ComponentModel/AsyncCompletedEvent.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.ExceptionServices;
+using System.Reflection;
 
 namespace System.ComponentModel
 {
@@ -16,23 +16,17 @@ namespace System.ComponentModel
             _cancelled = cancelled;
             _error = error;
             _state = userState;
-
-            if (error != null)
-            {
-                _edi = ExceptionDispatchInfo.Capture(error);
-            }
         }
 
         protected void RaiseExceptionIfNecessary()
         {
-            if (Cancelled)
+            if (Error != null)
             {
-                throw new OperationCanceledException(SR.Async_OperationCancelled);
+                throw new TargetInvocationException(SR.Async_ExceptionOccurred, Error);
             }
-
-            if (_edi != null)
+            else if (Cancelled)
             {
-                _edi.Throw();
+                throw new InvalidOperationException(SR.Async_OperationCancelled);
             }
         }
 
@@ -43,7 +37,6 @@ namespace System.ComponentModel
         private readonly bool _cancelled;
         private readonly Exception _error;
         private readonly object _state;
-        private readonly ExceptionDispatchInfo _edi;
 
     }
 }

--- a/src/System.ComponentModel.EventBasedAsync/tests/AsyncOperationTests.cs
+++ b/src/System.ComponentModel.EventBasedAsync/tests/AsyncOperationTests.cs
@@ -107,8 +107,8 @@ namespace System.ComponentModel.EventBasedAsync.Tests
                 // Pass a non-null state just to emphasize we're only testing passing a null delegate
                 var state = new object();
                 var operation = AsyncOperationManager.CreateOperation(state);
-                Assert.Throws<ArgumentNullException>("d", () => operation.Post(null, state));
-                Assert.Throws<ArgumentNullException>("d", () => operation.PostOperationCompleted(null, state));
+                Assert.Throws<ArgumentNullException>(() => operation.Post(null, state));
+                Assert.Throws<ArgumentNullException>(() => operation.PostOperationCompleted(null, state));
             }
             finally
             {

--- a/src/System.ComponentModel.EventBasedAsync/tests/BackgroundWorkerTests.cs
+++ b/src/System.ComponentModel.EventBasedAsync/tests/BackgroundWorkerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -161,8 +162,9 @@ namespace System.ComponentModel.EventBasedAsync.Tests
                 {
                     try
                     {
-                        TestException ex = Assert.Throws<TestException>(() => e.Result);
-                        Assert.Equal(expectedExceptionMsg, ex.Message);
+                        TargetInvocationException ex = Assert.Throws<TargetInvocationException>(() => e.Result);
+                        Assert.True(ex.InnerException is TestException);
+                        Assert.Equal(expectedExceptionMsg, ex.InnerException.Message);
                     }
                     finally
                     {

--- a/src/System.ComponentModel.EventBasedAsync/tests/System.ComponentModel.EventBasedAsync.Tests.csproj
+++ b/src/System.ComponentModel.EventBasedAsync/tests/System.ComponentModel.EventBasedAsync.Tests.csproj
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <!-- this tests run in multiple AppDomains in full framework, so if an Assert fails we would get a Serialization exception instead of the real failure.
+    adding this xunit so it runs in one AppDomain -->
+    <XunitOptions Condition="'$(TestTFM)'=='net46'">$(XunitOptions) -noappdomain </XunitOptions>
     <ProjectGuid>{59E9B218-81D0-4A80-A4B7-66C716136D82}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.ComponentModel.EventBasedAsync.Tests</AssemblyName>


### PR DESCRIPTION
Fixes #13482
Fixes #13418

cc @danmosemsft @joperezr @weshaggard @stephentoub 